### PR TITLE
updated: package installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ## Installation
 
 ```shell
-go get github.com/semihalev/sdns
+go install github.com/semihalev/sdns@latest
 ```
 
 #### Pre-build Binaries


### PR DESCRIPTION
deprecated go get method replaced with recent method

installing go packages with get has expired, that's why the documentation should be updated.