### PR TITLE
feat(dns64): RFC 6147 DNS64 middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,50 @@ answers = [
 
 Views are evaluated in declaration order; the first whose `networks` contains the client IP wins. `zone` is a free-form label used in error logs — it doesn't have to be a DNS zone name.
 
+#### DNS64 (RFC 6147)
+
+The DNS64 middleware lets IPv6-only clients reach IPv4-only services. When a client AAAA query has no usable answer, the middleware issues a secondary A-record lookup and synthesises AAAA records by embedding each IPv4 address into a configured Pref64::/n IPv6 prefix (RFC 6052). The client receives addresses in a NAT64-routable subnet and can connect to the IPv4-only target through a paired NAT64 gateway.
+
+**How It Works:**
+
+- The middleware sits between the `kubernetes` and `cache` middlewares. The cache stores the original AAAA response — synthesis runs per client query against that cached response. The secondary A lookup itself is cached, so repeat synthesis is bounded to a memcpy plus a cache hit. This preserves per-client correctness when `client_networks` restricts who gets synthesis.
+- **RCODE handling** follows RFC 6147 §5.1.2 / §5.1.3 / §5.5:
+  - `NOERROR` with at least one usable AAAA → pass through (after AAAA exclusion filtering, see below).
+  - `NXDOMAIN` → pass through unchanged. The name doesn't exist, so it has no A either.
+  - `SERVFAIL` carrying a DNSSEC-failure Extended DNS Error (codes 1/2/5–12/27 — Unsupported DNSKEY Algorithm, Unsupported DS Digest Type, DNSSEC Indeterminate, DNSSEC Bogus, Signature Expired/Not Yet Valid, DNSKEY/RRSIGs/NSEC Missing, No Zone Key Bit Set, Unsupported NSEC3 Iterations Value) → pass through unchanged. Synthesising over a validation failure would let an attacker bypass DNSSEC.
+  - `NOERROR` with no usable AAAA, or any other nonzero RCODE (`SERVFAIL` without a DNSSEC EDE, `REFUSED`, etc.) → treated as "no answer" and the secondary A lookup is attempted. When the A query yields empty/error too, that response (rcode + Authority + any CNAME/DNAME chain) becomes the basis for the client reply per §5.1.6.
+- **Recursion bit:** `RD=0` queries skip DNS64 entirely. Synthesis requires a recursive secondary lookup, so honouring the client's non-recursive intent means stepping aside.
+- **AAAA exclusion (RFC 6147 §5.1.4):** AAAA records returned by the upstream are filtered against `exclude_aaaa_networks` (default `::ffff:0:0/96` IPv4-mapped) before deciding pass-through vs synthesis. If every AAAA is excluded, the response is treated as if no AAAA were returned and synthesis proceeds. Excluded AAAAs are stripped from the Answer section even on the pass-through path so they never reach the client.
+- **A side filtering (RFC 6147 §5.1.4):** when the active prefix is the IANA Well-Known `64:ff9b::/96`, IPv4 addresses inside `exclude_a_networks` are dropped from synthesis. Operator-chosen prefixes ignore that list — you picked the prefix knowing the network's reachability.
+- **CNAME / DNAME chains (RFC 6147 §5.1.5)** are carried through into the synthesised answer. Synthesised AAAAs adopt the A record's owner — the terminal name after the chain has resolved.
+- **TTL (RFC 6147 §5.1.7):** the synthesised AAAA TTL is `min(A record TTL, AAAA negative-cache TTL)`. When the original AAAA carried no SOA, the synth TTL caps at 600 s. No artificial floor.
+- **Multi-prefix synthesis (RFC 6147 §5.2):** every configured prefix produces its own synthesised AAAA per A record, so a client receives every reachable Pref64 path in a single response. Per-prefix RFC 6147 §5.1.4 filtering still applies — a private IPv4 may be excluded under `64:ff9b::/96` but synthesised under an operator prefix listed alongside it.
+- **PTR translation (RFC 6147 §5.3.1):** `ip6.arpa` PTR queries whose embedded IPv4 falls under any configured Pref64 are answered with a CNAME pointing at the corresponding `in-addr.arpa` name; if the chase succeeds, the resolved PTR records are appended. Names that decode to addresses outside every Pref64 (or whose IPv4 hits the §5.1.4 exclusion under the well-known prefix) flow through normal recursion so real reverse zones still answer.
+- **DNSSEC (RFC 6147 §5.5):** when the original NODATA was `AD=1`, the synthesised reply clears AD and attaches Extended DNS Error 4 ("Forged Answer"). Clients that set `CD=1` are validating themselves and bypass synthesis (both AAAA and PTR paths).
+- **Internal sub-queries** (resolver NS chase, cache CNAME chase) skip DNS64 entirely — synthesis is a client-facing concern, not part of resolution semantics.
+
+**Configuration:**
+```toml
+[dns64]
+enabled = true
+prefixes = ["64:ff9b::/96"]         # IANA Well-Known Prefix; or your own /32, /40, /48, /56, /64, /96. List multiple to synthesise one AAAA per prefix per A.
+client_networks = []                # Empty = all clients eligible; restrict to your IPv6-only subnets to scope synthesis
+exclude_zones = []                  # FQDNs (suffix match) whose AAAA must never be synthesised
+exclude_aaaa_networks = ["::ffff:0:0/96"]  # IPv6 prefixes whose AAAA records are filtered out of upstream replies (RFC 6147 §5.1.4)
+exclude_a_networks = [              # IPv4 ranges skipped under the well-known prefix only (RFC 6147 §5.1.4)
+    "10.0.0.0/8", "172.16.0.0/12", "192.168.0.0/16",
+    # …plus the rest of the IANA Special-Purpose Address Registry; defaults documented in sdns.conf
+]
+```
+
+`exclude_aaaa_networks` defaults to `["::ffff:0:0/96"]` when the field is unset. Pass `[]` (declared empty) to opt out of AAAA filtering entirely. `exclude_a_networks` is consulted only when `64:ff9b::/96` is among the active prefixes.
+
+**Prometheus Metrics:**
+- `dns64_synthesised_total` — AAAA queries answered with synthesised records
+- `dns64_ptr_translated_total` — `ip6.arpa` PTR queries redirected to `in-addr.arpa`
+- `dns64_passthrough_total{reason}` — AAAA queries left untouched, labelled by reason: `aaaa_present`, `nxdomain`, `dnssec_fail`, `no_rd`, `client_excluded`, `zone_excluded`, `cd_bit`, `internal`, `a_excluded`
+- `dns64_a_lookup_failures_total{reason}` — failures of the secondary A lookup, labelled by reason
+
 #### Cache Metrics
 
 SDNS exports comprehensive cache metrics via the Prometheus `/metrics` endpoint for monitoring cache performance.
@@ -411,6 +455,7 @@ This is useful when:
 *   **Kubernetes DNS integration with a 256-way sharded registry and zero-allocation lookups**
 *   **Automatic TLS certificate reloading without downtime**
 *   **DNS amplification/reflection attack detection (Reflex)**
+*   **DNS64 synthesis for IPv6-only clients (RFC 6147)**
 
 ## TODO
 
@@ -426,7 +471,7 @@ This is useful when:
 *   \[x] Query name minimization to improve privacy described at RFC 7816
 *   \[x] DNAME Redirection in the DNS described at RFC 6672
 *   \[x] Automated Updates DNSSEC Trust Anchors described at RFC 5011
-*   \[ ] DNS64 DNS Extensions for NAT from IPv6 Clients to IPv4 Servers described at RFC 6147
+*   \[x] DNS64 DNS Extensions for NAT from IPv6 Clients to IPv4 Servers described at RFC 6147
 *   \[x] DNS over QUIC support described at RFC 9250
 *   \[x] Kubernetes DNS integration
 

--- a/config/config.go
+++ b/config/config.go
@@ -84,6 +84,11 @@ type Config struct {
 	// Kubernetes middleware configuration as a section
 	Kubernetes KubernetesConfig `toml:"kubernetes"`
 
+	// DNS64 middleware configuration (RFC 6147). Translates A
+	// records into AAAA records embedded in a configured IPv6
+	// prefix, so an IPv6-only client can reach IPv4-only services.
+	DNS64 DNS64Config `toml:"dns64"`
+
 	Plugins map[string]Plugin
 
 	CookieSecret string
@@ -144,6 +149,55 @@ type KubernetesTTLConfig struct {
 	Pod     uint32 `toml:"pod"`
 	SRV     uint32 `toml:"srv"`
 	PTR     uint32 `toml:"ptr"`
+}
+
+// DNS64Config holds DNS64 middleware configuration (RFC 6147).
+//
+// Prefixes lists Pref64::/n IPv6 prefixes used to embed IPv4
+// addresses in synthesised AAAA records. Each prefix length must
+// be one of /32, /40, /48, /56, /64, /96 per RFC 6052 §2.2. Per
+// RFC 6147 §5.2 every configured prefix synthesises in parallel:
+// each upstream A record produces one AAAA per prefix, so a
+// client receives every reachable Pref64 path in a single reply.
+// When DNS64 is enabled but no usable prefix is configured the
+// well-known 64:ff9b::/96 is the runtime default.
+//
+// ClientNetworks restricts synthesis to clients whose source IP
+// falls in one of the listed CIDRs. An empty list synthesises for
+// every client; "::/0" plus "0.0.0.0/0" achieves the same and is
+// the recommended explicit form.
+//
+// ExcludeZones is a list of fully-qualified domain names whose
+// AAAA responses are never synthesised (their original NODATA /
+// NXDOMAIN flows through unchanged). Useful for opting out
+// specific zones when some other middleware is expected to handle
+// IPv6.
+//
+// ExcludeANetworks is the RFC 6147 §5.1.4 / RFC 6052 §3.1
+// "do not translate" set. IPv4 addresses inside any listed CIDR
+// are dropped from synthesis when the well-known prefix
+// 64:ff9b::/96 is in use. Operator-chosen network-specific
+// prefixes ignore this list — they picked the prefix knowing the
+// network's reachability. When the field is omitted entirely
+// (nil) and the well-known prefix is active, a runtime default
+// list mirroring the IANA Special-Purpose Address Registry is
+// applied; declaring an explicit empty list opts out.
+//
+// ExcludeAAAANetworks lists IPv6 prefixes whose AAAA records in the
+// upstream response must be filtered before deciding pass-through
+// vs synthesis (RFC 6147 §5.1.4). The default ::ffff:0:0/96 (IPv4-
+// mapped IPv6) keeps misconfigured upstreams from leaking
+// non-routable addresses into the client. When every AAAA in the
+// upstream answer is excluded, the response is treated as if no
+// AAAA records were returned and synthesis proceeds. Declaring
+// an explicit empty list opts out of filtering.
+type DNS64Config struct {
+	Enabled             bool     `toml:"enabled"`
+	Prefixes            []string `toml:"prefixes"`
+	ClientNetworks      []string `toml:"client_networks"`
+	ExcludeZones        []string `toml:"exclude_zones"`
+	ExcludeANetworks    []string `toml:"exclude_a_networks"`
+	ExcludeAAAANetworks []string `toml:"exclude_aaaa_networks"`
 }
 
 // Plugin type.
@@ -604,6 +658,76 @@ srv = 30
 
 # TTL for PTR records (seconds)
 ptr = 30
+
+# ============================
+# DNS64 (RFC 6147)
+# ============================
+
+# Synthesise AAAA records from A records for IPv6-only clients
+# reaching IPv4-only services. When a client AAAA query returns
+# NOERROR-NODATA (or any nonzero RCODE other than NXDOMAIN, e.g.
+# SERVFAIL without a DNSSEC EDE), the resolver issues an A query
+# for the same name and synthesises AAAA records by embedding
+# each IPv4 inside one of the configured Pref64::/n prefixes
+# (RFC 6052). NXDOMAIN passes through unchanged; SERVFAIL with a
+# DNSSEC-failure Extended DNS Error also passes through so DNS64
+# can never mask a validation failure (RFC 6147 §5.5). Clients
+# that set RD=0 or CD=1 bypass DNS64 entirely.
+
+[dns64]
+# Enable DNS64 synthesis.
+enabled = false
+
+# IPv6 prefixes used to embed IPv4 addresses. Lengths must be one
+# of /32, /40, /48, /56, /64, /96. List multiple prefixes to
+# synthesise one AAAA per (A record, prefix) pair so the client
+# sees every reachable Pref64 path in a single reply. The IANA-
+# reserved Well-Known Prefix 64:ff9b::/96 is the typical choice
+# for general-purpose DNS64; if the field is omitted entirely
+# while DNS64 is enabled, that prefix is the runtime default
+# (RFC 6147 §5.2).
+prefixes = ["64:ff9b::/96"]
+
+# CIDR ranges of clients eligible for synthesis. Empty list means
+# all clients are eligible. Restrict to your IPv6-only subnets to
+# keep dual-stack clients on their original answers.
+client_networks = []
+
+# Fully-qualified domain names whose AAAA responses must not be
+# synthesised. Suffix match: "example.com." matches the zone and
+# every name under it.
+exclude_zones = []
+
+# IPv6 prefixes whose AAAA records must be filtered out of the
+# upstream response before deciding pass-through vs synthesis
+# (RFC 6147 §5.1.4). The IPv4-mapped IPv6 range ::ffff:0:0/96 is
+# the standard default; misconfigured upstreams that return
+# IPv4-mapped AAAAs are treated as if they returned no AAAA, so
+# DNS64 synthesises a routable address from the corresponding A.
+exclude_aaaa_networks = ["::ffff:0:0/96"]
+
+# IPv4 networks excluded from synthesis when the Well-Known Prefix
+# 64:ff9b::/96 is the active prefix (RFC 6147 §5.1.4). Operator-
+# chosen network-specific prefixes ignore this list. Defaults
+# below mirror the IANA Special-Purpose Address Registry.
+exclude_a_networks = [
+    "0.0.0.0/8",
+    "10.0.0.0/8",
+    "100.64.0.0/10",
+    "127.0.0.0/8",
+    "169.254.0.0/16",
+    "172.16.0.0/12",
+    "192.0.0.0/24",
+    "192.0.2.0/24",
+    "192.88.99.0/24",
+    "192.168.0.0/16",
+    "198.18.0.0/15",
+    "198.51.100.0/24",
+    "203.0.113.0/24",
+    "224.0.0.0/4",
+    "240.0.0.0/4",
+    "255.255.255.255/32",
+]
 
 # ============================
 # Plugins

--- a/gen.go
+++ b/gen.go
@@ -29,6 +29,7 @@ var middlewareList = []string{
 	"blocklist",
 	"as112",
 	"kubernetes",
+	"dns64",
 	"cache",
 	"failover",
 	"resolver",

--- a/middleware/dns64/config.go
+++ b/middleware/dns64/config.go
@@ -1,0 +1,267 @@
+package dns64
+
+import (
+	"net"
+	"strings"
+
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/zlog/v2"
+)
+
+// compiled holds the runtime form of cfg.DNS64 — prefixes and CIDR
+// lists as net.IPNet structs, the exclude-zone list canonicalised
+// to lower-case fully-qualified form, and the active prefix
+// pre-selected. compileConfig returns nil when DNS64 is disabled
+// or has no usable configuration so the constructor can short-
+// circuit to typed-nil.
+type compiled struct {
+	prefixes       []compiledPrefix
+	clientNetworks []*net.IPNet
+	excludeZones   []string
+	excludeAv4     []*net.IPNet
+	excludeAAAA    []*net.IPNet
+}
+
+// compiledPrefix is one Pref64 entry pre-validated and tagged with
+// whether it is the IANA Well-Known Prefix. RFC 6147 §5.1.4 ties
+// the IPv4 exclusion list to that prefix only, so the bool is the
+// per-prefix gate on shouldExcludeA.
+type compiledPrefix struct {
+	net       *net.IPNet
+	wellKnown bool
+}
+
+// hasWellKnown reports whether any configured prefix is the
+// well-known one. Used to decide whether to parse exclude_a_networks
+// (operator-only prefixes ignore that list, so when no well-known
+// is present we can skip the parse work entirely).
+func (c *compiled) hasWellKnown() bool {
+	for _, p := range c.prefixes {
+		if p.wellKnown {
+			return true
+		}
+	}
+	return false
+}
+
+// defaultExcludeAAAA is the RFC 6147 §5.1.4 baseline: filter
+// IPv4-mapped IPv6 addresses out of upstream AAAA responses so
+// DNS64 doesn't pass non-routable answers through to the client.
+// Used when the operator omits exclude_aaaa_networks entirely;
+// passing an explicit empty list keeps the filter empty.
+var defaultExcludeAAAA = []*net.IPNet{mustCIDR("::ffff:0:0/96")}
+
+// defaultExcludeAv4 is the runtime baseline for
+// exclude_a_networks when the well-known prefix 64:ff9b::/96 is
+// active and the operator hasn't supplied a list. RFC 6052 §3.1
+// forbids translating non-globally-reachable IPv4 ranges through
+// the WKP; this list mirrors the IANA Special-Purpose Address
+// Registry entries that fall in that category. Operators who
+// declare exclude_a_networks = [] explicitly opt out.
+var defaultExcludeAv4 = []*net.IPNet{
+	mustCIDR("0.0.0.0/8"),
+	mustCIDR("10.0.0.0/8"),
+	mustCIDR("100.64.0.0/10"),
+	mustCIDR("127.0.0.0/8"),
+	mustCIDR("169.254.0.0/16"),
+	mustCIDR("172.16.0.0/12"),
+	mustCIDR("192.0.0.0/24"),
+	mustCIDR("192.0.2.0/24"),
+	// 192.88.99.0/24 — 6to4 anycast relay range, deprecated by
+	// RFC 7526. The IANA Special-Purpose Address Registry marks
+	// 192.88.99.2/32 as Globally Reachable: False; we cover the
+	// whole /24 to stay aligned with RFC 6052 §3.1.
+	mustCIDR("192.88.99.0/24"),
+	mustCIDR("192.168.0.0/16"),
+	mustCIDR("198.18.0.0/15"),
+	mustCIDR("198.51.100.0/24"),
+	mustCIDR("203.0.113.0/24"),
+	mustCIDR("224.0.0.0/4"),
+	mustCIDR("240.0.0.0/4"),
+	mustCIDR("255.255.255.255/32"),
+}
+
+// compileConfig parses cfg.DNS64 into a runtime-friendly form. Bad
+// entries are logged and skipped (matching the views / accesslist
+// pattern), so a single typo in one prefix doesn't disable the
+// middleware. Returns nil when DNS64 is not enabled or has no
+// usable prefix — New translates that into a typed-nil Handler so
+// the registry skips the middleware entirely.
+func compileConfig(cfg *config.Config) *compiled {
+	c := cfg.DNS64
+	if !c.Enabled {
+		return nil
+	}
+
+	out := &compiled{}
+	for _, raw := range c.Prefixes {
+		_, p, err := net.ParseCIDR(strings.TrimSpace(raw))
+		if err != nil {
+			zlog.Error("DNS64 prefix parse failed", "prefix", raw, "error", err.Error())
+			continue
+		}
+		if err := validatePrefix(p); err != nil {
+			zlog.Error("DNS64 prefix invalid", "prefix", raw, "error", err.Error())
+			continue
+		}
+		out.prefixes = append(out.prefixes, compiledPrefix{
+			net:       p,
+			wellKnown: isWellKnownPrefix(p),
+		})
+	}
+	if len(out.prefixes) == 0 {
+		// RFC 6147 §5.2: when no usable prefix is configured the
+		// default is the IANA Well-Known Prefix 64:ff9b::/96.
+		// We arrive here either because the operator omitted
+		// the field entirely or every entry failed validation —
+		// either way, the default keeps DNS64 functional rather
+		// than silently disabling.
+		zlog.Info("DNS64 enabled with no configured prefix; defaulting to 64:ff9b::/96 per RFC 6147 §5.2")
+		out.prefixes = []compiledPrefix{{net: wellKnownPrefix, wellKnown: true}}
+	}
+
+	for _, raw := range c.ClientNetworks {
+		_, n, err := net.ParseCIDR(strings.TrimSpace(raw))
+		if err != nil {
+			zlog.Error("DNS64 client network parse failed", "cidr", raw, "error", err.Error())
+			continue
+		}
+		out.clientNetworks = append(out.clientNetworks, n)
+	}
+
+	for _, z := range c.ExcludeZones {
+		z = strings.TrimSpace(strings.ToLower(z))
+		if z == "" {
+			continue
+		}
+		if !strings.HasSuffix(z, ".") {
+			z += "."
+		}
+		out.excludeZones = append(out.excludeZones, z)
+	}
+
+	// Exclude-A networks are only consulted under the well-known
+	// prefix (RFC 6147 §5.1.4 / RFC 6052 §3.1). When that prefix
+	// is active we apply a runtime default if the field was
+	// omitted (nil) — the operator can opt out by declaring an
+	// explicit empty list. When no configured prefix is the
+	// well-known one, skip the parse entirely.
+	if out.hasWellKnown() {
+		if c.ExcludeANetworks == nil {
+			out.excludeAv4 = defaultExcludeAv4
+		} else {
+			for _, raw := range c.ExcludeANetworks {
+				_, n, err := net.ParseCIDR(strings.TrimSpace(raw))
+				if err != nil {
+					zlog.Error("DNS64 exclude-a-network parse failed", "cidr", raw, "error", err.Error())
+					continue
+				}
+				if len(n.Mask) != net.IPv4len {
+					zlog.Error("DNS64 exclude-a-network is not IPv4", "cidr", raw)
+					continue
+				}
+				out.excludeAv4 = append(out.excludeAv4, n)
+			}
+		}
+	}
+
+	// Exclude-AAAA networks (RFC 6147 §5.1.4): apply the default
+	// only when the operator left the field unset (nil). A
+	// declared-but-empty list opts out of filtering deliberately
+	// — the TOML decoder distinguishes nil from a zero-length
+	// slice for us.
+	if c.ExcludeAAAANetworks == nil {
+		out.excludeAAAA = defaultExcludeAAAA
+	} else {
+		for _, raw := range c.ExcludeAAAANetworks {
+			_, n, err := net.ParseCIDR(strings.TrimSpace(raw))
+			if err != nil {
+				zlog.Error("DNS64 exclude-aaaa-network parse failed", "cidr", raw, "error", err.Error())
+				continue
+			}
+			// net.ParseCIDR returns a 4-byte mask for IPv4 inputs
+			// and a 16-byte mask for IPv6 — IP.To4() is the wrong
+			// discriminator because IPv4-mapped IPv6 ranges like
+			// ::ffff:0:0/96 are themselves 16-byte addresses with
+			// a non-nil To4(). Use the mask length so the
+			// well-known IPv4-mapped exclusion default is
+			// accepted when explicitly listed.
+			if len(n.Mask) != net.IPv6len {
+				zlog.Error("DNS64 exclude-aaaa-network is IPv4, want IPv6", "cidr", raw)
+				continue
+			}
+			out.excludeAAAA = append(out.excludeAAAA, n)
+		}
+	}
+
+	return out
+}
+
+// shouldExcludeAAAA reports whether ip falls in any of the
+// configured exclude-AAAA prefixes. RFC 6147 §5.1.4 — applied
+// before deciding whether the upstream answer counts as
+// non-empty.
+func (c *compiled) shouldExcludeAAAA(ip net.IP) bool {
+	if len(c.excludeAAAA) == 0 {
+		return false
+	}
+	for _, n := range c.excludeAAAA {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// clientEligible reports whether ip should receive DNS64 synthesis.
+// An empty client-network list is treated as "all clients" — same
+// shape as accesslist's default.
+func (c *compiled) clientEligible(ip net.IP) bool {
+	if len(c.clientNetworks) == 0 {
+		return true
+	}
+	if ip == nil {
+		return false
+	}
+	for _, n := range c.clientNetworks {
+		if n.Contains(ip) {
+			return true
+		}
+	}
+	return false
+}
+
+// zoneExcluded reports whether qname (canonical, lower-case, FQDN)
+// suffix-matches one of the exclude-zone entries. The zone "." is
+// not allowed in the config (it would disable the middleware), so
+// the FQDN root never appears here. Match must occur on a label
+// boundary: "example.org." matches "example.org." and
+// "host.example.org.", but NOT "badexample.org.".
+func (c *compiled) zoneExcluded(qname string) bool {
+	if len(c.excludeZones) == 0 {
+		return false
+	}
+	for _, z := range c.excludeZones {
+		if qname == z {
+			return true
+		}
+		// z always ends with "." (FQDN'd at compile time), so
+		// "."+z forces the label boundary check — no fragment
+		// can match a longer label here.
+		if strings.HasSuffix(qname, "."+z) {
+			return true
+		}
+	}
+	return false
+}
+
+// shouldExcludeAOnPrefix reports whether v4 should be skipped per
+// RFC 6147 §5.1.4 when synthesising into the given prefix. The
+// IPv4 exclusion list is bound to the well-known prefix only;
+// operator-chosen prefixes always synthesise.
+func (c *compiled) shouldExcludeAOnPrefix(v4 net.IP, p compiledPrefix) bool {
+	if !p.wellKnown {
+		return false
+	}
+	return excludedV4(v4, c.excludeAv4)
+}

--- a/middleware/dns64/coverage_test.go
+++ b/middleware/dns64/coverage_test.go
@@ -1,0 +1,291 @@
+package dns64
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/middleware"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestName pins the registered middleware name so the gen.go entry
+// can't drift away from what the package reports.
+func TestName(t *testing.T) {
+	d := New(baseConfig())
+	assert.Equal(t, "dns64", d.Name())
+}
+
+// TestSetQueryer covers the trivial setter used by middleware.Setup
+// during auto-wire. We pass a Queryer-shaped value and read it
+// back via an A-lookup that exercises synthesise.
+func TestSetQueryer(t *testing.T) {
+	d := New(baseConfig())
+	q := &stubQueryer{resp: aRespMsg("foo.example.org.", 60, "192.0.2.33")}
+	d.SetQueryer(q)
+	if d.queryer != middleware.Queryer(q) {
+		t.Fatalf("SetQueryer did not install the provided queryer")
+	}
+}
+
+// TestClassifyQueryErr exercises every branch of the metric label
+// derivation so the cardinality contract is observable.
+func TestClassifyQueryErr(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want string
+	}{
+		{"no_response", middleware.ErrNoResponse, "no_response"},
+		{"max_recursion", middleware.ErrMaxRecursion, "max_recursion"},
+		{"queryer_error", errQueryerNotWired, "queryer_error"},
+		{"other", errors.New("unknown"), "other"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, classifyQueryErr(tc.err))
+		})
+	}
+}
+
+// TestCompileConfig_BadEntriesSkipped exercises the lenient parse
+// pattern: bad prefixes / bad CIDRs / bad exclude-A entries are
+// logged-and-skipped instead of disabling the middleware.
+func TestCompileConfig_BadEntriesSkipped(t *testing.T) {
+	cfg := &config.Config{DNS64: config.DNS64Config{
+		Enabled: true,
+		Prefixes: []string{
+			"not-a-cidr",    // unparseable → skip
+			"2001:db8::/49", // wrong length → skip
+			"64:ff9b::/96",  // good — picked
+			"2001:db8::/96", // ignored (first valid wins)
+		},
+		ClientNetworks:   []string{"bad-cidr", "10.0.0.0/8"},
+		ExcludeZones:     []string{"", "example.org"},
+		ExcludeANetworks: []string{"bad-cidr", "::1/128", "10.0.0.0/8"}, // first two skip
+	}}
+	c := compileConfig(cfg)
+	if c == nil {
+		t.Fatalf("compileConfig returned nil despite usable prefixes")
+	}
+	if assert.Len(t, c.prefixes, 2, "both valid prefixes are kept (well-known + operator)") {
+		assert.True(t, c.prefixes[0].net.IP.Equal(net.ParseIP("64:ff9b::")), "well-known appears first as configured")
+		assert.True(t, c.prefixes[0].wellKnown)
+		assert.True(t, c.prefixes[1].net.IP.Equal(net.ParseIP("2001:db8::")))
+		assert.False(t, c.prefixes[1].wellKnown)
+	}
+	assert.True(t, c.hasWellKnown())
+	assert.Len(t, c.clientNetworks, 1, "bad CIDR dropped, good one kept")
+	assert.Len(t, c.excludeZones, 1, "empty zone entry dropped, good one kept and FQDN'd")
+	assert.Equal(t, "example.org.", c.excludeZones[0])
+	assert.Len(t, c.excludeAv4, 1, "bad and IPv6 exclude entries dropped")
+}
+
+// TestCompileConfig_NoUsablePrefixFallsBackToWellKnown pins
+// RFC 6147 §5.2: when DNS64 is enabled but every configured
+// prefix is invalid (or the field is omitted entirely), the
+// well-known prefix 64:ff9b::/96 is the default rather than
+// silently disabling.
+func TestCompileConfig_NoUsablePrefixFallsBackToWellKnown(t *testing.T) {
+	cfg := &config.Config{DNS64: config.DNS64Config{
+		Enabled:  true,
+		Prefixes: []string{"not-a-cidr", "2001:db8::/49"},
+	}}
+	c := compileConfig(cfg)
+	if c == nil {
+		t.Fatalf("compileConfig must default to well-known prefix, not return nil")
+	}
+	if assert.Len(t, c.prefixes, 1) {
+		assert.True(t, c.prefixes[0].wellKnown)
+		assert.True(t, c.prefixes[0].net.IP.Equal(net.ParseIP("64:ff9b::")))
+	}
+}
+
+// TestCompileConfig_DisabledReturnsNil pins that explicit
+// enabled=false still bypasses the §5.2 default — operators have
+// the final word on whether DNS64 runs.
+func TestCompileConfig_DisabledReturnsNil(t *testing.T) {
+	cfg := &config.Config{DNS64: config.DNS64Config{Enabled: false}}
+	if c := compileConfig(cfg); c != nil {
+		t.Fatalf("compileConfig must return nil when enabled=false, got %#v", c)
+	}
+}
+
+// TestCompileConfig_DefaultExcludeAUnderWKP pins RFC 6052 §3.1:
+// when the well-known prefix is configured and the operator
+// omits exclude_a_networks entirely, the IANA Special-Purpose
+// default list is applied at runtime so private-space A records
+// are never embedded into 64:ff9b::/96.
+func TestCompileConfig_DefaultExcludeAUnderWKP(t *testing.T) {
+	cfg := &config.Config{DNS64: config.DNS64Config{
+		Enabled:  true,
+		Prefixes: []string{"64:ff9b::/96"},
+		// ExcludeANetworks left as nil (omitted).
+	}}
+	c := compileConfig(cfg)
+	if c == nil {
+		t.Fatalf("compileConfig should not disable")
+	}
+	assert.NotEmpty(t, c.excludeAv4, "WKP + nil exclude list must apply runtime default")
+	// Spot-check a couple of representative entries.
+	covers := func(ip string) bool {
+		for _, n := range c.excludeAv4 {
+			if n.Contains(net.ParseIP(ip).To4()) {
+				return true
+			}
+		}
+		return false
+	}
+	assert.True(t, covers("10.0.0.1"), "RFC 1918 must be excluded by default")
+	assert.True(t, covers("127.0.0.1"), "loopback must be excluded by default")
+	assert.True(t, covers("169.254.1.1"), "link-local must be excluded by default")
+	assert.True(t, covers("192.88.99.1"), "deprecated 6to4 anycast (RFC 7526) must be excluded")
+}
+
+// TestCompileConfig_ExplicitEmptyExcludeAOptsOut confirms an
+// operator can disable the runtime default by declaring
+// exclude_a_networks = [] explicitly.
+func TestCompileConfig_ExplicitEmptyExcludeAOptsOut(t *testing.T) {
+	cfg := &config.Config{DNS64: config.DNS64Config{
+		Enabled:          true,
+		Prefixes:         []string{"64:ff9b::/96"},
+		ExcludeANetworks: []string{}, // declared empty != nil
+	}}
+	c := compileConfig(cfg)
+	if c == nil {
+		t.Fatalf("compileConfig should not disable")
+	}
+	assert.Empty(t, c.excludeAv4, "explicit [] must opt out of the runtime default")
+}
+
+// TestCompileConfig_AcceptsIPv4MappedExcludeAAAA pins the fix
+// for the IP.To4() trap: ::ffff:0:0/96 is a legal IPv6 prefix
+// even though IPv4-mapped, and the documented default must
+// survive validation.
+func TestCompileConfig_AcceptsIPv4MappedExcludeAAAA(t *testing.T) {
+	cfg := &config.Config{DNS64: config.DNS64Config{
+		Enabled:             true,
+		Prefixes:            []string{"64:ff9b::/96"},
+		ExcludeAAAANetworks: []string{"::ffff:0:0/96"},
+	}}
+	c := compileConfig(cfg)
+	if c == nil {
+		t.Fatalf("compileConfig should not disable; ::ffff:0:0/96 is a valid IPv6 prefix")
+	}
+	if assert.Len(t, c.excludeAAAA, 1, "explicit ::ffff:0:0/96 must be retained") {
+		assert.True(t, c.excludeAAAA[0].IP.Equal(net.ParseIP("::ffff:0:0")))
+	}
+}
+
+// TestCompileConfig_OperatorPrefixSkipsExcludeA pins that the
+// exclude-A list is only parsed for the well-known prefix; an
+// operator-chosen prefix discards the list at compile time.
+func TestCompileConfig_OperatorPrefixSkipsExcludeA(t *testing.T) {
+	cfg := &config.Config{DNS64: config.DNS64Config{
+		Enabled:          true,
+		Prefixes:         []string{"2001:db8:64::/96"},
+		ExcludeANetworks: []string{"10.0.0.0/8"},
+	}}
+	c := compileConfig(cfg)
+	if c == nil {
+		t.Fatalf("expected non-nil compiled config")
+	}
+	assert.False(t, c.hasWellKnown(), "no well-known prefix configured")
+	assert.Empty(t, c.excludeAv4, "operator-only prefix list must not retain the exclude-A list")
+}
+
+// TestClientEligible_NilIP covers the explicit nil-IP guard, which
+// shows up if a writer somehow lacks RemoteAddr (mock variants in
+// downstream tests).
+func TestClientEligible_NilIP(t *testing.T) {
+	c := &compiled{
+		clientNetworks: []*net.IPNet{parseCIDR(t, "10.0.0.0/8")},
+	}
+	assert.False(t, c.clientEligible(nil))
+}
+
+// TestZoneExcluded covers exact-match, label-boundary suffix
+// match, the label-fragment trap, and the empty-list short-
+// circuit.
+func TestZoneExcluded(t *testing.T) {
+	c := &compiled{excludeZones: []string{"example.org."}}
+	assert.True(t, c.zoneExcluded("example.org."), "exact match should be excluded")
+	assert.True(t, c.zoneExcluded("host.example.org."), "label-boundary suffix should be excluded")
+	assert.True(t, c.zoneExcluded("a.b.example.org."), "deeper label-boundary suffix should be excluded")
+	assert.False(t, c.zoneExcluded("badexample.org."), "label-fragment match must NOT trigger exclusion")
+	assert.False(t, c.zoneExcluded("other.example.com."))
+
+	empty := &compiled{}
+	assert.False(t, empty.zoneExcluded("anything."))
+}
+
+// TestWriteMsg_Truncated_PassThrough pins the truncated-response
+// short-circuit branch — DNS64 must never rewrite a TC=1 reply
+// because the client will retry over TCP.
+func TestWriteMsg_Truncated_PassThrough(t *testing.T) {
+	d := New(baseConfig())
+	d.queryer = &stubQueryer{} // would loudly fail if invoked
+	tc := noDataMsg("foo.example.org.", 300)
+	tc.Truncated = true
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: tc}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+
+	d.ServeDNS(context.Background(), ch)
+	resp := mw.Msg()
+	assert.True(t, resp.Truncated, "truncated reply must pass through untouched")
+}
+
+// TestWriteMsg_ServFail_AResponseIsBasis covers RFC 6147 §5.1.6:
+// when the AAAA was SERVFAIL and the A lookup yielded a real
+// (empty) NOERROR answer, the A response — not the original
+// SERVFAIL — is the basis for the client reply. The client
+// therefore sees NOERROR-NODATA addressed to its AAAA question.
+func TestWriteMsg_ServFail_AResponseIsBasis(t *testing.T) {
+	d := New(baseConfig())
+	emptyA := new(dns.Msg)
+	emptyA.SetQuestion("foo.example.org.", dns.TypeA)
+	emptyA.Response = true
+	emptyA.Rcode = dns.RcodeSuccess
+	soa, _ := dns.NewRR("example.org. 3600 IN SOA ns. host. 1 7200 3600 604800 60")
+	emptyA.Ns = []dns.RR{soa}
+	d.queryer = &stubQueryer{resp: emptyA}
+
+	servfail := new(dns.Msg)
+	servfail.SetQuestion("foo.example.org.", dns.TypeAAAA)
+	servfail.Response = true
+	servfail.Rcode = dns.RcodeServerFailure
+	servfail.SetEdns0(4096, true)
+
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: servfail}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+
+	resp := mw.Msg()
+	assert.Equal(t, dns.RcodeSuccess, resp.Rcode, "A NOERROR-NODATA must replace AAAA SERVFAIL per RFC 6147 §5.1.6")
+	assert.Empty(t, resp.Answer, "no answer records for an empty A response")
+	assert.Equal(t, dns.TypeAAAA, resp.Question[0].Qtype, "client must see its original AAAA question")
+	if assert.Len(t, resp.Ns, 1, "SOA from A response carried into Authority section") {
+		_, ok := resp.Ns[0].(*dns.SOA)
+		assert.True(t, ok)
+	}
+}
+
+// TestSynthesise_QueryerNotWired pins the early-out when the
+// Queryer is nil. Production never reaches this branch — Setup
+// always wires before publishing the pipeline — but the guard
+// keeps tests from segfaulting and the metric label set documented.
+func TestSynthesise_QueryerNotWired(t *testing.T) {
+	d := New(baseConfig())
+	d.queryer = nil // explicit; New leaves it nil before SetQueryer
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: noDataMsg("foo.example.org.", 300)}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+
+	resp := mw.Msg()
+	assert.Equal(t, dns.RcodeSuccess, resp.Rcode, "original NODATA preserved")
+	for _, rr := range resp.Answer {
+		if rr.Header().Rrtype == dns.TypeAAAA {
+			t.Fatalf("no Queryer wired → no synthesis")
+		}
+	}
+}

