### PR TITLE
Remove CubeDNS in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,16 +224,6 @@ These benchmarks were run on a server with Intel Xeon E5-2609 v4 cpu and 32GB me
 
 <img src="https://github.com/semihalev/sdns/blob/master/benchmarks.png?raw=true">
 
-## Who Used
-
-_CubeDNS_ public open resolver project using sdns on multi location. The project supported both UDP and TCP also DoT and DoH.
-
-| Proto  | Servers                                  |
-| ------ | ---------------------------------------- |
-| IPv4   | 195.244.44.44, 195.244.44.45             |
-| IPv6   | 2a0a:be80::cbe:4444, 2a0a:be80::cbe:4445 |
-| DoH    | https://cubedns.com/dns-query            |
-
 ## Contributing
 
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.


### PR DESCRIPTION
CubeDNS doesn't seem to be available anymore for a while (more than a year).


The certificate was expired:

```
$ curl -I https://cubedns.com
curl: (60) SSL certificate problem: certificate has expired
More details here: https://curl.haxx.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
```

```
$ kdig +https @cubedns.com www.google.com
;; WARNING: TLS, failed to receive reply (The TLS connection was non-properly terminated.)
;; WARNING: can't receive reply from 195.244.44.44@443(TCP)
;; WARNING: TLS, handshake failed (The specified session has been invalidated for some reason.)
;; ERROR: failed to query server cubedns.com@443(TCP)
```

Twitter account doesn’t exist:
https://twitter.com/cubedns
![image](https://github.com/semihalev/sdns/assets/3691490/972c6e1f-2e74-4e91-9995-c21209bf496e)

GitHub empty:
https://github.com/cubedns

![image](https://github.com/semihalev/sdns/assets/3691490/34abab7f-9260-469d-85ef-f477a26db125)

