### PR TITLE
Publish to Arch User Repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ $ brew services start sdns
 $ snap install sdns
 ```
 
+#### AUR for ArchLinux
+
+```shell
+$ yay -S sdns-git
+```
+
 > **Tip:** Pre-build binaries, docker package, brew tap and snap automatically create by Github [workflows](https://github.com/semihalev/sdns/actions)
 
 ## Building


### PR DESCRIPTION
Hi! I like `sdns`, thank you for making it. I am an Arch user (btw :wink:) and have published `sdns` as a [`package`](https://aur.archlinux.org/packages/sdns-git) on the Arch User Repository. This pull request adds the AUR as an installation method for `sdns`, feel free to make any edits!