--- a/middleware/dns64/dns64.go
+++ b/middleware/dns64/dns64.go
@@ -1,0 +1,772 @@
+// Package dns64 implements RFC 6147 DNS64. When an IPv6-only client
+// queries AAAA for a name that has no usable AAAA records but does
+// have A records, DNS64 synthesises AAAA records by embedding the
+// IPv4 addresses inside a configured Pref64::/n IPv6 prefix (RFC
+// 6052). The client receives addresses in a NAT64-routable subnet
+// and can reach the IPv4-only service through a paired NAT64
+// gateway.
+//
+// Internal sub-queries skip DNS64 entirely (ClientOnly() == true):
+// the resolver's own NS / glue chase and our secondary A-record
+// lookup must not loop back through us, and the synthesis is a
+// client-facing concern.
+//
+// Implementation notes:
+//
+//   - Chain placement is between kubernetes and cache. The cache
+//     stores the original AAAA response (NODATA, NXDOMAIN, or AAAA
+//     RRset) — synthesis runs per client query against that
+//     cached response. The secondary A lookup is itself cached, so
+//     repeat synthesis costs an O(few-µs) memcpy plus a cache hit;
+//     this preserves per-client correctness when client_networks
+//     restricts synthesis.
+//   - RCODE handling follows RFC 6147 §5.1.2 / §5.1.3 / §5.5.
+//     NOERROR with no usable AAAA triggers synthesis. NXDOMAIN
+//     passes through unchanged — the name doesn't exist, so it
+//     has no A either. SERVFAIL carrying a DNSSEC-failure
+//     Extended DNS Error (Unsupported DNSKEY Algorithm /
+//     DS Digest Type / NSEC3 Iterations Value, Indeterminate,
+//     Bogus, Signature Expired/Not Yet Valid, DNSKEY/RRSIGs/NSEC
+//     Missing, No Zone Key Bit Set) also passes through — DNS64
+//     must never paper over a validation failure. Any other
+//     nonzero RCODE (plain SERVFAIL, REFUSED, etc.) is treated
+//     as "no answer" and attempts synthesis; if the A query is
+//     itself empty or errors, that response (rcode + Authority)
+//     becomes the basis for the client reply per §5.1.6.
+//   - AAAA records in the upstream response are filtered against
+//     exclude_aaaa_networks (RFC 6147 §5.1.4) before deciding
+//     pass-through vs synthesis. The default ::ffff:0:0/96 keeps
+//     IPv4-mapped IPv6 from leaking through.
+//   - Per RFC 6147 §5.5 a NODATA proven by AD=1 from the resolver
+//     is downgraded: the synthesised reply clears AD and attaches
+//     EDE 4 ("Forged Answer"). A client that set CD=1 is asking to
+//     validate itself, so synthesis is skipped.
+//   - The well-known prefix 64:ff9b::/96 enforces the RFC 6147
+//     §5.1.4 "do not translate" set on the IPv4 side at synthesis
+//     time. Operator-chosen prefixes do not.
+//   - Multiple prefixes synthesise in parallel per RFC 6147 §5.2:
+//     every (A, prefix) pair produces a synthesised AAAA so the
+//     client gets every reachable Pref64 path.
+//   - PTR translation per RFC 6147 §5.3.1: ip6.arpa queries whose
+//     embedded IPv4 falls inside a configured Pref64 are answered
+//     with a CNAME redirect to in-addr.arpa, optionally with the
+//     resolved PTR records appended.
+package dns64
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"sync"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/middleware"
+	"github.com/semihalev/sdns/util"
+	"github.com/semihalev/zlog/v2"
+)
+
+const name = "dns64"
+
+// noSOATTLCeiling is the cap RFC 6147 §5.1.7 mandates when the
+// upstream AAAA response carries no SOA — i.e. there's no
+// negative-cache TTL to take the minimum against. A synthesised
+// AAAA may still use a lower TTL via the A record's own TTL.
+const noSOATTLCeiling uint32 = 600
+
+// errQueryerNotWired guards the (impossible in production) case of
+// reaching the synthesis path before middleware.Setup ran. Shaped
+// like the cache middleware's equivalent for grep-ability.
+var errQueryerNotWired = errors.New("dns64: queryer not wired")
+
+// DNS64 is the middleware handler. The receiver may legitimately be
+// nil — New returns a typed-nil pointer when the middleware is
+// disabled in config. Methods invoked on the typed-nil are no-ops
+// where it makes sense; ServeDNS in particular is never called on
+// a typed-nil because Registry.Build skips disabled handlers.
+type DNS64 struct {
+	cfg     *compiled
+	queryer middleware.Queryer
+	pool    sync.Pool
+}
+
+// New constructs a DNS64 handler. Returns a typed-nil pointer when
+// DNS64 is disabled or has no usable configuration; the registry
+// detects that via isNilHandler and skips the middleware entirely.
+func New(cfg *config.Config) *DNS64 {
+	c := compileConfig(cfg)
+	if c == nil {
+		return nil
+	}
+	d := &DNS64{cfg: c}
+	d.pool.New = func() any { return &responseWriter{} }
+	prefixStrs := make([]string, len(c.prefixes))
+	for i, p := range c.prefixes {
+		prefixStrs[i] = p.net.String()
+	}
+	zlog.Info("DNS64 enabled",
+		"prefixes", prefixStrs,
+		"client_networks", len(c.clientNetworks),
+		"exclude_zones", len(c.excludeZones),
+		"exclude_a_networks", len(c.excludeAv4),
+		"exclude_aaaa_networks", len(c.excludeAAAA),
+	)
+	return d
+}
+
+// Name returns the registered middleware name.
+func (d *DNS64) Name() string { return name }
+
+// ClientOnly excludes DNS64 from the internal sub-pipeline. Internal
+// sub-queries (resolver NS chase, our own secondary A lookup, cache
+// CNAME chase) must not re-enter DNS64 — that would cause infinite
+// synthesis loops and leak synthesised AAAAs into delegation logic.
+func (d *DNS64) ClientOnly() bool { return true }
+
+// SetQueryer wires the internal-sub-pipeline Queryer used for the
+// secondary A-record lookup. Auto-wired by middleware.Setup.
+func (d *DNS64) SetQueryer(q middleware.Queryer) { d.queryer = q }
+
+// ServeDNS gates synthesis behind cheap fast-path checks before
+// committing to a writer wrap. The wrap (and consequently the
+// secondary A lookup) only happens for client AAAA-class-IN
+// queries that match the configured client networks and aren't on
+// an excluded zone. PTR queries inside ip6.arpa are intercepted
+// here too, when their address falls under one of the configured
+// Pref64 ranges (RFC 6147 §5.3.1).
+func (d *DNS64) ServeDNS(ctx context.Context, ch *middleware.Chain) {
+	w, req := ch.Writer, ch.Request
+
+	if len(req.Question) != 1 {
+		ch.Next(ctx)
+		return
+	}
+	q := req.Question[0]
+	if q.Qclass != dns.ClassINET {
+		ch.Next(ctx)
+		return
+	}
+	if w.Internal() {
+		Passthrough.WithLabelValues("internal").Inc()
+		ch.Next(ctx)
+		return
+	}
+	if !req.RecursionDesired {
+		// RD=0 clients are asking for a non-recursive response.
+		// DNS64 inherently issues a recursive secondary lookup
+		// (A for AAAA synthesis, in-addr.arpa PTR for ip6.arpa),
+		// so opting out preserves the client's policy. Without
+		// this gate, the cache rejects RD=0 with SERVFAIL and
+		// DNS64 would interpret that SERVFAIL as "no AAAA",
+		// firing a recursive A query that bypasses the
+		// non-recursion intent.
+		Passthrough.WithLabelValues("no_rd").Inc()
+		ch.Next(ctx)
+		return
+	}
+	if req.CheckingDisabled {
+		// RFC 6147 §5.5 — a CD=1 client has opted to validate
+		// itself; do not synthesise. Symmetric for PTR: the
+		// CNAME we'd synthesise points at an unsigned name we
+		// fabricated, so respect the bit.
+		Passthrough.WithLabelValues("cd_bit").Inc()
+		ch.Next(ctx)
+		return
+	}
+	if !d.cfg.clientEligible(w.RemoteIP()) {
+		Passthrough.WithLabelValues("client_excluded").Inc()
+		ch.Next(ctx)
+		return
+	}
+	qname := strings.ToLower(dns.CanonicalName(q.Name))
+
+	// PTR translation per RFC 6147 §5.3.1. If the qname falls in
+	// ip6.arpa under a configured Pref64 we synthesise a CNAME to
+	// the corresponding in-addr.arpa name and short-circuit the
+	// chain. Anything else (qname not under a configured Pref64,
+	// malformed encoding, exclusion under the well-known prefix)
+	// falls through to normal recursion so the resolver can answer
+	// real ip6.arpa zones.
+	if q.Qtype == dns.TypePTR && strings.HasSuffix(qname, ".ip6.arpa.") {
+		if d.handlePTR(ctx, ch, qname) {
+			return
+		}
+		ch.Next(ctx)
+		return
+	}
+
+	if q.Qtype != dns.TypeAAAA {
+		ch.Next(ctx)
+		return
+	}
+	if d.cfg.zoneExcluded(qname) {
+		Passthrough.WithLabelValues("zone_excluded").Inc()
+		ch.Next(ctx)
+		return
+	}
+
+	rw := d.pool.Get().(*responseWriter)
+	rw.ResponseWriter = w
+	rw.d = d
+	rw.ctx = ctx
+	rw.qname = qname
+	rw.req = req
+	ch.Writer = rw
+	defer func() {
+		ch.Writer = w
+		rw.reset()
+		d.pool.Put(rw)
+	}()
+
+	ch.Next(ctx)
+}
+
+// ptrSynthTTL is the TTL applied to a synthesised CNAME redirect.
+// Short enough to recover quickly if the operator re-points
+// prefixes; long enough to amortise the chase cost across a
+// session of reverse lookups.
+const ptrSynthTTL uint32 = 600
+
+// handlePTR translates an ip6.arpa PTR query whose embedded IPv4
+// falls under one of the configured Pref64 prefixes. On match it
+// writes a CNAME pointing at the corresponding in-addr.arpa name
+// (plus, if the chase succeeds, the resolved PTR records) and
+// short-circuits the chain. Returns true iff it answered; false
+// means "not a translation, let the normal chain handle it".
+func (d *DNS64) handlePTR(ctx context.Context, ch *middleware.Chain, qname string) bool {
+	addr, ok := parseIP6ArpaName(qname)
+	if !ok {
+		return false
+	}
+	var v4 net.IP
+	for _, p := range d.cfg.prefixes {
+		if !p.net.Contains(addr) {
+			continue
+		}
+		ext, ok := extractIPv4(p.net, addr)
+		if !ok {
+			continue
+		}
+		// Apply the same RFC 6147 §5.1.4 IPv4 exclusion that
+		// AAAA synthesis does — refuse to translate ip6.arpa
+		// names whose corresponding IPv4 address is in the
+		// "do not translate" set under the well-known prefix.
+		if d.cfg.shouldExcludeAOnPrefix(ext, p) {
+			continue
+		}
+		v4 = ext
+		break
+	}
+	if v4 == nil {
+		return false
+	}
+
+	target := inAddrArpa(v4)
+	cname := &dns.CNAME{
+		Hdr: dns.RR_Header{
+			Name:   ch.Request.Question[0].Name,
+			Rrtype: dns.TypeCNAME,
+			Class:  dns.ClassINET,
+			Ttl:    ptrSynthTTL,
+		},
+		Target: target,
+	}
+	answers := []dns.RR{cname}
+
+	// Best-effort chase the in-addr.arpa PTR through the internal
+	// sub-pipeline so the client gets a complete answer. Failures
+	// drop us back to "CNAME only" — RFC-compliant; the client can
+	// follow the CNAME themselves.
+	if d.queryer != nil {
+		sub := new(dns.Msg)
+		sub.SetQuestion(target, dns.TypePTR)
+		sub.RecursionDesired = true
+		if resp, err := d.queryer.Query(ctx, sub); err == nil && resp != nil && resp.Rcode == dns.RcodeSuccess {
+			for _, rr := range resp.Answer {
+				if rr.Header().Rrtype == dns.TypePTR {
+					answers = append(answers, rr)
+				}
+			}
+		}
+	}
+
+	out := new(dns.Msg)
+	out.SetReply(ch.Request)
+	out.RecursionAvailable = true
+	out.Rcode = dns.RcodeSuccess
+	out.Answer = answers
+	if len(ch.Request.Extra) > 0 {
+		out.Extra = make([]dns.RR, len(ch.Request.Extra))
+		copy(out.Extra, ch.Request.Extra)
+	}
+
+	PTRTranslated.Inc()
+	_ = ch.Writer.WriteMsg(out)
+	ch.Cancel()
+	return true
+}
+
+// responseWriter intercepts the downstream chain's WriteMsg. It
+// passes through every response that doesn't qualify for DNS64
+// synthesis and rewrites the rest.
+type responseWriter struct {
+	middleware.ResponseWriter
+	d     *DNS64
+	ctx   context.Context //nolint:containedctx // mirrors cache.ResponseWriter; the wrapper is per-request
+	req   *dns.Msg
+	qname string
+}
+
+func (w *responseWriter) reset() {
+	w.ResponseWriter = nil
+	w.d = nil
+	w.ctx = nil
+	w.req = nil
+	w.qname = ""
+}
+
+// WriteMsg observes the downstream reply and, when the client is
+// missing a usable AAAA, replaces it with a synthesised answer
+// derived from a secondary A lookup. RFC 6147 dispatch:
+//
+//   - Truncated / malformed → pass through unchanged.
+//   - NXDOMAIN → pass through (§5.1.2: the name doesn't exist, so
+//     it has no A either; synthesis would be misleading).
+//   - SERVFAIL with a DNSSEC-failure Extended DNS Error → pass
+//     through (§5.5: DNS64 must never mask a validation failure).
+//   - NOERROR with at least one AAAA RR that survives the
+//     exclude_aaaa_networks filter → pass through (§5.1.4 / §5.1.6).
+//   - NOERROR with no usable AAAA (post-filter), or any other
+//     nonzero RCODE (plain SERVFAIL, REFUSED, etc.; §5.1.3 treats
+//     these as "no answer") → secondary A lookup; replace the
+//     response with synthesised AAAAs plus any CNAME / DNAME chain
+//     from the A response.
+//
+// Note: AAAA records that are filtered out (e.g. ::ffff:0:0/96
+// IPv4-mapped) are stripped from the response even on the
+// pass-through path, so the client never sees a non-routable
+// address that the upstream put there in error.
+func (w *responseWriter) WriteMsg(m *dns.Msg) error {
+	if m == nil || m.Truncated || len(m.Question) == 0 {
+		return w.ResponseWriter.WriteMsg(m)
+	}
+	if m.Rcode == dns.RcodeNameError {
+		Passthrough.WithLabelValues("nxdomain").Inc()
+		return w.ResponseWriter.WriteMsg(m)
+	}
+	// RFC 6147 §5.5: a validating DNS64 must not paper over a
+	// resolver-side DNSSEC failure. The recursive resolver
+	// returns SERVFAIL with one of the DNSSEC Extended DNS Error
+	// codes (Bogus, Signature Expired/Not Yet Valid, DNSKEY /
+	// RRSIG / NSEC missing, etc.) on validation failure; in that
+	// case synthesis would mask the failure and let the client
+	// reach a target whose AAAA the upstream said was bogus.
+	// Pass the SERVFAIL through so the client sees the validation
+	// failure verbatim.
+	if isDNSSECFailure(m) {
+		Passthrough.WithLabelValues("dnssec_fail").Inc()
+		return w.ResponseWriter.WriteMsg(m)
+	}
+
+	// Filter the upstream Answer section against the AAAA
+	// exclude list. If anything survives, the response is
+	// "non-empty" per §5.1.4 and we forward the (possibly
+	// modified) version. If nothing survives — every AAAA was
+	// excluded, or there were none to begin with — fall through
+	// to the synthesis path.
+	if m.Rcode == dns.RcodeSuccess {
+		filtered, hadAAAA, kept, stripped := w.filterUpstreamAAAA(m)
+		if hadAAAA && kept > 0 {
+			Passthrough.WithLabelValues("aaaa_present").Inc()
+			if stripped > 0 {
+				// We modified the RRset, so any AD bit the
+				// validator set no longer covers what the client
+				// is about to see. Clear it; if the upstream had
+				// vouched for the response, advertise the reason
+				// via EDE 4 so a curious client can see why.
+				filtered.AuthenticatedData = false
+				if m.AuthenticatedData {
+					util.SetEDE(filtered, dns.ExtendedErrorCodeForgedAnswer, "DNS64 filtered IPv4-mapped AAAA")
+				}
+			}
+			return w.ResponseWriter.WriteMsg(filtered)
+		}
+		m = filtered
+	}
+
+	synth := w.synthesise(m)
+	if synth == nil {
+		// A lookup failed or yielded nothing usable; preserve the
+		// original (already AAAA-filtered) answer rather than
+		// papering over it. Reason has already been counted.
+		return w.ResponseWriter.WriteMsg(m)
+	}
+	Synthesised.Inc()
+	return w.ResponseWriter.WriteMsg(synth)
+}
+
+// filterUpstreamAAAA inspects m and, if any AAAA records fall in
+// the configured exclude_aaaa_networks set, returns a copy with
+// those records dropped from Answer. Returns:
+//
+//   - the (possibly mutated) message;
+//   - hadAAAA: did Answer carry any AAAA at all (regardless of
+//     survival);
+//   - kept: count of AAAA records retained after filtering;
+//   - stripped: count of AAAA records actually dropped.
+//
+// The dns.Msg.Copy is only made when stripped > 0 — a response
+// with non-AAAA records (CNAME, RRSIG, etc.) is otherwise
+// returned as-is to keep the common pass-through path
+// allocation-free.
+func (w *responseWriter) filterUpstreamAAAA(m *dns.Msg) (*dns.Msg, bool, int, int) {
+	hadAAAA := false
+	kept := 0
+	stripped := 0
+	for _, rr := range m.Answer {
+		if aaaa, ok := rr.(*dns.AAAA); ok {
+			hadAAAA = true
+			if w.d.cfg.shouldExcludeAAAA(aaaa.AAAA) {
+				stripped++
+				continue
+			}
+			kept++
+		}
+	}
+	if stripped == 0 {
+		return m, hadAAAA, kept, 0
+	}
+	out := m.Copy()
+	answer := out.Answer[:0]
+	for _, rr := range out.Answer {
+		if aaaa, ok := rr.(*dns.AAAA); ok {
+			if w.d.cfg.shouldExcludeAAAA(aaaa.AAAA) {
+				continue
+			}
+		}
+		answer = append(answer, rr)
+	}
+	out.Answer = answer
+	return out, hadAAAA, kept, stripped
+}
+
+// synthesise issues the secondary A-record lookup and builds the
+// replacement message. Returns nil only when the queryer itself
+// failed to deliver an A response — caller then falls back to the
+// original. When the A response simply has no usable records
+// (empty answer, NXDOMAIN, SERVFAIL), RFC 6147 §5.1.6 says the
+// A response is the basis for the client reply, so we return a
+// non-nil empty/error response addressed to the AAAA question.
+func (w *responseWriter) synthesise(orig *dns.Msg) *dns.Msg {
+	if w.d.queryer == nil {
+		ALookupFailures.WithLabelValues("queryer_error").Inc()
+		return nil
+	}
+
+	aReq := new(dns.Msg)
+	aReq.SetQuestion(w.req.Question[0].Name, dns.TypeA)
+	aReq.RecursionDesired = true
+	// Inherit CD from the client request so the A lookup honours
+	// the same validation policy. CD=1 was already filtered out at
+	// ServeDNS — this preserves whatever bit was set on the AAAA
+	// query's path through DO/AD.
+	aReq.CheckingDisabled = w.req.CheckingDisabled
+
+	aResp, err := w.d.queryer.Query(w.ctx, aReq)
+	if err != nil {
+		ALookupFailures.WithLabelValues(classifyQueryErr(err)).Inc()
+		return nil
+	}
+	if aResp == nil {
+		ALookupFailures.WithLabelValues("nil_response").Inc()
+		return nil
+	}
+	if aResp.Rcode != dns.RcodeSuccess {
+		switch aResp.Rcode {
+		case dns.RcodeServerFailure:
+			ALookupFailures.WithLabelValues("servfail").Inc()
+		case dns.RcodeNameError:
+			ALookupFailures.WithLabelValues("nxdomain").Inc()
+		default:
+			ALookupFailures.WithLabelValues("other_rcode").Inc()
+		}
+		return w.buildAResponseAsBasis(orig, aResp)
+	}
+
+	chain, addresses := splitChainAndA(aResp)
+	if len(addresses) == 0 {
+		// NOERROR with no A records — RFC 6147 §5.1.6 still
+		// applies: the empty A response is the basis for the
+		// client reply.
+		ALookupFailures.WithLabelValues("no_a").Inc()
+		return w.buildAResponseAsBasis(orig, aResp)
+	}
+
+	// RFC 6147 §5.1.7: synthesised TTL = min(A TTL, negative-cache
+	// TTL of the original AAAA response). When no SOA is present
+	// the upper bound is 600 seconds. The lower bound is whatever
+	// the A records carry — short-lived A records intentionally
+	// keep DNS64 answers short-lived too.
+	ttl := noSOATTLCeiling
+	if negTTL := negativeAAAATTL(orig); negTTL > 0 {
+		ttl = negTTL
+	}
+	for _, a := range addresses {
+		if a.Hdr.Ttl < ttl {
+			ttl = a.Hdr.Ttl
+		}
+	}
+
+	answers := make([]dns.RR, 0, len(chain)+len(addresses)*len(w.d.cfg.prefixes))
+	for _, c := range chain {
+		cp := dns.Copy(c)
+		if cp.Header().Ttl > ttl {
+			cp.Header().Ttl = ttl
+		}
+		answers = append(answers, cp)
+	}
+	// Synthesised AAAAs adopt the A record's owner — that's the
+	// terminal name after any CNAME / DNAME chain has been
+	// resolved by the upstream, and matches what the client
+	// expects in the Answer section. RFC 6147 §5.2 lets multiple
+	// configured prefixes coexist; we synthesise one AAAA per
+	// (A, prefix) pair so the client gets every configured path.
+	for _, p := range w.d.cfg.prefixes {
+		for _, a := range addresses {
+			v4 := a.A.To4()
+			if v4 == nil {
+				continue
+			}
+			if w.d.cfg.shouldExcludeAOnPrefix(v4, p) {
+				continue
+			}
+			rr := synthesizeAAAA(a.Hdr.Name, a, p.net, ttl)
+			if rr != nil {
+				answers = append(answers, rr)
+			}
+		}
+	}
+	// All (A, prefix) pairs were excluded (e.g. only the well-known
+	// prefix is configured and every A is in private space). RFC
+	// 6147 §5.1.4 — we treat the response as if no A records
+	// existed. Fall back to the original NODATA.
+	if !hasAAAAInList(answers) {
+		Passthrough.WithLabelValues("a_excluded").Inc()
+		return nil
+	}
+
+	out := new(dns.Msg)
+	out.SetReply(w.req)
+	out.RecursionAvailable = orig.RecursionAvailable
+	out.Rcode = dns.RcodeSuccess
+	out.Answer = answers
+
+	// RFC 6147 §5.4 + §5.3.2: Authority and Additional sections
+	// come from the final A response unmodified. §5.3.2 explicitly
+	// forbids the DNS64 from rewriting any RR type other than the
+	// AAAA-from-A synthesis above and CNAME/RRSIG handling — A
+	// records elsewhere in the message MUST pass through verbatim.
+	// The client's OPT (carrying DO/UDP-size/cookie state) is
+	// taken from the original AAAA reply so downstream writers
+	// see a well-formed EDNS frame.
+	out.Ns = copyExtraNoOPT(aResp.Ns)
+	out.Extra = appendOPTFrom(orig, copyExtraNoOPT(aResp.Extra))
+
+	// RFC 6147 §5.5: the synthesised AAAA RRset is not signed.
+	// Whatever AD we received from the validator on either the
+	// AAAA or A response no longer holds end-to-end. Clear AD; if
+	// the AAAA NODATA had been validated, attach EDE 4 so a
+	// curious client sees the reason.
+	out.AuthenticatedData = false
+	if orig.AuthenticatedData {
+		util.SetEDE(out, dns.ExtendedErrorCodeForgedAnswer, "DNS64 synthesis")
+	}
+	return out
+}
+
+// buildAResponseAsBasis implements RFC 6147 §5.1.6: when the
+// secondary A query yielded no usable records (empty answer,
+// NXDOMAIN, SERVFAIL, etc.), the A response — not the original
+// AAAA reply — is the basis for what the client receives. We
+// preserve the A response's RCODE and Authority/Additional
+// sections but rewrite the question to AAAA so the client sees
+// an answer addressed to its actual query. RFC 6147 §5.1.5
+// requires any CNAME/DNAME chain that led the A query to its
+// terminal name to remain in the Answer section so the client
+// can see the rewriting trail (e.g. CNAME → NODATA where the A
+// alias resolves but its target has no A record).
+func (w *responseWriter) buildAResponseAsBasis(orig, aResp *dns.Msg) *dns.Msg {
+	out := new(dns.Msg)
+	out.SetReply(w.req)
+	out.Rcode = aResp.Rcode
+	out.RecursionAvailable = aResp.RecursionAvailable
+	// CNAME/DNAME chain (if any) survives. A records would only
+	// appear here if the A response actually had answers; in that
+	// case we'd be on the synthesis path, not this one. splitChainAndA
+	// drops everything else (including any stray AAAAs / RRSIGs)
+	// to keep the response shape clean.
+	chain, _ := splitChainAndA(aResp)
+	if len(chain) > 0 {
+		out.Answer = make([]dns.RR, len(chain))
+		copy(out.Answer, chain)
+	}
+	// Authority (typically the SOA for negative caching) carries
+	// forward unchanged per RFC 6147 §5.3.2.
+	if len(aResp.Ns) > 0 {
+		out.Ns = make([]dns.RR, len(aResp.Ns))
+		copy(out.Ns, aResp.Ns)
+	}
+	out.Extra = appendOPTFrom(orig, copyExtraNoOPT(aResp.Extra))
+
+	// AD on the A response was derived against an A question, not
+	// the AAAA question we're answering. Clear it; if the original
+	// AAAA reply had been validated, attach EDE 4 so the client
+	// can see why we changed our mind.
+	out.AuthenticatedData = false
+	if orig.AuthenticatedData {
+		util.SetEDE(out, dns.ExtendedErrorCodeForgedAnswer, "DNS64 used A response as basis")
+	}
+	return out
+}
+
+// copyExtraNoOPT returns a copy of rrs with any OPT records
+// dropped. OPT is re-attached separately so the client's
+// EDNS state is preserved exactly once.
+func copyExtraNoOPT(rrs []dns.RR) []dns.RR {
+	if len(rrs) == 0 {
+		return nil
+	}
+	out := make([]dns.RR, 0, len(rrs))
+	for _, rr := range rrs {
+		if _, ok := rr.(*dns.OPT); ok {
+			continue
+		}
+		out = append(out, rr)
+	}
+	return out
+}
+
+// appendOPTFrom prepends the OPT record (if any) from src onto
+// the head of dst. Used to reattach the client's EDNS state to
+// a synthesised response without losing other Extra records.
+func appendOPTFrom(src *dns.Msg, dst []dns.RR) []dns.RR {
+	for _, rr := range src.Extra {
+		if opt, ok := rr.(*dns.OPT); ok {
+			out := make([]dns.RR, 0, len(dst)+1)
+			out = append(out, opt)
+			out = append(out, dst...)
+			return out
+		}
+	}
+	return dst
+}
+
+func hasAAAAInList(rrs []dns.RR) bool {
+	for _, rr := range rrs {
+		if rr.Header().Rrtype == dns.TypeAAAA {
+			return true
+		}
+	}
+	return false
+}
+
+// splitChainAndA pulls the CNAME / DNAME chain (in order) and A
+// records out of resp.Answer. RFC 6147 §5.1.5 requires the chain
+// to be carried into the synthesised response so the client can
+// follow the rewriting trail. The resolver already orders Answer
+// canonically, so iterating in slice order preserves the chain.
+func splitChainAndA(resp *dns.Msg) ([]dns.RR, []*dns.A) {
+	chain := make([]dns.RR, 0, len(resp.Answer))
+	addrs := make([]*dns.A, 0, len(resp.Answer))
+	for _, rr := range resp.Answer {
+		switch v := rr.(type) {
+		case *dns.CNAME, *dns.DNAME:
+			chain = append(chain, v)
+		case *dns.A:
+			addrs = append(addrs, v)
+		}
+	}
+	return chain, addrs
+}
+
+// isDNSSECFailure reports whether m looks like a recursive
+// resolver's "validation failed / cannot validate" response:
+// SERVFAIL with at least one DNSSEC-related Extended DNS Error
+// attached. RFC 8914 covers two clusters of failure modes that
+// DNS64 must surface to the client unchanged:
+//
+//   - codes 1, 2, 27: unsupported DNSKEY algorithm, unsupported
+//     DS digest type, unsupported NSEC3 iterations — the
+//     validator couldn't process the chain at all;
+//   - codes 5-12: indeterminate, bogus, signature expired/not
+//     yet valid, DNSKEY/RRSIG/NSEC missing, no zone key bit set
+//     — the validator processed it and rejected.
+//
+// In either cluster, papering over the SERVFAIL with synthesised
+// AAAAs would let a client reach a target whose AAAA the upstream
+// said it could not vouch for. We require RcodeServerFailure as
+// the gate so an EDE attached to a successful response (e.g. our
+// own EDE 4 on synthesised answers) doesn't mistakenly bypass
+// synthesis upstream.
+func isDNSSECFailure(m *dns.Msg) bool {
+	if m == nil || m.Rcode != dns.RcodeServerFailure {
+		return false
+	}
+	opt := m.IsEdns0()
+	if opt == nil {
+		return false
+	}
+	for _, o := range opt.Option {
+		ede, ok := o.(*dns.EDNS0_EDE)
+		if !ok {
+			continue
+		}
+		switch ede.InfoCode {
+		case dns.ExtendedErrorCodeUnsupportedDNSKEYAlgorithm,
+			dns.ExtendedErrorCodeUnsupportedDSDigestType,
+			dns.ExtendedErrorCodeUnsupportedNSEC3IterValue,
+			dns.ExtendedErrorCodeDNSSECIndeterminate,
+			dns.ExtendedErrorCodeDNSBogus,
+			dns.ExtendedErrorCodeSignatureExpired,
+			dns.ExtendedErrorCodeSignatureNotYetValid,
+			dns.ExtendedErrorCodeDNSKEYMissing,
+			dns.ExtendedErrorCodeRRSIGsMissing,
+			dns.ExtendedErrorCodeNoZoneKeyBitSet,
+			dns.ExtendedErrorCodeNSECMissing:
+			return true
+		}
+	}
+	return false
+}
+
+// negativeAAAATTL returns the SOA-derived minimum negative TTL of
+// the original AAAA response, or 0 if no SOA is present. RFC 2308
+// — the negative TTL is min(SOA.MINIMUM, SOA.TTL).
+func negativeAAAATTL(m *dns.Msg) uint32 {
+	for _, rr := range m.Ns {
+		if soa, ok := rr.(*dns.SOA); ok {
+			ttl := soa.Hdr.Ttl
+			if soa.Minttl > 0 && soa.Minttl < ttl {
+				ttl = soa.Minttl
+			}
+			return ttl
+		}
+	}
+	return 0
+}
+
+// classifyQueryErr collapses queryer errors to a small label set so
+// the metric cardinality stays bounded. Anything we don't recognise
+// flows under "other".
+func classifyQueryErr(err error) string {
+	switch {
+	case errors.Is(err, middleware.ErrNoResponse):
+		return "no_response"
+	case errors.Is(err, middleware.ErrMaxRecursion):
+		return "max_recursion"
+	case errors.Is(err, errQueryerNotWired):
+		return "queryer_error"
+	}
+	return "other"
+}

