### PR TITLE
fix(resolver): drop upstream responses with mismatched question

### DIFF
--- a/middleware/resolver/client.go
+++ b/middleware/resolver/client.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"io"
 	"net"
+	"strings"
 	"sync"
 	"time"
 
@@ -17,6 +18,12 @@ import (
 const (
 	headerSize = 12
 )
+
+// ErrQuestion is returned by Conn.Exchange when the response's question
+// section does not match the outstanding request. Accepting a mismatched
+// question lets a malicious upstream plant a cache entry under an unrelated
+// name (issue #469).
+var ErrQuestion = errors.New("dns: response question did not match request")
 
 // Conn A Conn represents a connection to a DNS server.
 type Conn struct {
@@ -47,10 +54,24 @@ func (co *Conn) Exchange(m *dns.Msg) (r *dns.Msg, rtt time.Duration, err error) 
 	if err == nil && r.Id != m.Id {
 		err = dns.ErrId
 	}
+	if err == nil && len(m.Question) > 0 && !questionMatches(m.Question[0], r.Question) {
+		err = ErrQuestion
+	}
 
 	rtt = time.Since(t)
 
 	return r, rtt, err
+}
+
+// questionMatches reports whether the response's question section answers the
+// outstanding request question. DNS names are compared case-insensitively
+// because they are not case-sensitive on the wire.
+func questionMatches(req dns.Question, resp []dns.Question) bool {
+	if len(resp) != 1 {
+		return false
+	}
+	r := resp[0]
+	return r.Qtype == req.Qtype && r.Qclass == req.Qclass && strings.EqualFold(r.Name, req.Name)
 }
 
 // (*Conn).ReadMsg readMsg reads a message from the connection co.

--- a/middleware/resolver/client_test.go
+++ b/middleware/resolver/client_test.go
@@ -49,3 +49,56 @@ func Test_Client(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, r)
 }
+
+// startMismatchedQuestionServer returns a UDP server that always replies with
+// a fixed question section (victim.test. A) regardless of what was asked. It
+// models a malicious upstream attempting cache poisoning via the response's
+// question section (issue #469).
+func startMismatchedQuestionServer(t *testing.T) (addr string, stop func()) {
+	t.Helper()
+
+	mux := dns.NewServeMux()
+	mux.HandleFunc(".", func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Question = []dns.Question{{Name: "victim.test.", Qtype: dns.TypeA, Qclass: dns.ClassINET}}
+		if rr, err := dns.NewRR("victim.test. 60 IN A 6.6.6.6"); err == nil {
+			m.Answer = []dns.RR{rr}
+		}
+		_ = w.WriteMsg(m)
+	})
+
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen udp: %v", err)
+	}
+	s := &dns.Server{Net: "udp", Handler: mux, PacketConn: pc}
+	go func() { _ = s.ActivateAndServe() }()
+	return pc.LocalAddr().String(), func() { _ = s.Shutdown() }
+}
+
+func Test_Client_RejectsMismatchedQuestion(t *testing.T) {
+	addr, stop := startMismatchedQuestionServer(t)
+	defer stop()
+
+	req := new(dns.Msg)
+	req.SetQuestion("attacker.test.", dns.TypeA)
+
+	dialer := &net.Dialer{Deadline: time.Now().Add(2 * time.Second)}
+	co := &Conn{}
+
+	var err error
+	co.Conn, err = dialer.Dial("udp", addr)
+	assert.NoError(t, err)
+	defer func() { _ = co.Close() }()
+
+	err = co.SetDeadline(time.Now().Add(2 * time.Second))
+	assert.NoError(t, err)
+
+	// The upstream returns a response whose question is victim.test. but the
+	// outstanding request asked for attacker.test. — Exchange must surface
+	// this as an error rather than handing the unrelated message back to the
+	// caller (which would otherwise cache it under victim.test.).
+	_, _, err = co.Exchange(req)
+	assert.ErrorIs(t, err, ErrQuestion)
+}


### PR DESCRIPTION
Follow-up to #470 covering the resolver half of #469.

`middleware/resolver/client.go:Conn.Exchange` previously validated only the DNS transaction ID. An upstream (a malicious authoritative server reached during recursion, or a stub configured to be reached over the recursive path) could return a response whose question section was unrelated to the outstanding query, and that response was passed straight back to the resolver. Because the cache keys entries by `resp.Question[0]`, the unrelated answer was stored under an attacker-chosen name and served from cache for later lookups.

This change mirrors the forwarder fix from #470 at the resolver wire layer:

- After the existing `r.Id != m.Id` check, require the response's question section to contain exactly one entry matching the request's `Qtype`, `Qclass`, and `Name` (compared with `strings.EqualFold` because DNS names are case-insensitive on the wire).
- On mismatch, return a new sentinel `ErrQuestion`. The existing `r.exchange` retry path (UDP → UDP → TCP, then next server) handles it like any other transport-level error, so a single bad upstream falls through to the next authority instead of poisoning the cache.

A regression test (`Test_Client_RejectsMismatchedQuestion`) spins up a local UDP server that always answers with a fixed `victim.test.` question regardless of what was asked, and asserts that `Conn.Exchange` surfaces `ErrQuestion` rather than handing the unrelated message back to the caller.

## Notes

- The check sits at the only `co.Exchange` call site (`resolver.go:1299`), so every authoritative response — UDP or TCP, pooled connection or fresh — is covered.
- A malicious upstream that returns a mismatched question costs three exchanges before the resolver moves on (UDP retry, then TCP retry). That's acceptable; tightening the retry logic to skip retries on `ErrQuestion` is a separate, bounded change and not required for the fix.
- Closes #469 once paired with #470.

## Test plan

- [x] `go test -race ./middleware/resolver/...` — full resolver suite green
- [x] `go test -v -race -run 'Test_Client' ./middleware/resolver/` — new test passes
- [x] `golangci-lint run ./middleware/resolver/...` — clean
- [x] `gofmt -w` — applied