### PR TITLE
fix(forwarder): drop upstream responses with mismatched question

### DIFF
--- a/middleware/forwarder/forwarder.go
+++ b/middleware/forwarder/forwarder.go
@@ -88,6 +88,16 @@ func (f *Forwarder) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 			continue
 		}
 
+		// Reject responses whose question section does not match the
+		// outstanding query. A malicious or misbehaving upstream that
+		// returns a different name/type/class would otherwise be cached
+		// under that question, poisoning lookups for unrelated names.
+		if !questionMatches(req.Question[0], resp.Question) {
+			zlog.Info("forwarder dropped response with mismatched question",
+				"query", formatQuestion(req.Question[0]))
+			continue
+		}
+
 		resp.Id = req.Id
 		resp.CheckingDisabled = clientCD
 
@@ -109,6 +119,17 @@ func (f *Forwarder) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 
 func formatQuestion(q dns.Question) string {
 	return strings.ToLower(q.Name) + " " + dns.ClassToString[q.Qclass] + " " + dns.TypeToString[q.Qtype]
+}
+
+// questionMatches reports whether the response's question section answers the
+// outstanding request question. The name comparison is case-insensitive
+// because DNS names are not case-sensitive on the wire.
+func questionMatches(req dns.Question, resp []dns.Question) bool {
+	if len(resp) != 1 {
+		return false
+	}
+	r := resp[0]
+	return r.Qtype == req.Qtype && r.Qclass == req.Qclass && strings.EqualFold(r.Name, req.Name)
 }
 
 const name = "forwarder"

--- a/middleware/forwarder/forwarder_test.go
+++ b/middleware/forwarder/forwarder_test.go
@@ -170,3 +170,50 @@ func Test_Forwarder(t *testing.T) {
 
 	assert.Equal(t, dns.RcodeSuccess, ch.Writer.Rcode())
 }
+
+// startMismatchedQuestionServer returns a UDP server that always replies with
+// a fixed question section (victim.test. A) regardless of the client's query.
+// It models a malicious or misbehaving upstream attempting cache poisoning.
+func startMismatchedQuestionServer(t *testing.T) (addr string, stop func()) {
+	t.Helper()
+
+	mux := dns.NewServeMux()
+	mux.HandleFunc(".", func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Question = []dns.Question{{Name: "victim.test.", Qtype: dns.TypeA, Qclass: dns.ClassINET}}
+		if rr, err := dns.NewRR("victim.test. 60 IN A 6.6.6.6"); err == nil {
+			m.Answer = []dns.RR{rr}
+		}
+		_ = w.WriteMsg(m)
+	})
+
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen udp: %v", err)
+	}
+	s := &dns.Server{Net: "udp", Handler: mux, PacketConn: pc}
+	go func() { _ = s.ActivateAndServe() }()
+	return pc.LocalAddr().String(), func() { _ = s.Shutdown() }
+}
+
+func Test_Forwarder_RejectsMismatchedQuestion(t *testing.T) {
+	addr, stop := startMismatchedQuestionServer(t)
+	defer stop()
+
+	f := &Forwarder{servers: []*server{{Addr: addr, Proto: "udp"}}}
+
+	ch := middleware.NewChain([]middleware.Handler{f})
+	mw := mock.NewWriter("udp", "127.0.0.1:0")
+
+	req := new(dns.Msg)
+	req.SetQuestion("attacker.test.", dns.TypeA)
+
+	ch.Reset(mw, req)
+	ch.Next(context.Background())
+
+	// Every upstream returns a mismatched question, so the forwarder must
+	// drop the response and report SERVFAIL rather than letting an unrelated
+	// answer through to the client (and the cache).
+	assert.Equal(t, dns.RcodeServerFailure, ch.Writer.Rcode())
+}


### PR DESCRIPTION
Fixes #469 (forwarder portion).

The forwarder previously accepted any DNS response from a configured upstream and wrote it back to the client without checking that `resp.Question[0]` matched the outstanding request. Because the cache keys entries by the response's question, a malicious or misbehaving upstream could plant an answer under an unrelated name and poison later lookups for that name.

This change rejects responses whose question does not match the request (Name case-insensitively, Qtype, Qclass) and falls through to the next upstream. A regression test (`Test_Forwarder_RejectsMismatchedQuestion`) uses a local UDP server that always answers with a fixed `victim.test.` question to exercise the path; it returns SERVFAIL with the fix and an unrelated SUCCESS without it.

Resolver-side mismatch (the second half of the issue) is not addressed here; happy to follow up in a separate PR if useful.