--- a/middleware/dns64/dns64_test.go
+++ b/middleware/dns64/dns64_test.go
@@ -1,0 +1,1113 @@
+package dns64
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/middleware"
+	"github.com/semihalev/sdns/mock"
+	"github.com/semihalev/sdns/util"
+	"github.com/stretchr/testify/assert"
+)
+
+// stubQueryer is a fixed-response Queryer used to drive the
+// secondary A-record lookup in tests.
+type stubQueryer struct {
+	resp *dns.Msg
+	err  error
+	last *dns.Msg
+}
+
+func (s *stubQueryer) Query(ctx context.Context, req *dns.Msg) (*dns.Msg, error) {
+	s.last = req
+	if s.err != nil {
+		return nil, s.err
+	}
+	if s.resp == nil {
+		return nil, nil
+	}
+	return s.resp, nil
+}
+
+// stubAnswerer writes a fixed dns.Msg when its turn in the chain
+// comes. Used as the downstream "resolver" so the dns64 wrapper
+// observes a real response.
+type stubAnswerer struct {
+	msg *dns.Msg
+}
+
+func (s *stubAnswerer) Name() string { return "stubAnswerer" }
+func (s *stubAnswerer) ServeDNS(ctx context.Context, ch *middleware.Chain) {
+	if s.msg == nil {
+		ch.Cancel()
+		return
+	}
+	resp := s.msg.Copy()
+	resp.Id = ch.Request.Id
+	resp.Question = ch.Request.Question
+	resp.Response = true
+	_ = ch.Writer.WriteMsg(resp)
+	ch.Cancel()
+}
+
+// baseConfig returns a minimal DNS64 config with the well-known
+// prefix and an empty client_networks list (i.e. all clients
+// eligible).
+func baseConfig() *config.Config {
+	return &config.Config{
+		DNS64: config.DNS64Config{
+			Enabled:  true,
+			Prefixes: []string{"64:ff9b::/96"},
+			ExcludeANetworks: []string{
+				"10.0.0.0/8", "192.168.0.0/16", "127.0.0.0/8",
+			},
+		},
+	}
+}
+
+// makeChain wires a dns64 handler in front of the given downstream
+// answerer with a mock writer addressed from clientAddr. EDNS0 is
+// attached to the request so EDE attachment paths are exercised.
+func makeChain(t *testing.T, d *DNS64, downstream middleware.Handler, clientAddr, qname string, qtype uint16) (*middleware.Chain, *mock.Writer) {
+	t.Helper()
+	ch := middleware.NewChain([]middleware.Handler{d, downstream})
+	mw := mock.NewWriter("udp", clientAddr)
+	req := new(dns.Msg)
+	req.SetQuestion(dns.Fqdn(qname), qtype)
+	req.SetEdns0(4096, true)
+	ch.Reset(mw, req)
+	return ch, mw
+}
+
+// noDataMsg returns a NOERROR/NODATA response with an SOA in the
+// Authority section carrying the given negative TTL.
+func noDataMsg(qname string, soaMin uint32) *dns.Msg {
+	m := new(dns.Msg)
+	m.SetQuestion(qname, dns.TypeAAAA)
+	m.Response = true
+	m.Rcode = dns.RcodeSuccess
+	m.RecursionAvailable = true
+	m.SetEdns0(4096, true)
+	soa, _ := dns.NewRR("example.org. 3600 IN SOA ns.example.org. hostmaster.example.org. 1 7200 3600 604800 " + uintToString(soaMin))
+	m.Ns = []dns.RR{soa}
+	return m
+}
+
+// nxDomainMsg returns an NXDOMAIN response.
+func nxDomainMsg(qname string) *dns.Msg {
+	m := new(dns.Msg)
+	m.SetQuestion(qname, dns.TypeAAAA)
+	m.Response = true
+	m.Rcode = dns.RcodeNameError
+	m.RecursionAvailable = true
+	m.SetEdns0(4096, true)
+	return m
+}
+
+// aRespMsg builds an A-record response for use as the stub
+// queryer's reply.
+func aRespMsg(qname string, ttl uint32, ips ...string) *dns.Msg {
+	m := new(dns.Msg)
+	m.SetQuestion(qname, dns.TypeA)
+	m.Response = true
+	m.Rcode = dns.RcodeSuccess
+	m.RecursionAvailable = true
+	for _, ip := range ips {
+		m.Answer = append(m.Answer, &dns.A{
+			Hdr: dns.RR_Header{Name: qname, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: ttl},
+			A:   net.ParseIP(ip),
+		})
+	}
+	return m
+}
+
+func uintToString(v uint32) string {
+	if v == 0 {
+		return "0"
+	}
+	var buf [12]byte
+	i := len(buf)
+	for v > 0 {
+		i--
+		buf[i] = byte('0' + v%10)
+		v /= 10
+	}
+	return string(buf[i:])
+}
+
+func TestDNS64_DisabledReturnsNil(t *testing.T) {
+	cfg := &config.Config{}
+	if d := New(cfg); d != nil {
+		t.Fatalf("disabled DNS64 should return typed-nil, got %#v", d)
+	}
+}
+
+func TestDNS64_ClientOnly(t *testing.T) {
+	d := New(baseConfig())
+	if d == nil {
+		t.Fatalf("expected non-nil DNS64 handler")
+	}
+	if !d.ClientOnly() {
+		t.Fatalf("DNS64 must be ClientOnly() == true")
+	}
+}
+
+func TestServeDNS_NonAAAA_FallsThrough(t *testing.T) {
+	d := New(baseConfig())
+	downstream := &stubAnswerer{msg: aRespMsg("foo.example.org.", 60, "192.0.2.1")}
+	ch, mw := makeChain(t, d, downstream, "203.0.113.5:53", "foo.example.org.", dns.TypeA)
+	d.queryer = &stubQueryer{} // should not be invoked
+
+	d.ServeDNS(context.Background(), ch)
+	assert.True(t, mw.Written())
+	resp := mw.Msg()
+	if assert.NotNil(t, resp) {
+		assert.Equal(t, dns.TypeA, resp.Answer[0].Header().Rrtype)
+	}
+}
+
+func TestServeDNS_PassThrough_NonEmptyAAAA(t *testing.T) {
+	d := New(baseConfig())
+	aaaaResp := new(dns.Msg)
+	aaaaResp.SetQuestion("foo.example.org.", dns.TypeAAAA)
+	aaaaResp.Response = true
+	aaaaResp.Answer = []dns.RR{&dns.AAAA{
+		Hdr:  dns.RR_Header{Name: "foo.example.org.", Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 60},
+		AAAA: net.ParseIP("2001:db8::1"),
+	}}
+	downstream := &stubAnswerer{msg: aaaaResp}
+	q := &stubQueryer{}
+	d.queryer = q
+
+	ch, mw := makeChain(t, d, downstream, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+
+	assert.True(t, mw.Written())
+	if q.last != nil {
+		t.Fatalf("non-empty AAAA must not trigger an A lookup; queryer was called with %+v", q.last)
+	}
+	resp := mw.Msg()
+	assert.Len(t, resp.Answer, 1)
+	assert.Equal(t, "2001:db8::1", resp.Answer[0].(*dns.AAAA).AAAA.String())
+}
+
+func TestServeDNS_Internal_NoSynth(t *testing.T) {
+	d := New(baseConfig())
+	d.queryer = &stubQueryer{resp: aRespMsg("foo.example.org.", 60, "192.0.2.1")}
+
+	ch := middleware.NewChain([]middleware.Handler{d, &stubAnswerer{msg: noDataMsg("foo.example.org.", 300)}})
+	mw := mock.NewWriter("udp", "127.0.0.255:0") // sentinel internal IP
+	req := new(dns.Msg)
+	req.SetQuestion("foo.example.org.", dns.TypeAAAA)
+	req.SetEdns0(4096, true)
+	ch.Reset(mw, req)
+
+	d.ServeDNS(context.Background(), ch)
+	assert.True(t, mw.Written())
+	resp := mw.Msg()
+	// Pass-through: original NODATA is preserved, no AAAA in answer.
+	assert.Equal(t, dns.RcodeSuccess, resp.Rcode)
+	for _, rr := range resp.Answer {
+		if rr.Header().Rrtype == dns.TypeAAAA {
+			t.Fatalf("internal query must not be synthesised, but got AAAA %s", rr)
+		}
+	}
+}
+
+func TestServeDNS_CDBit_NoSynth(t *testing.T) {
+	d := New(baseConfig())
+	q := &stubQueryer{resp: aRespMsg("foo.example.org.", 60, "192.0.2.1")}
+	d.queryer = q
+
+	ch := middleware.NewChain([]middleware.Handler{d, &stubAnswerer{msg: noDataMsg("foo.example.org.", 300)}})
+	mw := mock.NewWriter("udp", "203.0.113.5:53")
+	req := new(dns.Msg)
+	req.SetQuestion("foo.example.org.", dns.TypeAAAA)
+	req.SetEdns0(4096, true)
+	req.CheckingDisabled = true
+	ch.Reset(mw, req)
+
+	d.ServeDNS(context.Background(), ch)
+	assert.True(t, mw.Written())
+	if q.last != nil {
+		t.Fatalf("CD=1 must not trigger A lookup")
+	}
+}
+
+func TestServeDNS_ClientOutsideNetworks_NoSynth(t *testing.T) {
+	cfg := baseConfig()
+	cfg.DNS64.ClientNetworks = []string{"2001:db8::/32"}
+	d := New(cfg)
+	q := &stubQueryer{resp: aRespMsg("foo.example.org.", 60, "192.0.2.1")}
+	d.queryer = q
+
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: noDataMsg("foo.example.org.", 300)}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+	assert.True(t, mw.Written())
+	if q.last != nil {
+		t.Fatalf("client outside client_networks must not trigger A lookup")
+	}
+}
+
+func TestServeDNS_ZoneExcluded_NoSynth(t *testing.T) {
+	cfg := baseConfig()
+	cfg.DNS64.ExcludeZones = []string{"example.org."}
+	d := New(cfg)
+	q := &stubQueryer{resp: aRespMsg("foo.example.org.", 60, "192.0.2.1")}
+	d.queryer = q
+
+	ch, _ := makeChain(t, d, &stubAnswerer{msg: noDataMsg("foo.example.org.", 300)}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+	if q.last != nil {
+		t.Fatalf("excluded zone must not trigger A lookup")
+	}
+}
+
+func TestSynthesise_NODATA_HasA(t *testing.T) {
+	d := New(baseConfig())
+	d.queryer = &stubQueryer{resp: aRespMsg("foo.example.org.", 600, "192.0.2.33")}
+
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: noDataMsg("foo.example.org.", 300)}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+
+	assert.True(t, mw.Written())
+	resp := mw.Msg()
+	assert.Equal(t, dns.RcodeSuccess, resp.Rcode)
+	if assert.Len(t, resp.Answer, 1) {
+		aaaa, ok := resp.Answer[0].(*dns.AAAA)
+		if assert.True(t, ok) {
+			assert.Equal(t, "64:ff9b::c000:221", aaaa.AAAA.String())
+			// SOA-min (300) is lower than A TTL (600), so the
+			// synth TTL is clamped to 300.
+			assert.Equal(t, uint32(300), aaaa.Hdr.Ttl)
+			assert.Equal(t, "foo.example.org.", aaaa.Hdr.Name)
+		}
+	}
+}
+
+// TestNXDOMAIN_PassesThrough pins RFC 6147 §5.1.2: an upstream
+// NXDOMAIN means the name doesn't exist (so it can have no A
+// either), and DNS64 must forward it unchanged. A queryer that
+// would have returned A records is provided to confirm we never
+// reach the synthesis path.
+func TestNXDOMAIN_PassesThrough(t *testing.T) {
+	d := New(baseConfig())
+	q := &stubQueryer{resp: aRespMsg("foo.example.org.", 60, "192.0.2.33")}
+	d.queryer = q
+
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: nxDomainMsg("foo.example.org.")}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+
+	resp := mw.Msg()
+	assert.Equal(t, dns.RcodeNameError, resp.Rcode, "NXDOMAIN must pass through unchanged per RFC 6147 §5.1.2")
+	if q.last != nil {
+		t.Fatalf("NXDOMAIN must not trigger an A-record lookup; queryer was called")
+	}
+}
+
+// TestServFail_TriggersSynthesis pins RFC 6147 §5.1.3: nonzero
+// RCODEs other than NXDOMAIN are treated as "no answer" and the
+// secondary A lookup is attempted. Backwards-compatible with
+// upstreams that return SERVFAIL for AAAA on broken zones.
+func TestServFail_TriggersSynthesis(t *testing.T) {
+	d := New(baseConfig())
+	d.queryer = &stubQueryer{resp: aRespMsg("foo.example.org.", 60, "192.0.2.33")}
+
+	servfail := new(dns.Msg)
+	servfail.SetQuestion("foo.example.org.", dns.TypeAAAA)
+	servfail.Response = true
+	servfail.Rcode = dns.RcodeServerFailure
+	servfail.SetEdns0(4096, true)
+
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: servfail}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+
+	resp := mw.Msg()
+	assert.Equal(t, dns.RcodeSuccess, resp.Rcode)
+	if assert.Len(t, resp.Answer, 1) {
+		aaaa := resp.Answer[0].(*dns.AAAA)
+		assert.Equal(t, "64:ff9b::c000:221", aaaa.AAAA.String())
+	}
+}
+
+func TestSynthesise_QueryerError_FallsBack(t *testing.T) {
+	d := New(baseConfig())
+	d.queryer = &stubQueryer{err: errors.New("simulated upstream failure")}
+
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: noDataMsg("foo.example.org.", 300)}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+
+	resp := mw.Msg()
+	// Original NODATA preserved.
+	assert.Equal(t, dns.RcodeSuccess, resp.Rcode)
+	for _, rr := range resp.Answer {
+		if rr.Header().Rrtype == dns.TypeAAAA {
+			t.Fatalf("queryer error must not produce synthesised AAAA")
+		}
+	}
+}
+
+func TestSynthesise_AD_AddsEDE(t *testing.T) {
+	d := New(baseConfig())
+	d.queryer = &stubQueryer{resp: aRespMsg("foo.example.org.", 60, "192.0.2.33")}
+
+	orig := noDataMsg("foo.example.org.", 300)
+	orig.AuthenticatedData = true
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: orig}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+
+	d.ServeDNS(context.Background(), ch)
+	resp := mw.Msg()
+	assert.False(t, resp.AuthenticatedData, "synthesised reply must clear AD")
+
+	ede := util.GetEDE(resp)
+	if assert.NotNil(t, ede, "EDE 4 should be attached when original was AD=1") {
+		assert.Equal(t, dns.ExtendedErrorCodeForgedAnswer, ede.InfoCode)
+	}
+}
+
+func TestSynthesise_NoAD_NoEDE(t *testing.T) {
+	d := New(baseConfig())
+	d.queryer = &stubQueryer{resp: aRespMsg("foo.example.org.", 60, "192.0.2.33")}
+
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: noDataMsg("foo.example.org.", 300)}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+	resp := mw.Msg()
+	assert.Nil(t, util.GetEDE(resp), "EDE must NOT be attached when original was AD=0")
+}
+
+func TestSynthesise_PrivateA_WellKnownPrefix_AllExcluded(t *testing.T) {
+	d := New(baseConfig())
+	d.queryer = &stubQueryer{resp: aRespMsg("foo.example.org.", 60, "10.0.0.1")}
+
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: noDataMsg("foo.example.org.", 300)}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+
+	resp := mw.Msg()
+	assert.Equal(t, dns.RcodeSuccess, resp.Rcode)
+	for _, rr := range resp.Answer {
+		if rr.Header().Rrtype == dns.TypeAAAA {
+			t.Fatalf("RFC 6147 §5.1.4: private A under well-known prefix must not be synthesised")
+		}
+	}
+}
+
+func TestSynthesise_PrivateA_OperatorPrefix_Synth(t *testing.T) {
+	cfg := baseConfig()
+	cfg.DNS64.Prefixes = []string{"2001:db8:64::/96"}
+	cfg.DNS64.ExcludeANetworks = nil
+	d := New(cfg)
+	d.queryer = &stubQueryer{resp: aRespMsg("foo.example.org.", 60, "10.0.0.1")}
+
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: noDataMsg("foo.example.org.", 300)}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+
+	resp := mw.Msg()
+	if assert.Len(t, resp.Answer, 1) {
+		aaaa := resp.Answer[0].(*dns.AAAA)
+		assert.Equal(t, "2001:db8:64::a00:1", aaaa.AAAA.String())
+	}
+}
+
+// TestSynthesise_TTL_ATtlIsLower pins RFC 6147 §5.1.7: the synth
+// TTL is the lower of the A TTL and the SOA negative-cache TTL.
+// No artificial floor — a 30s A record produces a 30s AAAA.
+func TestSynthesise_TTL_ATtlIsLower(t *testing.T) {
+	d := New(baseConfig())
+	d.queryer = &stubQueryer{resp: aRespMsg("foo.example.org.", 30, "192.0.2.33")}
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: noDataMsg("foo.example.org.", 7200)}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+	aaaa := mw.Msg().Answer[0].(*dns.AAAA)
+	assert.Equal(t, uint32(30), aaaa.Hdr.Ttl)
+}
+
+// TestSynthesise_TTL_NegativeIsLower covers the symmetric case:
+// SOA min smaller than A TTL → SOA min wins.
+func TestSynthesise_TTL_NegativeIsLower(t *testing.T) {
+	d := New(baseConfig())
+	d.queryer = &stubQueryer{resp: aRespMsg("foo.example.org.", 600, "192.0.2.33")}
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: noDataMsg("foo.example.org.", 120)}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+	aaaa := mw.Msg().Answer[0].(*dns.AAAA)
+	assert.Equal(t, uint32(120), aaaa.Hdr.Ttl)
+}
+
+// TestSynthesise_TTL_NoSOA_Caps600 pins RFC 6147 §5.1.7: when
+// no SOA is present in the upstream NODATA, the synth TTL caps at
+// 600 even if A TTL is higher.
+func TestSynthesise_TTL_NoSOA_Caps600(t *testing.T) {
+	d := New(baseConfig())
+	d.queryer = &stubQueryer{resp: aRespMsg("foo.example.org.", 7200, "192.0.2.33")}
+
+	// NODATA without an SOA in Authority.
+	noSOA := new(dns.Msg)
+	noSOA.SetQuestion("foo.example.org.", dns.TypeAAAA)
+	noSOA.Response = true
+	noSOA.Rcode = dns.RcodeSuccess
+	noSOA.SetEdns0(4096, true)
+
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: noSOA}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+	aaaa := mw.Msg().Answer[0].(*dns.AAAA)
+	assert.Equal(t, uint32(600), aaaa.Hdr.Ttl, "no-SOA AAAA must cap synth TTL at 600 per RFC 6147 §5.1.7")
+}
+
+func TestSynthesise_CnameChain(t *testing.T) {
+	d := New(baseConfig())
+	aResp := new(dns.Msg)
+	aResp.SetQuestion("alias.example.org.", dns.TypeA)
+	aResp.Response = true
+	aResp.Rcode = dns.RcodeSuccess
+	cname, _ := dns.NewRR("alias.example.org. 60 IN CNAME target.example.org.")
+	aResp.Answer = []dns.RR{
+		cname,
+		&dns.A{
+			Hdr: dns.RR_Header{Name: "target.example.org.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+			A:   net.ParseIP("192.0.2.33"),
+		},
+	}
+	d.queryer = &stubQueryer{resp: aResp}
+
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: noDataMsg("alias.example.org.", 300)}, "203.0.113.5:53", "alias.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+
+	resp := mw.Msg()
+	if assert.Len(t, resp.Answer, 2) {
+		_, isCNAME := resp.Answer[0].(*dns.CNAME)
+		aaaa, isAAAA := resp.Answer[1].(*dns.AAAA)
+		assert.True(t, isCNAME, "first answer record must be the CNAME")
+		if assert.True(t, isAAAA) {
+			assert.Equal(t, "target.example.org.", aaaa.Hdr.Name, "synthesised AAAA must be owned by the CNAME target")
+			assert.Equal(t, "64:ff9b::c000:221", aaaa.AAAA.String())
+		}
+	}
+}
+
+func TestSynthesise_MultipleAs_AllSynthesised(t *testing.T) {
+	d := New(baseConfig())
+	d.queryer = &stubQueryer{resp: aRespMsg("foo.example.org.", 60, "192.0.2.33", "203.0.113.7")}
+
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: noDataMsg("foo.example.org.", 300)}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+
+	resp := mw.Msg()
+	count := 0
+	for _, rr := range resp.Answer {
+		if _, ok := rr.(*dns.AAAA); ok {
+			count++
+		}
+	}
+	assert.Equal(t, 2, count, "every A record should produce a synthesised AAAA")
+}
+
+// TestSynthesise_RetainsOPT pins the behaviour that lets EDE
+// attachment work — without OPT in Extra, util.SetEDE is a no-op
+// so the AD-bit downgrade would silently drop its rationale.
+func TestSynthesise_RetainsOPT(t *testing.T) {
+	d := New(baseConfig())
+	d.queryer = &stubQueryer{resp: aRespMsg("foo.example.org.", 60, "192.0.2.33")}
+
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: noDataMsg("foo.example.org.", 300)}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+	assert.NotNil(t, mw.Msg().IsEdns0(), "synthesised response must carry OPT")
+}
+
+// TestExcludedAAAA_TriggersSynthesis pins RFC 6147 §5.1.4: an
+// upstream that returns only IPv4-mapped AAAA records must be
+// treated as "no AAAA" so DNS64 falls through to synthesis from
+// the A side.
+func TestExcludedAAAA_TriggersSynthesis(t *testing.T) {
+	d := New(baseConfig())
+	d.queryer = &stubQueryer{resp: aRespMsg("foo.example.org.", 60, "192.0.2.33")}
+
+	upstream := new(dns.Msg)
+	upstream.SetQuestion("foo.example.org.", dns.TypeAAAA)
+	upstream.Response = true
+	upstream.SetEdns0(4096, true)
+	// IPv4-mapped IPv6: ::ffff:c000:221 is the wire form of 192.0.2.33.
+	upstream.Answer = []dns.RR{&dns.AAAA{
+		Hdr:  dns.RR_Header{Name: "foo.example.org.", Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 60},
+		AAAA: net.ParseIP("::ffff:c000:221"),
+	}}
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: upstream}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+
+	resp := mw.Msg()
+	if assert.Len(t, resp.Answer, 1) {
+		aaaa := resp.Answer[0].(*dns.AAAA)
+		assert.Equal(t, "64:ff9b::c000:221", aaaa.AAAA.String(), "IPv4-mapped AAAA was excluded; synthesised AAAA used instead")
+	}
+}
+
+// TestExcludedAAAA_StripsButPassesThrough covers the partial-
+// exclusion case: at least one AAAA survives the filter, so the
+// response is still pass-through, but excluded AAAAs are dropped
+// from Answer before reaching the client.
+func TestExcludedAAAA_StripsButPassesThrough(t *testing.T) {
+	d := New(baseConfig())
+	d.queryer = &stubQueryer{} // would loudly fail if called
+
+	upstream := new(dns.Msg)
+	upstream.SetQuestion("foo.example.org.", dns.TypeAAAA)
+	upstream.Response = true
+	upstream.SetEdns0(4096, true)
+	upstream.Answer = []dns.RR{
+		&dns.AAAA{ // excluded
+			Hdr:  dns.RR_Header{Name: "foo.example.org.", Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 60},
+			AAAA: net.ParseIP("::ffff:c000:221"),
+		},
+		&dns.AAAA{ // routable
+			Hdr:  dns.RR_Header{Name: "foo.example.org.", Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 60},
+			AAAA: net.ParseIP("2001:db8::1"),
+		},
+	}
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: upstream}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+
+	resp := mw.Msg()
+	if assert.Len(t, resp.Answer, 1, "excluded AAAA must be stripped, routable one preserved") {
+		aaaa := resp.Answer[0].(*dns.AAAA)
+		assert.Equal(t, "2001:db8::1", aaaa.AAAA.String())
+	}
+}
+
+// TestExcludedAAAA_OptOutEmptyList confirms an explicit empty
+// exclude_aaaa_networks (declared in TOML as []) opts out of
+// filtering — the IPv4-mapped AAAA reaches the client unchanged.
+func TestExcludedAAAA_OptOutEmptyList(t *testing.T) {
+	cfg := baseConfig()
+	cfg.DNS64.ExcludeAAAANetworks = []string{} // explicit empty
+	d := New(cfg)
+	d.queryer = &stubQueryer{}
+
+	upstream := new(dns.Msg)
+	upstream.SetQuestion("foo.example.org.", dns.TypeAAAA)
+	upstream.Response = true
+	upstream.SetEdns0(4096, true)
+	upstream.Answer = []dns.RR{&dns.AAAA{
+		Hdr:  dns.RR_Header{Name: "foo.example.org.", Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 60},
+		AAAA: net.ParseIP("::ffff:c000:221"),
+	}}
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: upstream}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+
+	resp := mw.Msg()
+	if assert.Len(t, resp.Answer, 1) {
+		aaaa := resp.Answer[0].(*dns.AAAA)
+		// net.IP.String prints IPv4-mapped IPv6 in dotted form, so
+		// compare via Equal against the canonical 16-byte form.
+		assert.True(t, aaaa.AAAA.Equal(net.ParseIP("::ffff:c000:221")),
+			"with filter disabled, IPv4-mapped AAAA passes through; got %s", aaaa.AAAA)
+	}
+}
+
+// TestSynthesise_ANXDOMAIN_BecomesClientResponse pins RFC 6147
+// §5.1.6: when the AAAA returned NODATA but the secondary A
+// query yielded NXDOMAIN, the A NXDOMAIN — not the original
+// AAAA NODATA — is the basis for the client reply.
+func TestSynthesise_ANXDOMAIN_BecomesClientResponse(t *testing.T) {
+	d := New(baseConfig())
+	nx := new(dns.Msg)
+	nx.SetQuestion("foo.example.org.", dns.TypeA)
+	nx.Response = true
+	nx.Rcode = dns.RcodeNameError
+	soa, _ := dns.NewRR("example.org. 3600 IN SOA ns. host. 1 7200 3600 604800 60")
+	nx.Ns = []dns.RR{soa}
+	d.queryer = &stubQueryer{resp: nx}
+
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: noDataMsg("foo.example.org.", 300)}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+
+	resp := mw.Msg()
+	assert.Equal(t, dns.RcodeNameError, resp.Rcode, "client sees the A NXDOMAIN promoted to AAAA")
+	assert.Empty(t, resp.Answer)
+	assert.Equal(t, dns.TypeAAAA, resp.Question[0].Qtype)
+}
+
+// TestSynthesise_AuthorityFromAResponse pins RFC 6147 §5.4: the
+// Authority section of the synthesised reply comes from the final
+// A response, not the original AAAA NODATA. The SOA-min in the
+// AAAA NODATA still drives the synth TTL via §5.1.7, but the
+// Authority records served to the client are the A-side ones.
+func TestSynthesise_AuthorityFromAResponse(t *testing.T) {
+	d := New(baseConfig())
+	aResp := aRespMsg("foo.example.org.", 60, "192.0.2.33")
+	aSOA, _ := dns.NewRR("example.org. 7200 IN SOA ns.example.org. host.example.org. 42 7200 3600 604800 60")
+	aResp.Ns = []dns.RR{aSOA}
+	d.queryer = &stubQueryer{resp: aResp}
+
+	orig := noDataMsg("foo.example.org.", 300)
+	// Override the original SOA with a different serial so we can
+	// detect which one survived in the synthesised reply.
+	origSOA, _ := dns.NewRR("example.org. 3600 IN SOA ns.original. host.original. 99 7200 3600 604800 300")
+	orig.Ns = []dns.RR{origSOA}
+
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: orig}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+
+	resp := mw.Msg()
+	if assert.Len(t, resp.Ns, 1, "exactly one SOA from the A response") {
+		soa, ok := resp.Ns[0].(*dns.SOA)
+		if assert.True(t, ok) {
+			assert.Equal(t, uint32(42), soa.Serial, "Authority SOA must come from the A response (serial 42), not original AAAA (serial 99)")
+		}
+	}
+}
+
+// TestDNSSECFailure_PassesThrough pins RFC 6147 §5.5: when the
+// upstream resolver returns SERVFAIL with a DNSSEC-failure EDE
+// (Bogus, Signature Expired, etc.), DNS64 must surface the
+// failure to the client unchanged. Synthesising over a
+// validation failure would let an attacker bypass DNSSEC by
+// poisoning the AAAA path while keeping the A path clean.
+func TestDNSSECFailure_PassesThrough(t *testing.T) {
+	codes := []uint16{
+		dns.ExtendedErrorCodeUnsupportedDNSKEYAlgorithm,
+		dns.ExtendedErrorCodeUnsupportedDSDigestType,
+		dns.ExtendedErrorCodeDNSSECIndeterminate,
+		dns.ExtendedErrorCodeDNSBogus,
+		dns.ExtendedErrorCodeSignatureExpired,
+		dns.ExtendedErrorCodeSignatureNotYetValid,
+		dns.ExtendedErrorCodeDNSKEYMissing,
+		dns.ExtendedErrorCodeRRSIGsMissing,
+		dns.ExtendedErrorCodeNoZoneKeyBitSet,
+		dns.ExtendedErrorCodeNSECMissing,
+		dns.ExtendedErrorCodeUnsupportedNSEC3IterValue,
+	}
+	for _, code := range codes {
+		t.Run(dns.ExtendedErrorCodeToString[code], func(t *testing.T) {
+			d := New(baseConfig())
+			q := &stubQueryer{resp: aRespMsg("foo.example.org.", 60, "192.0.2.33")}
+			d.queryer = q
+
+			servfail := new(dns.Msg)
+			servfail.SetQuestion("foo.example.org.", dns.TypeAAAA)
+			servfail.Response = true
+			servfail.Rcode = dns.RcodeServerFailure
+			servfail.SetEdns0(4096, true)
+			util.SetEDE(servfail, code, "")
+
+			ch, mw := makeChain(t, d, &stubAnswerer{msg: servfail}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+			d.ServeDNS(context.Background(), ch)
+
+			resp := mw.Msg()
+			assert.Equal(t, dns.RcodeServerFailure, resp.Rcode, "DNSSEC failure must surface to client unchanged")
+			if q.last != nil {
+				t.Fatalf("DNSSEC failure must not trigger an A lookup; queryer was called")
+			}
+			ede := util.GetEDE(resp)
+			if assert.NotNil(t, ede, "EDE must reach the client") {
+				assert.Equal(t, code, ede.InfoCode)
+			}
+		})
+	}
+}
+
+// TestServFail_NonDNSSEC_StillSynthesises confirms that a plain
+// transport-level SERVFAIL (no DNSSEC EDE) still triggers the
+// §5.1.3 "treat as empty answer" path. DNSSEC pass-through must
+// be gated on the EDE, not on SERVFAIL alone.
+func TestServFail_NonDNSSEC_StillSynthesises(t *testing.T) {
+	d := New(baseConfig())
+	d.queryer = &stubQueryer{resp: aRespMsg("foo.example.org.", 60, "192.0.2.33")}
+
+	servfail := new(dns.Msg)
+	servfail.SetQuestion("foo.example.org.", dns.TypeAAAA)
+	servfail.Response = true
+	servfail.Rcode = dns.RcodeServerFailure
+	servfail.SetEdns0(4096, true)
+	// No DNSSEC EDE attached — represents a plain network
+	// SERVFAIL where synthesis is still permissible.
+
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: servfail}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+
+	resp := mw.Msg()
+	assert.Equal(t, dns.RcodeSuccess, resp.Rcode)
+	if assert.Len(t, resp.Answer, 1) {
+		aaaa := resp.Answer[0].(*dns.AAAA)
+		assert.Equal(t, "64:ff9b::c000:221", aaaa.AAAA.String())
+	}
+}
+
+// TestRD0_PassesThrough pins the RD=0 escape hatch: a client
+// that didn't ask for recursion must reach the rest of the chain
+// untouched, so DNS64 doesn't smuggle a recursive secondary
+// lookup past the client's intent.
+func TestRD0_PassesThrough(t *testing.T) {
+	d := New(baseConfig())
+	q := &stubQueryer{resp: aRespMsg("foo.example.org.", 60, "192.0.2.33")}
+	d.queryer = q
+
+	answered := false
+	downstream := middleware.HandlerFunc(func(ctx context.Context, ch *middleware.Chain) {
+		answered = true
+		// Mimic the cache middleware's RD=0 rejection.
+		ch.CancelWithRcode(dns.RcodeServerFailure, false)
+	})
+
+	ch := middleware.NewChain([]middleware.Handler{d, downstream})
+	mw := mock.NewWriter("udp", "203.0.113.5:53")
+	req := new(dns.Msg)
+	req.SetQuestion("foo.example.org.", dns.TypeAAAA)
+	req.SetEdns0(4096, true)
+	req.RecursionDesired = false
+	ch.Reset(mw, req)
+
+	d.ServeDNS(context.Background(), ch)
+
+	assert.True(t, answered, "RD=0 must reach the rest of the chain")
+	assert.Equal(t, dns.RcodeServerFailure, mw.Msg().Rcode, "downstream rejection passes through verbatim")
+	if q.last != nil {
+		t.Fatalf("RD=0 must not trigger an A lookup; queryer was called")
+	}
+}
+
+// TestSynthesise_AResponseAsBasis_PreservesCNAME pins RFC 6147
+// §5.1.5: when the A response carries a CNAME chain that ends at
+// a name with no A records, the chain must survive into the
+// client's reply even though no AAAAs are synthesised. Otherwise
+// the client sees a bare NODATA at the original qname while the
+// resolver actually walked an alias.
+func TestSynthesise_AResponseAsBasis_PreservesCNAME(t *testing.T) {
+	d := New(baseConfig())
+	aResp := new(dns.Msg)
+	aResp.SetQuestion("alias.example.org.", dns.TypeA)
+	aResp.Response = true
+	aResp.Rcode = dns.RcodeSuccess
+	cname, _ := dns.NewRR("alias.example.org. 60 IN CNAME target.example.org.")
+	soa, _ := dns.NewRR("example.org. 3600 IN SOA ns. host. 1 7200 3600 604800 60")
+	aResp.Answer = []dns.RR{cname}
+	aResp.Ns = []dns.RR{soa}
+	d.queryer = &stubQueryer{resp: aResp}
+
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: noDataMsg("alias.example.org.", 300)}, "203.0.113.5:53", "alias.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+
+	resp := mw.Msg()
+	assert.Equal(t, dns.RcodeSuccess, resp.Rcode)
+	if assert.Len(t, resp.Answer, 1, "CNAME from A response must reach the client") {
+		c, ok := resp.Answer[0].(*dns.CNAME)
+		if assert.True(t, ok) {
+			assert.Equal(t, "target.example.org.", c.Target)
+		}
+	}
+	assert.Equal(t, dns.TypeAAAA, resp.Question[0].Qtype, "client sees its original AAAA question")
+}
+
+// TestSynthesise_AdditionalARecordsPassThrough pins RFC 6147
+// §5.3.2: A records anywhere except the Answer section must
+// reach the client unmodified. This catches the regression where
+// extra-section A records were being rewritten into synthetic
+// AAAAs.
+func TestSynthesise_AdditionalARecordsPassThrough(t *testing.T) {
+	d := New(baseConfig())
+	aResp := aRespMsg("foo.example.org.", 60, "192.0.2.33")
+	// Stuff a glue-style A into Additional. §5.3.2 says it MUST
+	// reach the client unchanged — neither dropped nor rewritten.
+	gluedA, _ := dns.NewRR("ns.example.org. 60 IN A 198.51.100.7")
+	aResp.Extra = []dns.RR{gluedA}
+	d.queryer = &stubQueryer{resp: aResp}
+
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: noDataMsg("foo.example.org.", 300)}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+
+	resp := mw.Msg()
+	// Find the additional-section A; OPT may also be present.
+	var found *dns.A
+	for _, rr := range resp.Extra {
+		if a, ok := rr.(*dns.A); ok {
+			found = a
+		}
+		if _, ok := rr.(*dns.AAAA); ok {
+			t.Fatalf("§5.3.2: Additional section must not contain a synthesised AAAA, got %s", rr)
+		}
+	}
+	if assert.NotNil(t, found, "extra-section A must be passed through unchanged") {
+		assert.Equal(t, "198.51.100.7", found.A.String())
+		assert.Equal(t, "ns.example.org.", found.Hdr.Name)
+	}
+}
+
+// TestSynthesise_AuthorityARecordsPassThrough pins the same rule
+// for the Authority section: A records there are not touched.
+// Authority A records are unusual in real responses but covered
+// by §5.3.2 ("DNS64 MUST NOT modify any RRtype other than CNAME
+// and RRSIG").
+func TestSynthesise_AuthorityARecordsPassThrough(t *testing.T) {
+	d := New(baseConfig())
+	aResp := aRespMsg("foo.example.org.", 60, "192.0.2.33")
+	aSOA, _ := dns.NewRR("example.org. 7200 IN SOA ns.example.org. host.example.org. 42 7200 3600 604800 60")
+	authA, _ := dns.NewRR("ns.example.org. 60 IN A 198.51.100.42")
+	aResp.Ns = []dns.RR{aSOA, authA}
+	d.queryer = &stubQueryer{resp: aResp}
+
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: noDataMsg("foo.example.org.", 300)}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+
+	resp := mw.Msg()
+	var foundA *dns.A
+	for _, rr := range resp.Ns {
+		if a, ok := rr.(*dns.A); ok {
+			foundA = a
+		}
+		if _, ok := rr.(*dns.AAAA); ok {
+			t.Fatalf("§5.3.2: Authority section must not contain a synthesised AAAA, got %s", rr)
+		}
+	}
+	if assert.NotNil(t, foundA) {
+		assert.Equal(t, "198.51.100.42", foundA.A.String())
+	}
+}
+
+// TestPassThrough_FilteredAAAAClearsAD pins the §5.1.4 modify-
+// the-RRset case: when DNS64 strips IPv4-mapped AAAA records but
+// at least one survives, the response we forward differs from
+// what the validator signed, so AD must be cleared.
+func TestPassThrough_FilteredAAAAClearsAD(t *testing.T) {
+	d := New(baseConfig())
+
+	upstream := new(dns.Msg)
+	upstream.SetQuestion("foo.example.org.", dns.TypeAAAA)
+	upstream.Response = true
+	upstream.AuthenticatedData = true
+	upstream.SetEdns0(4096, true)
+	upstream.Answer = []dns.RR{
+		&dns.AAAA{ // excluded → triggers strip
+			Hdr:  dns.RR_Header{Name: "foo.example.org.", Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 60},
+			AAAA: net.ParseIP("::ffff:c000:221"),
+		},
+		&dns.AAAA{ // routable → survives
+			Hdr:  dns.RR_Header{Name: "foo.example.org.", Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 60},
+			AAAA: net.ParseIP("2001:db8::1"),
+		},
+	}
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: upstream}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+
+	resp := mw.Msg()
+	assert.False(t, resp.AuthenticatedData, "AD must clear after RRset modification")
+	if ede := util.GetEDE(resp); assert.NotNil(t, ede, "EDE 4 should be attached when AD was set on the upstream") {
+		assert.Equal(t, dns.ExtendedErrorCodeForgedAnswer, ede.InfoCode)
+	}
+}
+
+// TestPassThrough_NoStripPreservesAD confirms a clean pass-through
+// (no AAAA stripped) does NOT clear AD — the RRset is exactly
+// what the validator signed.
+func TestPassThrough_NoStripPreservesAD(t *testing.T) {
+	d := New(baseConfig())
+
+	upstream := new(dns.Msg)
+	upstream.SetQuestion("foo.example.org.", dns.TypeAAAA)
+	upstream.Response = true
+	upstream.AuthenticatedData = true
+	upstream.SetEdns0(4096, true)
+	upstream.Answer = []dns.RR{&dns.AAAA{
+		Hdr:  dns.RR_Header{Name: "foo.example.org.", Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 60},
+		AAAA: net.ParseIP("2001:db8::1"),
+	}}
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: upstream}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+
+	resp := mw.Msg()
+	assert.True(t, resp.AuthenticatedData, "AD must survive a clean pass-through")
+}
+
+// TestSynthesise_MultiPrefix pins RFC 6147 §5.2: multiple
+// configured prefixes each yield a synthesised AAAA per A record,
+// so a client receives every reachable path.
+func TestSynthesise_MultiPrefix(t *testing.T) {
+	cfg := baseConfig()
+	cfg.DNS64.Prefixes = []string{"64:ff9b::/96", "2001:db8:64::/96"}
+	d := New(cfg)
+	d.queryer = &stubQueryer{resp: aRespMsg("foo.example.org.", 60, "192.0.2.33")}
+
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: noDataMsg("foo.example.org.", 300)}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+
+	resp := mw.Msg()
+	if assert.Len(t, resp.Answer, 2, "one synthesised AAAA per configured prefix") {
+		assert.Equal(t, "64:ff9b::c000:221", resp.Answer[0].(*dns.AAAA).AAAA.String())
+		assert.Equal(t, "2001:db8:64::c000:221", resp.Answer[1].(*dns.AAAA).AAAA.String())
+	}
+}
+
+// TestSynthesise_MultiPrefix_PerPrefixExclusion confirms the
+// IPv4 exclusion list is per-prefix: a private A is excluded
+// under 64:ff9b::/96 but synthesised under an operator prefix
+// listed alongside it.
+func TestSynthesise_MultiPrefix_PerPrefixExclusion(t *testing.T) {
+	cfg := baseConfig()
+	cfg.DNS64.Prefixes = []string{"64:ff9b::/96", "2001:db8:64::/96"}
+	d := New(cfg)
+	d.queryer = &stubQueryer{resp: aRespMsg("foo.example.org.", 60, "10.0.0.1")}
+
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: noDataMsg("foo.example.org.", 300)}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+
+	resp := mw.Msg()
+	if assert.Len(t, resp.Answer, 1, "private A excluded under well-known, kept under operator prefix") {
+		assert.Equal(t, "2001:db8:64::a00:1", resp.Answer[0].(*dns.AAAA).AAAA.String())
+	}
+}
+
+// TestPTR_TranslatesUnderWellKnown covers the happy path for
+// RFC 6147 §5.3.1: an ip6.arpa PTR for an address inside
+// 64:ff9b::/96 yields a CNAME to the corresponding in-addr.arpa.
+// The chase response is appended when present.
+func TestPTR_TranslatesUnderWellKnown(t *testing.T) {
+	d := New(baseConfig())
+	// Stub PTR response for the corresponding in-addr.arpa.
+	ptrResp := new(dns.Msg)
+	ptrResp.SetQuestion("33.2.0.192.in-addr.arpa.", dns.TypePTR)
+	ptrResp.Response = true
+	ptrResp.Rcode = dns.RcodeSuccess
+	rr, _ := dns.NewRR("33.2.0.192.in-addr.arpa. 600 IN PTR target.example.com.")
+	ptrResp.Answer = []dns.RR{rr}
+	d.queryer = &stubQueryer{resp: ptrResp}
+
+	// 192.0.2.33 embedded in 64:ff9b::/96 is 64:ff9b::c000:221.
+	// Reverse: 1.2.2.0.0.0.0.c.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.b.9.f.f.4.6.0.0.ip6.arpa.
+	qname := "1.2.2.0.0.0.0.c.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.b.9.f.f.4.6.0.0.ip6.arpa."
+
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: nil}, "203.0.113.5:53", qname, dns.TypePTR)
+	d.ServeDNS(context.Background(), ch)
+
+	resp := mw.Msg()
+	if !assert.NotNil(t, resp, "PTR translation must produce a response") {
+		return
+	}
+	assert.Equal(t, dns.RcodeSuccess, resp.Rcode)
+	if assert.GreaterOrEqual(t, len(resp.Answer), 1) {
+		cname, ok := resp.Answer[0].(*dns.CNAME)
+		if assert.True(t, ok, "first answer must be a CNAME") {
+			assert.Equal(t, qname, cname.Hdr.Name)
+			assert.Equal(t, "33.2.0.192.in-addr.arpa.", cname.Target)
+		}
+	}
+	if assert.Len(t, resp.Answer, 2, "chase result must be appended") {
+		ptr, ok := resp.Answer[1].(*dns.PTR)
+		if assert.True(t, ok) {
+			assert.Equal(t, "target.example.com.", ptr.Ptr)
+		}
+	}
+}
+
+// TestPTR_NoMatchFallsThrough confirms PTR queries for ip6.arpa
+// names whose address lies outside every configured Pref64 are
+// passed to the rest of the chain (so real reverse zones still
+// answer normally).
+func TestPTR_NoMatchFallsThrough(t *testing.T) {
+	d := New(baseConfig())
+	d.queryer = &stubQueryer{} // would loudly fail if called
+
+	// Address outside 64:ff9b::/96 — operator chose a different
+	// prefix elsewhere; this address shouldn't be translated by us.
+	qname := "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa."
+
+	answered := false
+	downstream := middleware.HandlerFunc(func(ctx context.Context, ch *middleware.Chain) {
+		answered = true
+		// Emulate a normal NXDOMAIN from the real zone.
+		nxd := new(dns.Msg)
+		nxd.SetRcode(ch.Request, dns.RcodeNameError)
+		nxd.Response = true
+		_ = ch.Writer.WriteMsg(nxd)
+		ch.Cancel()
+	})
+	ch, mw := makeChain(t, d, downstream, "203.0.113.5:53", qname, dns.TypePTR)
+	d.ServeDNS(context.Background(), ch)
+
+	assert.True(t, answered, "downstream must run when PTR is not under a configured Pref64")
+	assert.Equal(t, dns.RcodeNameError, mw.Msg().Rcode)
+}
+
+// TestPTR_ExcludedV4SkipsTranslation pins RFC 6147 §5.1.4
+// symmetry: a PTR whose embedded IPv4 is in the well-known
+// exclude list flows through normal recursion instead of being
+// rewritten.
+func TestPTR_ExcludedV4SkipsTranslation(t *testing.T) {
+	d := New(baseConfig())
+
+	// 10.0.0.1 embedded in 64:ff9b::/96 is 64:ff9b::a00:1.
+	// Reverse: 1.0.0.0.0.0.a.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.b.9.f.f.4.6.0.0.ip6.arpa.
+	qname := "1.0.0.0.0.0.a.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.b.9.f.f.4.6.0.0.ip6.arpa."
+
+	answered := false
+	downstream := middleware.HandlerFunc(func(ctx context.Context, ch *middleware.Chain) {
+		answered = true
+		ch.CancelWithRcode(dns.RcodeServerFailure, false)
+	})
+	ch, mw := makeChain(t, d, downstream, "203.0.113.5:53", qname, dns.TypePTR)
+	d.ServeDNS(context.Background(), ch)
+
+	assert.True(t, answered, "excluded-v4 PTR must fall through to the rest of the chain")
+	assert.Equal(t, dns.RcodeServerFailure, mw.Msg().Rcode)
+}
+
+// TestPTR_OperatorPrefixTranslates confirms PTR translation works
+// for an operator-chosen prefix (RFC 6147 §5.1.4 exclusion does
+// not apply, so private ranges are reachable).
+func TestPTR_OperatorPrefixTranslates(t *testing.T) {
+	cfg := baseConfig()
+	cfg.DNS64.Prefixes = []string{"2001:db8:64::/96"}
+	cfg.DNS64.ExcludeANetworks = nil
+	d := New(cfg)
+	d.queryer = nil // confirm the CNAME-only path is also fine
+
+	// 10.0.0.1 embedded in 2001:db8:64::/96 = 2001:db8:64::a00:1.
+	// Bytes: 20 01 0d b8 00 64 00 00 00 00 00 00 0a 00 00 01.
+	// 32 reverse nibbles (byte 15 low first, byte 0 high last) →
+	qname := "1.0.0.0.0.0.a.0.0.0.0.0.0.0.0.0.0.0.0.0.4.6.0.0.8.b.d.0.1.0.0.2.ip6.arpa."
+
+	ch, mw := makeChain(t, d, &stubAnswerer{}, "203.0.113.5:53", qname, dns.TypePTR)
+	d.ServeDNS(context.Background(), ch)
+
+	resp := mw.Msg()
+	if assert.NotNil(t, resp) && assert.Len(t, resp.Answer, 1) {
+		cname := resp.Answer[0].(*dns.CNAME)
+		assert.Equal(t, "1.0.0.10.in-addr.arpa.", cname.Target)
+	}
+}
+
+// TestSynthesise_DNAMEChain covers RFC 6147 §5.1.5: a DNAME in
+// the A response must be carried through into the synthesised
+// answer alongside any synthesised CNAME.
+func TestSynthesise_DNAMEChain(t *testing.T) {
+	d := New(baseConfig())
+	aResp := new(dns.Msg)
+	aResp.SetQuestion("alias.dept.example.org.", dns.TypeA)
+	aResp.Response = true
+	aResp.Rcode = dns.RcodeSuccess
+	dname, _ := dns.NewRR("dept.example.org. 60 IN DNAME hosts.example.net.")
+	cname, _ := dns.NewRR("alias.dept.example.org. 60 IN CNAME alias.hosts.example.net.")
+	aResp.Answer = []dns.RR{
+		dname,
+		cname,
+		&dns.A{
+			Hdr: dns.RR_Header{Name: "alias.hosts.example.net.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+			A:   net.ParseIP("192.0.2.33"),
+		},
+	}
+	d.queryer = &stubQueryer{resp: aResp}
+
+	ch, mw := makeChain(t, d, &stubAnswerer{msg: noDataMsg("alias.dept.example.org.", 300)}, "203.0.113.5:53", "alias.dept.example.org.", dns.TypeAAAA)
+	d.ServeDNS(context.Background(), ch)
+
+	resp := mw.Msg()
+	if assert.Len(t, resp.Answer, 3, "DNAME + synthesised CNAME + synthesised AAAA must all be present") {
+		_, isDNAME := resp.Answer[0].(*dns.DNAME)
+		_, isCNAME := resp.Answer[1].(*dns.CNAME)
+		aaaa, isAAAA := resp.Answer[2].(*dns.AAAA)
+		assert.True(t, isDNAME, "first record must be the DNAME")
+		assert.True(t, isCNAME, "second record must be the synthesised CNAME")
+		if assert.True(t, isAAAA) {
+			assert.Equal(t, "alias.hosts.example.net.", aaaa.Hdr.Name, "synthesised AAAA owner must follow the chain to the A's terminal name")
+			assert.Equal(t, "64:ff9b::c000:221", aaaa.AAAA.String())
+		}
+	}
+}

--- a/middleware/dns64/metrics.go
+++ b/middleware/dns64/metrics.go
@@ -1,0 +1,52 @@
+package dns64
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	// Synthesised counts AAAA records produced from A records.
+	// Bumped once per client query that resulted in synthesis,
+	// not per individual record — the metric tracks how often
+	// DNS64 had to step in, not how many addresses were embedded.
+	Synthesised = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "dns64_synthesised_total",
+			Help: "Total client AAAA queries answered with synthesised records",
+		},
+	)
+
+	// Passthrough counts AAAA queries that flowed through DNS64
+	// without synthesis, labelled by the reason. "aaaa_present"
+	// is the steady-state happy path; the rest are exclusion
+	// signals operators may want to monitor.
+	Passthrough = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "dns64_passthrough_total",
+			Help: "AAAA queries DNS64 left untouched, by reason",
+		},
+		[]string{"reason"},
+	)
+
+	// ALookupFailures counts secondary A-record lookups that did
+	// not yield a usable result (SERVFAIL, no answer, etc.).
+	// Reason labels are bounded to a small set so the cardinality
+	// stays low.
+	ALookupFailures = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: "dns64_a_lookup_failures_total",
+			Help: "Failures of the secondary A lookup issued during DNS64 synthesis",
+		},
+		[]string{"reason"},
+	)
+
+	// PTRTranslated counts ip6.arpa PTR queries DNS64 redirected
+	// to their in-addr.arpa counterpart per RFC 6147 §5.3.1.
+	PTRTranslated = promauto.NewCounter(
+		prometheus.CounterOpts{
+			Name: "dns64_ptr_translated_total",
+			Help: "Total ip6.arpa PTR queries answered with a CNAME to in-addr.arpa",
+		},
+	)
+)

