### PR TITLE
middleware: skip typed-nil handlers in Setup so disabled middlewares can't crash ServeDNS

### DIFF
--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"plugin"
+	"reflect"
 	"sync"
 
 	"github.com/semihalev/sdns/config"
@@ -79,6 +80,26 @@ func RegisterBefore(name string, new func(*config.Config) Handler, before string
 	panic(fmt.Sprintf("Middleware %s not found", before))
 }
 
+// isNilHandler reports whether the constructor result represents an unused
+// middleware. A middleware New() that returns a typed nil pointer (e.g.
+// `func New(cfg *config.Config) *Reflex { if !cfg.ReflexEnabled { return nil } }`)
+// produces a non-nil Handler interface whose underlying value is a nil pointer,
+// so a plain `h == nil` check misses it and the disabled middleware ends up in
+// the chain. The first request then panics with a nil-pointer dereference
+// inside ServeDNS. Detect both the untyped-nil and typed-nil cases here so any
+// middleware can keep its existing "return nil when disabled" pattern.
+func isNilHandler(h Handler) bool {
+	if h == nil {
+		return true
+	}
+	v := reflect.ValueOf(h)
+	switch v.Kind() {
+	case reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Map, reflect.Slice, reflect.Func:
+		return v.IsNil()
+	}
+	return false
+}
+
 // Setup handlers.
 func Setup(cfg *config.Config) {
 	if setup {
@@ -94,7 +115,7 @@ func Setup(cfg *config.Config) {
 
 	for i, handler := range m.handlers {
 		h := handler.new(m.cfg)
-		if h == nil {
+		if isNilHandler(h) {
 			zlog.Debug("Middleware not enabled", "name", handler.name, "index", i)
 			continue
 		}


### PR DESCRIPTION
## What

`Register` wraps each middleware's `New()` inside a closure returning `middleware.Handler`:

```go
middleware.Register("reflex", func(cfg *config.Config) middleware.Handler {
    return reflex.New(cfg)
})
```

Several middlewares (reflex, accesslist, kubernetes, hostsfile, blocklist, etc.) signal "disabled in config" by returning a typed nil pointer from `New()`:

```go
// middleware/reflex/reflex.go
func New(cfg *config.Config) *Reflex {
    if !cfg.ReflexEnabled {
        return nil
    }
    ...
}
```

The returned `*Reflex(nil)` is then assigned into the `middleware.Handler` interface by the registration wrapper. Go's interface has a non-nil itab at this point (points at `*Reflex`'s method set) but a nil underlying pointer. `Setup`'s check is:

```go
for i, handler := range m.handlers {
    h := handler.new(m.cfg)
    if h == nil {
        zlog.Debug("Middleware not enabled", ...)
        continue
    }
    chainHandlers = append(chainHandlers, h)
}
```

`h == nil` misses typed-nil interfaces, so the disabled middleware ends up in `chainHandlers` and the very first DNS request after startup panics inside the recovery middleware:

```
panic: runtime error: invalid memory address or nil pointer dereference
  reflex.(*Reflex).ServeDNS(0x0, ...)
      middleware/reflex/reflex.go:126 +0x1bb
  middleware.(*Chain).Next(...)
      middleware/chain.go:40
```

In the field this surfaces most reliably when the listener fails to bind (port already in use, or the startup error reporter in the referenced issue) and the user restarts sdns with a config that leaves `ReflexEnabled` unset — from that moment every recovered query hits the same panic path (#453).

## Fix

Detect the typed-nil case in `Setup` via `reflect` and skip it the same way we already skip an untyped nil:

```go
func isNilHandler(h Handler) bool {
    if h == nil {
        return true
    }
    v := reflect.ValueOf(h)
    switch v.Kind() {
    case reflect.Ptr, reflect.Interface, reflect.Chan, reflect.Map, reflect.Slice, reflect.Func:
        return v.IsNil()
    }
    return false
}

// Setup
for i, handler := range m.handlers {
    h := handler.new(m.cfg)
    if isNilHandler(h) {
        zlog.Debug("Middleware not enabled", ...)
        continue
    }
    chainHandlers = append(chainHandlers, h)
}
```

Every middleware keeps its existing `return nil when disabled` idiom. No change at any `New()` site is required. A middleware that returns a real implementation is unaffected because `reflect.ValueOf(h).IsNil()` on a non-nil pointer returns false.

## Alternative considered

Changing every `New(cfg) *T` signature to `New(cfg) Handler` so the `return nil` becomes an untyped nil at the return site. That's mechanically straightforward but touches ~18 middleware packages plus their tests, and re-introduces the same bug the moment someone adds a new middleware using the `*T` idiom. Fixing the single chokepoint in `Setup` is robust against that.

Fixes #453