### PR TITLE
feat(ecs): opt-in EDNS Client Subnet forwarding (Stage 1, #417)

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -17,7 +17,7 @@ import (
 	"github.com/semihalev/zlog/v2"
 )
 
-const configver = "1.6.7"
+const configver = "1.7.0"
 
 // Config type.
 type Config struct {
@@ -88,6 +88,15 @@ type Config struct {
 	// records into AAAA records embedded in a configured IPv6
 	// prefix, so an IPv6-only client can reach IPv4-only services.
 	DNS64 DNS64Config `toml:"dns64"`
+
+	// ECS (EDNS Client Subnet, RFC 7871) policy. Default-disabled
+	// per §11 privacy guidance: the resolver strips client ECS on
+	// the way out unless the operator opts in via [ecs].enabled.
+	// Stage 1 of the feature uses Enabled / ForwardV4Max /
+	// ForwardV6Max / ClientNetworks for upstream forwarding; the
+	// remaining fields ride along for the Stage 2 cache changes
+	// so the on-disk schema only bumps once.
+	ECS ECSConfig `toml:"ecs"`
 
 	Plugins map[string]Plugin
 
@@ -198,6 +207,34 @@ type DNS64Config struct {
 	ExcludeZones        []string `toml:"exclude_zones"`
 	ExcludeANetworks    []string `toml:"exclude_a_networks"`
 	ExcludeAAAANetworks []string `toml:"exclude_aaaa_networks"`
+}
+
+// ECSConfig holds the EDNS Client Subnet middleware configuration
+// (RFC 7871). Strictly opt-in: when Enabled is false, the resolver
+// strips every client-supplied ECS option before forwarding upstream,
+// matching the §11 privacy stance and SDNS's historical behaviour.
+//
+// When Enabled is true, ForwardV4Max and ForwardV6Max cap the
+// source-prefix length we'll forward — narrower (more specific)
+// client prefixes get clamped down. Defaults are /24 and /56,
+// matching common operator practice.
+//
+// ClientNetworks restricts forwarding to known clients (corporate
+// networks, internal load balancers, CDN edges); empty means every
+// eligible client.
+//
+// CacheLimitTTL, MinScopeV4, and MinScopeV6 control how scoped
+// answers are stored (Stage 2). They live here so the on-disk
+// schema only bumps once across the rollout, even though Stage 1
+// doesn't consume them yet.
+type ECSConfig struct {
+	Enabled        bool     `toml:"enabled"`
+	ForwardV4Max   uint8    `toml:"forward_v4"`
+	ForwardV6Max   uint8    `toml:"forward_v6"`
+	ClientNetworks []string `toml:"client_networks"`
+	CacheLimitTTL  Duration `toml:"cache_limit_ttl"`
+	MinScopeV4     uint8    `toml:"min_scope_v4"`
+	MinScopeV6     uint8    `toml:"min_scope_v6"`
 }
 
 // Plugin type.
@@ -728,6 +765,57 @@ exclude_a_networks = [
     "240.0.0.0/4",
     "255.255.255.255/32",
 ]
+
+# ============================
+# EDNS Client Subnet (RFC 7871)
+# ============================
+
+# ECS lets a recursive resolver pass a slice of the client's IP to
+# the authoritative server so geo-aware services (CDN, load
+# balancers) can return locality-appropriate answers. SDNS strips
+# ECS by default per RFC 7871 §11 privacy guidance; this section is
+# strictly opt-in.
+#
+# Stage 1 of the feature (this release) ships upstream forwarding.
+# Stage 2 (subsequent release) will partition the cache so a
+# geo-tailored answer for one client subnet isn't served to a
+# client in a different subnet (cache pollution). The cache_limit
+# and min_scope knobs below already live in the schema so the
+# Stage 2 upgrade doesn't bump configver again.
+[ecs]
+
+# Master switch. When false (default) every option below is ignored
+# and SDNS strips client ECS before forwarding. Leave off unless
+# downstream geo-routing actually benefits from per-subnet answers.
+enabled = false
+
+# Maximum source-prefix length forwarded upstream. Clients that
+# send narrower (more specific) prefixes get clamped to this value
+# so the resolver doesn't leak more locality than the operator
+# intended. /24 for IPv4 and /56 for IPv6 match common practice.
+forward_v4 = 24
+forward_v6 = 56
+
+# CIDRs eligible for ECS forwarding. Empty (the default) means
+# every client whose query reaches this resolver. Populate to scope
+# forwarding to known internal sources (load balancers, CDN edges,
+# corporate networks) and strip ECS for the open internet.
+client_networks = []
+
+# Stage 2 (cache) knobs — declared here so the config schema only
+# bumps once. They are no-ops in this release.
+
+# Ceiling on the TTL of any scoped (per-subnet) cache entry. Geo
+# answers tend to go stale faster than the resolver's general TTL
+# would suggest; "5m" is a defensible default.
+cache_limit_ttl = "5m"
+
+# Refuse to key the cache on scopes narrower than these. Caps
+# worst-case cardinality so a busy resolver with diverse clients
+# can't blow up the cache budget on per-client entries. Defaults
+# match the forwarding ceilings.
+min_scope_v4 = 24
+min_scope_v6 = 56
 
 # ============================
 # Plugins

--- a/contrib/linux/sdns.conf
+++ b/contrib/linux/sdns.conf
@@ -1,6 +1,6 @@
 
 # Configuration file version (not SDNS version)
-version = "1.6.7"
+version = "1.7.0"
 
 # ============================
 # Basic Server Configuration
@@ -503,6 +503,57 @@ exclude_a_networks = [
     "240.0.0.0/4",
     "255.255.255.255/32",
 ]
+
+# ============================
+# EDNS Client Subnet (RFC 7871)
+# ============================
+
+# ECS lets a recursive resolver pass a slice of the client's IP to
+# the authoritative server so geo-aware services (CDN, load
+# balancers) can return locality-appropriate answers. SDNS strips
+# ECS by default per RFC 7871 §11 privacy guidance; this section is
+# strictly opt-in.
+#
+# Stage 1 of the feature (this release) ships upstream forwarding.
+# Stage 2 (subsequent release) will partition the cache so a
+# geo-tailored answer for one client subnet isn't served to a
+# client in a different subnet (cache pollution). The cache_limit
+# and min_scope knobs below already live in the schema so the
+# Stage 2 upgrade doesn't bump configver again.
+[ecs]
+
+# Master switch. When false (default) every option below is ignored
+# and SDNS strips client ECS before forwarding. Leave off unless
+# downstream geo-routing actually benefits from per-subnet answers.
+enabled = false
+
+# Maximum source-prefix length forwarded upstream. Clients that
+# send narrower (more specific) prefixes get clamped to this value
+# so the resolver doesn't leak more locality than the operator
+# intended. /24 for IPv4 and /56 for IPv6 match common practice.
+forward_v4 = 24
+forward_v6 = 56
+
+# CIDRs eligible for ECS forwarding. Empty (the default) means
+# every client whose query reaches this resolver. Populate to scope
+# forwarding to known internal sources (load balancers, CDN edges,
+# corporate networks) and strip ECS for the open internet.
+client_networks = []
+
+# Stage 2 (cache) knobs — declared here so the config schema only
+# bumps once. They are no-ops in this release.
+
+# Ceiling on the TTL of any scoped (per-subnet) cache entry. Geo
+# answers tend to go stale faster than the resolver's general TTL
+# would suggest; "5m" is a defensible default.
+cache_limit_ttl = "5m"
+
+# Refuse to key the cache on scopes narrower than these. Caps
+# worst-case cardinality so a busy resolver with diverse clients
+# can't blow up the cache budget on per-client entries. Defaults
+# match the forwarding ceilings.
+min_scope_v4 = 24
+min_scope_v6 = 56
 
 # ============================
 # Plugins

--- a/internal/dnsutil/helpers.go
+++ b/internal/dnsutil/helpers.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"net/netip"
 
 	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/ecs"
 )
 
 // SetRcode returns message specified with rcode.
@@ -27,12 +29,19 @@ func SetRcode(req *dns.Msg, rcode int, do bool) *dns.Msg {
 // SetEdns0 returns replaced or new opt rr and if request has do.
 //
 // The function inspects the client's OPT record to harvest NSID / COOKIE
-// signalling, strips every option before forwarding (ECS in particular,
-// per RFC 7871 privacy guidance), and normalises the UDP size. Inspection
-// uses typed pointer assertions so we avoid the allocating option.String()
-// path, and the stripping reuses opt.Option's backing storage via opt.Option = nil
-// rather than allocating an empty slice.
-func SetEdns0(req *dns.Msg) (*dns.OPT, int, string, bool, bool) {
+// signalling, strips every option before forwarding (RFC 7871 §11 privacy
+// guidance is the default), and normalises the UDP size. Inspection uses
+// typed pointer assertions so we avoid the allocating option.String()
+// path, and the stripping reuses opt.Option's backing storage via
+// opt.Option = nil rather than allocating an empty slice.
+//
+// When `policy` is non-nil, enabled, and allows the supplied client, the
+// client's EDNS Client Subnet option (RFC 7871) is preserved on the
+// outgoing OPT instead of stripped — clamped to the policy's source-
+// prefix ceiling. Every other client-supplied option is still dropped.
+// A nil policy or an empty client address means strip everything, which
+// matches SDNS's historical behaviour and the privacy-first default.
+func SetEdns0(req *dns.Msg, policy *ecs.Policy, client netip.Addr) (*dns.OPT, int, string, bool, bool) {
 	do, nsid := false, false
 	opt := req.IsEdns0()
 	size := DefaultMsgSize
@@ -48,6 +57,7 @@ func SetEdns0(req *dns.Msg) (*dns.OPT, int, string, bool, bool) {
 		}
 		opt.SetUDPSize(DefaultMsgSize)
 
+		var clientSubnet *dns.EDNS0_SUBNET
 		for _, option := range opt.Option {
 			switch v := option.(type) {
 			case *dns.EDNS0_COOKIE:
@@ -57,8 +67,11 @@ func SetEdns0(req *dns.Msg) (*dns.OPT, int, string, bool, bool) {
 				}
 			case *dns.EDNS0_NSID:
 				nsid = true
-				// RFC 7871 EDNS Client Subnet is intentionally stripped
-				// for privacy; any other unknown options are also dropped.
+			case *dns.EDNS0_SUBNET:
+				// Capture for possible forwarding after the loop;
+				// dropped along with every other option if policy
+				// is nil / disabled / doesn't allow this client.
+				clientSubnet = v
 			}
 		}
 
@@ -66,6 +79,17 @@ func SetEdns0(req *dns.Msg) (*dns.OPT, int, string, bool, bool) {
 		// Nil-ing is cheaper than allocating a new empty slice and lets
 		// the old backing array be GC'd with the request.
 		opt.Option = nil
+
+		// If the policy allows ECS forwarding for this client, put a
+		// clamped copy of the client's option back on. Clamp() handles
+		// source-prefix ceiling, address truncation, and family sanity;
+		// a nil return means the option was unusable and we keep the
+		// strip.
+		if policy.Allows(client) && clientSubnet != nil {
+			if forwarded := policy.Clamp(clientSubnet); forwarded != nil {
+				opt.Option = append(opt.Option, forwarded)
+			}
+		}
 
 		if opt.Version() != 0 {
 			return opt, size, cookie, nsid, false

--- a/internal/dnsutil/helpers_test.go
+++ b/internal/dnsutil/helpers_test.go
@@ -1,9 +1,12 @@
 package dnsutil
 
 import (
+	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/ecs"
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/stretchr/testify/assert"
 )
@@ -147,7 +150,9 @@ func TestSetEdns0(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			opt, size, cookie, nsid, origDo := SetEdns0(tt.req)
+			// Nil policy + zero addr exercises the default-strip path,
+			// matching the pre-7871 contract this test was written for.
+			opt, size, cookie, nsid, origDo := SetEdns0(tt.req, nil, netip.Addr{})
 
 			assert.NotNil(t, opt)
 			assert.Equal(t, tt.expectedSize, size)
@@ -159,6 +164,112 @@ func TestSetEdns0(t *testing.T) {
 			reqOpt := tt.req.IsEdns0()
 			assert.NotNil(t, reqOpt)
 		})
+	}
+}
+
+// reqWithECS builds a query whose OPT carries one EDNS0_SUBNET.
+func reqWithECS(family uint16, src uint8, addr string) *dns.Msg {
+	req := new(dns.Msg)
+	req.SetQuestion("example.com.", dns.TypeA)
+	opt := new(dns.OPT)
+	opt.Hdr.Name = "."
+	opt.Hdr.Rrtype = dns.TypeOPT
+	opt.SetUDPSize(4096)
+	parsed := net.ParseIP(addr)
+	if family == 1 {
+		parsed = parsed.To4()
+	}
+	opt.Option = []dns.EDNS0{&dns.EDNS0_SUBNET{
+		Code: dns.EDNS0SUBNET, Family: family,
+		SourceNetmask: src, SourceScope: 0,
+		Address: parsed,
+	}}
+	req.Extra = []dns.RR{opt}
+	return req
+}
+
+// findECS returns the first EDNS0_SUBNET option on opt, or nil.
+func findECS(opt *dns.OPT) *dns.EDNS0_SUBNET {
+	for _, o := range opt.Option {
+		if v, ok := o.(*dns.EDNS0_SUBNET); ok {
+			return v
+		}
+	}
+	return nil
+}
+
+func TestSetEdns0_StripsECSByDefault(t *testing.T) {
+	// Regression: the historical contract (RFC 7871 §11) is to strip
+	// every option. Nil policy must keep that behaviour.
+	req := reqWithECS(1, 32, "203.0.113.5")
+	opt, _, _, _, _ := SetEdns0(req, nil, netip.Addr{})
+	if got := findECS(opt); got != nil {
+		t.Errorf("nil policy should strip ECS, got %+v", got)
+	}
+}
+
+func TestSetEdns0_StripsECSWhenPolicyDisabled(t *testing.T) {
+	req := reqWithECS(1, 24, "203.0.113.0")
+	policy := &ecs.Policy{Enabled: false, ForwardV4Max: 24}
+	client := netip.MustParseAddr("203.0.113.5")
+	opt, _, _, _, _ := SetEdns0(req, policy, client)
+	if got := findECS(opt); got != nil {
+		t.Errorf("disabled policy should strip ECS, got %+v", got)
+	}
+}
+
+func TestSetEdns0_ForwardsECSClampedToCeiling(t *testing.T) {
+	// Client sent /28 (too narrow); policy ceiling is /24. The
+	// outgoing OPT must carry a /24 with the host bits zeroed.
+	req := reqWithECS(1, 28, "203.0.113.42")
+	policy := &ecs.Policy{Enabled: true, ForwardV4Max: 24}
+	client := netip.MustParseAddr("203.0.113.42")
+	opt, _, _, _, _ := SetEdns0(req, policy, client)
+	got := findECS(opt)
+	if got == nil {
+		t.Fatal("expected ECS to be forwarded")
+	}
+	if got.SourceNetmask != 24 {
+		t.Errorf("source netmask = %d, want 24", got.SourceNetmask)
+	}
+	if got.Address.String() != "203.0.113.0" {
+		t.Errorf("address = %s, want 203.0.113.0 (truncated)", got.Address)
+	}
+	if got.SourceScope != 0 {
+		t.Errorf("outgoing scope must be 0, got %d", got.SourceScope)
+	}
+}
+
+func TestSetEdns0_DropsECSWhenClientNotInAllowList(t *testing.T) {
+	req := reqWithECS(1, 24, "203.0.113.0")
+	policy := &ecs.Policy{
+		Enabled:        true,
+		ForwardV4Max:   24,
+		ClientNetworks: []netip.Prefix{netip.MustParsePrefix("10.0.0.0/8")},
+	}
+	client := netip.MustParseAddr("203.0.113.5") // outside the allow-list
+	opt, _, _, _, _ := SetEdns0(req, policy, client)
+	if got := findECS(opt); got != nil {
+		t.Errorf("client outside allow-list should not get ECS forwarded, got %+v", got)
+	}
+}
+
+func TestSetEdns0_NoECSInRequestNoForwarding(t *testing.T) {
+	// Client didn't send ECS at all — Stage 1 is forward-only,
+	// not synthesise, so the outgoing OPT must have no ECS option.
+	req := new(dns.Msg)
+	req.SetQuestion("example.com.", dns.TypeA)
+	opt := new(dns.OPT)
+	opt.Hdr.Name = "."
+	opt.Hdr.Rrtype = dns.TypeOPT
+	opt.SetUDPSize(4096)
+	req.Extra = []dns.RR{opt}
+
+	policy := &ecs.Policy{Enabled: true, ForwardV4Max: 24}
+	client := netip.MustParseAddr("203.0.113.5")
+	out, _, _, _, _ := SetEdns0(req, policy, client)
+	if got := findECS(out); got != nil {
+		t.Errorf("no client ECS should mean no forwarded ECS, got %+v", got)
 	}
 }
 

--- a/internal/ecs/policy.go
+++ b/internal/ecs/policy.go
@@ -1,0 +1,191 @@
+// Package ecs holds the policy and helpers for EDNS Client Subnet
+// handling (RFC 7871). The package is deliberately tiny and free of
+// DNS handlers, goroutines, or other side effects so middleware/edns
+// (forwarding side) and middleware/cache (key-shape side) can both
+// import it without bringing each other into their dependency graph.
+//
+// RFC 7871 is opt-in by design — SDNS strips ECS by default to
+// honour §11's privacy guidance, and the operator must enable
+// forwarding explicitly via the [ecs] config block.
+package ecs
+
+import (
+	"net"
+	"net/netip"
+
+	"github.com/miekg/dns"
+)
+
+// Policy captures the operator's decisions about how SDNS handles
+// EDNS Client Subnet on inbound and outbound traffic. A nil *Policy
+// represents the pre-7871 default: strip ECS on the way out, ignore
+// SCOPE on the way back, do not key the cache on subnet. Methods on
+// Policy tolerate a nil receiver, so the strip-only default doesn't
+// need a sentinel.
+type Policy struct {
+	// Enabled toggles ECS forwarding upstream. When false every
+	// other field is ignored. Default false (RFC 7871 §11).
+	Enabled bool
+
+	// ForwardV4Max / ForwardV6Max are the ceilings on the
+	// source-prefix-length we'll forward upstream. Clients that
+	// send a narrower (more specific) prefix get clamped to these
+	// values — narrower prefixes leak more information about the
+	// client than the operator probably intends. Sensible defaults:
+	// /24 for IPv4 and /56 for IPv6, matching common practice.
+	ForwardV4Max uint8
+	ForwardV6Max uint8
+
+	// ClientNetworks restricts which clients are eligible for ECS
+	// forwarding. Empty == every client is eligible. A non-empty
+	// list lets an operator forward ECS only for known internal
+	// load balancers or CDN edges while stripping for the open
+	// internet.
+	ClientNetworks []netip.Prefix
+
+	// MinScopeV4 / MinScopeV6 are the Stage-2 cache safety knobs:
+	// when caching a scoped answer, refuse to key on a prefix
+	// narrower than this. Caps cache cardinality so a busy
+	// resolver with diverse clients can't blow up the cache
+	// budget on per-client scopes. Defaults match the forwarding
+	// ceilings.
+	MinScopeV4 uint8
+	MinScopeV6 uint8
+}
+
+// Allows reports whether `client` is eligible for ECS forwarding
+// under this policy. A nil or disabled policy never allows; otherwise
+// an empty ClientNetworks means everyone, and a populated list means
+// the client's address must fall inside one of the configured
+// prefixes.
+func (p *Policy) Allows(client netip.Addr) bool {
+	if p == nil || !p.Enabled {
+		return false
+	}
+	if !client.IsValid() {
+		return false
+	}
+	if len(p.ClientNetworks) == 0 {
+		return true
+	}
+	for _, n := range p.ClientNetworks {
+		if n.Contains(client) {
+			return true
+		}
+	}
+	return false
+}
+
+// Clamp returns a normalised EDNS0_SUBNET safe to forward upstream
+// under this policy, or nil when the input is unusable (no address,
+// unsupported family). The returned option is always a fresh value
+// — the caller can attach it to an outgoing OPT without aliasing
+// the inbound request's storage.
+//
+// Source-prefix is capped to ForwardV4Max / ForwardV6Max, then the
+// address is truncated to that many bits so we don't accidentally
+// leak the host portion if a client sent a /32 address with a /16
+// netmask (some implementations do that).
+func (p *Policy) Clamp(in *dns.EDNS0_SUBNET) *dns.EDNS0_SUBNET {
+	if p == nil || in == nil || in.Address == nil {
+		return nil
+	}
+
+	addr, ok := ipToAddr(in.Address)
+	if !ok {
+		return nil
+	}
+
+	var (
+		family uint16
+		maxBit uint8
+	)
+	switch in.Family {
+	case 1: // IPv4
+		if !addr.Is4() {
+			return nil
+		}
+		family, maxBit = 1, p.ForwardV4Max
+	case 2: // IPv6
+		if !addr.Is6() {
+			return nil
+		}
+		family, maxBit = 2, p.ForwardV6Max
+	default:
+		return nil
+	}
+
+	source := min(in.SourceNetmask, maxBit)
+
+	// Truncate the address itself to `source` bits so the wire form
+	// matches what we're claiming the scope is. Without this, an
+	// upstream that hashes (Address, SourceNetmask) sees inconsistent
+	// state on every clamped request.
+	prefix, err := addr.Prefix(int(source))
+	if err != nil {
+		return nil
+	}
+
+	return &dns.EDNS0_SUBNET{
+		Code:          dns.EDNS0SUBNET,
+		Family:        family,
+		SourceNetmask: source,
+		SourceScope:   0, // queries always send SCOPE = 0
+		Address:       prefix.Addr().AsSlice(),
+	}
+}
+
+// ClampScope normalises an authoritative server's response SCOPE for
+// cache-key purposes. Two RFC 7871 rules apply:
+//
+//   - §7.1.2: a server MUST NOT return SCOPE > SOURCE. If it does
+//     (privacy violation), clamp down to SOURCE so the misbehaving
+//     authority can't widen our cache key past what we forwarded.
+//
+//   - Stage-2 cardinality cap: scopes narrower than MinScopeV4 /
+//     MinScopeV6 are widened to the minimum, capping the worst-case
+//     entry count per name.
+//
+// Used by middleware/cache when storing a scoped answer in Stage 2.
+// A nil *Policy returns the input unchanged.
+func (p *Policy) ClampScope(scope, source netip.Prefix) netip.Prefix {
+	if p == nil || !scope.IsValid() {
+		return scope
+	}
+
+	bits := scope.Bits()
+	if source.IsValid() && bits > source.Bits() {
+		bits = source.Bits()
+	}
+
+	// bits is always in [0, 128] here — netip.Prefix.Bits() never
+	// returns negative — so the int→uint8 conversion below is safe.
+	switch {
+	case scope.Addr().Is4():
+		if uint8(bits) > p.MinScopeV4 { //nolint:gosec // bits ≤ 32 for v4
+			bits = int(p.MinScopeV4)
+		}
+	case scope.Addr().Is6():
+		if uint8(bits) > p.MinScopeV6 { //nolint:gosec // bits ≤ 128, fits uint8
+			bits = int(p.MinScopeV6)
+		}
+	}
+
+	clamped, err := scope.Addr().Prefix(bits)
+	if err != nil {
+		return scope
+	}
+	return clamped
+}
+
+// ipToAddr converts a miekg net.IP into a netip.Addr, normalising
+// the 4-in-16 (::ffff:a.b.c.d) form to a 4-byte IPv4 address so the
+// rest of the package can rely on Is4() / Is6() returning what the
+// caller expects.
+func ipToAddr(ip net.IP) (netip.Addr, bool) {
+	if v4 := ip.To4(); v4 != nil {
+		a, ok := netip.AddrFromSlice(v4)
+		return a, ok
+	}
+	return netip.AddrFromSlice(ip)
+}

--- a/internal/ecs/policy_test.go
+++ b/internal/ecs/policy_test.go
@@ -1,0 +1,213 @@
+package ecs
+
+import (
+	"net"
+	"net/netip"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func mustPrefix(t *testing.T, s string) netip.Prefix {
+	t.Helper()
+	p, err := netip.ParsePrefix(s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return p
+}
+
+func mustAddr(t *testing.T, s string) netip.Addr {
+	t.Helper()
+	a, err := netip.ParseAddr(s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return a
+}
+
+func TestPolicy_Allows_NilOrDisabled(t *testing.T) {
+	client := mustAddr(t, "203.0.113.5")
+
+	if (*Policy)(nil).Allows(client) {
+		t.Errorf("nil policy should never allow")
+	}
+	if (&Policy{Enabled: false}).Allows(client) {
+		t.Errorf("disabled policy should never allow")
+	}
+}
+
+func TestPolicy_Allows_EnabledNoNetworks(t *testing.T) {
+	p := &Policy{Enabled: true}
+	for _, addr := range []string{"203.0.113.5", "2001:db8::1"} {
+		if !p.Allows(mustAddr(t, addr)) {
+			t.Errorf("enabled+empty ClientNetworks should allow %s", addr)
+		}
+	}
+}
+
+func TestPolicy_Allows_ClientNetworksGate(t *testing.T) {
+	p := &Policy{
+		Enabled: true,
+		ClientNetworks: []netip.Prefix{
+			mustPrefix(t, "10.0.0.0/8"),
+			mustPrefix(t, "2001:db8::/32"),
+		},
+	}
+	allowed := []string{"10.1.2.3", "2001:db8:0:1::5"}
+	denied := []string{"203.0.113.5", "192.168.1.1", "2001:db9::1"}
+	for _, addr := range allowed {
+		if !p.Allows(mustAddr(t, addr)) {
+			t.Errorf("expected allow for %s", addr)
+		}
+	}
+	for _, addr := range denied {
+		if p.Allows(mustAddr(t, addr)) {
+			t.Errorf("expected deny for %s", addr)
+		}
+	}
+}
+
+func TestPolicy_Clamp_NilPolicyOrInput(t *testing.T) {
+	in := &dns.EDNS0_SUBNET{
+		Family: 1, SourceNetmask: 24, Address: net.ParseIP("203.0.113.0").To4(),
+	}
+	if got := (*Policy)(nil).Clamp(in); got != nil {
+		t.Errorf("nil policy should return nil, got %+v", got)
+	}
+	p := &Policy{Enabled: true, ForwardV4Max: 24}
+	if got := p.Clamp(nil); got != nil {
+		t.Errorf("nil input should return nil, got %+v", got)
+	}
+	if got := p.Clamp(&dns.EDNS0_SUBNET{Family: 1, SourceNetmask: 24}); got != nil {
+		t.Errorf("input with no address should return nil, got %+v", got)
+	}
+}
+
+func TestPolicy_Clamp_ClampsV4PrefixAndAddress(t *testing.T) {
+	p := &Policy{Enabled: true, ForwardV4Max: 24}
+	in := &dns.EDNS0_SUBNET{
+		Family:        1,
+		SourceNetmask: 32, // narrower than ceiling
+		Address:       net.ParseIP("203.0.113.42").To4(),
+	}
+	out := p.Clamp(in)
+	if out == nil {
+		t.Fatal("expected clamped output, got nil")
+	}
+	if out.SourceNetmask != 24 {
+		t.Errorf("source netmask = %d, want 24", out.SourceNetmask)
+	}
+	// Address must be truncated to /24 so the wire form matches what
+	// we're claiming the source is — without truncation, an upstream
+	// that hashes (Address, SourceNetmask) sees inconsistent state.
+	if got := out.Address.String(); got != "203.0.113.0" {
+		t.Errorf("address = %s, want 203.0.113.0 (host bits zeroed)", got)
+	}
+	if out.SourceScope != 0 {
+		t.Errorf("source scope on outgoing query must be 0, got %d", out.SourceScope)
+	}
+	if out.Family != 1 {
+		t.Errorf("family = %d, want 1", out.Family)
+	}
+}
+
+func TestPolicy_Clamp_PassesNarrowerThanCeiling(t *testing.T) {
+	// Client already sent /20 — the ceiling (/24) shouldn't widen.
+	p := &Policy{Enabled: true, ForwardV4Max: 24}
+	in := &dns.EDNS0_SUBNET{
+		Family:        1,
+		SourceNetmask: 20,
+		Address:       net.ParseIP("203.0.96.0").To4(),
+	}
+	out := p.Clamp(in)
+	if out == nil {
+		t.Fatal("expected clamped output")
+	}
+	if out.SourceNetmask != 20 {
+		t.Errorf("source netmask = %d, want 20 (untouched, narrower than ceiling)", out.SourceNetmask)
+	}
+}
+
+func TestPolicy_Clamp_V6Family(t *testing.T) {
+	p := &Policy{Enabled: true, ForwardV6Max: 56}
+	in := &dns.EDNS0_SUBNET{
+		Family:        2,
+		SourceNetmask: 64, // narrower than ceiling
+		Address:       net.ParseIP("2001:db8:1:2:3:4:5:6"),
+	}
+	out := p.Clamp(in)
+	if out == nil {
+		t.Fatal("expected clamped output")
+	}
+	if out.SourceNetmask != 56 {
+		t.Errorf("source netmask = %d, want 56", out.SourceNetmask)
+	}
+	if out.Family != 2 {
+		t.Errorf("family = %d, want 2", out.Family)
+	}
+}
+
+func TestPolicy_Clamp_FamilyMismatchRejected(t *testing.T) {
+	p := &Policy{Enabled: true, ForwardV4Max: 24, ForwardV6Max: 56}
+	// Family claims IPv4 but address is IPv6.
+	in := &dns.EDNS0_SUBNET{
+		Family: 1, SourceNetmask: 24, Address: net.ParseIP("2001:db8::1"),
+	}
+	if got := p.Clamp(in); got != nil {
+		t.Errorf("family/address mismatch should be rejected, got %+v", got)
+	}
+}
+
+func TestPolicy_ClampScope_NilOrInvalid(t *testing.T) {
+	if got := (*Policy)(nil).ClampScope(mustPrefix(t, "203.0.113.0/24"), netip.Prefix{}); got.Bits() != 24 {
+		t.Errorf("nil policy should pass through, got %s", got)
+	}
+	p := &Policy{MinScopeV4: 24, MinScopeV6: 56}
+	if got := p.ClampScope(netip.Prefix{}, netip.Prefix{}); got.IsValid() {
+		t.Errorf("invalid input should pass through invalid, got %s", got)
+	}
+}
+
+func TestPolicy_ClampScope_RejectsScopeNarrowerThanSource(t *testing.T) {
+	// RFC 7871 §7.1.2: SCOPE > SOURCE is a privacy violation; widen
+	// to source so the misbehaving authority can't push the cache
+	// key past what we forwarded.
+	p := &Policy{MinScopeV4: 24}
+	scope := mustPrefix(t, "203.0.113.42/30") // narrower than what we forwarded
+	source := mustPrefix(t, "203.0.113.0/24")
+	got := p.ClampScope(scope, source)
+	if got.Bits() != 24 {
+		t.Errorf("scope/30 with source/24 should clamp to /24, got %s", got)
+	}
+}
+
+func TestPolicy_ClampScope_EnforcesMinScope(t *testing.T) {
+	p := &Policy{MinScopeV4: 24}
+	scope := mustPrefix(t, "203.0.113.0/28")
+	source := mustPrefix(t, "203.0.113.0/24")
+	got := p.ClampScope(scope, source)
+	if got.Bits() != 24 {
+		t.Errorf("scope/28 with min/24 should widen to /24, got %s", got)
+	}
+}
+
+func TestPolicy_ClampScope_PassesAcceptableScope(t *testing.T) {
+	p := &Policy{MinScopeV4: 24, MinScopeV6: 56}
+	for _, in := range []string{"203.0.113.0/24", "203.0.0.0/20", "2001:db8::/48"} {
+		got := p.ClampScope(mustPrefix(t, in), netip.Prefix{})
+		if got.String() != in {
+			t.Errorf("acceptable scope %s should pass through, got %s", in, got)
+		}
+	}
+}
+
+func TestIpToAddr_V4Mapped(t *testing.T) {
+	// ::ffff:203.0.113.5 is the IPv4-mapped IPv6 form of the same v4
+	// address. Without normalisation the netip.Addr would report
+	// Is4() == false and downstream family checks would misbehave.
+	a, ok := ipToAddr(net.ParseIP("203.0.113.5"))
+	if !ok || !a.Is4() {
+		t.Fatalf("expected Is4() for v4 input, got ok=%v Is4=%v", ok, a.Is4())
+	}
+}

--- a/internal/ecs/scope.go
+++ b/internal/ecs/scope.go
@@ -1,0 +1,69 @@
+package ecs
+
+import (
+	"net/netip"
+
+	"github.com/miekg/dns"
+)
+
+// ReadResponseScope extracts the SCOPE prefix from an authoritative
+// server's response OPT, expressed as a netip.Prefix the cache can
+// key on. Returns (invalid, false) when:
+//
+//   - the response has no OPT, or
+//   - the OPT has no EDNS0_SUBNET, or
+//   - the option's Address is missing / unparseable, or
+//   - SourceScope == 0 (RFC 7871 §6: "the answer is suitable for the
+//     entire address space", i.e. cache shared-key, not scoped).
+//
+// The returned prefix is built from the option's Address truncated
+// to SourceScope bits — that's the slice of IP space the authority
+// is asserting the answer covers. The caller (cache insert path)
+// can hand that prefix to Policy.ClampScope before keying.
+//
+// Used by middleware/cache in Stage 2; lives here so middleware/edns
+// and middleware/cache share one definition.
+func ReadResponseScope(resp *dns.Msg) (netip.Prefix, bool) {
+	if resp == nil {
+		return netip.Prefix{}, false
+	}
+	opt := resp.IsEdns0()
+	if opt == nil {
+		return netip.Prefix{}, false
+	}
+	for _, o := range opt.Option {
+		sub, ok := o.(*dns.EDNS0_SUBNET)
+		if !ok {
+			continue
+		}
+		if sub.SourceScope == 0 {
+			// "Global" answer per §6 — no scoping wanted.
+			return netip.Prefix{}, false
+		}
+		addr, ok := ipToAddr(sub.Address)
+		if !ok {
+			return netip.Prefix{}, false
+		}
+		// Family sanity: a response that says Family=1 with a 16-byte
+		// non-mapped address (or vice versa) is malformed; refuse to
+		// build a scope from it.
+		switch sub.Family {
+		case 1:
+			if !addr.Is4() {
+				return netip.Prefix{}, false
+			}
+		case 2:
+			if !addr.Is6() {
+				return netip.Prefix{}, false
+			}
+		default:
+			return netip.Prefix{}, false
+		}
+		prefix, err := addr.Prefix(int(sub.SourceScope))
+		if err != nil {
+			return netip.Prefix{}, false
+		}
+		return prefix, true
+	}
+	return netip.Prefix{}, false
+}

--- a/internal/ecs/scope_test.go
+++ b/internal/ecs/scope_test.go
@@ -1,0 +1,100 @@
+package ecs
+
+import (
+	"net"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func msgWithECS(opt *dns.EDNS0_SUBNET) *dns.Msg {
+	m := new(dns.Msg)
+	if opt == nil {
+		return m
+	}
+	o := new(dns.OPT)
+	o.Hdr.Name = "."
+	o.Hdr.Rrtype = dns.TypeOPT
+	o.Option = []dns.EDNS0{opt}
+	m.Extra = []dns.RR{o}
+	return m
+}
+
+func TestReadResponseScope_NilOrNoOpt(t *testing.T) {
+	if _, ok := ReadResponseScope(nil); ok {
+		t.Errorf("nil response should not yield a scope")
+	}
+	if _, ok := ReadResponseScope(new(dns.Msg)); ok {
+		t.Errorf("response with no OPT should not yield a scope")
+	}
+}
+
+func TestReadResponseScope_NoSubnetOption(t *testing.T) {
+	m := msgWithECS(nil)
+	o := new(dns.OPT)
+	o.Hdr.Name = "."
+	o.Hdr.Rrtype = dns.TypeOPT
+	// OPT without an EDNS0_SUBNET option.
+	o.Option = []dns.EDNS0{&dns.EDNS0_NSID{Code: dns.EDNS0NSID, Nsid: ""}}
+	m.Extra = []dns.RR{o}
+
+	if _, ok := ReadResponseScope(m); ok {
+		t.Errorf("OPT without ECS option should not yield a scope")
+	}
+}
+
+func TestReadResponseScope_GlobalAnswerSkipped(t *testing.T) {
+	// RFC 7871 §6: SCOPE = 0 means "valid for entire address space",
+	// i.e. cache shared-key, not scoped. ReadResponseScope must NOT
+	// return a prefix for that case.
+	m := msgWithECS(&dns.EDNS0_SUBNET{
+		Code: dns.EDNS0SUBNET, Family: 1,
+		SourceNetmask: 24, SourceScope: 0,
+		Address: net.ParseIP("203.0.113.0").To4(),
+	})
+	if _, ok := ReadResponseScope(m); ok {
+		t.Errorf("SCOPE=0 should be reported as 'no scope'")
+	}
+}
+
+func TestReadResponseScope_ValidV4Scope(t *testing.T) {
+	m := msgWithECS(&dns.EDNS0_SUBNET{
+		Code: dns.EDNS0SUBNET, Family: 1,
+		SourceNetmask: 24, SourceScope: 24,
+		Address: net.ParseIP("203.0.113.0").To4(),
+	})
+	got, ok := ReadResponseScope(m)
+	if !ok {
+		t.Fatal("expected valid scope")
+	}
+	if want := "203.0.113.0/24"; got.String() != want {
+		t.Errorf("scope = %s, want %s", got, want)
+	}
+}
+
+func TestReadResponseScope_ValidV6Scope(t *testing.T) {
+	m := msgWithECS(&dns.EDNS0_SUBNET{
+		Code: dns.EDNS0SUBNET, Family: 2,
+		SourceNetmask: 56, SourceScope: 56,
+		Address: net.ParseIP("2001:db8::"),
+	})
+	got, ok := ReadResponseScope(m)
+	if !ok {
+		t.Fatal("expected valid scope")
+	}
+	if want := "2001:db8::/56"; got.String() != want {
+		t.Errorf("scope = %s, want %s", got, want)
+	}
+}
+
+func TestReadResponseScope_FamilyMismatchRejected(t *testing.T) {
+	// Family=1 (IPv4) but a 16-byte non-mapped v6 address. Malformed.
+	m := msgWithECS(&dns.EDNS0_SUBNET{
+		Code: dns.EDNS0SUBNET, Family: 1,
+		SourceNetmask: 24, SourceScope: 24,
+		Address: net.ParseIP("2001:db8::1"),
+	})
+	if _, ok := ReadResponseScope(m); ok {
+		t.Errorf("family/address mismatch should be rejected")
+	}
+}

--- a/middleware/edns/edns.go
+++ b/middleware/edns/edns.go
@@ -11,6 +11,7 @@ import (
 	"github.com/semihalev/sdns/internal/dnsutil"
 	"github.com/semihalev/sdns/internal/ecs"
 	"github.com/semihalev/sdns/middleware"
+	"github.com/semihalev/zlog/v2"
 )
 
 // responseWriterPool reuses per-query ResponseWriter wrappers. A wrapper
@@ -43,37 +44,73 @@ func New(cfg *config.Config) *EDNS {
 
 // buildECSPolicy translates the operator's [ecs] config block into a
 // reusable *ecs.Policy. Returns nil when the feature is disabled so
-// SetEdns0 takes the cheap nil-policy fast path. CIDR strings that
-// fail to parse are dropped with no log — config validation is the
-// loader's job, and a malformed entry shouldn't make the resolver
-// fall back to "forward everything" silently.
+// SetEdns0 takes the cheap nil-policy fast path.
+//
+// Validation is fail-closed: any malformed input (bad CIDR in
+// client_networks, source ceiling outside [1, 32]/[1, 128], etc.)
+// disables the policy entirely and logs the reason. The earlier
+// implementation silently dropped bad CIDRs which, if every entry
+// failed to parse, collapsed a restrictive `client_networks` list
+// into "no list specified = allow everyone" — a quiet fail-open.
+// Forwarding off is always a safer fallback than forwarding too much.
 func buildECSPolicy(cfg *config.Config) *ecs.Policy {
 	c := cfg.ECS
 	if !c.Enabled {
 		return nil
 	}
+
 	v4 := c.ForwardV4Max
 	if v4 == 0 {
 		v4 = 24
+	}
+	if v4 > 32 {
+		zlog.Error("ECS: forward_v4 out of range; forwarding disabled",
+			zlog.Int("value", int(v4)), zlog.Int("max", 32))
+		return nil
 	}
 	v6 := c.ForwardV6Max
 	if v6 == 0 {
 		v6 = 56
 	}
+	if v6 > 128 {
+		zlog.Error("ECS: forward_v6 out of range; forwarding disabled",
+			zlog.Int("value", int(v6)), zlog.Int("max", 128))
+		return nil
+	}
 	mv4 := c.MinScopeV4
 	if mv4 == 0 {
 		mv4 = v4
+	}
+	if mv4 > 32 {
+		zlog.Error("ECS: min_scope_v4 out of range; forwarding disabled",
+			zlog.Int("value", int(mv4)), zlog.Int("max", 32))
+		return nil
 	}
 	mv6 := c.MinScopeV6
 	if mv6 == 0 {
 		mv6 = v6
 	}
+	if mv6 > 128 {
+		zlog.Error("ECS: min_scope_v6 out of range; forwarding disabled",
+			zlog.Int("value", int(mv6)), zlog.Int("max", 128))
+		return nil
+	}
+
 	nets := make([]netip.Prefix, 0, len(c.ClientNetworks))
 	for _, s := range c.ClientNetworks {
-		if p, err := netip.ParsePrefix(s); err == nil {
-			nets = append(nets, p)
+		p, err := netip.ParsePrefix(s)
+		if err != nil {
+			// Fail-closed: a typo'd CIDR (`10.0.0.0/33`) must not
+			// collapse the allow-list to empty and re-open the
+			// feature to every client. Disable the policy entirely
+			// so the operator sees the loud log and fixes the typo.
+			zlog.Error("ECS: invalid client_networks CIDR; forwarding disabled",
+				zlog.String("entry", s), zlog.String("error", err.Error()))
+			return nil
 		}
+		nets = append(nets, p)
 	}
+
 	return &ecs.Policy{
 		Enabled:        true,
 		ForwardV4Max:   v4,
@@ -196,6 +233,21 @@ func (w *ResponseWriter) WriteMsg(m *dns.Msg) error {
 			// This is response OPT, need to merge our options
 			opt.Option = append(opt.Option, w.opt.Option...)
 		}
+
+		// Strip every EDNS0_SUBNET from the client-facing response.
+		// Two leak paths feed into here:
+		//   (a) the resolver re-attaches the request OPT (which we
+		//       may have mutated to forward ECS upstream) onto the
+		//       response, and
+		//   (b) the merge above copies w.opt.Option — which contains
+		//       our forwarded ECS — onto the response OPT.
+		// Either way, the clamped query ECS would otherwise appear
+		// in the client's reply (with SourceScope=0, or duplicated
+		// alongside any ECS the upstream itself returned). Stripping
+		// here is the simplest closure; the cache middleware sits
+		// below edns in the writer chain so it still reads the
+		// upstream's response ECS before this strip happens.
+		opt.Option = stripECS(opt.Option)
 	} else {
 		// EDNS disabled, remove all OPT records
 		m = dnsutil.ClearOPT(m)
@@ -213,6 +265,20 @@ func (w *ResponseWriter) WriteMsg(m *dns.Msg) error {
 	}
 
 	return w.ResponseWriter.WriteMsg(m)
+}
+
+// stripECS returns opts with every EDNS0_SUBNET entry removed.
+// Done in place when the result is the same length (common case:
+// nothing to strip) so the typical OPT write doesn't allocate.
+func stripECS(opts []dns.EDNS0) []dns.EDNS0 {
+	keep := opts[:0]
+	for _, o := range opts {
+		if _, isECS := o.(*dns.EDNS0_SUBNET); isECS {
+			continue
+		}
+		keep = append(keep, o)
+	}
+	return keep
 }
 
 func (w *ResponseWriter) setCookie() {

--- a/middleware/edns/edns.go
+++ b/middleware/edns/edns.go
@@ -3,11 +3,13 @@ package edns
 import (
 	"context"
 	"encoding/hex"
+	"net/netip"
 	"sync"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/config"
 	"github.com/semihalev/sdns/internal/dnsutil"
+	"github.com/semihalev/sdns/internal/ecs"
 	"github.com/semihalev/sdns/middleware"
 )
 
@@ -22,11 +24,64 @@ var responseWriterPool = sync.Pool{
 type EDNS struct {
 	cookiesecret string
 	nsidstr      string
+
+	// ecsPolicy is built once from cfg.ECS and read every request.
+	// nil is a valid value: it means the historical strip-everything
+	// behaviour, which is also what `[ecs] enabled = false` (the
+	// default) collapses to.
+	ecsPolicy *ecs.Policy
 }
 
 // New return edns.
 func New(cfg *config.Config) *EDNS {
-	return &EDNS{cookiesecret: cfg.CookieSecret, nsidstr: cfg.NSID}
+	return &EDNS{
+		cookiesecret: cfg.CookieSecret,
+		nsidstr:      cfg.NSID,
+		ecsPolicy:    buildECSPolicy(cfg),
+	}
+}
+
+// buildECSPolicy translates the operator's [ecs] config block into a
+// reusable *ecs.Policy. Returns nil when the feature is disabled so
+// SetEdns0 takes the cheap nil-policy fast path. CIDR strings that
+// fail to parse are dropped with no log — config validation is the
+// loader's job, and a malformed entry shouldn't make the resolver
+// fall back to "forward everything" silently.
+func buildECSPolicy(cfg *config.Config) *ecs.Policy {
+	c := cfg.ECS
+	if !c.Enabled {
+		return nil
+	}
+	v4 := c.ForwardV4Max
+	if v4 == 0 {
+		v4 = 24
+	}
+	v6 := c.ForwardV6Max
+	if v6 == 0 {
+		v6 = 56
+	}
+	mv4 := c.MinScopeV4
+	if mv4 == 0 {
+		mv4 = v4
+	}
+	mv6 := c.MinScopeV6
+	if mv6 == 0 {
+		mv6 = v6
+	}
+	nets := make([]netip.Prefix, 0, len(c.ClientNetworks))
+	for _, s := range c.ClientNetworks {
+		if p, err := netip.ParsePrefix(s); err == nil {
+			nets = append(nets, p)
+		}
+	}
+	return &ecs.Policy{
+		Enabled:        true,
+		ForwardV4Max:   v4,
+		ForwardV6Max:   v6,
+		ClientNetworks: nets,
+		MinScopeV4:     mv4,
+		MinScopeV6:     mv6,
+	}
 }
 
 // (*EDNS).Name name return middleware name.
@@ -59,7 +114,15 @@ func (e *EDNS) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 
 	noedns := req.IsEdns0() == nil
 
-	opt, size, cookie, nsid, do := dnsutil.SetEdns0(req)
+	// Convert the writer's net.IP to a netip.Addr for the ECS policy
+	// check. AddrFromSlice handles v4 vs v6 by length; an unusable
+	// address falls through as a zero netip.Addr, which Policy.Allows
+	// safely refuses.
+	clientAddr, _ := netip.AddrFromSlice(w.RemoteIP())
+	if clientAddr.Is4In6() {
+		clientAddr = clientAddr.Unmap()
+	}
+	opt, size, cookie, nsid, do := dnsutil.SetEdns0(req, e.ecsPolicy, clientAddr)
 	if opt.Version() != 0 {
 		opt.SetVersion(0)
 

--- a/middleware/edns/edns_test.go
+++ b/middleware/edns/edns_test.go
@@ -101,3 +101,113 @@ func Test_EDNS(t *testing.T) {
 	ch.Reset(mw, req)
 	ch.Next(context.Background())
 }
+
+// optCapture is a downstream handler that snapshots req.Extra at the
+// moment it sees the chain, so a test can assert what the EDNS
+// middleware put on the outgoing OPT.
+type optCapture struct {
+	got *dns.OPT
+}
+
+func (c *optCapture) ServeDNS(ctx context.Context, ch *middleware.Chain) {
+	c.got = ch.Request.IsEdns0()
+	m := new(dns.Msg)
+	m.SetReply(ch.Request)
+	_ = ch.Writer.WriteMsg(m)
+}
+
+func (c *optCapture) Name() string { return "opt-capture" }
+
+func findSubnet(opt *dns.OPT) *dns.EDNS0_SUBNET {
+	if opt == nil {
+		return nil
+	}
+	for _, o := range opt.Option {
+		if v, ok := o.(*dns.EDNS0_SUBNET); ok {
+			return v
+		}
+	}
+	return nil
+}
+
+func ecsRequest(domain string, src uint8, addr string) *dns.Msg {
+	req := new(dns.Msg)
+	req.SetQuestion(domain, dns.TypeA)
+	req.SetEdns0(4096, false)
+	opt := req.IsEdns0()
+	opt.Option = append(opt.Option, &dns.EDNS0_SUBNET{
+		Code: dns.EDNS0SUBNET, Family: 1,
+		SourceNetmask: src, SourceScope: 0,
+		Address: net.ParseIP(addr).To4(),
+	})
+	return req
+}
+
+func TestEDNS_StripsECSWhenPolicyDisabled(t *testing.T) {
+	// Default config: ECS disabled. Even if the client sends ECS, the
+	// outgoing OPT must not carry it (RFC 7871 §11 default).
+	cfg := new(config.Config)
+	e := New(cfg)
+	cap := &optCapture{}
+	ch := middleware.NewChain([]middleware.Handler{e, cap})
+
+	req := ecsRequest("example.com.", 24, "203.0.113.0")
+	mw := mock.NewWriter("udp", "203.0.113.5:0")
+	ch.Reset(mw, req)
+	ch.Next(context.Background())
+
+	if got := findSubnet(cap.got); got != nil {
+		t.Errorf("disabled policy must strip ECS, got %+v", got)
+	}
+}
+
+func TestEDNS_ForwardsECSClampedDownstream(t *testing.T) {
+	// Client sends /28, policy ceiling is /24. The downstream handler
+	// must see a /24 with the host bits zeroed — proves the forwarding
+	// path round-trips through middleware/edns end-to-end.
+	cfg := new(config.Config)
+	cfg.ECS = config.ECSConfig{
+		Enabled:      true,
+		ForwardV4Max: 24,
+		ForwardV6Max: 56,
+	}
+	e := New(cfg)
+	cap := &optCapture{}
+	ch := middleware.NewChain([]middleware.Handler{e, cap})
+
+	req := ecsRequest("example.com.", 28, "203.0.113.42")
+	mw := mock.NewWriter("udp", "203.0.113.42:0")
+	ch.Reset(mw, req)
+	ch.Next(context.Background())
+
+	got := findSubnet(cap.got)
+	if got == nil {
+		t.Fatal("expected ECS to be forwarded to downstream")
+	}
+	assert.Equal(t, uint8(24), got.SourceNetmask, "ceiling clamp")
+	assert.Equal(t, "203.0.113.0", got.Address.String(), "host bits zeroed")
+	assert.Equal(t, uint8(0), got.SourceScope, "outgoing SCOPE must be 0")
+}
+
+func TestEDNS_ForwardsECSGatedByClientNetworks(t *testing.T) {
+	// Same policy but with a client_networks gate that excludes the
+	// test client. Forwarding must stop even though policy is enabled.
+	cfg := new(config.Config)
+	cfg.ECS = config.ECSConfig{
+		Enabled:        true,
+		ForwardV4Max:   24,
+		ClientNetworks: []string{"10.0.0.0/8"},
+	}
+	e := New(cfg)
+	cap := &optCapture{}
+	ch := middleware.NewChain([]middleware.Handler{e, cap})
+
+	req := ecsRequest("example.com.", 24, "203.0.113.0")
+	mw := mock.NewWriter("udp", "203.0.113.5:0")
+	ch.Reset(mw, req)
+	ch.Next(context.Background())
+
+	if got := findSubnet(cap.got); got != nil {
+		t.Errorf("client outside allow-list should not see ECS forwarded, got %+v", got)
+	}
+}

--- a/middleware/edns/edns_test.go
+++ b/middleware/edns/edns_test.go
@@ -102,15 +102,24 @@ func Test_EDNS(t *testing.T) {
 	ch.Next(context.Background())
 }
 
-// optCapture is a downstream handler that snapshots req.Extra at the
-// moment it sees the chain, so a test can assert what the EDNS
-// middleware put on the outgoing OPT.
+// optCapture is a downstream handler that snapshots the EDNS0_SUBNET
+// option (by value) at the moment it sees the chain. A pointer
+// snapshot would be misleading: the EDNS middleware reuses the
+// request OPT for the outgoing response and now strips ECS from it
+// before client write, so any pointer-based assertion read *after*
+// ch.Next returns would observe the stripped state, not what
+// downstream actually received.
 type optCapture struct {
-	got *dns.OPT
+	ecs *dns.EDNS0_SUBNET
 }
 
 func (c *optCapture) ServeDNS(ctx context.Context, ch *middleware.Chain) {
-	c.got = ch.Request.IsEdns0()
+	if opt := ch.Request.IsEdns0(); opt != nil {
+		if sub := findSubnet(opt); sub != nil {
+			snap := *sub
+			c.ecs = &snap
+		}
+	}
 	m := new(dns.Msg)
 	m.SetReply(ch.Request)
 	_ = ch.Writer.WriteMsg(m)
@@ -156,7 +165,7 @@ func TestEDNS_StripsECSWhenPolicyDisabled(t *testing.T) {
 	ch.Reset(mw, req)
 	ch.Next(context.Background())
 
-	if got := findSubnet(cap.got); got != nil {
+	if got := cap.ecs; got != nil {
 		t.Errorf("disabled policy must strip ECS, got %+v", got)
 	}
 }
@@ -180,13 +189,94 @@ func TestEDNS_ForwardsECSClampedDownstream(t *testing.T) {
 	ch.Reset(mw, req)
 	ch.Next(context.Background())
 
-	got := findSubnet(cap.got)
+	got := cap.ecs
 	if got == nil {
 		t.Fatal("expected ECS to be forwarded to downstream")
 	}
 	assert.Equal(t, uint8(24), got.SourceNetmask, "ceiling clamp")
 	assert.Equal(t, "203.0.113.0", got.Address.String(), "host bits zeroed")
 	assert.Equal(t, uint8(0), got.SourceScope, "outgoing SCOPE must be 0")
+}
+
+// TestEDNS_ResponseDoesNotLeakForwardedECS pins the P2 fix from the
+// ultrareview: with ECS forwarding enabled, the clamped query ECS we
+// put on the request OPT for upstream propagation must NOT round-trip
+// to the client. Two leak paths exist (resolver re-attaches the
+// request OPT to the response, edns merges w.opt.Option into the
+// response OPT); the strip in WriteMsg closes both.
+func TestEDNS_ResponseDoesNotLeakForwardedECS(t *testing.T) {
+	cfg := new(config.Config)
+	cfg.ECS = config.ECSConfig{Enabled: true, ForwardV4Max: 24}
+	e := New(cfg)
+
+	// Downstream handler mimics the resolver leak path (a): it
+	// re-attaches the request OPT — possibly mutated by SetEdns0 to
+	// include the forwarded ECS — onto its response message.
+	leak := middleware.HandlerFunc(func(ctx context.Context, ch *middleware.Chain) {
+		req := ch.Request
+		resp := new(dns.Msg)
+		resp.SetReply(req)
+		if opt := req.IsEdns0(); opt != nil {
+			resp.Extra = append(resp.Extra, opt)
+		}
+		_ = ch.Writer.WriteMsg(resp)
+	})
+	ch := middleware.NewChain([]middleware.Handler{e, leak})
+
+	req := ecsRequest("example.com.", 24, "203.0.113.0")
+	mw := mock.NewWriter("udp", "203.0.113.5:0")
+	ch.Reset(mw, req)
+	ch.Next(context.Background())
+
+	written := mw.Msg()
+	if written == nil {
+		t.Fatal("no response written")
+	}
+	if got := findSubnet(written.IsEdns0()); got != nil {
+		t.Errorf("client must not see ECS in response, got %+v", got)
+	}
+}
+
+// TestEDNS_DisabledOnBadClientNetworks pins the P1 fix from the
+// ultrareview. A typo'd CIDR collapses the allow-list to empty under
+// the previous silent-drop policy, re-opening the feature to every
+// client. The fail-closed build must disable the policy entirely so
+// SetEdns0 falls back to strip-everything.
+func TestEDNS_DisabledOnBadClientNetworks(t *testing.T) {
+	cfg := new(config.Config)
+	cfg.ECS = config.ECSConfig{
+		Enabled:        true,
+		ForwardV4Max:   24,
+		ClientNetworks: []string{"10.0.0.0/33"}, // intentional typo
+	}
+	e := New(cfg)
+	if e.ecsPolicy != nil {
+		t.Fatal("malformed client_networks must disable the policy")
+	}
+
+	cap := &optCapture{}
+	ch := middleware.NewChain([]middleware.Handler{e, cap})
+
+	req := ecsRequest("example.com.", 24, "10.0.0.0")
+	mw := mock.NewWriter("udp", "10.0.0.5:0")
+	ch.Reset(mw, req)
+	ch.Next(context.Background())
+
+	if got := cap.ecs; got != nil {
+		t.Errorf("disabled policy must strip ECS, got %+v", got)
+	}
+}
+
+// TestEDNS_DisabledOnOutOfRangeCeiling covers the source-prefix
+// validation branch of P1: forward_v4 = 200 is nonsense and must
+// disable the policy rather than silently letting Clamp's
+// netip.Prefix call fail mid-request.
+func TestEDNS_DisabledOnOutOfRangeCeiling(t *testing.T) {
+	cfg := new(config.Config)
+	cfg.ECS = config.ECSConfig{Enabled: true, ForwardV4Max: 200}
+	if got := New(cfg).ecsPolicy; got != nil {
+		t.Errorf("out-of-range forward_v4 must disable the policy, got %+v", got)
+	}
 }
 
 func TestEDNS_ForwardsECSGatedByClientNetworks(t *testing.T) {
@@ -207,7 +297,7 @@ func TestEDNS_ForwardsECSGatedByClientNetworks(t *testing.T) {
 	ch.Reset(mw, req)
 	ch.Next(context.Background())
 
-	if got := findSubnet(cap.got); got != nil {
+	if got := cap.ecs; got != nil {
 		t.Errorf("client outside allow-list should not see ECS forwarded, got %+v", got)
 	}
 }


### PR DESCRIPTION
First half of the #417 work: adds an opt-in [ecs] config block and the plumbing to forward client-supplied EDNS Client Subnet options upstream when the operator explicitly enables it. SDNS continues to strip ECS by default per RFC 7871 §11.

The cache pollution the issue actually reports is fixed in the next PR (Stage 2 — partitions the cache by SCOPE). This PR is the staged-rollout-friendly first step: an operator can enable forwarding, watch ECS reach their authorities via tcpdump or upstream logs, and decide on the cache change separately.

## Summary

- New \`internal/ecs\` package — tiny, pure helpers. \`Policy\` struct, source-prefix \`Clamp\`, RFC 7871 §7.1.2 \`ClampScope\`, and \`ReadResponseScope\` (the last two are unused in this PR; they live here for Stage 2's cache work without adding cross-package coupling later).
- \`internal/dnsutil.SetEdns0\` now takes \`(*ecs.Policy, netip.Addr)\`. Nil policy / empty address ⇒ historical strip-everything behaviour, bit-for-bit. Enabled policy ⇒ preserves a clamped copy of the client's \`EDNS0_SUBNET\` on the outgoing OPT.
- \`middleware/edns\` builds the policy once in \`New(cfg)\` and reads the client address from the writer per request. No new middleware position, no Setup-order surprises.

## Config

\`\`\`toml
[ecs]
enabled         = false        # default off (RFC 7871 §11)
forward_v4      = 24           # source-prefix ceiling for IPv4
forward_v6      = 56           # source-prefix ceiling for IPv6
client_networks = []           # CIDRs eligible for forwarding; [] = all

# Stage-2 fields declared here so configver only bumps once.
cache_limit_ttl = \"5m\"
min_scope_v4    = 24
min_scope_v6    = 56
\`\`\`

\`configver\` bumps 1.6.7 → 1.7.0. \`contrib/linux/sdns.conf\` regenerated.

## What's intentionally NOT in this PR

- **Cache partitioning.** Cache continues to key on \`(qname, qtype, qclass, CD)\` only. Operators who enable ECS forwarding before Stage 2 lands will still see the pollution behaviour from #417. Documented in the [ecs] block comment.
- **ECS synthesis from client IP.** This is forward-only — if the client didn't send ECS, the outgoing OPT doesn't carry it either. Synthesis is a separate, larger decision (privacy, config surface, fallback semantics).

## Test plan

- [x] \`go test ./internal/ecs/... ./internal/dnsutil/... ./middleware/edns/...\` — covers strip-by-default (regression), disabled policy, narrow-than-ceiling pass-through, wider-than-ceiling clamp + address truncation, family mismatch rejection, \`client_networks\` allow-list gate, no-ECS-in-request case.
- [x] \`go test ./...\` whole project clean.
- [x] \`golangci-lint run ./...\` zero issues.
- [x] Generated binary boots with the new [ecs] section in \`contrib/linux/sdns.conf\`.
- [ ] Manual: \`dig +subnet=203.0.113.0/24 cdn.example.com @<sdns-host>\` with \`[ecs] enabled = true\`, confirm via tcpdump on the upstream interface that ECS reaches the authoritative server. (Operator-side validation.)

## Stage 2 preview

The follow-up PR will:
- Extend \`internal/cache.Key\` with a scope-aware variant.
- Make \`middleware/cache\` derive client scope on lookup (longest-prefix-match), and key the insert by the authority's SCOPE.
- Apply \`cache_limit_ttl\` / \`min_scope_*\` from this PR's config.
- Add \`dns_cache_ecs_lookups_total{outcome}\` metrics.

That PR will close #417.