### PR TITLE
fix(blocklist): block subdomains for bare blocklist domains (#478)

### DIFF
--- a/middleware/blocklist/blocklist.go
+++ b/middleware/blocklist/blocklist.go
@@ -15,7 +15,14 @@ import (
 )
 
 // BlockList type
-// Supports wildcard domains like "*.example.com" to block all subdomains.
+//
+// Matching semantics:
+//   - A bare domain (e.g. "example.com") blocks that exact name AND every
+//     subdomain ("sub.example.com", "a.b.example.com", ...). This mirrors
+//     how Pi-hole/AdGuard/dnsmasq treat a blocked domain and makes the
+//     popular plain-domain lists (e.g. hagezi *-onlydomains) work as users
+//     expect.
+//   - A "*.example.com" wildcard blocks subdomains only, not the apex.
 type BlockList struct {
 	mu sync.RWMutex
 
@@ -29,8 +36,8 @@ type BlockList struct {
 	nullroute  net.IP
 	null6route net.IP
 
-	m    map[string]bool // blocked domains (exact matches)
-	wild map[string]bool // wildcard domains suffix -> true (e.g., "example.com." from "*.example.com.")
+	m    map[string]bool // blocked domains; match the name itself and any subdomain
+	wild map[string]bool // wildcard domains suffix -> true (e.g., "example.com." from "*.example.com."); subdomains only
 	w    map[string]bool // whitelist
 
 	cfg *config.Config
@@ -304,18 +311,20 @@ func (b *BlockList) Exists(key string) bool {
 		return false
 	}
 
-	// Direct match - fastest path
+	// Direct match - fastest path (exact name)
 	if _, ok := b.m[key]; ok {
 		return true
 	}
 
-	// No wildcards to check
-	if len(b.wild) == 0 {
+	// Nothing that could match as a parent suffix.
+	if len(b.m) == 0 && len(b.wild) == 0 {
 		return false
 	}
 
-	// Check wildcard matches by walking up the domain hierarchy
-	// For "sub.example.com." check "example.com." and "com."
+	// Walk up the domain hierarchy. For "sub.example.com." check
+	// "example.com." then "com." against both maps: a bare domain in
+	// b.m covers all its subdomains, and a "*.domain" entry in b.wild
+	// covers subdomains only.
 	offset := 0
 	for {
 		idx := strings.IndexByte(key[offset:], '.')
@@ -326,6 +335,9 @@ func (b *BlockList) Exists(key string) bool {
 
 		if offset < len(key) {
 			suffix := key[offset:]
+			if _, ok := b.m[suffix]; ok {
+				return true
+			}
 			if _, ok := b.wild[suffix]; ok {
 				return true
 			}

--- a/middleware/blocklist/blocklist_test.go
+++ b/middleware/blocklist/blocklist_test.go
@@ -114,10 +114,12 @@ func Test_BlockList_Wildcard(t *testing.T) {
 	assert.False(t, blocklist.Exists("notblocked.com."))
 	assert.False(t, blocklist.Exists("subdomain.notblocked.com."))
 
-	// Test exact domain blocking
+	// A bare domain blocks the name itself and every subdomain
+	// (matches Pi-hole/AdGuard/dnsmasq; see issue #478).
 	blocklist.Set("exact.com.")
 	assert.True(t, blocklist.Exists("exact.com."))
-	assert.False(t, blocklist.Exists("subdomain.exact.com."))
+	assert.True(t, blocklist.Exists("subdomain.exact.com."))
+	assert.True(t, blocklist.Exists("deep.subdomain.exact.com."))
 
 	// Test multiple wildcard levels
 	blocklist.Set("*.subdomain.multi.com.")
@@ -149,6 +151,40 @@ func Test_BlockList_Wildcard(t *testing.T) {
 	// Test case insensitivity
 	assert.True(t, blocklist.Exists("TEST.BLOCKED.COM."))
 	assert.True(t, blocklist.Exists("Test.Blocked.Com."))
+}
+
+// Test_BlockList_Issue478 loads a plain-domain list (hagezi
+// "*-onlydomains.txt" style: bare domains, no "*." prefix) through the
+// on-disk blocklist path and verifies that subdomains — what devices
+// actually query — are blocked, not just the apex.
+func Test_BlockList_Issue478(t *testing.T) {
+	dir := filepath.Join(os.TempDir(), "sdns_temp_issue478")
+	assert.NoError(t, os.RemoveAll(dir))
+	assert.NoError(t, os.MkdirAll(dir, 0750))
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	onlyDomains := "# Syntax: Domains (without subdomains)\nmiui.net\nkuyun.com\n"
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "xiaomi-onlydomains.txt"), []byte(onlyDomains), 0600))
+
+	cfg := new(config.Config)
+	cfg.Nullroute = "0.0.0.0"
+	cfg.Nullroutev6 = "::0"
+	cfg.BlockListDir = dir
+
+	blocklist := New(cfg)
+
+	// Apex names are blocked.
+	assert.True(t, blocklist.Exists("miui.net."))
+	assert.True(t, blocklist.Exists("kuyun.com."))
+
+	// Subdomains are blocked too — the actual fix for #478.
+	assert.True(t, blocklist.Exists("tracking.miui.net."))
+	assert.True(t, blocklist.Exists("api.kuyun.com."))
+	assert.True(t, blocklist.Exists("a.b.kuyun.com."))
+
+	// Unrelated names and sibling apexes stay unblocked.
+	assert.False(t, blocklist.Exists("notblocked.com."))
+	assert.False(t, blocklist.Exists("miui.net.evil.com."))
 }
 
 func Test_BlockList_FastPath(t *testing.T) {


### PR DESCRIPTION
Bare domains were stored as exact matches only, so an entry like "miui.net" blocked the apex but not "tracking.miui.net" — the names devices actually query. Popular plain-domain lists (hagezi *-onlydomains, OISD, etc.) therefore appeared to load fine yet let most traffic through.

Exists now walks the domain hierarchy against the exact map too, so a bare domain covers the name and every subdomain, matching how Pi-hole/AdGuard/dnsmasq behave. "*.domain" wildcards keep their subdomain-only semantics. Matching is done in the lookup rather than by duplicating entries into the wildcard map, so memory is unchanged for large lists.

Fixes #478