--- a/middleware/dns64/synth.go
+++ b/middleware/dns64/synth.go
@@ -1,0 +1,302 @@
+package dns64
+
+import (
+	"fmt"
+	"net"
+	"strings"
+
+	"github.com/miekg/dns"
+)
+
+// validPrefixBits is the set of IPv6 prefix lengths permitted for
+// IPv4-embedded IPv6 addresses by RFC 6052 §2.2. Any other length is
+// rejected at config-load time.
+var validPrefixBits = map[int]bool{
+	32: true,
+	40: true,
+	48: true,
+	56: true,
+	64: true,
+	96: true,
+}
+
+// wellKnownPrefix is the "Well-Known Prefix" 64:ff9b::/96 from RFC
+// 6052 §2.1. Translation through this prefix is restricted: per RFC
+// 6052 §3.1 and RFC 6147 §5.1.4, IPv4 addresses in special-use
+// ranges (RFC 5735 / RFC 6890) MUST NOT be embedded into the
+// well-known prefix because the resulting IPv6 address would not be
+// globally reachable.
+var wellKnownPrefix = mustCIDR("64:ff9b::/96")
+
+func mustCIDR(s string) *net.IPNet {
+	_, n, err := net.ParseCIDR(s)
+	if err != nil {
+		panic(err)
+	}
+	return n
+}
+
+// validatePrefix verifies prefix is a valid Pref64::/n per RFC 6052
+// §2.2. Returns an error with a descriptive message on rejection.
+func validatePrefix(p *net.IPNet) error {
+	if p == nil {
+		return fmt.Errorf("dns64: nil prefix")
+	}
+	// Use mask length, not IP.To4(), to distinguish IPv4 from
+	// IPv6 inputs — IPv4-mapped IPv6 ranges like ::ffff:0:0/96
+	// have a non-nil To4() but are still legal Pref64 inputs.
+	if len(p.Mask) != net.IPv6len {
+		return fmt.Errorf("dns64: prefix %s is IPv4, want IPv6", p.String())
+	}
+	bits, _ := p.Mask.Size()
+	if !validPrefixBits[bits] {
+		return fmt.Errorf("dns64: prefix length /%d invalid; must be /32, /40, /48, /56, /64, or /96", bits)
+	}
+	// Per RFC 6052 §2.2 byte 8 (bits 64-71) MUST be zero in the
+	// resulting address. For /96 the operator's prefix already
+	// covers byte 8, so reject prefixes with a non-zero byte 8 up
+	// front rather than silently producing a non-conformant result.
+	if bits == 96 && len(p.IP) >= 9 && p.IP[8] != 0 {
+		return fmt.Errorf("dns64: /96 prefix %s has non-zero byte 8 (RFC 6052 §2.2 reserved)", p.String())
+	}
+	return nil
+}
+
+// embedIPv4 returns the IPv4-embedded IPv6 address built from prefix
+// and v4 per RFC 6052 §2.2. prefix must satisfy validatePrefix; v4
+// must be a 4-byte IPv4 address (callers should pass v4.To4()).
+//
+// The v4 octets are interleaved around byte 8 (the "u" octet) for
+// /32, /40, /48, /56, /64 prefixes. Byte 8 itself is always written
+// as zero, regardless of any value the operator may have placed
+// there in the configured prefix — RFC 6052 §2.2 reserves it.
+//
+// Trailing octets beyond the embedded v4 are zeroed (the "suffix"
+// in the RFC's terminology). Suffix is reserved for future use and
+// must be transmitted as zero.
+func embedIPv4(prefix *net.IPNet, v4 net.IP) net.IP {
+	bits, _ := prefix.Mask.Size()
+	out := make(net.IP, net.IPv6len)
+	// Copy the prefix bytes that are fully covered by the mask.
+	// For /32 prefix this is bytes 0-3, for /96 it is bytes 0-11.
+	prefixBytes := bits / 8
+	copy(out[:prefixBytes], prefix.IP[:prefixBytes])
+
+	// v4 must be exactly 4 bytes here.
+	switch bits {
+	case 32:
+		// v4 at bytes 4-7; byte 8 = 0; suffix zero.
+		copy(out[4:8], v4)
+	case 40:
+		// v4 high 24 bits at bytes 5-7; byte 8 = 0; v4 low 8 bits at byte 9.
+		copy(out[5:8], v4[:3])
+		out[9] = v4[3]
+	case 48:
+		// v4 high 16 bits at bytes 6-7; byte 8 = 0; v4 low 16 bits at bytes 9-10.
+		copy(out[6:8], v4[:2])
+		copy(out[9:11], v4[2:])
+	case 56:
+		// v4 high 8 bits at byte 7; byte 8 = 0; v4 low 24 bits at bytes 9-11.
+		out[7] = v4[0]
+		copy(out[9:12], v4[1:])
+	case 64:
+		// byte 8 = 0; v4 at bytes 9-12.
+		copy(out[9:13], v4)
+	case 96:
+		// v4 at bytes 12-15.
+		copy(out[12:16], v4)
+	}
+	return out
+}
+
+// excludedV4 reports whether v4 falls in any of the "do not
+// translate" ranges. RFC 6147 §5.1.4 directs the implementation to
+// skip synthesis for IPv4 addresses that would not be globally
+// reachable when expressed as 64:ff9b::/96. The caller decides
+// whether to apply the check (only the well-known prefix is bound
+// by §5.1.4; operator-chosen network-specific prefixes have their
+// own scope and may legitimately translate private addresses).
+func excludedV4(v4 net.IP, exclusions []*net.IPNet) bool {
+	if len(exclusions) == 0 {
+		return false
+	}
+	for _, n := range exclusions {
+		if n.Contains(v4) {
+			return true
+		}
+	}
+	return false
+}
+
+// isWellKnownPrefix reports whether p is exactly 64:ff9b::/96. RFC
+// 6147 §5.1.4 exclusions apply to this prefix only.
+func isWellKnownPrefix(p *net.IPNet) bool {
+	if p == nil {
+		return false
+	}
+	pBits, _ := p.Mask.Size()
+	wkBits, _ := wellKnownPrefix.Mask.Size()
+	if pBits != wkBits {
+		return false
+	}
+	return p.IP.Equal(wellKnownPrefix.IP)
+}
+
+// synthesizeAAAA builds a synthetic AAAA RR for qname from the given
+// A record using prefix. The synthesised record uses ttl as its TTL
+// (caller selects per RFC 6147 §5.1.7 — the lower of the original
+// AAAA negative TTL and the A TTL). qname is used as the owner so
+// the record matches the client's question regardless of any CNAME
+// chain that landed on the A record's owner.
+func synthesizeAAAA(qname string, a *dns.A, prefix *net.IPNet, ttl uint32) *dns.AAAA {
+	v4 := a.A.To4()
+	if v4 == nil {
+		return nil
+	}
+	return &dns.AAAA{
+		Hdr: dns.RR_Header{
+			Name:   qname,
+			Rrtype: dns.TypeAAAA,
+			Class:  dns.ClassINET,
+			Ttl:    ttl,
+		},
+		AAAA: embedIPv4(prefix, v4),
+	}
+}
+
+// extractIPv4 is the inverse of embedIPv4. It returns the IPv4
+// address embedded in addr under prefix, plus true on success.
+// Returns false when prefix doesn't actually contain addr, when
+// the reserved "u" octet (byte 8) is non-zero for a /32../64
+// prefix, or when the suffix bits beyond the embedded v4 are
+// non-zero (RFC 6052 §2.2 reserves them as MUST-be-zero).
+//
+// The strict zero-bit checks matter for PTR translation: a
+// non-conformant address inside the prefix range may not actually
+// be a translated address, so refusing to extract avoids
+// returning a confusing CNAME for unrelated traffic.
+func extractIPv4(prefix *net.IPNet, addr net.IP) (net.IP, bool) {
+	if !prefix.Contains(addr) {
+		return nil, false
+	}
+	bits, _ := prefix.Mask.Size()
+	if !validPrefixBits[bits] {
+		return nil, false
+	}
+	a := addr.To16()
+	if a == nil {
+		return nil, false
+	}
+	out := make(net.IP, net.IPv4len)
+	switch bits {
+	case 32:
+		copy(out, a[4:8])
+		if !bytesAllZero(a[8:]) {
+			return nil, false
+		}
+	case 40:
+		copy(out[:3], a[5:8])
+		if a[8] != 0 {
+			return nil, false
+		}
+		out[3] = a[9]
+		if !bytesAllZero(a[10:]) {
+			return nil, false
+		}
+	case 48:
+		copy(out[:2], a[6:8])
+		if a[8] != 0 {
+			return nil, false
+		}
+		copy(out[2:], a[9:11])
+		if !bytesAllZero(a[11:]) {
+			return nil, false
+		}
+	case 56:
+		out[0] = a[7]
+		if a[8] != 0 {
+			return nil, false
+		}
+		copy(out[1:], a[9:12])
+		if !bytesAllZero(a[12:]) {
+			return nil, false
+		}
+	case 64:
+		if a[8] != 0 {
+			return nil, false
+		}
+		copy(out, a[9:13])
+		if !bytesAllZero(a[13:]) {
+			return nil, false
+		}
+	case 96:
+		copy(out, a[12:16])
+	}
+	return out, true
+}
+
+func bytesAllZero(b []byte) bool {
+	for _, v := range b {
+		if v != 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// parseIP6ArpaName decodes an ip6.arpa.-suffixed PTR query name
+// into its 16-byte IPv6 address. Returns false when the name
+// isn't well-formed (wrong number of labels, non-hex nibble,
+// labels longer than one character).
+func parseIP6ArpaName(qname string) (net.IP, bool) {
+	q := strings.ToLower(qname)
+	q = strings.TrimSuffix(q, ".")
+	if !strings.HasSuffix(q, ".ip6.arpa") {
+		return nil, false
+	}
+	head := strings.TrimSuffix(q, ".ip6.arpa")
+	parts := strings.Split(head, ".")
+	if len(parts) != 32 {
+		return nil, false
+	}
+	out := make(net.IP, net.IPv6len)
+	for i, label := range parts {
+		if len(label) != 1 {
+			return nil, false
+		}
+		nib, ok := hexNibble(label[0])
+		if !ok {
+			return nil, false
+		}
+		nibbleIdx := 31 - i
+		byteIdx := nibbleIdx / 2
+		if nibbleIdx%2 == 0 {
+			out[byteIdx] |= nib << 4
+		} else {
+			out[byteIdx] |= nib
+		}
+	}
+	return out, true
+}
+
+func hexNibble(c byte) (byte, bool) {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0', true
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10, true
+	}
+	return 0, false
+}
+
+// inAddrArpa returns the in-addr.arpa.-suffixed reverse name for
+// the given IPv4 address. Used to redirect ip6.arpa PTR queries
+// that fall under a configured Pref64 to their IPv4 reverse-zone
+// counterpart per RFC 6147 §5.3.1.
+func inAddrArpa(v4 net.IP) string {
+	v4 = v4.To4()
+	if v4 == nil {
+		return ""
+	}
+	return fmt.Sprintf("%d.%d.%d.%d.in-addr.arpa.", v4[3], v4[2], v4[1], v4[0])
+}

--- a/middleware/dns64/synth_test.go
+++ b/middleware/dns64/synth_test.go
@@ -1,0 +1,286 @@
+package dns64
+
+import (
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func parseCIDR(t *testing.T, s string) *net.IPNet {
+	t.Helper()
+	_, n, err := net.ParseCIDR(s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return n
+}
+
+// TestEmbedIPv4_RFC6052Vectors covers every permitted prefix length
+// using the test vectors illustrated in RFC 6052 §2.4. v4 is
+// 192.0.2.33 throughout, so every output can be cross-checked
+// against the table in the RFC.
+func TestEmbedIPv4_RFC6052Vectors(t *testing.T) {
+	v4 := net.ParseIP("192.0.2.33").To4()
+	cases := []struct {
+		name   string
+		prefix string
+		want   string
+	}{
+		{"/32", "2001:db8::/32", "2001:db8:c000:221::"},
+		{"/40", "2001:db8:100::/40", "2001:db8:1c0:2:21::"},
+		{"/48", "2001:db8:122::/48", "2001:db8:122:c000:2:2100::"},
+		{"/56", "2001:db8:122:300::/56", "2001:db8:122:3c0:0:221::"},
+		{"/64", "2001:db8:122:344::/64", "2001:db8:122:344:c0:2:2100:0"},
+		{"/96", "2001:db8:122:344::/96", "2001:db8:122:344::c000:221"},
+		{"/96 well-known", "64:ff9b::/96", "64:ff9b::c000:221"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := embedIPv4(parseCIDR(t, tc.prefix), v4)
+			want := net.ParseIP(tc.want)
+			if !got.Equal(want) {
+				t.Fatalf("embedIPv4(%s, 192.0.2.33) = %s, want %s", tc.prefix, got, want)
+			}
+		})
+	}
+}
+
+// TestEmbedIPv4_ZeroesUOctet pins the RFC 6052 §2.2 invariant that
+// byte 8 of the synthesised address is always zero, regardless of
+// whatever (non-/96) prefix the operator configured. We don't allow
+// non-zero byte 8 in /96 prefixes (validatePrefix rejects them);
+// for /32-/64 the prefix mask doesn't even reach byte 8, so this
+// test exercises the embed function's own zero-write behaviour.
+func TestEmbedIPv4_ZeroesUOctet(t *testing.T) {
+	v4 := net.ParseIP("203.0.113.7").To4()
+	for _, p := range []string{
+		"2001:db8::/32",
+		"2001:db8:100::/40",
+		"2001:db8:122::/48",
+		"2001:db8:122:300::/56",
+		"2001:db8:122:344::/64",
+	} {
+		got := embedIPv4(parseCIDR(t, p), v4)
+		if got[8] != 0 {
+			t.Errorf("prefix %s: byte 8 = %#x, want 0", p, got[8])
+		}
+	}
+}
+
+func TestValidatePrefix(t *testing.T) {
+	cases := []struct {
+		name    string
+		prefix  string
+		wantErr bool
+	}{
+		{"valid /32", "2001:db8::/32", false},
+		{"valid /96", "2001:db8::/96", false},
+		{"valid well-known /96", "64:ff9b::/96", false},
+		{"invalid /48 +1", "2001:db8::/49", true},
+		{"invalid /128", "2001:db8::1/128", true},
+		{"invalid /0", "::/0", true},
+		{"ipv4 prefix", "192.0.2.0/24", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validatePrefix(parseCIDR(t, tc.prefix))
+			if tc.wantErr && err == nil {
+				t.Fatalf("validatePrefix(%s) = nil, want error", tc.prefix)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("validatePrefix(%s) = %v, want nil", tc.prefix, err)
+			}
+		})
+	}
+}
+
+func TestValidatePrefix_NonZeroByte8For96(t *testing.T) {
+	// Byte 8 (bits 64-71) is the 5th hextet's high byte, so we need a
+	// /96 prefix whose 5th hextet is non-zero. 2001:db8:0:0:ff00::/96
+	// gives byte 8 = 0xff.
+	_, p, err := net.ParseCIDR("2001:db8:0:0:ff00::/96")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if p.IP[8] == 0 {
+		t.Fatalf("test setup error: byte 8 must be non-zero, got %#x in %s", p.IP[8], p.IP)
+	}
+	if err := validatePrefix(p); err == nil {
+		t.Fatalf("validatePrefix accepted /96 with non-zero byte 8")
+	}
+}
+
+func TestExcludedV4(t *testing.T) {
+	exclusions := []*net.IPNet{
+		parseCIDR(t, "10.0.0.0/8"),
+		parseCIDR(t, "192.168.0.0/16"),
+		parseCIDR(t, "127.0.0.0/8"),
+	}
+	cases := []struct {
+		ip   string
+		want bool
+	}{
+		{"10.0.0.1", true},
+		{"192.168.42.7", true},
+		{"127.0.0.1", true},
+		{"8.8.8.8", false},
+		{"203.0.113.10", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.ip, func(t *testing.T) {
+			got := excludedV4(net.ParseIP(tc.ip).To4(), exclusions)
+			if got != tc.want {
+				t.Fatalf("excludedV4(%s) = %v, want %v", tc.ip, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestExcludedV4_EmptyList(t *testing.T) {
+	if excludedV4(net.ParseIP("10.0.0.1").To4(), nil) {
+		t.Fatalf("empty exclusions should never exclude")
+	}
+}
+
+func TestIsWellKnownPrefix(t *testing.T) {
+	if !isWellKnownPrefix(parseCIDR(t, "64:ff9b::/96")) {
+		t.Fatalf("64:ff9b::/96 should be the well-known prefix")
+	}
+	if isWellKnownPrefix(parseCIDR(t, "2001:db8::/96")) {
+		t.Fatalf("2001:db8::/96 is not the well-known prefix")
+	}
+	if isWellKnownPrefix(parseCIDR(t, "64:ff9b::/64")) {
+		t.Fatalf("/64 prefix length cannot match well-known /96")
+	}
+}
+
+func TestSynthesizeAAAA(t *testing.T) {
+	a := &dns.A{
+		Hdr: dns.RR_Header{
+			Name:   "alias.example.org.",
+			Rrtype: dns.TypeA,
+			Class:  dns.ClassINET,
+			Ttl:    600,
+		},
+		A: net.ParseIP("192.0.2.33"),
+	}
+	prefix := parseCIDR(t, "64:ff9b::/96")
+	got := synthesizeAAAA("client.example.com.", a, prefix, 300)
+	if got == nil {
+		t.Fatalf("synthesizeAAAA returned nil")
+	}
+	if got.Hdr.Name != "client.example.com." {
+		t.Errorf("owner = %s, want client.example.com.", got.Hdr.Name)
+	}
+	if got.Hdr.Ttl != 300 {
+		t.Errorf("TTL = %d, want 300 (the explicitly clamped value)", got.Hdr.Ttl)
+	}
+	if !got.AAAA.Equal(net.ParseIP("64:ff9b::c000:221")) {
+		t.Errorf("AAAA = %s, want 64:ff9b::c000:221", got.AAAA)
+	}
+}
+
+func TestSynthesizeAAAA_NilForNonV4(t *testing.T) {
+	a := &dns.A{
+		Hdr: dns.RR_Header{Name: "x.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+		A:   net.ParseIP("::1"),
+	}
+	if synthesizeAAAA("x.", a, parseCIDR(t, "64:ff9b::/96"), 60) != nil {
+		t.Fatalf("synthesizeAAAA should return nil for non-IPv4 address")
+	}
+}
+
+// TestExtractIPv4_RoundTrip pins that embedIPv4 ↔ extractIPv4 are
+// consistent across every permitted prefix length.
+func TestExtractIPv4_RoundTrip(t *testing.T) {
+	v4 := net.ParseIP("192.0.2.33").To4()
+	for _, prefix := range []string{
+		"2001:db8::/32",
+		"2001:db8:100::/40",
+		"2001:db8:122::/48",
+		"2001:db8:122:300::/56",
+		"2001:db8:122:344::/64",
+		"2001:db8:122:344::/96",
+		"64:ff9b::/96",
+	} {
+		t.Run(prefix, func(t *testing.T) {
+			p := parseCIDR(t, prefix)
+			embedded := embedIPv4(p, v4)
+			got, ok := extractIPv4(p, embedded)
+			if !ok {
+				t.Fatalf("extractIPv4 returned !ok for %s + %s", prefix, embedded)
+			}
+			if !got.Equal(v4) {
+				t.Fatalf("round-trip mismatch: got %s, want %s", got, v4)
+			}
+		})
+	}
+}
+
+func TestExtractIPv4_RejectsNonZeroSuffix(t *testing.T) {
+	prefix := parseCIDR(t, "2001:db8:122:344::/64")
+	v4 := net.ParseIP("192.0.2.33").To4()
+	addr := embedIPv4(prefix, v4)
+	addr[15] = 0xff // suffix byte must be zero per RFC 6052 §2.2
+	if _, ok := extractIPv4(prefix, addr); ok {
+		t.Fatalf("extractIPv4 must refuse addresses with non-zero suffix")
+	}
+}
+
+func TestExtractIPv4_RejectsNonZeroUOctet(t *testing.T) {
+	prefix := parseCIDR(t, "2001:db8::/32")
+	v4 := net.ParseIP("192.0.2.33").To4()
+	addr := embedIPv4(prefix, v4)
+	addr[8] = 0xff // u octet must be zero
+	if _, ok := extractIPv4(prefix, addr); ok {
+		t.Fatalf("extractIPv4 must refuse addresses with non-zero u octet")
+	}
+}
+
+func TestExtractIPv4_AddressOutsidePrefix(t *testing.T) {
+	prefix := parseCIDR(t, "64:ff9b::/96")
+	if _, ok := extractIPv4(prefix, net.ParseIP("2001:db8::1")); ok {
+		t.Fatalf("extractIPv4 must return false for addresses outside the prefix")
+	}
+}
+
+func TestParseIP6ArpaName_RoundTrip(t *testing.T) {
+	// 192.0.2.33 embedded in 64:ff9b::/96 = 64:ff9b::c000:221.
+	qname := "1.2.2.0.0.0.0.c.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.b.9.f.f.4.6.0.0.ip6.arpa."
+	addr, ok := parseIP6ArpaName(qname)
+	if !ok {
+		t.Fatalf("parseIP6ArpaName(%q) returned !ok", qname)
+	}
+	if !addr.Equal(net.ParseIP("64:ff9b::c000:221")) {
+		t.Fatalf("parsed address = %s, want 64:ff9b::c000:221", addr)
+	}
+}
+
+func TestParseIP6ArpaName_BadShape(t *testing.T) {
+	cases := []string{
+		"foo.bar.",                               // wrong suffix
+		"1.2.3.ip6.arpa.",                        // too few labels
+		strings.Repeat("0.", 32) + "z.ip6.arpa.", // 33 labels
+		"x.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa.",  // bad nibble
+		"00.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa.", // multi-char label
+	}
+	for _, q := range cases {
+		t.Run(q, func(t *testing.T) {
+			if _, ok := parseIP6ArpaName(q); ok {
+				t.Fatalf("parseIP6ArpaName accepted malformed %q", q)
+			}
+		})
+	}
+}
+
+func TestInAddrArpa(t *testing.T) {
+	got := inAddrArpa(net.ParseIP("192.0.2.33"))
+	if got != "33.2.0.192.in-addr.arpa." {
+		t.Fatalf("inAddrArpa(192.0.2.33) = %q, want 33.2.0.192.in-addr.arpa.", got)
+	}
+	if inAddrArpa(net.ParseIP("::1")) != "" {
+		t.Fatalf("inAddrArpa must return \"\" for non-IPv4 input")
+	}
+}

--- a/registry.go
+++ b/registry.go
@@ -12,6 +12,7 @@ import (
 	"github.com/semihalev/sdns/middleware/blocklist"
 	"github.com/semihalev/sdns/middleware/cache"
 	"github.com/semihalev/sdns/middleware/chaos"
+	"github.com/semihalev/sdns/middleware/dns64"
 	"github.com/semihalev/sdns/middleware/dnstap"
 	"github.com/semihalev/sdns/middleware/edns"
 	"github.com/semihalev/sdns/middleware/failover"
@@ -41,6 +42,7 @@ func init() {
 	middleware.Register("blocklist", func(cfg *config.Config) middleware.Handler { return blocklist.New(cfg) })
 	middleware.Register("as112", func(cfg *config.Config) middleware.Handler { return as112.New(cfg) })
 	middleware.Register("kubernetes", func(cfg *config.Config) middleware.Handler { return kubernetes.New(cfg) })
+	middleware.Register("dns64", func(cfg *config.Config) middleware.Handler { return dns64.New(cfg) })
 	middleware.Register("cache", func(cfg *config.Config) middleware.Handler { return cache.New(cfg) })
 	middleware.Register("failover", func(cfg *config.Config) middleware.Handler { return failover.New(cfg) })
 	middleware.Register("resolver", func(cfg *config.Config) middleware.Handler { return resolver.New(cfg) })


### PR DESCRIPTION
## Summary

New `middleware/dns64` implementing RFC 6147 DNS64 — synthesises AAAA records from A records for IPv6-only clients reaching IPv4-only services. Closes the only open item in the README TODO.

Sits between `kubernetes` and `cache` in the chain. When a client AAAA query lacks a usable answer, DNS64 issues a secondary A-record lookup through the internal Queryer and embeds each IPv4 into a configured Pref64::/n per RFC 6052 §2.2. Internal sub-queries skip DNS64 entirely (`ClientOnly() == true`) so the resolver's own NS / CNAME chases never loop.

## RFC 6147 coverage

- **§5.1.2 / §5.1.3** RCODE dispatch — NOERROR-NODATA and other nonzero RCODEs trigger synthesis; NXDOMAIN passes through.
- **§5.1.4** AAAA exclusion (default `::ffff:0:0/96`) plus per-prefix IPv4 exclusion under the well-known `64:ff9b::/96` (default IANA Special-Purpose set, including 6to4 anycast `192.88.99.0/24`).
- **§5.1.5** CNAME / DNAME chains preserved on both synthesis and no-A-records paths.
- **§5.1.6** A response (rcode + Authority + chain) becomes the basis for the client reply when the A query is also empty / error.
- **§5.1.7** TTL = `min(A TTL, AAAA negative-cache TTL)`, 600 s ceiling when no SOA.
- **§5.2** Multiple Pref64 prefixes synthesise in parallel; well-known is the runtime default when none configured.
- **§5.3.1** PTR translation via CNAME to `in-addr.arpa` with best-effort chase appended.
- **§5.3.2** Authority / Additional pass through unmodified — only Answer-section AAAAs are synthesised.
- **§5.5** `CD=1` and `SERVFAIL` carrying any DNSSEC-failure EDE (codes 1, 2, 5–12, 27) bypass synthesis. AD is cleared on synthesised replies with EDE 4 (Forged Answer) attached when the upstream had AD=1.
- `RD=0` clients skip DNS64 entirely so non-recursive intent is honoured.

## Config

```toml
[dns64]
enabled = true
prefixes = [\"64:ff9b::/96\"]
client_networks = []
exclude_zones = []
exclude_aaaa_networks = [\"::ffff:0:0/96\"]
exclude_a_networks = [...]   # IANA Special-Purpose default applied at runtime when omitted under WKP
```

## Metrics

- \`dns64_synthesised_total\`
- \`dns64_ptr_translated_total\`
- \`dns64_passthrough_total{reason}\` — \`aaaa_present\`, \`nxdomain\`, \`dnssec_fail\`, \`no_rd\`, \`client_excluded\`, \`zone_excluded\`, \`cd_bit\`, \`internal\`, \`a_excluded\`
- \`dns64_a_lookup_failures_total{reason}\`

## Test plan

- [x] \`go test ./middleware/dns64/...\` — 50+ tests, RFC 6052 §2.4 vectors, every RFC 6147 path including DNSSEC EDE pass-through, RD=0, multi-prefix, PTR with operator + well-known prefixes, Authority/Additional pass-through, label-fragment exclude_zones trap.
- [x] \`go test ./...\` — full repo green.
- [x] \`gofmt -w .\` clean.
- [x] \`golangci-lint run\` — 0 issues.
- [x] Coverage: 92.9 % of statements in \`middleware/dns64\`.