### PR TITLE
Remove additional `--update` for apk in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ COPY . /go/src/github.com/semihalev/sdns/
 
 WORKDIR /go/src/github.com/semihalev/sdns
 
-RUN apk --update --no-cache add \
+RUN apk --no-cache add \
 	ca-certificates \
 	gcc \
 	git \


### PR DESCRIPTION
In Alpine Linux, `--no-cache` with `apk` already fetches the latest package index, making `--update` redundant. It also prevents cache from being stored in the image, which will make the image tidier. Thus, `apk add --no-cache` should be used in our Dockerfile for brevity and efficiency.