### PR TITLE
remove escaping to fix blocklist downloads

### DIFF
--- a/middleware/blocklist/updater.go
+++ b/middleware/blocklist/updater.go
@@ -72,7 +72,7 @@ func (b *BlockList) downloadBlocklist(uri, name string) error {
 		}
 	}()
 
-	response, err := http.Get(url.QueryEscape(uri))
+	response, err := http.Get(uri)
 	if err != nil {
 		return fmt.Errorf("error downloading source: %s", err)
 	}


### PR DESCRIPTION
I think it should be more like this, right? Did this ever work with escaping?!