### PR TITLE
feat(ecs): cache partitions by ECS scope (Stage 2, closes #417)

### DIFF
--- a/internal/cache/key.go
+++ b/internal/cache/key.go
@@ -120,6 +120,66 @@ func KeyString(qname string, qtype, qclass uint16, cd bool) uint64 {
 	return hash
 }
 
+// KeyWithScope is an ECS-aware variant of Key. When scope is the
+// empty slice (the canonical "no scope" value) the returned hash is
+// bit-identical to Key(q, cd), so cache entries written before this
+// function existed still resolve on lookup — no flush needed on
+// upgrade.
+//
+// When scope is non-empty the bytes are folded into the hash
+// preimage with a single-byte length prefix so a /24 keyed entry
+// can't collide with a /20 of the same address. Callers should pass
+// scope as `prefix.Addr().AsSlice()[:prefixLenBytes]` rounded up
+// to the nearest byte; the helper does no normalisation.
+func KeyWithScope(q dns.Question, cd bool, scope []byte) uint64 {
+	if len(scope) == 0 {
+		return Key(q, cd)
+	}
+
+	kb := keyBufferPool.Get().(*keyBuffer)
+	buf := kb.buf[:0]
+
+	// Same prefix as Key so a scoped key with len(scope)==0 (handled
+	// above) and an unscoped Key collide deliberately.
+	buf = append(buf, byte(q.Qclass>>8), byte(q.Qclass&0xFF)) //nolint:gosec // intentional uint16 byte extraction
+	buf = append(buf, byte(q.Qtype>>8), byte(q.Qtype&0xFF))   //nolint:gosec // intentional uint16 byte extraction
+
+	if cd {
+		buf = append(buf, 1)
+	} else {
+		buf = append(buf, 0)
+	}
+
+	nameLen := len(q.Name)
+	if len(buf)+nameLen+1+len(scope) > len(kb.buf) {
+		// Extremely long qnames or future scope widening could push
+		// past the on-stack buffer; fall through to heap. Rare.
+		newBuf := make([]byte, len(buf), len(buf)+nameLen+1+len(scope))
+		copy(newBuf, buf)
+		buf = newBuf
+	}
+
+	for i := range nameLen {
+		c := q.Name[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		buf = append(buf, c)
+	}
+
+	// Scope length first so a /24 prefix can't be confused with a
+	// /20 truncation of the same address. Callers (CacheKey.Hash)
+	// always supply at most 16 bytes (full IPv6 address), so this
+	// truncating cast can't lose information in practice.
+	scopeLen := min(len(scope), 255)
+	buf = append(buf, byte(scopeLen)) //nolint:gosec // bounded above
+	buf = append(buf, scope[:scopeLen]...)
+
+	hash := xxhash.Sum64(buf)
+	keyBufferPool.Put(kb)
+	return hash
+}
+
 // KeySimple generates a cache key without pooling for comparison.
 // This is exported for benchmarking purposes only.
 func KeySimple(q dns.Question, cd ...bool) uint64 {

--- a/internal/cache/key.go
+++ b/internal/cache/key.go
@@ -2,6 +2,7 @@
 package cache
 
 import (
+	"net/netip"
 	"sync"
 
 	"github.com/cespare/xxhash/v2"
@@ -120,27 +121,34 @@ func KeyString(qname string, qtype, qclass uint16, cd bool) uint64 {
 	return hash
 }
 
-// KeyWithScope is an ECS-aware variant of Key. When scope is the
-// empty slice (the canonical "no scope" value) the returned hash is
-// bit-identical to Key(q, cd), so cache entries written before this
-// function existed still resolve on lookup — no flush needed on
-// upgrade.
+// KeyWithPrefix is an ECS-aware variant of Key. An invalid prefix
+// (the canonical "no scope" value) collapses to Key(q, cd) so cache
+// entries written before this function existed still resolve on
+// lookup — no flush needed on upgrade.
 //
-// When scope is non-empty the bytes are folded into the hash
-// preimage with a single-byte length prefix so a /24 keyed entry
-// can't collide with a /20 of the same address. Callers should pass
-// scope as `prefix.Addr().AsSlice()[:prefixLenBytes]` rounded up
-// to the nearest byte; the helper does no normalisation.
-func KeyWithScope(q dns.Question, cd bool, scope []byte) uint64 {
-	if len(scope) == 0 {
+// When prefix is valid, family + bit-length + the address bytes
+// rounded up to a byte are folded into the hash preimage. The
+// distinct family byte means an IPv4 /24 of [a, b, c] cannot
+// collide with an IPv6 /24 whose first three bytes happen to be
+// [a, b, c]. The distinct bit-length byte means /22 and /24 of
+// 203.0.112.0 hash differently even though their byte-rounded
+// addresses are both [203, 0, 112] — the earlier scope-bytes-only
+// encoding aliased here and would serve a wider supernet's answer
+// to a narrower-subnet query.
+func KeyWithPrefix(q dns.Question, cd bool, prefix netip.Prefix) uint64 {
+	if !prefix.IsValid() {
 		return Key(q, cd)
 	}
+
+	bits := prefix.Bits()
+	addrBytes := prefix.Addr().AsSlice()
+	addrLen := min((bits+7)/8, len(addrBytes))
 
 	kb := keyBufferPool.Get().(*keyBuffer)
 	buf := kb.buf[:0]
 
-	// Same prefix as Key so a scoped key with len(scope)==0 (handled
-	// above) and an unscoped Key collide deliberately.
+	// Same prefix as Key so a KeyWithPrefix call with an invalid
+	// prefix (handled above) and an unscoped Key collide deliberately.
 	buf = append(buf, byte(q.Qclass>>8), byte(q.Qclass&0xFF)) //nolint:gosec // intentional uint16 byte extraction
 	buf = append(buf, byte(q.Qtype>>8), byte(q.Qtype&0xFF))   //nolint:gosec // intentional uint16 byte extraction
 
@@ -151,10 +159,10 @@ func KeyWithScope(q dns.Question, cd bool, scope []byte) uint64 {
 	}
 
 	nameLen := len(q.Name)
-	if len(buf)+nameLen+1+len(scope) > len(kb.buf) {
-		// Extremely long qnames or future scope widening could push
-		// past the on-stack buffer; fall through to heap. Rare.
-		newBuf := make([]byte, len(buf), len(buf)+nameLen+1+len(scope))
+	// Reserve space for qname + family byte + bits byte + scope bytes.
+	required := len(buf) + nameLen + 2 + addrLen
+	if required > len(kb.buf) {
+		newBuf := make([]byte, len(buf), required)
 		copy(newBuf, buf)
 		buf = newBuf
 	}
@@ -167,13 +175,19 @@ func KeyWithScope(q dns.Question, cd bool, scope []byte) uint64 {
 		buf = append(buf, c)
 	}
 
-	// Scope length first so a /24 prefix can't be confused with a
-	// /20 truncation of the same address. Callers (CacheKey.Hash)
-	// always supply at most 16 bytes (full IPv6 address), so this
-	// truncating cast can't lose information in practice.
-	scopeLen := min(len(scope), 255)
-	buf = append(buf, byte(scopeLen)) //nolint:gosec // bounded above
-	buf = append(buf, scope[:scopeLen]...)
+	// Family: 4 for IPv4, 6 for IPv6 (mirrors the human-meaningful
+	// shorthand, not the wire-format Family field which uses 1/2).
+	// Distinct values prevent a v4 scope from colliding with a v6
+	// scope whose first bytes happen to match.
+	if prefix.Addr().Is4() {
+		buf = append(buf, 4)
+	} else {
+		buf = append(buf, 6)
+	}
+	// Bit-length so /22 and /24 of the same byte-rounded address
+	// hash differently. Bits is at most 128, fits a single byte.
+	buf = append(buf, byte(bits)) //nolint:gosec // 0 ≤ bits ≤ 128
+	buf = append(buf, addrBytes[:addrLen]...)
 
 	hash := xxhash.Sum64(buf)
 	keyBufferPool.Put(kb)

--- a/internal/cache/key_test.go
+++ b/internal/cache/key_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"fmt"
+	"net/netip"
 	"sync"
 	"testing"
 
@@ -76,53 +77,63 @@ func TestKey(t *testing.T) {
 	}
 }
 
-func TestKeyWithScope_NilScopeMatchesKey(t *testing.T) {
-	// Migration safety: KeyWithScope(q, cd, nil) must hash to the
-	// same value as Key(q, cd). Pre-Stage-2 entries (shared key)
-	// keep hitting after the upgrade because the cache still keys
-	// non-ECS requests through this same nil path.
+func TestKeyWithPrefix_InvalidScopeMatchesKey(t *testing.T) {
+	// Migration safety: KeyWithPrefix(q, cd, invalid) must hash to
+	// the same value as Key(q, cd). Pre-Stage-2 entries (shared
+	// key) keep hitting after the upgrade because the cache routes
+	// non-ECS requests through this fallback.
 	q := dns.Question{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
-	if got, want := KeyWithScope(q, false, nil), Key(q, false); got != want {
-		t.Errorf("KeyWithScope(nil) = %d, Key = %d", got, want)
+	if got, want := KeyWithPrefix(q, false, netip.Prefix{}), Key(q, false); got != want {
+		t.Errorf("KeyWithPrefix(invalid) = %d, Key = %d", got, want)
 	}
-	if got, want := KeyWithScope(q, true, nil), Key(q, true); got != want {
-		t.Errorf("KeyWithScope(nil, cd=true) = %d, Key(cd=true) = %d", got, want)
+	if got, want := KeyWithPrefix(q, true, netip.Prefix{}), Key(q, true); got != want {
+		t.Errorf("KeyWithPrefix(invalid, cd=true) = %d, Key(cd=true) = %d", got, want)
 	}
 }
 
-func TestKeyWithScope_DistinctScopesDistinctHashes(t *testing.T) {
+func TestKeyWithPrefix_DistinctScopesDistinctHashes(t *testing.T) {
 	q := dns.Question{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
-	scopeA := []byte{203, 0, 113}  // 203.0.113.0/24
-	scopeB := []byte{198, 51, 100} // 198.51.100.0/24
+	scopeA := netip.MustParsePrefix("203.0.113.0/24")
+	scopeB := netip.MustParsePrefix("198.51.100.0/24")
 
-	hA := KeyWithScope(q, false, scopeA)
-	hB := KeyWithScope(q, false, scopeB)
+	hA := KeyWithPrefix(q, false, scopeA)
+	hB := KeyWithPrefix(q, false, scopeB)
 	if hA == hB {
 		t.Errorf("different scopes hashed identically: %d", hA)
 	}
 
-	// And the scoped hash must differ from the shared-key hash
-	// (the #417 pollution lives in the inverse of this property).
+	// Scoped hash must differ from the unscoped (#417 lives in the
+	// inverse of this property).
 	if hA == Key(q, false) {
 		t.Errorf("scoped hash collided with unscoped hash for %q", q.Name)
 	}
 }
 
-func TestKeyWithScope_LengthPrefixPreventsCollision(t *testing.T) {
-	// /24 of 203.0.0.0 (bytes {203, 0, 0}) must NOT collide with /20
-	// of the same /24-truncated address — the length byte we prepend
-	// inside the hash preimage is what makes those two prefixes
-	// hash distinctly even though the address-byte slices look the
-	// same when read raw.
+func TestKeyWithPrefix_BitLengthDistinguishesAliasedAddresses(t *testing.T) {
+	// 203.0.112.0/22 and 203.0.112.0/24 both round to the same
+	// three address bytes [203, 0, 112], so an encoder that
+	// folded only the address bytes (with a byte-length prefix
+	// that's also identical) aliased them — and supernet probes
+	// served narrower subnets the wider answer. The explicit
+	// bit-length byte in the hash preimage makes them distinct.
 	q := dns.Question{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
-	hSlash24 := KeyWithScope(q, false, []byte{203, 0, 113})
-	// "/20" with the same first three bytes is contrived but covers
-	// the scope-length-byte property. In real usage the byte slice
-	// for a /20 would be 3 bytes too (rounded up), so a length
-	// prefix is the only thing distinguishing them.
-	hAnother := KeyWithScope(q, false, []byte{203, 0, 0})
-	if hSlash24 == hAnother {
-		t.Errorf("distinct scope addresses hashed identically: %d", hSlash24)
+	h22 := KeyWithPrefix(q, false, netip.MustParsePrefix("203.0.112.0/22"))
+	h24 := KeyWithPrefix(q, false, netip.MustParsePrefix("203.0.112.0/24"))
+	if h22 == h24 {
+		t.Errorf("/22 and /24 with the same byte-rounded address aliased: %d", h22)
+	}
+}
+
+func TestKeyWithPrefix_FamilyDistinguishesAliasedAddresses(t *testing.T) {
+	// Contrived but the property is real: an IPv4 /24 of [203, 0, 112]
+	// and an IPv6 /24 whose first three bytes happen to be the same
+	// must hash distinctly. The family byte in the preimage carries
+	// the distinction.
+	q := dns.Question{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	v4 := KeyWithPrefix(q, false, netip.MustParsePrefix("203.0.112.0/24"))
+	v6 := KeyWithPrefix(q, false, netip.MustParsePrefix("cb00:7000::/24"))
+	if v4 == v6 {
+		t.Errorf("v4 and v6 scopes with same leading bytes aliased: %d", v4)
 	}
 }
 

--- a/internal/cache/key_test.go
+++ b/internal/cache/key_test.go
@@ -76,6 +76,56 @@ func TestKey(t *testing.T) {
 	}
 }
 
+func TestKeyWithScope_NilScopeMatchesKey(t *testing.T) {
+	// Migration safety: KeyWithScope(q, cd, nil) must hash to the
+	// same value as Key(q, cd). Pre-Stage-2 entries (shared key)
+	// keep hitting after the upgrade because the cache still keys
+	// non-ECS requests through this same nil path.
+	q := dns.Question{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	if got, want := KeyWithScope(q, false, nil), Key(q, false); got != want {
+		t.Errorf("KeyWithScope(nil) = %d, Key = %d", got, want)
+	}
+	if got, want := KeyWithScope(q, true, nil), Key(q, true); got != want {
+		t.Errorf("KeyWithScope(nil, cd=true) = %d, Key(cd=true) = %d", got, want)
+	}
+}
+
+func TestKeyWithScope_DistinctScopesDistinctHashes(t *testing.T) {
+	q := dns.Question{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	scopeA := []byte{203, 0, 113}  // 203.0.113.0/24
+	scopeB := []byte{198, 51, 100} // 198.51.100.0/24
+
+	hA := KeyWithScope(q, false, scopeA)
+	hB := KeyWithScope(q, false, scopeB)
+	if hA == hB {
+		t.Errorf("different scopes hashed identically: %d", hA)
+	}
+
+	// And the scoped hash must differ from the shared-key hash
+	// (the #417 pollution lives in the inverse of this property).
+	if hA == Key(q, false) {
+		t.Errorf("scoped hash collided with unscoped hash for %q", q.Name)
+	}
+}
+
+func TestKeyWithScope_LengthPrefixPreventsCollision(t *testing.T) {
+	// /24 of 203.0.0.0 (bytes {203, 0, 0}) must NOT collide with /20
+	// of the same /24-truncated address — the length byte we prepend
+	// inside the hash preimage is what makes those two prefixes
+	// hash distinctly even though the address-byte slices look the
+	// same when read raw.
+	q := dns.Question{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	hSlash24 := KeyWithScope(q, false, []byte{203, 0, 113})
+	// "/20" with the same first three bytes is contrived but covers
+	// the scope-length-byte property. In real usage the byte slice
+	// for a /20 would be 3 bytes too (rounded up), so a length
+	// prefix is the only thing distinguishing them.
+	hAnother := KeyWithScope(q, false, []byte{203, 0, 0})
+	if hSlash24 == hAnother {
+		t.Errorf("distinct scope addresses hashed identically: %d", hSlash24)
+	}
+}
+
 func TestKeyUniqueness(t *testing.T) {
 	// Test that different queries produce different keys
 	keys := make(map[uint64]string)

--- a/internal/ecs/policy.go
+++ b/internal/ecs/policy.go
@@ -53,6 +53,94 @@ type Policy struct {
 	MinScopeV6 uint8
 }
 
+// Build constructs a Policy from raw config primitives, returning
+// (nil, nil) when the feature is disabled and (nil, error) on any
+// malformed input. Callers (middleware/edns, middleware/cache) log
+// the error context themselves. Keeping the constructor here keeps
+// internal/ecs at the bottom of the dependency graph — no config
+// import — while preventing two middleware from drifting on what
+// "enabled" means.
+//
+// Bad input is fail-closed: a single typo'd CIDR or out-of-range
+// source ceiling disables the entire policy. Forwarding off is
+// always safer than forwarding too much.
+func Build(
+	enabled bool,
+	forwardV4, forwardV6 uint8,
+	minScopeV4, minScopeV6 uint8,
+	clientNetworks []string,
+) (*Policy, error) {
+	if !enabled {
+		return nil, nil
+	}
+	if forwardV4 == 0 {
+		forwardV4 = 24
+	}
+	if forwardV4 > 32 {
+		return nil, &policyError{field: "forward_v4", value: int(forwardV4), maxv: 32}
+	}
+	if forwardV6 == 0 {
+		forwardV6 = 56
+	}
+	if forwardV6 > 128 {
+		return nil, &policyError{field: "forward_v6", value: int(forwardV6), maxv: 128}
+	}
+	if minScopeV4 == 0 {
+		minScopeV4 = forwardV4
+	}
+	if minScopeV4 > 32 {
+		return nil, &policyError{field: "min_scope_v4", value: int(minScopeV4), maxv: 32}
+	}
+	if minScopeV6 == 0 {
+		minScopeV6 = forwardV6
+	}
+	if minScopeV6 > 128 {
+		return nil, &policyError{field: "min_scope_v6", value: int(minScopeV6), maxv: 128}
+	}
+	nets := make([]netip.Prefix, 0, len(clientNetworks))
+	for _, s := range clientNetworks {
+		p, err := netip.ParsePrefix(s)
+		if err != nil {
+			return nil, &policyError{field: "client_networks", entry: s, cause: err}
+		}
+		nets = append(nets, p)
+	}
+	return &Policy{
+		Enabled:        true,
+		ForwardV4Max:   forwardV4,
+		ForwardV6Max:   forwardV6,
+		ClientNetworks: nets,
+		MinScopeV4:     minScopeV4,
+		MinScopeV6:     minScopeV6,
+	}, nil
+}
+
+// policyError carries enough context for callers to log a
+// human-meaningful "ECS disabled: <reason>" line without parsing
+// the message back out.
+type policyError struct {
+	field string
+	value int    // for numeric range failures
+	maxv  int    // for numeric range failures
+	entry string // for client_networks parse failures
+	cause error  // underlying parse error, if any
+}
+
+func (e *policyError) Error() string {
+	if e.cause != nil {
+		return e.field + " entry " + e.entry + ": " + e.cause.Error()
+	}
+	return e.field + " out of range"
+}
+
+// Field, Value, Max, Entry, Cause expose the parts for structured
+// logging without resorting to error message regex.
+func (e *policyError) Field() string { return e.field }
+func (e *policyError) Value() int    { return e.value }
+func (e *policyError) Max() int      { return e.maxv }
+func (e *policyError) Entry() string { return e.entry }
+func (e *policyError) Cause() error  { return e.cause }
+
 // Allows reports whether `client` is eligible for ECS forwarding
 // under this policy. A nil or disabled policy never allows; otherwise
 // an empty ClientNetworks means everyone, and a populated list means

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -318,11 +318,13 @@ func (c *Cache) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	// When the request carries ECS, probe scoped keys first
 	// (longest-prefix-match), then fall through to the shared key
 	// so SCOPE=0 / pre-Stage-2 entries still hit. checkCache
-	// records the metric on the shared-key path; scopedLookup
-	// records its own Hit on the scoped path so we don't
-	// double-count or under-count. ecsLookups breaks the same
-	// outcome down by ECS-vs-shared so operators can see how much
-	// the scoped path is actually carrying.
+	// records the generic Hit/Miss metric on the shared-key path;
+	// scopedLookup records its own Hit on the scoped path so we
+	// don't double-count or under-count. ecsLookups breaks ECS
+	// requests down by which path served them — operators read it
+	// to see how much of the ECS-aware code path is actually
+	// carrying traffic (non-ECS lookups are already counted by
+	// dns_cache_hits_total / dns_cache_misses_total).
 	if clientScope.IsValid() {
 		if entry, scopedKey := c.scopedLookup(q, req.CheckingDisabled, clientScope); entry != nil {
 			ecsLookups.WithLabelValues("hit_scoped").Inc()
@@ -334,8 +336,6 @@ func (c *Cache) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	if entry := c.checkCache(cacheKey); entry != nil {
 		if clientScope.IsValid() {
 			ecsLookups.WithLabelValues("hit_shared").Inc()
-		} else {
-			ecsLookups.WithLabelValues("non_ecs").Inc()
 		}
 		if c.handleCacheHit(ctx, ch, entry, cacheKey) {
 			return

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -475,37 +475,26 @@ func (c *Cache) requestScope(req *dns.Msg, client netip.Addr) netip.Prefix {
 // try the unscoped key in case the authority returned SCOPE=0
 // (cached shared) or the entry predates Stage 2.
 //
-// Iteration runs from the client's source prefix down to the
-// policy's min_scope ceiling, clamped to never exceed the client
-// prefix itself: when a client sends a source broader than
-// min_scope (e.g. /20 with min_scope_v4=24) Policy.Clamp passes
-// the /20 through unchanged and ClampScope stores answers at /20,
-// so the lookup must also reach /20 or the inserted entry can
-// never be hit again. Probing wider than the client prefix
-// would walk past what the client itself sent — that range would
-// never match an entry derived from this client's source.
+// Iteration runs from the client's source bits down to /1. The
+// upper bound is the client's own prefix because a stored prefix
+// narrower than the client's address could never contain it. The
+// lower bound is /1 because ClampScope allows arbitrarily-broad
+// response scopes (min_scope is a *storage* floor — refuse to
+// store anything narrower — not a *lookup* floor): a /24 source
+// with a /20 SCOPE response stores an entry at /20, and a later
+// /24 query from the same client has to probe /20 to find it.
+// Probing the unscoped /0 key would duplicate the shared-key
+// check the caller does after this returns; we stop at /1.
 //
-// Worst case is ~9 probes for IPv4 (forward_v4 down to min_scope_v4)
-// and ~9 for IPv6 (forward_v6 down to min_scope_v6); each probe is
-// one hash compute + one map lookup, well below the cost of an
-// upstream resolution.
+// Worst case ~32 probes for IPv4 (one per bit-length 1..32) and
+// ~128 for IPv6. Each probe is one hash compute + one map lookup
+// — ~100 ns total — well below the cost of an upstream lookup
+// or a single GC sweep.
 func (c *Cache) scopedLookup(q dns.Question, cd bool, clientPrefix netip.Prefix) (*CacheEntry, uint64) {
 	if !clientPrefix.IsValid() {
 		return nil, 0
 	}
-	var minBits int
-	if clientPrefix.Addr().Is4() {
-		minBits = int(c.ecsPolicy.MinScopeV4)
-	} else {
-		minBits = int(c.ecsPolicy.MinScopeV6)
-	}
-	// Clamp the lower bound to never exceed the client's own prefix —
-	// otherwise a broader-than-min client (/20 with min_scope_v4=24)
-	// would do zero probes even though insert can store at /20.
-	if clientPrefix.Bits() < minBits {
-		minBits = clientPrefix.Bits()
-	}
-	for bits := clientPrefix.Bits(); bits >= minBits; bits-- {
+	for bits := clientPrefix.Bits(); bits >= 1; bits-- {
 		scope, err := clientPrefix.Addr().Prefix(bits)
 		if err != nil {
 			continue

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -476,10 +476,19 @@ func (c *Cache) requestScope(req *dns.Msg, client netip.Addr) netip.Prefix {
 // (cached shared) or the entry predates Stage 2.
 //
 // Iteration runs from the client's source prefix down to the
-// policy's min_scope ceiling — at most 33 probes for IPv4 or 129
-// for IPv6, but in practice ≤ 8 because forward_v4/v6 caps the
-// upper bound. Each probe is one hash compute + one map lookup,
-// well below the cost of an upstream resolution.
+// policy's min_scope ceiling, clamped to never exceed the client
+// prefix itself: when a client sends a source broader than
+// min_scope (e.g. /20 with min_scope_v4=24) Policy.Clamp passes
+// the /20 through unchanged and ClampScope stores answers at /20,
+// so the lookup must also reach /20 or the inserted entry can
+// never be hit again. Probing wider than the client prefix
+// would walk past what the client itself sent — that range would
+// never match an entry derived from this client's source.
+//
+// Worst case is ~9 probes for IPv4 (forward_v4 down to min_scope_v4)
+// and ~9 for IPv6 (forward_v6 down to min_scope_v6); each probe is
+// one hash compute + one map lookup, well below the cost of an
+// upstream resolution.
 func (c *Cache) scopedLookup(q dns.Question, cd bool, clientPrefix netip.Prefix) (*CacheEntry, uint64) {
 	if !clientPrefix.IsValid() {
 		return nil, 0
@@ -489,6 +498,12 @@ func (c *Cache) scopedLookup(q dns.Question, cd bool, clientPrefix netip.Prefix)
 		minBits = int(c.ecsPolicy.MinScopeV4)
 	} else {
 		minBits = int(c.ecsPolicy.MinScopeV6)
+	}
+	// Clamp the lower bound to never exceed the client's own prefix —
+	// otherwise a broader-than-min client (/20 with min_scope_v4=24)
+	// would do zero probes even though insert can store at /20.
+	if clientPrefix.Bits() < minBits {
+		minBits = clientPrefix.Bits()
 	}
 	for bits := clientPrefix.Bits(); bits >= minBits; bits-- {
 		scope, err := clientPrefix.Addr().Prefix(bits)

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -113,6 +113,7 @@ func New(cfg *config.Config) *Cache {
 		MinTTL:      minTTL,
 		MaxTTL:      maxTTL,
 		RateLimit:   cfg.RateLimit,
+		ECSMaxTTL:   cfg.ECS.CacheLimitTTL.Duration,
 	}
 
 	// Validate configuration and actually apply defaults when

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"errors"
+	"net/netip"
 	"os"
 	"slices"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/config"
 	"github.com/semihalev/sdns/internal/dnsutil"
+	"github.com/semihalev/sdns/internal/ecs"
 	"github.com/semihalev/sdns/internal/waitgroup"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/zlog/v2"
@@ -83,6 +85,12 @@ type Cache struct {
 	config  CacheConfig
 	metrics *CacheMetrics
 
+	// ecsPolicy mirrors middleware/edns's policy: nil when ECS
+	// forwarding is off (cache keys stay shared, today's behaviour),
+	// non-nil when on (lookup probes scoped keys, insert keys by
+	// the authority's SCOPE). Built once at New().
+	ecsPolicy *ecs.Policy
+
 	// Request deduplication
 	wg *waitgroup.WaitGroup
 
@@ -145,8 +153,9 @@ func New(cfg *config.Config) *Cache {
 
 		store: NewStore(positive, negative, cacheConfig),
 
-		config:  cacheConfig,
-		metrics: metrics,
+		config:    cacheConfig,
+		metrics:   metrics,
+		ecsPolicy: buildCacheECSPolicy(cfg),
 
 		wg: waitgroup.New(15 * time.Second),
 
@@ -177,6 +186,28 @@ func New(cfg *config.Config) *Cache {
 
 // (*Cache).Name name returns middleware name.
 func (c *Cache) Name() string { return name }
+
+// buildCacheECSPolicy parses [ecs] config the same way
+// middleware/edns does, so the cache and the forwarder agree on
+// who is in the allow-list, what the source-prefix ceiling is, and
+// what min-scope cap to apply when keying. Invalid configuration
+// disables ECS-aware caching (cache falls back to shared keys for
+// the affected requests); a startup log line surfaces the reason.
+func buildCacheECSPolicy(cfg *config.Config) *ecs.Policy {
+	c := cfg.ECS
+	p, err := ecs.Build(
+		c.Enabled,
+		c.ForwardV4Max, c.ForwardV6Max,
+		c.MinScopeV4, c.MinScopeV6,
+		c.ClientNetworks,
+	)
+	if err != nil {
+		zlog.Error("ECS-aware caching disabled: invalid [ecs] configuration",
+			"error", err.Error())
+		return nil
+	}
+	return p
+}
 
 // (*Cache).Store returns the storage facade, typed as
 // middleware.Store so Cache satisfies middleware.StoreProvider for
@@ -256,18 +287,60 @@ func (c *Cache) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		return
 	}
 
+	// Derive the client's ECS source prefix once and reuse it for
+	// scoped lookup, dedup, and insert. Zero prefix means ECS-aware
+	// caching doesn't apply (policy off, client not in allow-list,
+	// or no ECS option) and the request takes today's shared-key
+	// path bit-for-bit.
+	clientAddr, _ := netip.AddrFromSlice(w.RemoteIP())
+	if clientAddr.Is4In6() {
+		clientAddr = clientAddr.Unmap()
+	}
+	clientScope := c.requestScope(req, clientAddr)
+
 	// Cache key uses (name, qtype, class, CD) — same granularity
 	// as the dedup key so followers release into a lookup that
 	// matches what the leader wrote.
 	cacheKey := CacheKey{Question: q, CD: req.CheckingDisabled}.Hash()
+	dedupKey := cacheKey
+	if clientScope.IsValid() {
+		// Dedup at the client's source prefix so two clients in
+		// different ECS scopes don't share an upstream query (their
+		// answers would lose the scope distinction).
+		dedupKey = CacheKey{Question: q, CD: req.CheckingDisabled, Scope: clientScope}.Hash()
+	}
 
 	// Hot path: cache check before dedup. Concurrent cache hits
 	// used to take the waitgroup lock and allocate a Join
 	// context/timer even when the entry was already live.
+	//
+	// When the request carries ECS, probe scoped keys first
+	// (longest-prefix-match), then fall through to the shared key
+	// so SCOPE=0 / pre-Stage-2 entries still hit. checkCache
+	// records the metric on the shared-key path; scopedLookup
+	// records its own Hit on the scoped path so we don't
+	// double-count or under-count. ecsLookups breaks the same
+	// outcome down by ECS-vs-shared so operators can see how much
+	// the scoped path is actually carrying.
+	if clientScope.IsValid() {
+		if entry, scopedKey := c.scopedLookup(q, req.CheckingDisabled, clientScope); entry != nil {
+			ecsLookups.WithLabelValues("hit_scoped").Inc()
+			if c.handleCacheHit(ctx, ch, entry, scopedKey) {
+				return
+			}
+		}
+	}
 	if entry := c.checkCache(cacheKey); entry != nil {
+		if clientScope.IsValid() {
+			ecsLookups.WithLabelValues("hit_shared").Inc()
+		} else {
+			ecsLookups.WithLabelValues("non_ecs").Inc()
+		}
 		if c.handleCacheHit(ctx, ch, entry, cacheKey) {
 			return
 		}
+	} else if clientScope.IsValid() {
+		ecsLookups.WithLabelValues("miss").Inc()
 	}
 
 	// Miss. Dedup upstream work: followers wait for the leader
@@ -293,15 +366,26 @@ func (c *Cache) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	// ctx-based successor for code paths without a writer in
 	// scope.
 	if !w.Internal() {
-		if wait := c.wg.Join(cacheKey); wait != nil {
+		if wait := c.wg.Join(dedupKey); wait != nil {
 			<-wait
+			// Re-check both paths after a follower wakes up: the
+			// leader may have just stored a scoped entry (a
+			// shared-key check would miss it), or a SCOPE=0
+			// shared entry (a scoped check alone would miss it).
+			if clientScope.IsValid() {
+				if entry, scopedKey := c.scopedLookup(q, req.CheckingDisabled, clientScope); entry != nil {
+					if c.handleCacheHit(ctx, ch, entry, scopedKey) {
+						return
+					}
+				}
+			}
 			if entry := c.checkCache(cacheKey); entry != nil {
 				if c.handleCacheHit(ctx, ch, entry, cacheKey) {
 					return
 				}
 			}
 		} else {
-			defer c.wg.Done(cacheKey)
+			defer c.wg.Done(dedupKey)
 		}
 	}
 
@@ -318,10 +402,15 @@ func (c *Cache) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	// sub-query. The field is cleared on release so a pooled
 	// writer doesn't leak a ctx reference between uses.
 	rw.ctx = ctx
+	// Stash the client's request scope so WriteMsg can derive
+	// the insert key without re-reading the OPT (which by then
+	// may have been mutated by the edns wrapper on the response).
+	rw.clientScope = clientScope
 	ch.Writer = rw
 	defer func() {
 		ch.Writer = w
 		rw.ctx = nil
+		rw.clientScope = netip.Prefix{}
 		c.writerPool.Put(rw)
 	}()
 
@@ -340,6 +429,78 @@ func (c *Cache) checkCache(key uint64) *CacheEntry {
 
 	c.metrics.Miss()
 	return nil
+}
+
+// requestScope derives the client's ECS source prefix for cache
+// keying, returning the zero prefix when ECS-aware caching shouldn't
+// apply to this request (policy off, client not in allow-list, no
+// ECS option, malformed option). Uses the (already-clamped) ECS
+// source the edns middleware preserved on req.Extra rather than
+// re-clamping from the writer's RemoteIP — keeps lookup and insert
+// keying agreed on a single derivation.
+func (c *Cache) requestScope(req *dns.Msg, client netip.Addr) netip.Prefix {
+	if c.ecsPolicy == nil || !c.ecsPolicy.Allows(client) {
+		return netip.Prefix{}
+	}
+	opt := req.IsEdns0()
+	if opt == nil {
+		return netip.Prefix{}
+	}
+	for _, o := range opt.Option {
+		sub, ok := o.(*dns.EDNS0_SUBNET)
+		if !ok {
+			continue
+		}
+		addr, ok := netip.AddrFromSlice(sub.Address)
+		if !ok {
+			return netip.Prefix{}
+		}
+		if addr.Is4In6() {
+			addr = addr.Unmap()
+		}
+		p, err := addr.Prefix(int(sub.SourceNetmask))
+		if err != nil {
+			return netip.Prefix{}
+		}
+		return p
+	}
+	return netip.Prefix{}
+}
+
+// scopedLookup probes the cache for the longest scope match that
+// covers `clientPrefix`. Returns the entry + the key it was found
+// under, or (nil, 0) on miss. The shared-key fallback is the
+// caller's responsibility — a scoped probe that misses should still
+// try the unscoped key in case the authority returned SCOPE=0
+// (cached shared) or the entry predates Stage 2.
+//
+// Iteration runs from the client's source prefix down to the
+// policy's min_scope ceiling — at most 33 probes for IPv4 or 129
+// for IPv6, but in practice ≤ 8 because forward_v4/v6 caps the
+// upper bound. Each probe is one hash compute + one map lookup,
+// well below the cost of an upstream resolution.
+func (c *Cache) scopedLookup(q dns.Question, cd bool, clientPrefix netip.Prefix) (*CacheEntry, uint64) {
+	if !clientPrefix.IsValid() {
+		return nil, 0
+	}
+	var minBits int
+	if clientPrefix.Addr().Is4() {
+		minBits = int(c.ecsPolicy.MinScopeV4)
+	} else {
+		minBits = int(c.ecsPolicy.MinScopeV6)
+	}
+	for bits := clientPrefix.Bits(); bits >= minBits; bits-- {
+		scope, err := clientPrefix.Addr().Prefix(bits)
+		if err != nil {
+			continue
+		}
+		key := CacheKey{Question: q, CD: cd, Scope: scope}.Hash()
+		if entry, ok := c.store.LookupByKey(key); ok {
+			c.metrics.Hit()
+			return entry, key
+		}
+	}
+	return nil, 0
 }
 
 // handleCacheHit processes a cache hit.
@@ -368,7 +529,12 @@ func (c *Cache) handleCacheHit(ctx context.Context, ch *middleware.Chain, entry 
 	// prefetch=true and ShouldPrefetch returns false until an
 	// unrelated expiry or replacement clears it — prefetch
 	// would silently disable itself for that key.
-	if c.prefetchQueue != nil && entry.ShouldPrefetch(c.config.Prefetch) {
+	//
+	// PrefetchEligible() gates scoped entries out: the prefetch
+	// worker has no client IP, so a refresh would forward without
+	// ECS and create a shared-key entry under the scoped key —
+	// wrong audience, wrong answer. Scoped entries just expire.
+	if c.prefetchQueue != nil && entry.PrefetchEligible() && entry.ShouldPrefetch(c.config.Prefetch) {
 		if entry.prefetch.CompareAndSwap(false, true) {
 			if !c.prefetchQueue.Add(PrefetchRequest{
 				Request: req.Copy(),
@@ -495,6 +661,13 @@ type ResponseWriter struct {
 	// additionalAnswer's sub-query. Set by Cache.ServeDNS when the
 	// writer is pulled from the pool; cleared on defer.
 	ctx context.Context
+	// clientScope is the prefix derived from the request's ECS
+	// option (already clamped by the edns middleware to the policy
+	// ceiling). Zero value when ECS doesn't apply, in which case
+	// WriteMsg falls back to the unscoped insert path bit-for-bit
+	// — that's how pre-Stage-2 traffic and SCOPE=0 responses keep
+	// the same cache shape they had before.
+	clientScope netip.Prefix
 }
 
 // (*ResponseWriter).WriteMsg writeMsg implements the ResponseWriter interface.
@@ -514,8 +687,29 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 	// Classify, filter, and store via Store. Key is derived from
 	// the response's CD bit — today's behaviour and the contract
 	// the cache dedup leader and follower agree on.
-	key := CacheKey{Question: q, CD: res.CheckingDisabled}.Hash()
-	w.cache.store.SetFromResponseWithKey(key, res)
+	//
+	// When the request carried an ECS scope this writer was set up
+	// to understand, read the authority's SCOPE off the response.
+	// SCOPE=0 ("global") means the authority's answer is suitable
+	// for everyone — fall back to the shared key so any later
+	// client (with or without ECS) hits the same entry. SCOPE>0
+	// means the answer is geo-tailored and gets a scoped key,
+	// clamped to the policy ceiling so cardinality stays bounded.
+	if w.clientScope.IsValid() {
+		if respScope, ok := ecs.ReadResponseScope(res); ok {
+			clamped := w.cache.ecsPolicy.ClampScope(respScope, w.clientScope)
+			scopedKey := CacheKey{Question: q, CD: res.CheckingDisabled, Scope: clamped}.Hash()
+			w.cache.store.SetFromResponseScoped(scopedKey, res)
+		} else {
+			// No SCOPE in response (or SCOPE=0): authority says
+			// "global"; cache shared so future non-ECS clients hit.
+			key := CacheKey{Question: q, CD: res.CheckingDisabled}.Hash()
+			w.cache.store.SetFromResponseWithKey(key, res)
+		}
+	} else {
+		key := CacheKey{Question: q, CD: res.CheckingDisabled}.Hash()
+		w.cache.store.SetFromResponseWithKey(key, res)
+	}
 
 	// Resolve CNAME chains before sending to client (matching V1
 	// behavior). Depth counter replaces the pre-Phase-3d

--- a/middleware/cache/cache_ecs_test.go
+++ b/middleware/cache/cache_ecs_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/semihalev/sdns/config"
 	internalcache "github.com/semihalev/sdns/internal/cache"
 	"github.com/semihalev/sdns/internal/mock"
@@ -437,6 +438,76 @@ func TestECSCache_BroaderThanMinClientScopeHits(t *testing.T) {
 	respB := sendAndExpect(t, c, h, reqWithECS("broad.example.", 1, 20, "203.0.96.0"), "203.0.96.5")
 	assert.Equal(t, "10.20.30.40", answerA(respB), "second /20 query missed the /20 entry just inserted")
 	assert.Equal(t, 1, h.Calls(), "second /20 query went upstream instead of hitting the cache")
+}
+
+// TestECSCache_LookupsMetricCountsOnlyECSPaths pins the sixth-round
+// ultrareview P3 fix: dns_cache_ecs_lookups_total{outcome=...} must
+// count every request that went through the ECS-aware lookup path
+// exactly once (no skipped misses). Non-ECS lookups stay on the
+// existing dns_cache_hits_total / dns_cache_misses_total counters
+// — we don't duplicate them here.
+func TestECSCache_LookupsMetricCountsOnlyECSPaths(t *testing.T) {
+	cfg := makeECSTestConfig(t)
+	defer os.RemoveAll(cfg.Directory)
+	c := New(cfg)
+	defer c.Stop()
+
+	// Counter is package-global; snapshot before / after so we
+	// don't depend on whatever previous tests left behind.
+	hitScopedBefore := metricValue(t, "hit_scoped")
+	hitSharedBefore := metricValue(t, "hit_shared")
+	missBefore := metricValue(t, "miss")
+
+	h := &echoHandler{aRecord: "10.20.30.40", scopeBits: 24}
+
+	// (1) ECS request, cache empty → miss, then store.
+	_ = sendAndExpect(t, c, h,
+		reqWithECS("metric.example.", 1, 24, "203.0.113.0"),
+		"203.0.113.5")
+
+	// (2) Same ECS request → hit_scoped.
+	_ = sendAndExpect(t, c, h,
+		reqWithECS("metric.example.", 1, 24, "203.0.113.0"),
+		"203.0.113.5")
+
+	// (3) Non-ECS request — must NOT touch the ECS metric at all.
+	plain := new(dns.Msg)
+	plain.SetQuestion("metric.example.", dns.TypeA)
+	_ = sendAndExpect(t, c, h, plain, "10.0.0.7")
+
+	// (4) Another non-ECS that misses (different qname so no hit).
+	plainMiss := new(dns.Msg)
+	plainMiss.SetQuestion("absent.example.", dns.TypeA)
+	_ = sendAndExpect(t, c, h, plainMiss, "10.0.0.8")
+
+	gotMiss := metricValue(t, "miss") - missBefore
+	gotHitScoped := metricValue(t, "hit_scoped") - hitScopedBefore
+	gotHitShared := metricValue(t, "hit_shared") - hitSharedBefore
+
+	if gotMiss != 1 {
+		t.Errorf("miss delta = %v, want 1", gotMiss)
+	}
+	if gotHitScoped != 1 {
+		t.Errorf("hit_scoped delta = %v, want 1", gotHitScoped)
+	}
+	if gotHitShared != 0 {
+		t.Errorf("hit_shared delta = %v, want 0", gotHitShared)
+	}
+}
+
+// metricValue reads the current counter value for an ecsLookups
+// outcome. Returns 0 if the label has never been observed.
+func metricValue(t *testing.T, outcome string) float64 {
+	t.Helper()
+	m, err := ecsLookups.GetMetricWithLabelValues(outcome)
+	if err != nil {
+		t.Fatalf("get metric: %v", err)
+	}
+	var pb dto.Metric
+	if err := m.Write(&pb); err != nil {
+		t.Fatalf("write metric: %v", err)
+	}
+	return pb.GetCounter().GetValue()
 }
 
 // TestECSCache_PurgeIsCaseInsensitive pins the third-round

--- a/middleware/cache/cache_ecs_test.go
+++ b/middleware/cache/cache_ecs_test.go
@@ -351,6 +351,40 @@ func TestECSCache_PurgeRemovesScopedEntries(t *testing.T) {
 	}
 }
 
+// TestECSCache_BroaderThanMinClientScopeHits pins the fourth-round
+// ultrareview P2 fix: a client whose source prefix is broader than
+// the policy's min_scope (e.g. /20 with min_scope_v4=24) must still
+// be able to look up an entry it just inserted. The earlier
+// scopedLookup loop's `bits >= minBits` bound did zero probes when
+// the client's own bits fell below min_scope, even though Policy.Clamp
+// passed the /20 source through unchanged and the insert path
+// happily stored a /20 entry. The fix clamps the loop's lower bound
+// to never exceed the client prefix itself.
+func TestECSCache_BroaderThanMinClientScopeHits(t *testing.T) {
+	cfg := makeECSTestConfig(t) // defaults: ForwardV4Max=24, MinScopeV4=24
+	cfg.ECS.ForwardV4Max = 20   // allow /20 sources through
+	defer os.RemoveAll(cfg.Directory)
+	c := New(cfg)
+	defer c.Stop()
+
+	// echoHandler returns SCOPE=20 to match the client's /20 source —
+	// RFC 7871 §7.1.2 forbids SCOPE > SOURCE, so /20 is the strictest
+	// scope this authority can claim for this audience.
+	h := &echoHandler{aRecord: "10.20.30.40", scopeBits: 20}
+
+	// First request inserts the /20 entry.
+	req := reqWithECS("broad.example.", 1, 20, "203.0.96.0")
+	respA := sendAndExpect(t, c, h, req, "203.0.96.5")
+	assert.Equal(t, "10.20.30.40", answerA(respA))
+	require.Equal(t, 1, h.Calls())
+
+	// Second request from the same /20 must HIT the cache.
+	h.aRecord = "should-not-be-used"
+	respB := sendAndExpect(t, c, h, reqWithECS("broad.example.", 1, 20, "203.0.96.0"), "203.0.96.5")
+	assert.Equal(t, "10.20.30.40", answerA(respB), "second /20 query missed the /20 entry just inserted")
+	assert.Equal(t, 1, h.Calls(), "second /20 query went upstream instead of hitting the cache")
+}
+
 // TestECSCache_PurgeIsCaseInsensitive pins the third-round
 // ultrareview P2 fix: the scoped purge sweep compares names
 // directly, but cache keys lowercase the name during hashing.

--- a/middleware/cache/cache_ecs_test.go
+++ b/middleware/cache/cache_ecs_test.go
@@ -351,6 +351,44 @@ func TestECSCache_PurgeRemovesScopedEntries(t *testing.T) {
 	}
 }
 
+// TestECSCache_PurgeIsCaseInsensitive pins the third-round
+// ultrareview P2 fix: the scoped purge sweep compares names
+// directly, but cache keys lowercase the name during hashing.
+// An entry whose stored Question carries upper-case characters
+// (because the upstream response echoed the client's case) must
+// still be removed by a purge of the lowercase form.
+func TestECSCache_PurgeIsCaseInsensitive(t *testing.T) {
+	cfg := makeECSTestConfig(t)
+	defer os.RemoveAll(cfg.Directory)
+	c := New(cfg)
+	defer c.Stop()
+
+	// Seed under the stored Question with mixed case — that's what
+	// the cache would record if the client (or upstream response)
+	// used mixed case. The hash key itself is case-insensitive
+	// (Key + KeyWithPrefix both lowercase during hashing), so the
+	// stored question Name diverges from the lowercase form the
+	// operator-facing purge API will use.
+	req := new(dns.Msg)
+	req.SetQuestion("Mixed.Example.", dns.TypeA)
+	scope := netip.MustParsePrefix("203.0.113.0/24")
+	key := CacheKey{Question: req.Question[0], CD: false, Scope: scope}.Hash()
+	c.store.SetFromResponseScoped(key, reply(req, "10.0.0.1", 24))
+	require.Truef(t, func() bool { _, ok := c.store.LookupByKey(key); return ok }(),
+		"seed did not land in cache")
+
+	// Operator purges via the canonical lowercase FQDN.
+	c.store.Purge(dns.Question{
+		Name:   "mixed.example.",
+		Qtype:  dns.TypeA,
+		Qclass: dns.ClassINET,
+	})
+
+	if _, ok := c.store.LookupByKey(key); ok {
+		t.Errorf("scoped entry stored under mixed-case Question survived a lowercase purge")
+	}
+}
+
 // TestECSCache_CacheLimitTTLCapsScopedWrites pins the ultrareview
 // P2 fix: cache_limit_ttl must clamp the TTL of scoped entries so
 // a misbehaving upstream sending a multi-hour TTL on a /24 answer

--- a/middleware/cache/cache_ecs_test.go
+++ b/middleware/cache/cache_ecs_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/config"
@@ -134,12 +135,19 @@ func answerA(m *dns.Msg) string {
 
 // sendAndExpect runs `req` through `c` + `h`, returning the message
 // the client would have received.
+//
+// Drives the chain with ch.Next so the chain index advances through
+// the handlers normally. Calling c.ServeDNS directly would dispatch
+// the cache at chain index 0 — then the cache's own ch.Next would
+// re-dispatch index 0 (itself) instead of advancing to h, causing
+// recursive entry on the same dedup key. The follower path would
+// then wait 15 s for the leader to release.
 func sendAndExpect(t *testing.T, c *Cache, h middleware.Handler, req *dns.Msg, clientIP string) *dns.Msg {
 	t.Helper()
 	mw := mock.NewWriter("udp", clientIP+":0")
 	ch := middleware.NewChain([]middleware.Handler{c, h})
 	ch.Reset(mw, req)
-	c.ServeDNS(context.Background(), ch)
+	ch.Next(context.Background())
 	require.True(t, mw.Written(), "writer was not written")
 	return mw.Msg()
 }
@@ -299,5 +307,96 @@ func TestECSCache_ScopedEntryNotPrefetched(t *testing.T) {
 	unscoped := NewCacheEntry(new(dns.Msg), 60_000_000_000, 0)
 	if !unscoped.PrefetchEligible() {
 		t.Errorf("unscoped entry must be prefetch-eligible")
+	}
+}
+
+// TestECSCache_PurgeRemovesScopedEntries pins the ultrareview P2
+// fix: Store.Purge must also remove ECS-keyed entries, not just
+// the two unscoped CD keys. Otherwise an API-triggered purge
+// reports success while stale geo-tailored answers continue to
+// be served until their TTL expires.
+func TestECSCache_PurgeRemovesScopedEntries(t *testing.T) {
+	cfg := makeECSTestConfig(t)
+	defer os.RemoveAll(cfg.Directory)
+	c := New(cfg)
+	defer c.Stop()
+
+	req := new(dns.Msg)
+	req.SetQuestion("purge.example.", dns.TypeA)
+
+	// Seed two scoped entries and one unscoped (shared-key) entry
+	// for the same qname/qtype/qclass.
+	for _, addr := range []string{"203.0.113.0/24", "198.51.100.0/24"} {
+		scope := netip.MustParsePrefix(addr)
+		key := CacheKey{Question: req.Question[0], CD: false, Scope: scope}.Hash()
+		c.store.SetFromResponseScoped(key, reply(req, "10.0.0.1", 24))
+		if _, ok := c.store.LookupByKey(key); !ok {
+			t.Fatalf("scoped seed for %s did not land in cache", addr)
+		}
+	}
+	sharedKey := CacheKey{Question: req.Question[0], CD: false}.Hash()
+	c.store.SetFromResponseWithKey(sharedKey, reply(req, "10.0.0.99", 0))
+
+	c.store.Purge(req.Question[0])
+
+	if _, ok := c.store.LookupByKey(sharedKey); ok {
+		t.Errorf("shared-key entry survived Purge")
+	}
+	for _, addr := range []string{"203.0.113.0/24", "198.51.100.0/24"} {
+		scope := netip.MustParsePrefix(addr)
+		key := CacheKey{Question: req.Question[0], CD: false, Scope: scope}.Hash()
+		if _, ok := c.store.LookupByKey(key); ok {
+			t.Errorf("scoped entry %s survived Purge", addr)
+		}
+	}
+}
+
+// TestECSCache_CacheLimitTTLCapsScopedWrites pins the ultrareview
+// P2 fix: cache_limit_ttl must clamp the TTL of scoped entries so
+// a misbehaving upstream sending a multi-hour TTL on a /24 answer
+// can't pin that audience to a stale CDN node.
+func TestECSCache_CacheLimitTTLCapsScopedWrites(t *testing.T) {
+	cfg := makeECSTestConfig(t)
+	cfg.ECS.CacheLimitTTL.Duration = 30 * time.Second
+	defer os.RemoveAll(cfg.Directory)
+	c := New(cfg)
+	defer c.Stop()
+
+	// Build a response with a 1-hour TTL — well over the 30 s cap.
+	req := new(dns.Msg)
+	req.SetQuestion("ttlcap.example.", dns.TypeA)
+	resp := new(dns.Msg)
+	resp.SetReply(req)
+	resp.Answer = []dns.RR{makeRR("ttlcap.example. 3600 IN A 10.0.0.1")}
+	o := new(dns.OPT)
+	o.Hdr.Name = "."
+	o.Hdr.Rrtype = dns.TypeOPT
+	o.Option = []dns.EDNS0{&dns.EDNS0_SUBNET{
+		Code: dns.EDNS0SUBNET, Family: 1,
+		SourceNetmask: 24, SourceScope: 24,
+		Address: net.ParseIP("203.0.113.0").To4(),
+	}}
+	resp.Extra = []dns.RR{o}
+
+	scope := netip.MustParsePrefix("203.0.113.0/24")
+	key := CacheKey{Question: req.Question[0], CD: false, Scope: scope}.Hash()
+	c.store.SetFromResponseScoped(key, resp)
+
+	entry, ok := c.store.LookupByKey(key)
+	require.True(t, ok, "scoped seed did not land in cache")
+	if entry.ttl > cfg.ECS.CacheLimitTTL.Duration {
+		t.Errorf("scoped TTL %s exceeded cache_limit_ttl cap %s",
+			entry.ttl, cfg.ECS.CacheLimitTTL.Duration)
+	}
+
+	// Unscoped writes must NOT be capped — the cap is per
+	// CacheConfig.ECSMaxTTL gated by `scoped == true`.
+	plainKey := CacheKey{Question: req.Question[0], CD: false}.Hash()
+	c.store.SetFromResponseWithKey(plainKey, resp)
+	plain, ok := c.store.LookupByKey(plainKey)
+	require.True(t, ok)
+	if plain.ttl <= cfg.ECS.CacheLimitTTL.Duration {
+		t.Errorf("unscoped TTL %s was capped at %s (should not be)",
+			plain.ttl, cfg.ECS.CacheLimitTTL.Duration)
 	}
 }

--- a/middleware/cache/cache_ecs_test.go
+++ b/middleware/cache/cache_ecs_test.go
@@ -1,0 +1,303 @@
+package cache
+
+import (
+	"context"
+	"net"
+	"net/netip"
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	internalcache "github.com/semihalev/sdns/internal/cache"
+	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/middleware"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// makeECSTestConfig builds a config with ECS enabled at /24 IPv4
+// and /56 IPv6 ceilings, matching the defaults the production
+// builder applies. Tests opt into specific cardinality knobs via
+// the returned config.
+func makeECSTestConfig(t *testing.T) *config.Config {
+	t.Helper()
+	cfg := makeTestConfig()
+	cfg.ECS = config.ECSConfig{
+		Enabled:      true,
+		ForwardV4Max: 24,
+		ForwardV6Max: 56,
+		MinScopeV4:   24,
+		MinScopeV6:   56,
+	}
+	return cfg
+}
+
+// reqWithECS builds an A query for `name` carrying an ECS option
+// at the requested family / netmask / address — mirrors what the
+// edns middleware would leave on req.Extra after clamping.
+func reqWithECS(name string, family uint16, src uint8, addr string) *dns.Msg {
+	req := new(dns.Msg)
+	req.SetQuestion(name, dns.TypeA)
+	req.SetEdns0(4096, false)
+	opt := req.IsEdns0()
+	parsed := net.ParseIP(addr)
+	if family == 1 {
+		parsed = parsed.To4()
+	}
+	opt.Option = append(opt.Option, &dns.EDNS0_SUBNET{
+		Code: dns.EDNS0SUBNET, Family: family,
+		SourceNetmask: src, SourceScope: 0,
+		Address: parsed,
+	})
+	return req
+}
+
+// reply builds an upstream response for `req` with one A record and
+// (optionally) an ECS SCOPE the test wants to simulate.
+func reply(req *dns.Msg, aRecord string, scopeNetmask uint8) *dns.Msg {
+	m := new(dns.Msg)
+	m.SetReply(req)
+	m.Answer = []dns.RR{
+		makeRR(req.Question[0].Name + " 300 IN A " + aRecord),
+	}
+	if scopeNetmask > 0 {
+		o := new(dns.OPT)
+		o.Hdr.Name = "."
+		o.Hdr.Rrtype = dns.TypeOPT
+		// Mirror the request's ECS Source so RFC 7871 §7.1.2 is
+		// satisfied: SCOPE never wider than SOURCE.
+		var srcAddr net.IP
+		var family uint16
+		if reqOpt := req.IsEdns0(); reqOpt != nil {
+			for _, opt := range reqOpt.Option {
+				if v, ok := opt.(*dns.EDNS0_SUBNET); ok {
+					srcAddr = v.Address
+					family = v.Family
+					break
+				}
+			}
+		}
+		o.Option = []dns.EDNS0{&dns.EDNS0_SUBNET{
+			Code: dns.EDNS0SUBNET, Family: family,
+			SourceNetmask: scopeNetmask,
+			SourceScope:   scopeNetmask,
+			Address:       srcAddr,
+		}}
+		m.Extra = []dns.RR{o}
+	}
+	return m
+}
+
+// echoHandler is a downstream middleware that returns a canned A
+// record plus the ECS SCOPE the test asked for. Records how many
+// times it was invoked so dedup / cache-hit semantics can be
+// asserted from the test side.
+type echoHandler struct {
+	aRecord    string
+	scopeBits  uint8 // 0 = no SCOPE (treated as shared by cache)
+	mu         sync.Mutex
+	callCount  int
+	lastClient string
+}
+
+func (h *echoHandler) ServeDNS(_ context.Context, ch *middleware.Chain) {
+	h.mu.Lock()
+	h.callCount++
+	h.lastClient = ch.Writer.RemoteAddr().String()
+	h.mu.Unlock()
+
+	resp := reply(ch.Request, h.aRecord, h.scopeBits)
+	_ = ch.Writer.WriteMsg(resp)
+}
+
+func (h *echoHandler) Name() string { return "echo" }
+
+func (h *echoHandler) Calls() int {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	return h.callCount
+}
+
+// answerA returns the first A record on the response, or "" if
+// none. Tests use this as the proxy for "did the client get
+// audience-A's answer or audience-B's?"
+func answerA(m *dns.Msg) string {
+	for _, rr := range m.Answer {
+		if a, ok := rr.(*dns.A); ok {
+			return a.A.String()
+		}
+	}
+	return ""
+}
+
+// sendAndExpect runs `req` through `c` + `h`, returning the message
+// the client would have received.
+func sendAndExpect(t *testing.T, c *Cache, h middleware.Handler, req *dns.Msg, clientIP string) *dns.Msg {
+	t.Helper()
+	mw := mock.NewWriter("udp", clientIP+":0")
+	ch := middleware.NewChain([]middleware.Handler{c, h})
+	ch.Reset(mw, req)
+	c.ServeDNS(context.Background(), ch)
+	require.True(t, mw.Written(), "writer was not written")
+	return mw.Msg()
+}
+
+// TestECSCache_NoCrossContamination is the verbatim #417 regression.
+// Two clients in different /24s query the same name; each should see
+// their own audience's answer, never the other's.
+func TestECSCache_NoCrossContamination(t *testing.T) {
+	cfg := makeECSTestConfig(t)
+	defer os.RemoveAll(cfg.Directory)
+	c := New(cfg)
+	defer c.Stop()
+
+	// Two responses keyed by client subnet. We swap which is "live"
+	// by mutating echoHandler.aRecord between calls.
+	h := &echoHandler{aRecord: "10.20.30.40", scopeBits: 24}
+
+	// First: client A in 203.0.113.0/24 gets 10.20.30.40 (cached
+	// under scope 203.0.113.0/24).
+	respA := sendAndExpect(t, c, h, reqWithECS("cdn.example.", 1, 24, "203.0.113.0"), "203.0.113.5")
+	assert.Equal(t, "10.20.30.40", answerA(respA), "client A first lookup")
+	require.Equal(t, 1, h.Calls(), "upstream called once for client A")
+
+	// Authority now answers a different address for the next miss.
+	h.aRecord = "10.20.30.99"
+
+	// Second: client B in 198.51.100.0/24 — must NOT see client A's
+	// cached answer (#417 regression). The cache miss falls through
+	// to the upstream which serves the new audience-B answer.
+	respB := sendAndExpect(t, c, h, reqWithECS("cdn.example.", 1, 24, "198.51.100.0"), "198.51.100.5")
+	assert.Equal(t, "10.20.30.99", answerA(respB), "client B must NOT inherit client A's cached answer")
+	require.Equal(t, 2, h.Calls(), "upstream called once for client B (no cache cross-contamination)")
+
+	// Third: client A again. Must hit the cache (no third upstream
+	// call), still serving 10.20.30.40.
+	respA2 := sendAndExpect(t, c, h, reqWithECS("cdn.example.", 1, 24, "203.0.113.0"), "203.0.113.5")
+	assert.Equal(t, "10.20.30.40", answerA(respA2), "client A second lookup hits scoped cache")
+	assert.Equal(t, 2, h.Calls(), "no extra upstream call for client A's cache hit")
+}
+
+// TestECSCache_SharedKeyOnGlobalScope verifies that a SCOPE=0
+// response is cached under the shared key, so a later non-ECS
+// client hits the same entry (RFC 7871 §6 "global" answers).
+func TestECSCache_SharedKeyOnGlobalScope(t *testing.T) {
+	cfg := makeECSTestConfig(t)
+	defer os.RemoveAll(cfg.Directory)
+	c := New(cfg)
+	defer c.Stop()
+
+	// Authority returns NO scope on the response → treat as global.
+	h := &echoHandler{aRecord: "10.0.0.1", scopeBits: 0}
+
+	// ECS client populates the cache under the shared key (because
+	// the response had SCOPE=0).
+	respECS := sendAndExpect(t, c, h, reqWithECS("global.example.", 1, 24, "203.0.113.0"), "203.0.113.5")
+	assert.Equal(t, "10.0.0.1", answerA(respECS))
+	require.Equal(t, 1, h.Calls())
+
+	// Plain (non-ECS) client must hit the same entry.
+	plain := new(dns.Msg)
+	plain.SetQuestion("global.example.", dns.TypeA)
+	respPlain := sendAndExpect(t, c, h, plain, "10.0.0.2")
+	assert.Equal(t, "10.0.0.1", answerA(respPlain), "non-ECS client must hit the SCOPE=0 shared entry")
+	assert.Equal(t, 1, h.Calls(), "no extra upstream — shared-key hit")
+}
+
+// TestECSCache_PreStage2EntriesStillHit pins migration safety: a
+// cache entry written by today's shared-key path (the test seeds
+// the store directly with the unscoped Key) must still hit on a
+// later non-ECS lookup. The Stage 2 hash routing falls through to
+// the same Key() for Scope.IsZero(), but verifying end-to-end here
+// catches accidental key drift.
+func TestECSCache_PreStage2EntriesStillHit(t *testing.T) {
+	cfg := makeECSTestConfig(t)
+	defer os.RemoveAll(cfg.Directory)
+	c := New(cfg)
+	defer c.Stop()
+
+	// Seed the cache as the pre-Stage-2 code would have done.
+	req := new(dns.Msg)
+	req.SetQuestion("legacy.example.", dns.TypeA)
+	pre := reply(req, "192.0.2.50", 0)
+	sharedKey := internalcache.Key(req.Question[0], false)
+	c.store.SetFromResponseWithKey(sharedKey, pre)
+
+	// Plain client lookup hits without an upstream call.
+	h := &echoHandler{aRecord: "should-not-be-used", scopeBits: 0}
+	resp := sendAndExpect(t, c, h, req, "10.0.0.7")
+	assert.Equal(t, "192.0.2.50", answerA(resp))
+	assert.Equal(t, 0, h.Calls(), "pre-Stage-2 entry must hit without upstream")
+}
+
+// TestECSCache_SupernetHit covers the longest-prefix-match fallback:
+// an entry cached at /22 should serve a /24 client whose address
+// falls inside that /22 supernet (the cache probes /24 first, then
+// /23, then /22).
+func TestECSCache_SupernetHit(t *testing.T) {
+	cfg := makeECSTestConfig(t)
+	cfg.ECS.MinScopeV4 = 22 // allow lookups to widen down to /22
+	defer os.RemoveAll(cfg.Directory)
+	c := New(cfg)
+	defer c.Stop()
+
+	// Seed at /22 directly so the test doesn't depend on routing a
+	// matching SCOPE through the writer path. The shape mirrors
+	// what ResponseWriter.WriteMsg would have stored.
+	req := new(dns.Msg)
+	req.SetQuestion("super.example.", dns.TypeA)
+	scope, err := netip.ParsePrefix("203.0.112.0/22")
+	require.NoError(t, err)
+	key := CacheKey{Question: req.Question[0], CD: false, Scope: scope}.Hash()
+	c.store.SetFromResponseScoped(key, reply(req, "10.1.1.1", 22))
+
+	// Client at 203.0.113.42 — its /24 is 203.0.113.0, which falls
+	// inside 203.0.112.0/22. Lookup probes /24 (miss), /23 (miss),
+	// /22 (hit).
+	h := &echoHandler{aRecord: "should-not-be-used", scopeBits: 0}
+	resp := sendAndExpect(t, c, h, reqWithECS("super.example.", 1, 24, "203.0.113.0"), "203.0.113.42")
+	assert.Equal(t, "10.1.1.1", answerA(resp))
+	assert.Equal(t, 0, h.Calls(), "supernet probe must hit without upstream")
+}
+
+// TestECSCache_PolicyOffBypassesEverything: even an ECS-laden
+// request hits the shared-key path bit-for-bit when [ecs].enabled
+// is false. Stage 2 does not change behaviour for operators that
+// haven't opted in.
+func TestECSCache_PolicyOffBypassesEverything(t *testing.T) {
+	cfg := makeTestConfig() // ECS unset → disabled
+	defer os.RemoveAll(cfg.Directory)
+	c := New(cfg)
+	defer c.Stop()
+
+	h := &echoHandler{aRecord: "10.10.10.10", scopeBits: 24}
+
+	// Two clients in different /24s with ECS in the request still
+	// see the same cached answer — because policy is off and the
+	// cache keys both under the shared key.
+	respA := sendAndExpect(t, c, h, reqWithECS("nopolicy.example.", 1, 24, "203.0.113.0"), "203.0.113.5")
+	assert.Equal(t, "10.10.10.10", answerA(respA))
+	require.Equal(t, 1, h.Calls())
+
+	h.aRecord = "10.10.10.99" // never observed because cache hits
+	respB := sendAndExpect(t, c, h, reqWithECS("nopolicy.example.", 1, 24, "198.51.100.0"), "198.51.100.5")
+	assert.Equal(t, "10.10.10.10", answerA(respB), "policy off → client B sees client A's cached answer (today's behaviour)")
+	assert.Equal(t, 1, h.Calls(), "policy off → no extra upstream call")
+}
+
+// TestECSCache_ScopedEntryNotPrefetched: a scoped entry's
+// PrefetchEligible() must return false so the prefetch worker
+// (which has no client IP) doesn't refresh it as a shared-key
+// answer and pollute the scope.
+func TestECSCache_ScopedEntryNotPrefetched(t *testing.T) {
+	scoped := NewScopedCacheEntry(new(dns.Msg), 60_000_000_000, 0)
+	if scoped.PrefetchEligible() {
+		t.Errorf("scoped entry must NOT be prefetch-eligible")
+	}
+	unscoped := NewCacheEntry(new(dns.Msg), 60_000_000_000, 0)
+	if !unscoped.PrefetchEligible() {
+		t.Errorf("unscoped entry must be prefetch-eligible")
+	}
+}

--- a/middleware/cache/cache_ecs_test.go
+++ b/middleware/cache/cache_ecs_test.go
@@ -351,6 +351,59 @@ func TestECSCache_PurgeRemovesScopedEntries(t *testing.T) {
 	}
 }
 
+// TestECSCache_BroaderScopeOnNormalClientHits pins the fifth-round
+// ultrareview P2 fix: when an authority returns a broader-than-min
+// SCOPE for a normal client (the common case — a /24 source with a
+// /20 SCOPE response, meaning "this answer covers the whole /20"),
+// the inserted /20 entry must be reachable by the same /24 client
+// on its next query. The earlier loop capped probes at min_scope_v4
+// = 24, so a /24 client only probed /24 and never found the /20
+// entry it had just caused to be stored.
+//
+// Distinct from BroaderThanMinClientScopeHits: that test exercises
+// a /20 *client* source. This one exercises the much more common
+// /24 *client* source with a broader *response* SCOPE.
+func TestECSCache_BroaderScopeOnNormalClientHits(t *testing.T) {
+	cfg := makeECSTestConfig(t) // defaults: ForwardV4Max=24, MinScopeV4=24
+	defer os.RemoveAll(cfg.Directory)
+	c := New(cfg)
+	defer c.Stop()
+
+	// Authority claims the answer is valid for the whole /20 around
+	// the client, even though the client itself sent a /24 source.
+	// RFC 7871 allows SCOPE wider than SOURCE (it's the authority
+	// saying "I'd give the same answer to a broader audience"); only
+	// SCOPE > SOURCE is the RFC violation that ClampScope clamps.
+	h := &echoHandler{aRecord: "10.1.2.3", scopeBits: 20}
+
+	// First /24 query inserts the /20 entry.
+	respA := sendAndExpect(t, c, h,
+		reqWithECS("broad-scope.example.", 1, 24, "203.0.112.0"),
+		"203.0.112.5")
+	assert.Equal(t, "10.1.2.3", answerA(respA))
+	require.Equal(t, 1, h.Calls())
+
+	// Second /24 query from the same client must HIT — same source
+	// prefix, the stored /20 entry covers it.
+	h.aRecord = "should-not-be-used"
+	respB := sendAndExpect(t, c, h,
+		reqWithECS("broad-scope.example.", 1, 24, "203.0.112.0"),
+		"203.0.112.5")
+	assert.Equal(t, "10.1.2.3", answerA(respB),
+		"second /24 query missed the /20 entry the first query inserted")
+	assert.Equal(t, 1, h.Calls(),
+		"second /24 query went upstream instead of hitting the broader cached entry")
+
+	// A different /24 *within* the same /20 must also hit — that's
+	// the whole point of caching at a broader SCOPE.
+	respC := sendAndExpect(t, c, h,
+		reqWithECS("broad-scope.example.", 1, 24, "203.0.113.0"),
+		"203.0.113.42")
+	assert.Equal(t, "10.1.2.3", answerA(respC),
+		"sibling /24 within the same /20 missed the broader entry")
+	assert.Equal(t, 1, h.Calls(), "sibling /24 went upstream needlessly")
+}
+
 // TestECSCache_BroaderThanMinClientScopeHits pins the fourth-round
 // ultrareview P2 fix: a client whose source prefix is broader than
 // the policy's min_scope (e.g. /20 with min_scope_v4=24) must still
@@ -358,8 +411,9 @@ func TestECSCache_PurgeRemovesScopedEntries(t *testing.T) {
 // scopedLookup loop's `bits >= minBits` bound did zero probes when
 // the client's own bits fell below min_scope, even though Policy.Clamp
 // passed the /20 source through unchanged and the insert path
-// happily stored a /20 entry. The fix clamps the loop's lower bound
-// to never exceed the client prefix itself.
+// happily stored a /20 entry. After the fifth-round fix lookup
+// probes down to /1 unconditionally, so this is implicitly covered;
+// kept as a focused regression for the broader-client axis.
 func TestECSCache_BroaderThanMinClientScopeHits(t *testing.T) {
 	cfg := makeECSTestConfig(t) // defaults: ForwardV4Max=24, MinScopeV4=24
 	cfg.ECS.ForwardV4Max = 20   // allow /20 sources through

--- a/middleware/cache/prometheus.go
+++ b/middleware/cache/prometheus.go
@@ -35,6 +35,18 @@ var (
 		Name: "dns_cache_hit_rate",
 		Help: "DNS cache hit rate percentage",
 	}, calculateHitRate)
+
+	// ECS-specific counters (RFC 7871). Tracks how much of the cache
+	// traffic the ECS-aware path is handling vs the shared-key
+	// fallback. outcome labels:
+	//   - hit_scoped:     scoped lookup found the entry
+	//   - hit_shared:     scoped lookup missed, shared-key hit (SCOPE=0 or pre-Stage-2 entry)
+	//   - miss:           neither path found an entry
+	//   - non_ecs:        request had no ECS or policy didn't apply; shared-key path only
+	ecsLookups = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "dns_cache_ecs_lookups_total",
+		Help: "ECS-aware cache lookups, partitioned by outcome",
+	}, []string{"outcome"})
 )
 
 // cacheInstance holds references to cache components for metrics
@@ -51,6 +63,7 @@ func init() {
 	prometheus.MustRegister(cachePrefetches)
 	prometheus.MustRegister(cacheSize)
 	prometheus.MustRegister(cacheHitRate)
+	prometheus.MustRegister(ecsLookups)
 }
 
 // SetMetricsInstance sets the metrics instance for hit rate calculation

--- a/middleware/cache/prometheus.go
+++ b/middleware/cache/prometheus.go
@@ -36,13 +36,15 @@ var (
 		Help: "DNS cache hit rate percentage",
 	}, calculateHitRate)
 
-	// ECS-specific counters (RFC 7871). Tracks how much of the cache
-	// traffic the ECS-aware path is handling vs the shared-key
-	// fallback. outcome labels:
-	//   - hit_scoped:     scoped lookup found the entry
-	//   - hit_shared:     scoped lookup missed, shared-key hit (SCOPE=0 or pre-Stage-2 entry)
-	//   - miss:           neither path found an entry
-	//   - non_ecs:        request had no ECS or policy didn't apply; shared-key path only
+	// ECS-specific counter (RFC 7871). Counts only requests that
+	// went through the ECS-aware lookup path; non-ECS lookups are
+	// already counted by dns_cache_hits_total /
+	// dns_cache_misses_total and aren't duplicated here. outcome
+	// labels:
+	//   - hit_scoped: scoped lookup found the entry
+	//   - hit_shared: scoped lookup missed, shared-key hit (SCOPE=0
+	//                 authority answer or pre-Stage-2 entry)
+	//   - miss:       both scoped probe and shared-key check missed
 	ecsLookups = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "dns_cache_ecs_lookups_total",
 		Help: "ECS-aware cache lookups, partitioned by outcome",

--- a/middleware/cache/store.go
+++ b/middleware/cache/store.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"strings"
 	"time"
 
 	"github.com/miekg/dns"
@@ -183,7 +184,14 @@ func (s *Store) Purge(q dns.Question) {
 			return true
 		}
 		eq := e.msg.Question[0]
-		if eq.Name == q.Name && eq.Qtype == q.Qtype && eq.Qclass == q.Qclass {
+		// DNS names compare case-insensitively (RFC 4343). The
+		// unscoped purge path is already case-insensitive — its
+		// key derives from internal/cache.Key which lowercases the
+		// name during hashing. The scoped sweep enumerates raw
+		// stored Questions, so the comparison has to match the
+		// hash's semantics or an entry cached for EXAMPLE.COM.
+		// would survive a purge of example.com.
+		if eq.Qtype == q.Qtype && eq.Qclass == q.Qclass && strings.EqualFold(eq.Name, q.Name) {
 			hits = append(hits, located{positive: positive, key: key})
 		}
 		return true

--- a/middleware/cache/store.go
+++ b/middleware/cache/store.go
@@ -91,17 +91,39 @@ func (s *Store) SetFromResponse(resp *dns.Msg, keyCD bool) {
 // SetFromResponseWithKey is the pre-keyed form of SetFromResponse,
 // used by ResponseWriter.WriteMsg, which has the key already.
 func (s *Store) SetFromResponseWithKey(key uint64, resp *dns.Msg) {
+	s.setFromResponseWithKey(key, resp, false)
+}
+
+// SetFromResponseScoped is SetFromResponseWithKey for entries that
+// were keyed under an ECS scope (RFC 7871 §7.1.2). The entry's
+// PrefetchEligible is false — the prefetch worker has no client IP
+// to derive ECS from, so refreshing a scoped entry would lose its
+// scope and store the wrong-audience answer.
+func (s *Store) SetFromResponseScoped(key uint64, resp *dns.Msg) {
+	s.setFromResponseWithKey(key, resp, true)
+}
+
+func (s *Store) setFromResponseWithKey(key uint64, resp *dns.Msg, scoped bool) {
 	mt, _ := dnsutil.ClassifyResponse(resp, time.Now().UTC())
 	filtered := filterCacheableAnswer(resp)
 	msgTTL := dnsutil.CalculateCacheTTL(filtered, mt)
 
+	newEntry := func(msg *dns.Msg, ttl time.Duration) *CacheEntry {
+		if scoped {
+			e := NewScopedCacheEntry(msg, ttl, s.cfg.RateLimit)
+			e.rateLimKey = key
+			return e
+		}
+		return NewCacheEntryWithKey(msg, ttl, s.cfg.RateLimit, key)
+	}
+
 	switch mt {
 	case dnsutil.TypeSuccess, dnsutil.TypeReferral, dnsutil.TypeNXDomain, dnsutil.TypeNoRecords:
 		ttl := s.positive.ttl.Calculate(msgTTL)
-		s.positive.Set(key, NewCacheEntryWithKey(filtered, ttl, s.cfg.RateLimit, key))
+		s.positive.Set(key, newEntry(filtered, ttl))
 	case dnsutil.TypeServerFailure:
 		ttl := s.negative.ttl.Calculate(msgTTL)
-		s.negative.Set(key, NewCacheEntryWithKey(filtered, ttl, s.cfg.RateLimit, key))
+		s.negative.Set(key, newEntry(filtered, ttl))
 	}
 }
 

--- a/middleware/cache/store.go
+++ b/middleware/cache/store.go
@@ -108,6 +108,19 @@ func (s *Store) setFromResponseWithKey(key uint64, resp *dns.Msg, scoped bool) {
 	filtered := filterCacheableAnswer(resp)
 	msgTTL := dnsutil.CalculateCacheTTL(filtered, mt)
 
+	// Scoped (ECS) entries get an additional cap: geo answers go
+	// stale faster than the resolver's normal MaxTTL would allow,
+	// and a misconfigured upstream sending a huge TTL on a /24
+	// answer shouldn't pin that audience-specific entry for hours.
+	// Zero ECSMaxTTL leaves scoped writes uncapped (operator opted
+	// in to long-lived scoped entries).
+	capTTL := func(ttl time.Duration) time.Duration {
+		if scoped && s.cfg.ECSMaxTTL > 0 && ttl > s.cfg.ECSMaxTTL {
+			return s.cfg.ECSMaxTTL
+		}
+		return ttl
+	}
+
 	newEntry := func(msg *dns.Msg, ttl time.Duration) *CacheEntry {
 		if scoped {
 			e := NewScopedCacheEntry(msg, ttl, s.cfg.RateLimit)
@@ -119,10 +132,10 @@ func (s *Store) setFromResponseWithKey(key uint64, resp *dns.Msg, scoped bool) {
 
 	switch mt {
 	case dnsutil.TypeSuccess, dnsutil.TypeReferral, dnsutil.TypeNXDomain, dnsutil.TypeNoRecords:
-		ttl := s.positive.ttl.Calculate(msgTTL)
+		ttl := capTTL(s.positive.ttl.Calculate(msgTTL))
 		s.positive.Set(key, newEntry(filtered, ttl))
 	case dnsutil.TypeServerFailure:
-		ttl := s.negative.ttl.Calculate(msgTTL)
+		ttl := capTTL(s.negative.ttl.Calculate(msgTTL))
 		s.negative.Set(key, newEntry(filtered, ttl))
 	}
 }
@@ -141,12 +154,46 @@ func (s *Store) SetEntryWithKey(key uint64, entry *CacheEntry, mt dnsutil.Respon
 }
 
 // Purge removes both CD=true and CD=false entries for q from
-// positive and negative caches.
+// positive and negative caches, including ECS-scoped entries.
+//
+// Scoped entries don't have a deterministic key the caller could
+// reproduce without enumerating every (qname, scope) the cache
+// has ever seen — there's no per-qname index. We sweep them with
+// ForEach: collect matching keys in one pass (snapshotting the
+// per-segment locks individually), then Remove outside the
+// iteration to avoid mutate-during-iterate hazards.
+//
+// O(n) on the cache size; Purge is rare (explicit operator API
+// call) so the linear scan is acceptable. If purge becomes
+// hot, a per-qname index would lift this back to O(matches).
 func (s *Store) Purge(q dns.Question) {
 	for _, cd := range []bool{false, true} {
 		key := CacheKey{Question: q, CD: cd}.Hash()
 		s.positive.Remove(key)
 		s.negative.Remove(key)
+	}
+
+	type located struct {
+		positive bool
+		key      uint64
+	}
+	var hits []located
+	s.ForEach(func(positive bool, key uint64, e *CacheEntry) bool {
+		if e == nil || !e.scoped || e.msg == nil || len(e.msg.Question) == 0 {
+			return true
+		}
+		eq := e.msg.Question[0]
+		if eq.Name == q.Name && eq.Qtype == q.Qtype && eq.Qclass == q.Qclass {
+			hits = append(hits, located{positive: positive, key: key})
+		}
+		return true
+	})
+	for _, h := range hits {
+		if h.positive {
+			s.positive.Remove(h.key)
+		} else {
+			s.negative.Remove(h.key)
+		}
 	}
 }
 

--- a/middleware/cache/types.go
+++ b/middleware/cache/types.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"errors"
+	"net/netip"
 	"sync/atomic"
 	"time"
 
@@ -28,12 +29,34 @@ type CacheEntry struct {
 	rateLimit  int            // Rate limit value (0 = no limit)
 	rateLimKey uint64         // Key for shared rate limiter lookup
 	ede        *dns.EDNS0_EDE // Preserved EDE information
+
+	// scoped is true when this entry was keyed under an ECS scope
+	// rather than the shared key. The prefetch worker can't
+	// resynthesise the client IP a scoped query implied, so scoped
+	// entries are not eligible for background refresh — they just
+	// expire normally. PrefetchEligible() reflects this.
+	scoped bool
 }
 
 // NewCacheEntry creates a new cache entry from a DNS message.
 func NewCacheEntry(msg *dns.Msg, ttl time.Duration, rateLimit int) *CacheEntry {
 	return NewCacheEntryWithKey(msg, ttl, rateLimit, 0)
 }
+
+// NewScopedCacheEntry creates a cache entry that's been keyed under
+// an ECS scope. The flag suppresses prefetch (the worker has no
+// client IP to derive the scope from on refresh).
+func NewScopedCacheEntry(msg *dns.Msg, ttl time.Duration, rateLimit int) *CacheEntry {
+	e := NewCacheEntryWithKey(msg, ttl, rateLimit, 0)
+	e.scoped = true
+	return e
+}
+
+// PrefetchEligible reports whether the prefetch worker may refresh
+// this entry. Scoped entries are skipped because the worker has no
+// client IP, so a refresh would lose the ECS scope and create a
+// shared-key entry instead — wrong answer for the wrong audience.
+func (e *CacheEntry) PrefetchEligible() bool { return !e.scoped }
 
 // NewCacheEntryWithKey creates a new cache entry with a specific key for rate limiting
 func NewCacheEntryWithKey(msg *dns.Msg, ttl time.Duration, rateLimit int, key uint64) *CacheEntry {
@@ -191,14 +214,50 @@ func (e *CacheEntry) GetRateLimiter() *rate.Limiter {
 }
 
 // CacheKey represents a structured cache key.
+//
+// Scope is the ECS prefix (RFC 7871) the authority claimed its
+// answer is scoped to. The zero value means "shared" — an entry
+// keyed with no scope is reachable by any client, which is the
+// pre-Stage-2 default and how non-ECS traffic and SCOPE=0
+// authority answers continue to behave after the upgrade.
 type CacheKey struct {
 	Question dns.Question
 	CD       bool
+	Scope    netip.Prefix
 }
 
-// (CacheKey).Hash hash returns the cache key hash.
+// (CacheKey).Hash returns the cache key hash. Falls back to the
+// unscoped Key() — bit-identical to pre-Stage-2 — when Scope is
+// the zero value, so old cache entries keep hitting after upgrade.
 func (k CacheKey) Hash() uint64 {
-	return cache.Key(k.Question, k.CD)
+	if !k.Scope.IsValid() {
+		return cache.Key(k.Question, k.CD)
+	}
+	return cache.KeyWithScope(k.Question, k.CD, scopeBytes(k.Scope))
+}
+
+// scopeBytes returns the address portion of p truncated to the
+// number of bytes the prefix actually covers (rounded up). This is
+// what we fold into the hash — it captures the scope's identity
+// without leaking the address-family bytes outside the prefix.
+func scopeBytes(p netip.Prefix) []byte {
+	if !p.IsValid() {
+		return nil
+	}
+	bits := p.Bits()
+	if bits == 0 {
+		// A /0 scope is a degenerate "global" hint — treat as no
+		// scope to keep collision behaviour with the unscoped path.
+		return nil
+	}
+	n := (bits + 7) / 8
+	addr := p.Addr().AsSlice()
+	if n > len(addr) {
+		n = len(addr)
+	}
+	out := make([]byte, n)
+	copy(out, addr[:n])
+	return out
 }
 
 // CacheConfig holds cache configuration with validation.

--- a/middleware/cache/types.go
+++ b/middleware/cache/types.go
@@ -226,38 +226,18 @@ type CacheKey struct {
 	Scope    netip.Prefix
 }
 
-// (CacheKey).Hash returns the cache key hash. Falls back to the
-// unscoped Key() — bit-identical to pre-Stage-2 — when Scope is
-// the zero value, so old cache entries keep hitting after upgrade.
+// (CacheKey).Hash returns the cache key hash. Routes to
+// cache.KeyWithPrefix when Scope is valid (family + bit-length +
+// address are all folded in so /22 and /24 of the same address
+// don't alias), and to the legacy cache.Key — bit-identical to
+// pre-Stage-2 — when Scope is the zero value, so old entries keep
+// hitting after upgrade. A /0 scope collapses to the unscoped key
+// because a /0 answer is semantically "global", same as no scope.
 func (k CacheKey) Hash() uint64 {
-	if !k.Scope.IsValid() {
+	if !k.Scope.IsValid() || k.Scope.Bits() == 0 {
 		return cache.Key(k.Question, k.CD)
 	}
-	return cache.KeyWithScope(k.Question, k.CD, scopeBytes(k.Scope))
-}
-
-// scopeBytes returns the address portion of p truncated to the
-// number of bytes the prefix actually covers (rounded up). This is
-// what we fold into the hash — it captures the scope's identity
-// without leaking the address-family bytes outside the prefix.
-func scopeBytes(p netip.Prefix) []byte {
-	if !p.IsValid() {
-		return nil
-	}
-	bits := p.Bits()
-	if bits == 0 {
-		// A /0 scope is a degenerate "global" hint — treat as no
-		// scope to keep collision behaviour with the unscoped path.
-		return nil
-	}
-	n := (bits + 7) / 8
-	addr := p.Addr().AsSlice()
-	if n > len(addr) {
-		n = len(addr)
-	}
-	out := make([]byte, n)
-	copy(out, addr[:n])
-	return out
+	return cache.KeyWithPrefix(k.Question, k.CD, k.Scope)
 }
 
 // CacheConfig holds cache configuration with validation.
@@ -269,6 +249,14 @@ type CacheConfig struct {
 	MinTTL      time.Duration
 	MaxTTL      time.Duration
 	RateLimit   int
+
+	// ECSMaxTTL caps the lifetime of cache entries keyed under an
+	// ECS scope. Geo-routed answers tend to go stale faster than
+	// the resolver's general MaxTTL would suggest — a CDN
+	// re-pointing a /24 between PoPs is normal traffic. Zero
+	// disables the cap (scoped entries live as long as their
+	// upstream TTL allowed). Populated from cfg.ECS.CacheLimitTTL.
+	ECSMaxTTL time.Duration
 }
 
 // (CacheConfig).Validate validate checks if the configuration is valid.

--- a/middleware/edns/edns.go
+++ b/middleware/edns/edns.go
@@ -43,82 +43,23 @@ func New(cfg *config.Config) *EDNS {
 }
 
 // buildECSPolicy translates the operator's [ecs] config block into a
-// reusable *ecs.Policy. Returns nil when the feature is disabled so
-// SetEdns0 takes the cheap nil-policy fast path.
-//
-// Validation is fail-closed: any malformed input (bad CIDR in
-// client_networks, source ceiling outside [1, 32]/[1, 128], etc.)
-// disables the policy entirely and logs the reason. The earlier
-// implementation silently dropped bad CIDRs which, if every entry
-// failed to parse, collapsed a restrictive `client_networks` list
-// into "no list specified = allow everyone" — a quiet fail-open.
-// Forwarding off is always a safer fallback than forwarding too much.
+// reusable *ecs.Policy. Returns nil when the feature is disabled or
+// when the config is invalid (fail-closed). Logs the reason in the
+// invalid case so the operator sees the typo on the next start.
 func buildECSPolicy(cfg *config.Config) *ecs.Policy {
 	c := cfg.ECS
-	if !c.Enabled {
+	p, err := ecs.Build(
+		c.Enabled,
+		c.ForwardV4Max, c.ForwardV6Max,
+		c.MinScopeV4, c.MinScopeV6,
+		c.ClientNetworks,
+	)
+	if err != nil {
+		zlog.Error("ECS: invalid configuration; forwarding disabled",
+			zlog.String("error", err.Error()))
 		return nil
 	}
-
-	v4 := c.ForwardV4Max
-	if v4 == 0 {
-		v4 = 24
-	}
-	if v4 > 32 {
-		zlog.Error("ECS: forward_v4 out of range; forwarding disabled",
-			zlog.Int("value", int(v4)), zlog.Int("max", 32))
-		return nil
-	}
-	v6 := c.ForwardV6Max
-	if v6 == 0 {
-		v6 = 56
-	}
-	if v6 > 128 {
-		zlog.Error("ECS: forward_v6 out of range; forwarding disabled",
-			zlog.Int("value", int(v6)), zlog.Int("max", 128))
-		return nil
-	}
-	mv4 := c.MinScopeV4
-	if mv4 == 0 {
-		mv4 = v4
-	}
-	if mv4 > 32 {
-		zlog.Error("ECS: min_scope_v4 out of range; forwarding disabled",
-			zlog.Int("value", int(mv4)), zlog.Int("max", 32))
-		return nil
-	}
-	mv6 := c.MinScopeV6
-	if mv6 == 0 {
-		mv6 = v6
-	}
-	if mv6 > 128 {
-		zlog.Error("ECS: min_scope_v6 out of range; forwarding disabled",
-			zlog.Int("value", int(mv6)), zlog.Int("max", 128))
-		return nil
-	}
-
-	nets := make([]netip.Prefix, 0, len(c.ClientNetworks))
-	for _, s := range c.ClientNetworks {
-		p, err := netip.ParsePrefix(s)
-		if err != nil {
-			// Fail-closed: a typo'd CIDR (`10.0.0.0/33`) must not
-			// collapse the allow-list to empty and re-open the
-			// feature to every client. Disable the policy entirely
-			// so the operator sees the loud log and fixes the typo.
-			zlog.Error("ECS: invalid client_networks CIDR; forwarding disabled",
-				zlog.String("entry", s), zlog.String("error", err.Error()))
-			return nil
-		}
-		nets = append(nets, p)
-	}
-
-	return &ecs.Policy{
-		Enabled:        true,
-		ForwardV4Max:   v4,
-		ForwardV6Max:   v6,
-		ClientNetworks: nets,
-		MinScopeV4:     mv4,
-		MinScopeV6:     mv6,
-	}
+	return p
 }
 
 // (*EDNS).Name name return middleware name.


### PR DESCRIPTION
The actual #417 fix. Stage 1 (#483) added opt-in ECS forwarding upstream; this PR makes the cache key on the response's SCOPE so a geo-tailored answer for one client subnet no longer gets served to a client in a different subnet.

## What changes

- **`internal/cache.KeyWithScope`** — zero-alloc variant of `Key` that folds scope-prefix-length + scope-address bytes into the existing buffer pool. Nil scope hashes identically to today's `Key`, so pre-Stage-2 entries keep hitting after upgrade (no flush needed).
- **`middleware/cache.CacheKey.Scope`** — new field; `Hash()` routes between scoped / unscoped hashes based on validity.
- **Lookup path** — when the request carries ECS and the policy applies, probe scoped keys longest-first (down to `min_scope_v{4,6}`), then fall through to the shared key so SCOPE=0 answers and pre-Stage-2 entries still hit. Dedup key (`waitgroup.Join`) is scope-aware too so two clients in different subnets get separate upstream queries.
- **Insert path** — request's clamped client prefix stashed on the wrapped writer at `ServeDNS`; `WriteMsg` reads `ecs.ReadResponseScope(res)`, clamps via `Policy.ClampScope` (enforces RFC 7871 §7.1.2 + cardinality cap), keys the new entry.
- **Prefetch gate** — scoped entries are `PrefetchEligible() == false`. The worker has no client IP, so a refresh would forward without ECS and create the wrong-audience answer under a scoped key.
- **Policy build refactor** — `config.ECSConfig` → `*ecs.Policy` lifted into `internal/ecs.Build` so `middleware/cache` and `middleware/edns` share one validation path. Each middleware logs failure in its own voice.
- **Metric** — `dns_cache_ecs_lookups_total{outcome}` partitions cache traffic into \`hit_scoped / hit_shared / miss / non_ecs\`.

## Cardinality safety

`Policy.ClampScope` enforces \`min_scope_v{4,6}\` on the insert key (default = forwarding ceiling, 24/56). A misbehaving authority returning very narrow scopes can't blow up the cache budget on per-client entries. RFC 7871 §7.1.2 (SCOPE never wider than SOURCE) enforced on the same call.

## Tests (`cache_ecs_test.go`)

- \`TestECSCache_NoCrossContamination\` — verbatim #417 regression: clients in different /24s get distinct cached answers, no cross-contamination.
- \`TestECSCache_SharedKeyOnGlobalScope\` — SCOPE=0 cached shared, served to non-ECS client.
- \`TestECSCache_PreStage2EntriesStillHit\` — entry seeded under the unscoped Key still hits a non-ECS lookup.
- \`TestECSCache_SupernetHit\` — /22-keyed entry serves /24 client in that /22.
- \`TestECSCache_PolicyOffBypassesEverything\` — disabled policy = today's shared-key behaviour bit-for-bit.
- \`TestECSCache_ScopedEntryNotPrefetched\` — scoped entry skips prefetch eligibility.

## Verification

- [x] \`go test ./...\` clean
- [x] \`go test -race ./internal/cache/... ./middleware/cache/...\` clean
- [x] \`golangci-lint run ./...\` 0 issues
- [ ] Manual: two \`dig\` invocations with \`+subnet=203.0.113.0/24\` and \`+subnet=198.51.100.0/24\` against a geo-aware test domain — confirm each gets its audience's answer on first miss and that subsequent same-subnet queries hit the cache without an upstream round-trip. (Operator-side validation.)

## Operator notes

- Stage 1 + Stage 2 together close #417. Operators already on Stage 1 just enable / reload — no config bump (configver stayed 1.7.0 from Stage 1).
- The \`[ecs]\` block's Stage-2 knobs (\`cache_limit_ttl\`, \`min_scope_v4\`, \`min_scope_v6\`) are now live; documented in the Stage-1 \`contrib/linux/sdns.conf\`.
- New metric \`dns_cache_ecs_lookups_total{outcome}\` is the easiest first check ("is the scoped path actually carrying traffic?").

Closes #417.