### PR TITLE
Reorder Go struct to fix library on ARM32

### DIFF
--- a/authcache/authserver.go
+++ b/authcache/authserver.go
@@ -9,9 +9,10 @@ import (
 
 // AuthServer type
 type AuthServer struct {
-	Addr    string
+	// place atomic members at the start to fix alignment for ARM32
 	Rtt     int64
 	Count   int64
+	Addr    string
 	Version Version
 }
 
@@ -70,14 +71,14 @@ func (a *AuthServer) String() string {
 // AuthServers type
 type AuthServers struct {
 	sync.RWMutex
-
+	// place atomic members at the start to fix alignment for ARM32
+	Called     uint64
+	ErrorCount uint32
+	
 	Zone string
 
 	List []*AuthServer
 	Nss  []string
-
-	ErrorCount uint32
-	Called     uint64
 
 	CheckingDisable bool
 	Checked         bool


### PR DESCRIPTION
I was compiling this project for ARM32 (specifically Raspberry Pi 3/4) and had a runtime `panic: runtime error: invalid memory address or nil pointer dereference`. A quick look showed that there was a relatively easy to fix alignment issue in 2 structures that contain members that are in turn used for atomic loads and increments. 

As per https://github.com/golang/go/issues/5278 on 32 bit systems - "The caller of 64-bit atomic operation must make sure the
pointer address is aligned to 8-byte boundary."

I fixed this by changing the order of the variables in the structure and it is working on Raspberry Pi as per light testing.