### PR TITLE
feat(metric): introduce internal/metric package and broaden observability

### DIFF
--- a/internal/metric/metric.go
+++ b/internal/metric/metric.go
@@ -1,0 +1,512 @@
+// Package metric is a thin shim over Prometheus that trades a small
+// amount of staleness for a much faster hot path.
+//
+// # Why it exists
+//
+// A direct Prometheus counter is already one atomic add internally —
+// fast in isolation, but a single shared cache line under heavy
+// concurrent contention (~33 ns/op on an 8-core M5). The Vec form
+// adds a per-call WithLabelValues map lookup that pushes the
+// contended cost to ~120 ns/op. Multiplied across every middleware
+// in a busy SDNS process, this is real CPU.
+//
+// metric's hot path:
+//
+//   - For an unlabeled Counter: runtime.procPin + an atomic add on a
+//     per-CPU shard. ~2 ns/op under 8-core contention. There is no
+//     shared cache line — each P writes its own.
+//   - For a CounterVec: an atomic.Pointer load of an immutable label-
+//     tuple map (rare write, COW) + map lookup, then the same
+//     per-CPU shard add as above. ~7 ns/op under 8-core contention
+//     for single-label vectors, ~12 ns/op for multi-label vectors
+//     (a pooled buffer + unsafe.String view keeps the hit path
+//     allocation-free even with multi-byte length-prefixed keys).
+//
+// # Lifecycle
+//
+// The flush goroutine starts automatically on first NewCounter or
+// NewCounterVec call and ticks at the configured interval (default
+// 1 s; override with SetFlushInterval BEFORE the first counter is
+// created). Each tick sums every Counter's shards and pushes the
+// delta into the underlying Prometheus counter via Add. Prometheus'
+// scraped value therefore lags by at most one flush interval —
+// invisible at the typical 15-s scrape, since rate() operates over
+// windows that dwarf the flush interval.
+//
+// At shutdown, callers MUST invoke Stop() to drain the final flush
+// before the process exits — otherwise up to one flush interval of
+// counts is lost. Stop is safe to call multiple times and from
+// multiple goroutines concurrently.
+//
+// # Constructors and registries
+//
+// NewCounter and NewCounterVec take a prometheus.Registerer. Pass
+// nil to use prometheus.DefaultRegisterer. Tests should pass a
+// fresh prometheus.NewRegistry() so repeated construction never
+// hits the MustRegister duplicate-collector panic.
+//
+// # Cost model
+//
+// Memory: each Counter is shardCount * 64 B = 512 B (8 cache-line-
+// padded atomics). A CounterVec with N distinct label tuples
+// allocates N Counters + one immutable map of N entries.
+//
+// Crash safety: up to one flush interval of un-flushed counts is
+// lost on process death. Acceptable for ops metrics.
+//
+// Concurrency: Counter.Inc/Add and CounterVec.WithLabelValues are
+// safe for unlimited concurrent calls. The flusher runs in one
+// dedicated goroutine and reads each Counter's lastSent without
+// synchronization — that field is owned by the flusher; the
+// registry's flushMu serialises all flush passes.
+//
+// # Limitations
+//
+// CounterVec is intended for CLOSED label sets — qtypes, rcodes,
+// named outcomes, etc. — where the cardinality is bounded by code
+// rather than by traffic. There is no Delete or unregister API:
+// every distinct label tuple stays in the COW map and the flush
+// registry for the rest of the process lifetime. Metrics with
+// runtime-unbounded labels (per-domain, per-client-IP) should use
+// prometheus.CounterVec directly and manage their own LRU eviction
+// (see middleware/metrics for the existing pattern).
+//
+// Histograms are intentionally out of scope. Bucket counts don't
+// compose under delta-flush the way scalars do, and the histogram
+// hot-path cost (~260 ns under 8-core contention) is dominated by
+// bucket lookup, not by cache-line contention. Sampling at the
+// observation site is the right answer for hot-path histograms.
+package metric
+
+import (
+	"encoding/binary"
+	"fmt"
+	"maps"
+	"sync"
+	"sync/atomic"
+	"time"
+	"unsafe"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+//go:linkname runtime_procPin runtime.procPin
+func runtime_procPin() int
+
+//go:linkname runtime_procUnpin runtime.procUnpin
+func runtime_procUnpin()
+
+// shardCount is the number of per-CPU shards each Counter holds.
+// Must be a power of two so the pid -> shard mapping is one AND.
+// 8 covers typical edge-box CPU counts (4-8 cores) without false
+// sharing; servers with >8 cores spread writes across the same 8
+// lines, which still wins on contention but does not scale linearly.
+// Bumping to 32 buys headroom at 4x memory; leave it 8 until profiles
+// say otherwise.
+const shardCount = 8
+
+// paddedAtomic places one atomic.Int64 on its own 64-byte cache line
+// so two adjacent shards never share an L1 line.
+type paddedAtomic struct {
+	v atomic.Int64
+	_ [56]byte
+}
+
+// Counter is a sharded counter that mirrors into a Prometheus Counter
+// on a background tick. Inc and Add are the hot path; flush is called
+// by the registry.
+//
+// The lastSent field is touched only by the flusher goroutine. The
+// registry serialises flushes per counter via its own snapshot, so no
+// atomic is needed here.
+type Counter struct {
+	shards   [shardCount]paddedAtomic
+	prom     prometheus.Counter
+	lastSent int64
+}
+
+// NewCounter constructs a Counter, registers the underlying
+// prometheus.Counter with reg (or prometheus.DefaultRegisterer when
+// reg is nil), enrolls it in metric's flush loop, and starts the
+// background flusher on first call. Panics on duplicate registration
+// (matches prometheus.MustRegister semantics so misconfiguration
+// fails loudly at boot).
+//
+// Tests should pass a fresh prometheus.NewRegistry() so repeated
+// construction across test runs never collides.
+func NewCounter(reg prometheus.Registerer, opts prometheus.CounterOpts) *Counter {
+	if reg == nil {
+		reg = prometheus.DefaultRegisterer
+	}
+	prom := prometheus.NewCounter(opts)
+	reg.MustRegister(prom)
+	c := &Counter{prom: prom}
+	defaultRegistry.add(c)
+	ensureFlusher()
+	return c
+}
+
+// Inc adds one to the counter.
+func (c *Counter) Inc() { c.Add(1) }
+
+// Add adds delta to the counter. Panics on negative delta, matching
+// prometheus.Counter.Add semantics — a negative add would also
+// silently deduct from a future positive add by lowering sum below
+// lastSent, so refusing it at the call site is the loud-failure
+// behaviour callers expect.
+func (c *Counter) Add(delta int64) {
+	if delta < 0 {
+		panic(fmt.Sprintf("metric: Counter.Add called with negative delta %d", delta))
+	}
+	pid := runtime_procPin()
+	c.shards[pid&(shardCount-1)].v.Add(delta)
+	runtime_procUnpin()
+}
+
+// Value returns the live cross-shard sum. Cheap (8 atomic loads),
+// but not free — callers should not poll it on a hot path. Used by
+// the flusher and by tests.
+func (c *Counter) Value() int64 {
+	var sum int64
+	for i := range c.shards {
+		sum += c.shards[i].v.Load()
+	}
+	return sum
+}
+
+// flush pushes the delta-since-last-flush into the underlying
+// Prometheus counter. Called only by the registry's flusher.
+func (c *Counter) flush() {
+	sum := c.Value()
+	if delta := sum - c.lastSent; delta > 0 {
+		c.prom.Add(float64(delta))
+		c.lastSent = sum
+	}
+}
+
+// CounterVec is the label-bearing form of Counter. Per-tuple Counter
+// pointers live in an immutable map behind an atomic.Pointer; reads
+// are a single atomic load + map lookup, writes (rare) clone the map
+// under a small mutex and CAS the pointer.
+//
+// First WithLabelValues call for a new tuple is slow (allocates +
+// registers a Counter, clones the map). Subsequent calls are wait-
+// free AND allocation-free for both single- and multi-label vectors
+// (multi-label lookups borrow a buffer from a sync.Pool and use
+// unsafe.String to view the encoded key without copying).
+//
+// For closed label sets (qtypes, rcodes, named outcomes), call
+// Register at startup so the map never grows after init.
+type CounterVec struct {
+	promVec *prometheus.CounterVec
+
+	// arity is the declared label-count of the underlying CounterVec.
+	// We validate every WithLabelValues call against it so a bad-
+	// arity call can't collide-hit an existing cached key. arity is
+	// set once at construction; never mutated.
+	arity int
+
+	// m holds the current (key -> *Counter) map. Replaced wholesale
+	// on writes via writeMu; readers atomic-load it without locks.
+	m       atomic.Pointer[map[string]*Counter]
+	writeMu sync.Mutex
+}
+
+// keyBufPool reuses byte buffers for multi-label key encoding so the
+// hot-path WithLabelValues call doesn't allocate even with several
+// labels. The pool's items are *[]byte (heap-stable across resets).
+var keyBufPool = sync.Pool{
+	New: func() any {
+		b := make([]byte, 0, 64)
+		return &b
+	},
+}
+
+// NewCounterVec constructs a CounterVec, registers the underlying
+// prometheus.CounterVec with reg (or prometheus.DefaultRegisterer
+// when reg is nil), and starts the background flusher on first call.
+func NewCounterVec(reg prometheus.Registerer, opts prometheus.CounterOpts, labels []string) *CounterVec {
+	if reg == nil {
+		reg = prometheus.DefaultRegisterer
+	}
+	pv := prometheus.NewCounterVec(opts, labels)
+	reg.MustRegister(pv)
+	cv := &CounterVec{promVec: pv, arity: len(labels)}
+	empty := map[string]*Counter{}
+	cv.m.Store(&empty)
+	ensureFlusher()
+	return cv
+}
+
+// Register pre-creates the Counter for the given label tuple and
+// returns it. Calling Register at boot for known label tuples avoids
+// any map clone in steady state.
+func (cv *CounterVec) Register(values ...string) *Counter {
+	return cv.WithLabelValues(values...)
+}
+
+// WithLabelValues returns the sharded Counter for the given label
+// tuple, creating one on first use. Panics on arity mismatch — same
+// loud failure as prometheus.CounterVec.WithLabelValues; without
+// this guard a bad-arity call could collide-hit an existing cached
+// key and silently increment the wrong series.
+//
+// For single-label vectors, the call is allocation-free (uses
+// values[0] directly as the map key). For multi-label vectors, the
+// encoded key is built into a pooled buffer and viewed via
+// unsafe.String for the lookup; if it hits, we return without any
+// allocation. Only the cache-miss path materialises a real string
+// for the map insert.
+func (cv *CounterVec) WithLabelValues(values ...string) *Counter {
+	if len(values) != cv.arity {
+		panic(fmt.Sprintf("metric: WithLabelValues called with %d values, vec declared %d labels",
+			len(values), cv.arity))
+	}
+	// Single-label fast path: the value is its own key, no encoding
+	// needed (and length-prefix encoding would just be a waste here
+	// since arity is fixed per-vec and validated above).
+	if cv.arity == 1 {
+		m := cv.m.Load()
+		if c, ok := (*m)[values[0]]; ok {
+			return c
+		}
+		return cv.create(values[0], values)
+	}
+
+	// Multi-label: encode into a pooled buffer using length-prefix
+	// so no two distinct (v1, v2, ...) tuples can ever produce the
+	// same bytes regardless of value content.
+	pb := keyBufPool.Get().(*[]byte)
+	*pb = encodeKey((*pb)[:0], values)
+
+	// Alloc-free string view of the encoded bytes — valid only while
+	// pb is checked out and unmodified. Used purely for the map
+	// lookup, which neither retains nor mutates the key. The unsafe
+	// is bounded: the resulting string never escapes this function
+	// on the hit path, and on the miss path we materialise a real
+	// string before releasing pb back to the pool.
+	keyView := unsafe.String(unsafe.SliceData(*pb), len(*pb)) //nolint:gosec // see comment above
+
+	m := cv.m.Load()
+	if c, ok := (*m)[keyView]; ok {
+		keyBufPool.Put(pb)
+		return c
+	}
+
+	// Cache miss: copy the encoded bytes into a real string so it
+	// stays valid after we return pb to the pool.
+	realKey := string(*pb)
+	keyBufPool.Put(pb)
+	return cv.create(realKey, values)
+}
+
+func (cv *CounterVec) create(key string, values []string) *Counter {
+	cv.writeMu.Lock()
+	defer cv.writeMu.Unlock()
+
+	// Re-check under the lock — another goroutine may have created
+	// this tuple between our Load and our acquire of writeMu.
+	cur := cv.m.Load()
+	if c, ok := (*cur)[key]; ok {
+		return c
+	}
+
+	promCounter := cv.promVec.WithLabelValues(values...)
+	c := &Counter{prom: promCounter}
+
+	// Enrol with the flush registry BEFORE making the counter
+	// publicly findable via cv.m. If we published first, a brief
+	// window exists where another goroutine could WithLabelValues +
+	// Inc, while a concurrent FlushAll snapshot misses the not-yet-
+	// registered counter — the increment would never reach
+	// Prometheus, and at shutdown a final flush would drop it
+	// silently. Counter.flush on an empty (un-incremented) counter
+	// is a no-op, so a spuriously-early flush here is harmless.
+	defaultRegistry.add(c)
+
+	next := make(map[string]*Counter, len(*cur)+1)
+	maps.Copy(next, *cur)
+	next[key] = c
+	cv.m.Store(&next)
+
+	return c
+}
+
+// encodeKey writes a collision-free length-prefixed encoding of
+// values into b and returns the extended slice. Each value is
+// preceded by its uvarint length, so neither separator collisions
+// nor arity collisions are possible: ("a\x1Fb",) and ("a", "b")
+// encode to different byte sequences.
+//
+// The arity is fixed per-vec and validated before calling, so we
+// don't need to encode it here.
+func encodeKey(b []byte, values []string) []byte {
+	var lenBuf [binary.MaxVarintLen64]byte
+	for _, v := range values {
+		n := binary.PutUvarint(lenBuf[:], uint64(len(v)))
+		b = append(b, lenBuf[:n]...)
+		b = append(b, v...)
+	}
+	return b
+}
+
+// Registry tracks every Counter so the flush goroutine can find them.
+// There is exactly one default registry per process.
+//
+// mu guards the counters slice (write side: add; read side: snapshot
+// inside flushAll). flushMu serialises flushAll itself — Counter.flush
+// performs a read-modify-write on lastSent without atomics, so two
+// concurrent flushes on the same counter would race on lastSent and
+// could double-count or lose deltas. flushMu is taken for the whole
+// flush pass; it's coarse but flushes run once per second at most.
+type Registry struct {
+	mu       sync.Mutex
+	flushMu  sync.Mutex
+	counters []*Counter
+}
+
+var defaultRegistry = &Registry{}
+
+func (r *Registry) add(c *Counter) {
+	r.mu.Lock()
+	r.counters = append(r.counters, c)
+	r.mu.Unlock()
+}
+
+// flushAll snapshots the slice under r.mu, then runs flush on each
+// counter under r.flushMu. The two locks are intentionally separate:
+// mu must not be held while a Counter is flushing (the flush might
+// allocate, and Prometheus' Add takes its own lock — holding mu
+// across that would block new metric registrations). flushMu must
+// be held across the whole pass to keep Counter.flush single-writer.
+//
+// Counters added mid-flush publish one interval late; that is fine.
+func (r *Registry) flushAll() {
+	r.flushMu.Lock()
+	defer r.flushMu.Unlock()
+
+	r.mu.Lock()
+	counters := append([]*Counter(nil), r.counters...)
+	r.mu.Unlock()
+	for _, c := range counters {
+		c.flush()
+	}
+}
+
+// FlushAll runs one flush of every registered counter. Useful at
+// shutdown and in tests.
+func FlushAll() { defaultRegistry.flushAll() }
+
+// Flusher state — process-singleton, started lazily on the first
+// NewCounter / NewCounterVec call so the package is impossible to
+// use unsafely (a forgotten StartFlusher used to mean silent zeros
+// on scrape, which is worse than any complexity).
+//
+// flusherInterval is the tick interval, configurable via
+// SetFlushInterval before the flusher starts. Once started the
+// interval is fixed for the goroutine's lifetime.
+var (
+	flusherInterval    = time.Second
+	flusherIntervalMu  sync.Mutex
+	flusherStartedOnce sync.Once
+	flusherStopOnce    sync.Once
+	flusherStarted     atomic.Bool
+	flusherStop        chan struct{}
+	flusherDone        chan struct{}
+)
+
+// SetFlushInterval overrides the default 1-second flush interval.
+// Must be called BEFORE the first NewCounter / NewCounterVec; once
+// the flusher goroutine is running its ticker is fixed. Panics on
+// d <= 0 or if the flusher has already started.
+func SetFlushInterval(d time.Duration) {
+	if d <= 0 {
+		panic(fmt.Sprintf("metric: SetFlushInterval requires d > 0, got %v", d))
+	}
+	flusherIntervalMu.Lock()
+	defer flusherIntervalMu.Unlock()
+	if flusherStarted.Load() {
+		panic("metric: SetFlushInterval must be called before the first NewCounter / NewCounterVec")
+	}
+	flusherInterval = d
+}
+
+// ensureFlusher starts the background goroutine on first call.
+// Idempotent — subsequent calls are no-ops. Called automatically
+// by NewCounter and NewCounterVec.
+//
+// The interval read and the started transition both happen under
+// flusherIntervalMu so SetFlushInterval can't slip between them:
+// either it runs before the lock is taken (its update is observed),
+// or it runs after Store(true) commits (it panics). It cannot
+// "succeed too late" — return successfully while the goroutine
+// silently uses the old interval. Channels are allocated BEFORE
+// the lock so a concurrent Stop() that observes started=true
+// always finds non-nil channels.
+func ensureFlusher() {
+	flusherStartedOnce.Do(func() {
+		flusherStop = make(chan struct{})
+		flusherDone = make(chan struct{})
+
+		flusherIntervalMu.Lock()
+		interval := flusherInterval
+		flusherStarted.Store(true)
+		flusherIntervalMu.Unlock()
+
+		go func() {
+			defer close(flusherDone)
+			t := time.NewTicker(interval)
+			defer t.Stop()
+			for {
+				select {
+				case <-t.C:
+					defaultRegistry.flushAll()
+				case <-flusherStop:
+					defaultRegistry.flushAll()
+					return
+				}
+			}
+		}()
+	})
+}
+
+// Stop drains the final flush and stops the background goroutine.
+// Safe to call multiple times and from multiple goroutines
+// concurrently; only the first call has effect. If the flusher
+// never started (no counters were ever registered), Stop is a
+// no-op.
+//
+// Callers MUST invoke Stop at shutdown — otherwise the last flush
+// interval of counts is lost.
+func Stop() {
+	if !flusherStarted.Load() {
+		return
+	}
+	flusherStopOnce.Do(func() {
+		close(flusherStop)
+		<-flusherDone
+	})
+}
+
+// resetForTest clears registry + flusher state so a follow-up test
+// starts from scratch. Tests only — never call from production code.
+func resetForTest() {
+	defaultRegistry.mu.Lock()
+	defaultRegistry.counters = nil
+	defaultRegistry.mu.Unlock()
+
+	if flusherStarted.Load() {
+		flusherStopOnce.Do(func() { close(flusherStop) })
+		if flusherDone != nil {
+			<-flusherDone
+		}
+	}
+	flusherStop = nil
+	flusherDone = nil
+	flusherStarted.Store(false)
+	flusherStartedOnce = sync.Once{}
+	flusherStopOnce = sync.Once{}
+	flusherIntervalMu.Lock()
+	flusherInterval = time.Second
+	flusherIntervalMu.Unlock()
+}

--- a/internal/metric/metric_test.go
+++ b/internal/metric/metric_test.go
@@ -1,0 +1,612 @@
+package metric
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+)
+
+// promValue reads the current value of a Prometheus counter via the
+// model interface. Avoids depending on client_golang's testutil
+// package, which pulls in heavier deps.
+func promValue(t *testing.T, c prometheus.Counter) float64 {
+	t.Helper()
+	m := &dto.Metric{}
+	if err := c.Write(m); err != nil {
+		t.Fatalf("counter Write: %v", err)
+	}
+	if m.Counter == nil || m.Counter.Value == nil {
+		return 0
+	}
+	return *m.Counter.Value
+}
+
+// newTestCounter builds a Counter without touching the global
+// Prometheus registry — tests can run repeatedly without
+// duplicate-registration panics.
+func newTestCounter(name string) (*Counter, prometheus.Counter) {
+	prom := prometheus.NewCounter(prometheus.CounterOpts{Name: name, Help: "test"})
+	c := &Counter{prom: prom}
+	return c, prom
+}
+
+// newTestCounterVec builds a CounterVec without touching the global
+// Prometheus registry. Mirrors NewCounterVec but uses a fresh
+// CounterVec each call so re-running the test never panics on
+// duplicate registration.
+func newTestCounterVec(name string, labels []string) *CounterVec {
+	pv := prometheus.NewCounterVec(prometheus.CounterOpts{Name: name, Help: "test"}, labels)
+	cv := &CounterVec{promVec: pv, arity: len(labels)}
+	empty := map[string]*Counter{}
+	cv.m.Store(&empty)
+	return cv
+}
+
+func TestCounterIncBasic(t *testing.T) {
+	c, _ := newTestCounter("test_inc_basic")
+
+	for range 100 {
+		c.Inc()
+	}
+
+	if got := c.Value(); got != 100 {
+		t.Errorf("Value = %d, want 100", got)
+	}
+}
+
+func TestCounterAdd(t *testing.T) {
+	c, _ := newTestCounter("test_add")
+
+	c.Add(5)
+	c.Add(7)
+	c.Add(13)
+
+	if got := c.Value(); got != 25 {
+		t.Errorf("Value = %d, want 25", got)
+	}
+}
+
+func TestCounterFlushPushesDelta(t *testing.T) {
+	c, prom := newTestCounter("test_flush_delta")
+
+	c.Add(10)
+	c.flush()
+	if got := promValue(t, prom); got != 10 {
+		t.Errorf("after first flush, prom = %v, want 10", got)
+	}
+
+	c.Add(5)
+	c.flush()
+	if got := promValue(t, prom); got != 15 {
+		t.Errorf("after second flush, prom = %v, want 15 (10 + 5 delta)", got)
+	}
+}
+
+func TestCounterFlushIsIdempotent(t *testing.T) {
+	c, prom := newTestCounter("test_flush_idempotent")
+
+	c.Add(42)
+	c.flush()
+	c.flush()
+	c.flush()
+
+	if got := promValue(t, prom); got != 42 {
+		t.Errorf("after 3 flushes with no new writes, prom = %v, want 42", got)
+	}
+}
+
+func TestCounterFlushWithNoData(t *testing.T) {
+	c, prom := newTestCounter("test_flush_empty")
+
+	c.flush()
+	if got := promValue(t, prom); got != 0 {
+		t.Errorf("flush of empty counter = %v, want 0", got)
+	}
+}
+
+// TestCounterConcurrentInc proves the hot path doesn't lose writes
+// under contention. Run with -race; the per-shard atomic add is
+// fully synchronised by sync/atomic semantics.
+func TestCounterConcurrentInc(t *testing.T) {
+	c, prom := newTestCounter("test_concurrent_inc")
+
+	const goroutines = 64
+	const perGoroutine = 10_000
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for range goroutines {
+		go func() {
+			defer wg.Done()
+			for range perGoroutine {
+				c.Inc()
+			}
+		}()
+	}
+	wg.Wait()
+
+	want := int64(goroutines * perGoroutine)
+	if got := c.Value(); got != want {
+		t.Errorf("Value after concurrent Inc = %d, want %d (lost %d)", got, want, want-got)
+	}
+
+	c.flush()
+	if got := promValue(t, prom); got != float64(want) {
+		t.Errorf("Prom value after flush = %v, want %d", got, want)
+	}
+}
+
+// TestCounterConcurrentIncAndFlush runs Inc and flush concurrently to
+// catch races between hot-path writers and the background flusher.
+// flush only reads atomic shard values + touches lastSent (single-
+// writer field), so no atomic on lastSent should be required.
+func TestCounterConcurrentIncAndFlush(t *testing.T) {
+	c, prom := newTestCounter("test_concurrent_inc_flush")
+
+	const writers = 16
+	const writes = 5_000
+	stop := make(chan struct{})
+	var wg sync.WaitGroup
+
+	wg.Add(writers)
+	for range writers {
+		go func() {
+			defer wg.Done()
+			for range writes {
+				c.Inc()
+			}
+		}()
+	}
+
+	// Flusher races alongside writers.
+	flushDone := make(chan struct{})
+	go func() {
+		defer close(flushDone)
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+				c.flush()
+				time.Sleep(time.Microsecond)
+			}
+		}
+	}()
+
+	wg.Wait()
+	close(stop)
+	<-flushDone
+
+	c.flush() // catch any tail writes
+	want := int64(writers * writes)
+	if got := c.Value(); got != want {
+		t.Errorf("Value = %d, want %d", got, want)
+	}
+	if got := promValue(t, prom); got != float64(want) {
+		t.Errorf("Prom value = %v, want %d", got, want)
+	}
+}
+
+// TestCounterShardsAreUsed sanity-checks that procPin actually spreads
+// writes. With many goroutines, more than one shard should have a non-
+// zero value. This is informational — flaky if Go's scheduler happens
+// to pin everything to one P during the test, but on multi-core
+// runners that essentially never happens.
+func TestCounterShardsAreUsed(t *testing.T) {
+	c, _ := newTestCounter("test_shards_used")
+
+	var wg sync.WaitGroup
+	wg.Add(32)
+	for range 32 {
+		go func() {
+			defer wg.Done()
+			for range 1000 {
+				c.Inc()
+			}
+		}()
+	}
+	wg.Wait()
+
+	used := 0
+	for i := range c.shards {
+		if c.shards[i].v.Load() > 0 {
+			used++
+		}
+	}
+	if used < 2 {
+		t.Logf("only %d shard(s) used — scheduler may have pinned everything to one P. Not a failure, but unusual.", used)
+	}
+}
+
+func TestCounterVecLazyCreate(t *testing.T) {
+	cv := newTestCounterVec("test_vec_lazy", []string{"outcome"})
+
+	c1 := cv.WithLabelValues("hit")
+	c2 := cv.WithLabelValues("miss")
+	c3 := cv.WithLabelValues("hit") // should reuse c1
+
+	if c1 == c2 {
+		t.Errorf("distinct labels returned the same counter")
+	}
+	if c1 != c3 {
+		t.Errorf("same label returned different counters across calls")
+	}
+
+	c1.Inc()
+	c1.Inc()
+	c2.Inc()
+
+	if got := c1.Value(); got != 2 {
+		t.Errorf("c1.Value = %d, want 2", got)
+	}
+	if got := c2.Value(); got != 1 {
+		t.Errorf("c2.Value = %d, want 1", got)
+	}
+}
+
+// TestCounterVecConcurrentCreate stresses the create() path with many
+// goroutines racing to register the same brand-new tuple. Only one
+// Counter should win, and all goroutines must observe the same
+// pointer. Catches double-create bugs in the LoadOrStore equivalent
+// (re-check under writeMu).
+func TestCounterVecConcurrentCreate(t *testing.T) {
+	cv := newTestCounterVec("test_vec_concurrent", []string{"outcome"})
+
+	const goroutines = 64
+	results := make([]*Counter, goroutines)
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func() {
+			defer wg.Done()
+			<-start
+			results[i] = cv.WithLabelValues("brand_new")
+		}()
+	}
+	close(start)
+	wg.Wait()
+
+	first := results[0]
+	for i, c := range results {
+		if c != first {
+			t.Errorf("goroutine %d got different counter pointer", i)
+		}
+	}
+
+	// All Inc calls below land on the single shared counter.
+	for _, c := range results {
+		c.Inc()
+	}
+	if got := first.Value(); got != int64(goroutines) {
+		t.Errorf("Value = %d, want %d", got, goroutines)
+	}
+}
+
+// TestCounterVecConcurrentCreateDistinct stresses the create() path
+// with many goroutines registering DIFFERENT tuples — exercises the
+// map-copy step under the writeMu. Map grows from 0 to N entries.
+func TestCounterVecConcurrentCreateDistinct(t *testing.T) {
+	cv := newTestCounterVec("test_vec_distinct", []string{"outcome"})
+
+	const goroutines = 64
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := range goroutines {
+		go func() {
+			defer wg.Done()
+			key := fmt.Sprintf("outcome_%d", i)
+			c := cv.WithLabelValues(key)
+			c.Inc()
+		}()
+	}
+	wg.Wait()
+
+	m := cv.m.Load()
+	if len(*m) != goroutines {
+		t.Errorf("map size = %d, want %d", len(*m), goroutines)
+	}
+	for i := range goroutines {
+		key := fmt.Sprintf("outcome_%d", i)
+		c, ok := (*m)[key]
+		if !ok {
+			t.Errorf("key %q missing from map", key)
+			continue
+		}
+		if got := c.Value(); got != 1 {
+			t.Errorf("counter for %q = %d, want 1", key, got)
+		}
+	}
+}
+
+func TestJoinLabels(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []string
+	}{
+		{"empty", nil},
+		{"single", []string{"foo"}},
+		{"two", []string{"A", "NOERROR"}},
+		{"three", []string{"a", "b", "c"}},
+		{"with empty", []string{"a", "", "c"}},
+	}
+	// We don't pin exact bytes — the encoding format is internal.
+	// What we DO pin: each input produces a distinct encoding.
+	seen := map[string]string{}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := string(encodeKey(nil, tc.values))
+			if prev, ok := seen[got]; ok && prev != tc.name {
+				t.Errorf("encodeKey(%q) collided with %q encoding", tc.values, prev)
+			}
+			seen[got] = tc.name
+		})
+	}
+}
+
+// TestEncodeKeyCollisionResistance covers the bugs the old
+// separator-based joinLabels would silently allow:
+//
+//   - ("a", "bc") vs ("ab", "c") — boundary ambiguity
+//   - ("a\x1Fb",) vs ("a", "b") — separator-in-value collision
+//   - () vs ("",) — zero-arity vs one-empty-value collision
+//
+// All three pairs must encode to distinct keys.
+func TestEncodeKeyCollisionResistance(t *testing.T) {
+	pairs := [][2][]string{
+		{{"a", "bc"}, {"ab", "c"}},
+		{{"a\x1fb"}, {"a", "b"}},
+		{nil, {""}},
+		{{""}, {"", ""}},
+	}
+	for i, p := range pairs {
+		a := string(encodeKey(nil, p[0]))
+		b := string(encodeKey(nil, p[1]))
+		if a == b {
+			t.Errorf("pair %d: %q and %q encode to the same key %q", i, p[0], p[1], a)
+		}
+	}
+}
+
+// TestFlusherLifecycle: the flusher starts on first counter
+// registration, a tick publishes counts to Prometheus, and Stop()
+// drains the final flush so no counts are lost at shutdown.
+func TestFlusherLifecycle(t *testing.T) {
+	t.Cleanup(resetForTest)
+	resetForTest()
+
+	SetFlushInterval(10 * time.Millisecond)
+	c := NewCounter(prometheus.NewRegistry(),
+		prometheus.CounterOpts{Name: "test_flusher_lifecycle", Help: "t"})
+
+	for range 7 {
+		c.Inc()
+	}
+	time.Sleep(40 * time.Millisecond)
+	if got := promValue(t, c.prom); got != 7 {
+		t.Errorf("after tick, prom = %v, want 7", got)
+	}
+
+	c.Add(3)
+	Stop()
+
+	if got := promValue(t, c.prom); got != 10 {
+		t.Errorf("after Stop, prom = %v, want 10 (final-flush captured the 3)", got)
+	}
+}
+
+// TestStopIdempotent: Stop must be safe to call multiple times.
+func TestStopIdempotent(t *testing.T) {
+	t.Cleanup(resetForTest)
+	resetForTest()
+
+	NewCounter(prometheus.NewRegistry(),
+		prometheus.CounterOpts{Name: "test_stop_idempotent", Help: "t"})
+	Stop()
+	Stop() // must not panic
+}
+
+// TestStopBeforeAnyCounter: Stop with no counters ever registered
+// must be a no-op (flusher never started).
+func TestStopBeforeAnyCounter(t *testing.T) {
+	t.Cleanup(resetForTest)
+	resetForTest()
+	Stop() // must not panic, must not block
+}
+
+// TestSetFlushIntervalValidates: zero / negative intervals must
+// panic loudly rather than tripping time.NewTicker inside the
+// goroutine.
+func TestSetFlushIntervalValidates(t *testing.T) {
+	t.Cleanup(resetForTest)
+
+	t.Run("zero", func(t *testing.T) {
+		resetForTest()
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("SetFlushInterval(0) did not panic")
+			}
+		}()
+		SetFlushInterval(0)
+	})
+	t.Run("negative", func(t *testing.T) {
+		resetForTest()
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("SetFlushInterval(-1) did not panic")
+			}
+		}()
+		SetFlushInterval(-1 * time.Second)
+	})
+}
+
+// TestSetFlushIntervalAfterStartPanics: changing the interval after
+// the flusher is already running cannot work (ticker is fixed) and
+// silently doing nothing would be worse than panic.
+func TestSetFlushIntervalAfterStartPanics(t *testing.T) {
+	t.Cleanup(resetForTest)
+	resetForTest()
+
+	NewCounter(prometheus.NewRegistry(),
+		prometheus.CounterOpts{Name: "test_set_after_start", Help: "t"})
+
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("SetFlushInterval after first counter did not panic")
+		}
+	}()
+	SetFlushInterval(5 * time.Second)
+}
+
+// TestLazyAutoStart: registering a Counter must implicitly start
+// the flusher — no caller-visible StartFlusher needed.
+func TestLazyAutoStart(t *testing.T) {
+	t.Cleanup(resetForTest)
+	resetForTest()
+	SetFlushInterval(10 * time.Millisecond)
+
+	c := NewCounter(prometheus.NewRegistry(),
+		prometheus.CounterOpts{Name: "test_lazy_start", Help: "t"})
+	c.Add(5)
+
+	time.Sleep(40 * time.Millisecond)
+	if got := promValue(t, c.prom); got != 5 {
+		t.Errorf("auto-started flusher didn't publish: prom = %v, want 5", got)
+	}
+}
+
+// TestNoNewCounterLost: a Counter registered while flushAll is
+// already iterating the snapshot must NOT cause a flush-skip on the
+// next tick. The "add mid-flush" race is the dangerous one.
+func TestNoNewCounterLost(t *testing.T) {
+	t.Cleanup(resetForTest)
+	resetForTest()
+
+	cv := newTestCounterVec("test_no_lost", []string{"k"})
+
+	// Pre-create some counters and seed values to give flushAll work.
+	for i := range 10 {
+		c := cv.WithLabelValues(fmt.Sprintf("k%d", i))
+		c.Add(int64(i + 1))
+	}
+
+	// Fire flushAll and a new counter creation in parallel.
+	var newCounter atomic.Pointer[Counter]
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		FlushAll()
+	}()
+	go func() {
+		defer wg.Done()
+		c := cv.WithLabelValues("brand_new_mid_flush")
+		c.Add(99)
+		newCounter.Store(c)
+	}()
+	wg.Wait()
+
+	// Now run FlushAll again. The new counter MUST be in the snapshot
+	// this time and its 99 should reach Prometheus.
+	FlushAll()
+	nc := newCounter.Load()
+	if nc == nil {
+		t.Fatal("test bug: newCounter not stored")
+	}
+	if got := promValue(t, nc.prom); got != 99 {
+		t.Errorf("new counter's Prom value after second flushAll = %v, want 99", got)
+	}
+}
+
+// TestCounterAddNegativeDeltaPanics: Prometheus counters disallow
+// negative additions, and our flush logic would silently swallow
+// later positive increments after a negative add. Add must panic
+// instead.
+func TestCounterAddNegativeDeltaPanics(t *testing.T) {
+	c, _ := newTestCounter("test_add_negative")
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Counter.Add(-1) did not panic")
+		}
+	}()
+	c.Add(-1)
+}
+
+// TestCounterVecArityMismatchPanics: calling WithLabelValues with
+// the wrong number of values must panic, matching prometheus.
+// CounterVec semantics. Without this guard, a bad-arity call could
+// collide-hit a cached key and silently increment the wrong series.
+func TestCounterVecArityMismatchPanics(t *testing.T) {
+	cv := newTestCounterVec("test_vec_arity", []string{"qtype", "rcode"})
+
+	t.Run("too few", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("WithLabelValues with too few values did not panic")
+			}
+		}()
+		cv.WithLabelValues("A")
+	})
+	t.Run("too many", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Error("WithLabelValues with too many values did not panic")
+			}
+		}()
+		cv.WithLabelValues("A", "NOERROR", "extra")
+	})
+}
+
+// TestCounterVecMultiLabelCollisionFree: encode + lookup for multi-
+// label vectors must distinguish boundary-ambiguous tuples that
+// would have collided under the old separator-based encoding.
+func TestCounterVecMultiLabelCollisionFree(t *testing.T) {
+	cv := newTestCounterVec("test_vec_multilabel_collision", []string{"a", "b"})
+
+	c1 := cv.WithLabelValues("a", "bc")
+	c2 := cv.WithLabelValues("ab", "c")
+	c3 := cv.WithLabelValues("a\x1fb", "c")
+
+	if c1 == c2 || c1 == c3 || c2 == c3 {
+		t.Errorf("collision: c1=%p c2=%p c3=%p", c1, c2, c3)
+	}
+
+	c1.Add(10)
+	c2.Add(20)
+	c3.Add(30)
+
+	if got := c1.Value(); got != 10 {
+		t.Errorf("c1.Value = %d, want 10", got)
+	}
+	if got := c2.Value(); got != 20 {
+		t.Errorf("c2.Value = %d, want 20", got)
+	}
+	if got := c3.Value(); got != 30 {
+		t.Errorf("c3.Value = %d, want 30", got)
+	}
+}
+
+// TestStopConcurrent: many goroutines call Stop() at the same time.
+// sync.Once around the close + drain must keep this safe.
+func TestStopConcurrent(t *testing.T) {
+	t.Cleanup(resetForTest)
+	resetForTest()
+
+	NewCounter(prometheus.NewRegistry(),
+		prometheus.CounterOpts{Name: "test_stop_concurrent", Help: "t"})
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for range 32 {
+		wg.Go(func() {
+			<-start
+			Stop()
+		})
+	}
+	close(start)
+	wg.Wait() // must not panic
+}

--- a/internal/metric/raceprobe_test.go
+++ b/internal/metric/raceprobe_test.go
@@ -1,0 +1,52 @@
+package metric
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// TestRaceConcurrentFlushAll: tight loop of concurrent FlushAll calls
+// while a writer adds to the counter. flushAll's flushMu must
+// serialise the underlying Counter.flush calls so the lastSent
+// read-modify-write doesn't race.
+func TestRaceConcurrentFlushAll(t *testing.T) {
+	t.Cleanup(resetForTest)
+	resetForTest()
+
+	prom := prometheus.NewCounter(prometheus.CounterOpts{Name: "race_probe", Help: "x"})
+	c := &Counter{prom: prom}
+	defaultRegistry.add(c)
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Go(func() {
+			<-start
+			for range 5_000 {
+				FlushAll()
+			}
+		})
+	}
+	// Writer to ensure flush always has work to do.
+	wg.Go(func() {
+		<-start
+		for range 1_000_000 {
+			c.Inc()
+		}
+	})
+
+	close(start)
+	wg.Wait()
+
+	// Final correctness check: the counter must equal what the
+	// writer added (no double-counting from concurrent flushes).
+	FlushAll()
+	if got := c.Value(); got != 1_000_000 {
+		t.Errorf("Value = %d, want 1_000_000", got)
+	}
+	if got := promValue(t, prom); got != 1_000_000 {
+		t.Errorf("Prom value = %v, want 1_000_000 (double-counting bug)", got)
+	}
+}

--- a/middleware/accesslist/accesslist.go
+++ b/middleware/accesslist/accesslist.go
@@ -4,11 +4,21 @@ import (
 	"context"
 	"net"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/metric"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/zlog/v2"
 	"github.com/yl2chen/cidranger"
 )
+
+// accessDenied counts queries dropped because the client IP isn't in
+// the configured access list. Security-relevant — a spike indicates
+// scanning or a misconfigured client trying repeatedly.
+var accessDenied = metric.NewCounter(nil, prometheus.CounterOpts{
+	Name: "dns_accesslist_denied_total",
+	Help: "Total DNS queries denied by the accesslist middleware",
+})
 
 // List type.
 type List struct {
@@ -57,6 +67,7 @@ func (a *List) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	allowed, _ := a.ranger.Contains(ch.Writer.RemoteIP())
 
 	if !allowed {
+		accessDenied.Inc()
 		// no reply to client
 		ch.Cancel()
 		return

--- a/middleware/blocklist/blocklist.go
+++ b/middleware/blocklist/blocklist.go
@@ -10,9 +10,19 @@ import (
 	"sync"
 
 	"github.com/miekg/dns"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/metric"
 	"github.com/semihalev/sdns/middleware"
 )
+
+// blocklistHits counts queries that matched a blocklist entry and
+// were synthesised away from the resolver chain. Operators use this
+// to monitor block effectiveness vs the legitimate query rate.
+var blocklistHits = metric.NewCounter(nil, prometheus.CounterOpts{
+	Name: "dns_blocklist_hits_total",
+	Help: "Total DNS queries blocked by the blocklist middleware",
+})
 
 // BlockList type
 //
@@ -99,6 +109,8 @@ func (b *BlockList) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		ch.Next(ctx)
 		return
 	}
+
+	blocklistHits.Inc()
 
 	msg := new(dns.Msg)
 	msg.SetReply(req)

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -327,7 +327,7 @@ func (c *Cache) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	// dns_cache_hits_total / dns_cache_misses_total).
 	if clientScope.IsValid() {
 		if entry, scopedKey := c.scopedLookup(q, req.CheckingDisabled, clientScope); entry != nil {
-			ecsLookups.WithLabelValues("hit_scoped").Inc()
+			ecsLookupHitScoped.Inc()
 			if c.handleCacheHit(ctx, ch, entry, scopedKey) {
 				return
 			}
@@ -335,13 +335,13 @@ func (c *Cache) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	}
 	if entry := c.checkCache(cacheKey); entry != nil {
 		if clientScope.IsValid() {
-			ecsLookups.WithLabelValues("hit_shared").Inc()
+			ecsLookupHitShared.Inc()
 		}
 		if c.handleCacheHit(ctx, ch, entry, cacheKey) {
 			return
 		}
 	} else if clientScope.IsValid() {
-		ecsLookups.WithLabelValues("miss").Inc()
+		ecsLookupMiss.Inc()
 	}
 
 	// Miss. Dedup upstream work: followers wait for the leader

--- a/middleware/cache/cache_ecs_test.go
+++ b/middleware/cache/cache_ecs_test.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
-	dto "github.com/prometheus/client_model/go"
 	"github.com/semihalev/sdns/config"
 	internalcache "github.com/semihalev/sdns/internal/cache"
 	"github.com/semihalev/sdns/internal/mock"
@@ -495,19 +494,12 @@ func TestECSCache_LookupsMetricCountsOnlyECSPaths(t *testing.T) {
 	}
 }
 
-// metricValue reads the current counter value for an ecsLookups
-// outcome. Returns 0 if the label has never been observed.
+// metricValue reads the live counter value for an ecsLookups
+// outcome via metric.Counter.Value (cross-shard sum). No flush
+// needed because Value reads the shards directly, not Prometheus.
 func metricValue(t *testing.T, outcome string) float64 {
 	t.Helper()
-	m, err := ecsLookups.GetMetricWithLabelValues(outcome)
-	if err != nil {
-		t.Fatalf("get metric: %v", err)
-	}
-	var pb dto.Metric
-	if err := m.Write(&pb); err != nil {
-		t.Fatalf("write metric: %v", err)
-	}
-	return pb.GetCounter().GetValue()
+	return float64(ecsLookups.WithLabelValues(outcome).Value())
 }
 
 // TestECSCache_BuildPolicyFailClosed covers the error path of

--- a/middleware/cache/prometheus.go
+++ b/middleware/cache/prometheus.go
@@ -2,25 +2,33 @@ package cache
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/semihalev/sdns/internal/metric"
 )
 
+// Counters use the internal/metric package (sharded + background
+// flush) — they're on the per-query hot path and benefit ~20x from
+// avoiding the direct prometheus.Counter atomic.
+//
+// Gauges (cacheSize, cacheHitRate) stay on direct Prometheus —
+// internal/metric is scalar-counter only, and these are scraped
+// once per Prometheus pull, not on every request.
 var (
-	cacheHits = prometheus.NewCounter(prometheus.CounterOpts{
+	cacheHits = metric.NewCounter(nil, prometheus.CounterOpts{
 		Name: "dns_cache_hits_total",
 		Help: "Total number of DNS cache hits",
 	})
 
-	cacheMisses = prometheus.NewCounter(prometheus.CounterOpts{
+	cacheMisses = metric.NewCounter(nil, prometheus.CounterOpts{
 		Name: "dns_cache_misses_total",
 		Help: "Total number of DNS cache misses",
 	})
 
-	cacheEvictions = prometheus.NewCounter(prometheus.CounterOpts{
+	cacheEvictions = metric.NewCounter(nil, prometheus.CounterOpts{
 		Name: "dns_cache_evictions_total",
 		Help: "Total number of DNS cache evictions",
 	})
 
-	cachePrefetches = prometheus.NewCounter(prometheus.CounterOpts{
+	cachePrefetches = metric.NewCounter(nil, prometheus.CounterOpts{
 		Name: "dns_cache_prefetches_total",
 		Help: "Total number of DNS cache prefetches",
 	})
@@ -45,10 +53,16 @@ var (
 	//   - hit_shared: scoped lookup missed, shared-key hit (SCOPE=0
 	//                 authority answer or pre-Stage-2 entry)
 	//   - miss:       both scoped probe and shared-key check missed
-	ecsLookups = prometheus.NewCounterVec(prometheus.CounterOpts{
+	ecsLookups = metric.NewCounterVec(nil, prometheus.CounterOpts{
 		Name: "dns_cache_ecs_lookups_total",
 		Help: "ECS-aware cache lookups, partitioned by outcome",
 	}, []string{"outcome"})
+
+	// Pre-resolved ECS outcome handles to skip the per-call map
+	// lookup. Closed set: any new outcome must be added here too.
+	ecsLookupHitScoped = ecsLookups.Register("hit_scoped")
+	ecsLookupHitShared = ecsLookups.Register("hit_shared")
+	ecsLookupMiss      = ecsLookups.Register("miss")
 )
 
 // cacheInstance holds references to cache components for metrics
@@ -59,13 +73,8 @@ var (
 )
 
 func init() {
-	prometheus.MustRegister(cacheHits)
-	prometheus.MustRegister(cacheMisses)
-	prometheus.MustRegister(cacheEvictions)
-	prometheus.MustRegister(cachePrefetches)
 	prometheus.MustRegister(cacheSize)
 	prometheus.MustRegister(cacheHitRate)
-	prometheus.MustRegister(ecsLookups)
 }
 
 // SetMetricsInstance sets the metrics instance for hit rate calculation

--- a/middleware/dns64/dns64.go
+++ b/middleware/dns64/dns64.go
@@ -148,7 +148,7 @@ func (d *DNS64) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		return
 	}
 	if w.Internal() {
-		Passthrough.WithLabelValues("internal").Inc()
+		passthroughInternal.Inc()
 		ch.Next(ctx)
 		return
 	}
@@ -161,7 +161,7 @@ func (d *DNS64) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		// DNS64 would interpret that SERVFAIL as "no AAAA",
 		// firing a recursive A query that bypasses the
 		// non-recursion intent.
-		Passthrough.WithLabelValues("no_rd").Inc()
+		passthroughNoRD.Inc()
 		ch.Next(ctx)
 		return
 	}
@@ -170,12 +170,12 @@ func (d *DNS64) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		// itself; do not synthesise. Symmetric for PTR: the
 		// CNAME we'd synthesise points at an unsigned name we
 		// fabricated, so respect the bit.
-		Passthrough.WithLabelValues("cd_bit").Inc()
+		passthroughCDBit.Inc()
 		ch.Next(ctx)
 		return
 	}
 	if !d.cfg.clientEligible(w.RemoteIP()) {
-		Passthrough.WithLabelValues("client_excluded").Inc()
+		passthroughClientExcluded.Inc()
 		ch.Next(ctx)
 		return
 	}
@@ -201,7 +201,7 @@ func (d *DNS64) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		return
 	}
 	if d.cfg.zoneExcluded(qname) {
-		Passthrough.WithLabelValues("zone_excluded").Inc()
+		passthroughZoneExcluded.Inc()
 		ch.Next(ctx)
 		return
 	}
@@ -352,7 +352,7 @@ func (w *responseWriter) WriteMsg(m *dns.Msg) error {
 		return w.ResponseWriter.WriteMsg(m)
 	}
 	if m.Rcode == dns.RcodeNameError {
-		Passthrough.WithLabelValues("nxdomain").Inc()
+		passthroughNXDomain.Inc()
 		return w.ResponseWriter.WriteMsg(m)
 	}
 	// RFC 6147 §5.5: a validating DNS64 must not paper over a
@@ -365,7 +365,7 @@ func (w *responseWriter) WriteMsg(m *dns.Msg) error {
 	// Pass the SERVFAIL through so the client sees the validation
 	// failure verbatim.
 	if isDNSSECFailure(m) {
-		Passthrough.WithLabelValues("dnssec_fail").Inc()
+		passthroughDNSSECFail.Inc()
 		return w.ResponseWriter.WriteMsg(m)
 	}
 
@@ -378,7 +378,7 @@ func (w *responseWriter) WriteMsg(m *dns.Msg) error {
 	if m.Rcode == dns.RcodeSuccess {
 		filtered, hadAAAA, kept, stripped := w.filterUpstreamAAAA(m)
 		if hadAAAA && kept > 0 {
-			Passthrough.WithLabelValues("aaaa_present").Inc()
+			passthroughAAAAPresent.Inc()
 			if stripped > 0 {
 				// We modified the RRset, so any AD bit the
 				// validator set no longer covers what the client
@@ -460,7 +460,7 @@ func (w *responseWriter) filterUpstreamAAAA(m *dns.Msg) (*dns.Msg, bool, int, in
 // non-nil empty/error response addressed to the AAAA question.
 func (w *responseWriter) synthesise(orig *dns.Msg) *dns.Msg {
 	if w.d.queryer == nil {
-		ALookupFailures.WithLabelValues("queryer_error").Inc()
+		aLookupQueryerError.Inc()
 		return nil
 	}
 
@@ -479,17 +479,17 @@ func (w *responseWriter) synthesise(orig *dns.Msg) *dns.Msg {
 		return nil
 	}
 	if aResp == nil {
-		ALookupFailures.WithLabelValues("nil_response").Inc()
+		aLookupNilResponse.Inc()
 		return nil
 	}
 	if aResp.Rcode != dns.RcodeSuccess {
 		switch aResp.Rcode {
 		case dns.RcodeServerFailure:
-			ALookupFailures.WithLabelValues("servfail").Inc()
+			aLookupServfail.Inc()
 		case dns.RcodeNameError:
-			ALookupFailures.WithLabelValues("nxdomain").Inc()
+			aLookupNXDomain.Inc()
 		default:
-			ALookupFailures.WithLabelValues("other_rcode").Inc()
+			aLookupOtherRcode.Inc()
 		}
 		return w.buildAResponseAsBasis(orig, aResp)
 	}
@@ -499,7 +499,7 @@ func (w *responseWriter) synthesise(orig *dns.Msg) *dns.Msg {
 		// NOERROR with no A records — RFC 6147 §5.1.6 still
 		// applies: the empty A response is the basis for the
 		// client reply.
-		ALookupFailures.WithLabelValues("no_a").Inc()
+		aLookupNoA.Inc()
 		return w.buildAResponseAsBasis(orig, aResp)
 	}
 
@@ -552,7 +552,7 @@ func (w *responseWriter) synthesise(orig *dns.Msg) *dns.Msg {
 	// 6147 §5.1.4 — we treat the response as if no A records
 	// existed. Fall back to the original NODATA.
 	if !hasAAAAInList(answers) {
-		Passthrough.WithLabelValues("a_excluded").Inc()
+		passthroughAExcluded.Inc()
 		return nil
 	}
 

--- a/middleware/dns64/metrics.go
+++ b/middleware/dns64/metrics.go
@@ -2,7 +2,7 @@ package dns64
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/semihalev/sdns/internal/metric"
 )
 
 var (
@@ -10,43 +10,58 @@ var (
 	// Bumped once per client query that resulted in synthesis,
 	// not per individual record — the metric tracks how often
 	// DNS64 had to step in, not how many addresses were embedded.
-	Synthesised = promauto.NewCounter(
-		prometheus.CounterOpts{
-			Name: "dns64_synthesised_total",
-			Help: "Total client AAAA queries answered with synthesised records",
-		},
-	)
+	Synthesised = metric.NewCounter(nil, prometheus.CounterOpts{
+		Name: "dns64_synthesised_total",
+		Help: "Total client AAAA queries answered with synthesised records",
+	})
 
 	// Passthrough counts AAAA queries that flowed through DNS64
 	// without synthesis, labelled by the reason. "aaaa_present"
 	// is the steady-state happy path; the rest are exclusion
 	// signals operators may want to monitor.
-	Passthrough = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "dns64_passthrough_total",
-			Help: "AAAA queries DNS64 left untouched, by reason",
-		},
-		[]string{"reason"},
-	)
+	Passthrough = metric.NewCounterVec(nil, prometheus.CounterOpts{
+		Name: "dns64_passthrough_total",
+		Help: "AAAA queries DNS64 left untouched, by reason",
+	}, []string{"reason"})
+
+	// Pre-resolved Passthrough handles — closed set; new reason
+	// strings introduced in dns64.go must be added here too.
+	passthroughInternal       = Passthrough.Register("internal")
+	passthroughNoRD           = Passthrough.Register("no_rd")
+	passthroughCDBit          = Passthrough.Register("cd_bit")
+	passthroughClientExcluded = Passthrough.Register("client_excluded")
+	passthroughZoneExcluded   = Passthrough.Register("zone_excluded")
+	passthroughNXDomain       = Passthrough.Register("nxdomain")
+	passthroughDNSSECFail     = Passthrough.Register("dnssec_fail")
+	passthroughAAAAPresent    = Passthrough.Register("aaaa_present")
+	passthroughAExcluded      = Passthrough.Register("a_excluded")
 
 	// ALookupFailures counts secondary A-record lookups that did
 	// not yield a usable result (SERVFAIL, no answer, etc.).
 	// Reason labels are bounded to a small set so the cardinality
 	// stays low.
-	ALookupFailures = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "dns64_a_lookup_failures_total",
-			Help: "Failures of the secondary A lookup issued during DNS64 synthesis",
-		},
-		[]string{"reason"},
-	)
+	ALookupFailures = metric.NewCounterVec(nil, prometheus.CounterOpts{
+		Name: "dns64_a_lookup_failures_total",
+		Help: "Failures of the secondary A lookup issued during DNS64 synthesis",
+	}, []string{"reason"})
+
+	// Pre-resolved ALookupFailures handles. The "other" /
+	// classifyQueryErr labels are also registered here so the
+	// dynamic-label call site never hits a cold-create.
+	aLookupQueryerError = ALookupFailures.Register("queryer_error")
+	aLookupNilResponse  = ALookupFailures.Register("nil_response")
+	aLookupServfail     = ALookupFailures.Register("servfail")
+	aLookupNXDomain     = ALookupFailures.Register("nxdomain")
+	aLookupOtherRcode   = ALookupFailures.Register("other_rcode")
+	aLookupNoA          = ALookupFailures.Register("no_a")
+	_                   = ALookupFailures.Register("no_response")
+	_                   = ALookupFailures.Register("max_recursion")
+	_                   = ALookupFailures.Register("other")
 
 	// PTRTranslated counts ip6.arpa PTR queries DNS64 redirected
 	// to their in-addr.arpa counterpart per RFC 6147 §5.3.1.
-	PTRTranslated = promauto.NewCounter(
-		prometheus.CounterOpts{
-			Name: "dns64_ptr_translated_total",
-			Help: "Total ip6.arpa PTR queries answered with a CNAME to in-addr.arpa",
-		},
-	)
+	PTRTranslated = metric.NewCounter(nil, prometheus.CounterOpts{
+		Name: "dns64_ptr_translated_total",
+		Help: "Total ip6.arpa PTR queries answered with a CNAME to in-addr.arpa",
+	})
 )

--- a/middleware/edns/edns.go
+++ b/middleware/edns/edns.go
@@ -7,11 +7,26 @@ import (
 	"sync"
 
 	"github.com/miekg/dns"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/semihalev/sdns/config"
 	"github.com/semihalev/sdns/internal/dnsutil"
 	"github.com/semihalev/sdns/internal/ecs"
+	"github.com/semihalev/sdns/internal/metric"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/zlog/v2"
+)
+
+// ednsErrors counts EDNS protocol-level rejections — queries the
+// middleware short-circuits before they reach the resolver chain.
+// Closed-set "reason" labels keep the cardinality bounded.
+var (
+	ednsErrors = metric.NewCounterVec(nil, prometheus.CounterOpts{
+		Name: "dns_edns_errors_total",
+		Help: "EDNS protocol errors that caused the query to be rejected, by reason",
+	}, []string{"reason"})
+
+	ednsErrorOpcodeUnsupp = ednsErrors.Register("opcode_unsupported")
+	ednsErrorBadVersion   = ednsErrors.Register("bad_version")
 )
 
 // responseWriterPool reuses per-query ResponseWriter wrappers. A wrapper
@@ -84,6 +99,7 @@ func (e *EDNS) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	w, req := ch.Writer, ch.Request
 
 	if req.Opcode > 0 {
+		ednsErrorOpcodeUnsupp.Inc()
 		_ = dnsutil.NotSupported(w, req)
 
 		ch.Cancel()
@@ -102,6 +118,7 @@ func (e *EDNS) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	}
 	opt, size, cookie, nsid, do := dnsutil.SetEdns0(req, e.ecsPolicy, clientAddr)
 	if opt.Version() != 0 {
+		ednsErrorBadVersion.Inc()
 		opt.SetVersion(0)
 
 		ch.CancelWithRcode(dns.RcodeBadVers, do)

--- a/middleware/failover/failover.go
+++ b/middleware/failover/failover.go
@@ -7,10 +7,30 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/semihalev/sdns/config"
 	"github.com/semihalev/sdns/internal/dnsutil"
+	"github.com/semihalev/sdns/internal/metric"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/zlog/v2"
+)
+
+var (
+	// failoverAttempts counts every time WriteMsg was about to write
+	// a SERVFAIL and instead started trying fallback servers. One
+	// increment per primary failure (not per fallback server tried).
+	failoverAttempts = metric.NewCounter(nil, prometheus.CounterOpts{
+		Name: "dns_failover_attempts_total",
+		Help: "Total times failover engaged after a SERVFAIL from primary resolution",
+	})
+
+	// failoverSuccess counts attempts that ended with a usable
+	// answer from a fallback server. The ratio failoverSuccess /
+	// failoverAttempts is the fallback-pool health signal.
+	failoverSuccess = metric.NewCounter(nil, prometheus.CounterOpts{
+		Name: "dns_failover_success_total",
+		Help: "Total queries answered by a fallback server after primary SERVFAIL",
+	})
 )
 
 // Failover type.
@@ -69,6 +89,8 @@ func (w *ResponseWriter) WriteMsg(m *dns.Msg) error {
 		return w.ResponseWriter.WriteMsg(m)
 	}
 
+	failoverAttempts.Inc()
+
 	req := new(dns.Msg)
 	req.SetQuestion(m.Question[0].Name, m.Question[0].Qtype)
 	req.Question[0].Qclass = m.Question[0].Qclass
@@ -86,6 +108,7 @@ func (w *ResponseWriter) WriteMsg(m *dns.Msg) error {
 
 		resp.Id = m.Id
 
+		failoverSuccess.Inc()
 		return w.ResponseWriter.WriteMsg(resp)
 	}
 

--- a/middleware/forwarder/forwarder.go
+++ b/middleware/forwarder/forwarder.go
@@ -7,10 +7,35 @@ import (
 	"strings"
 
 	"github.com/miekg/dns"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/semihalev/sdns/config"
 	"github.com/semihalev/sdns/internal/dnsutil"
+	"github.com/semihalev/sdns/internal/metric"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/zlog/v2"
+)
+
+var (
+	// forwarderFailures counts upstream exchanges that returned an
+	// error (timeout, connection refused, TLS handshake failure,
+	// etc). Bumped per upstream tried, so an SDNS configured with
+	// two forwarders that both fail increments by 2 for one client
+	// query. That matches "operator wants to know upstream health"
+	// better than a per-client increment would.
+	forwarderFailures = metric.NewCounter(nil, prometheus.CounterOpts{
+		Name: "dns_forwarder_failures_total",
+		Help: "Total upstream forwarder exchange failures",
+	})
+
+	// forwarderResponseMismatch counts responses whose question
+	// section did not match the outstanding query. A non-zero rate
+	// is a security signal — a real upstream never returns a
+	// mismatched question, so persistent counts here suggest a
+	// poisoning attempt or a broken upstream.
+	forwarderResponseMismatch = metric.NewCounter(nil, prometheus.CounterOpts{
+		Name: "dns_forwarder_response_mismatch_total",
+		Help: "Total upstream responses dropped due to question-section mismatch (potential poisoning signal)",
+	})
 )
 
 type server struct {
@@ -84,6 +109,7 @@ func (f *Forwarder) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 
 		resp, err := dnsutil.Exchange(ctx, req, server.Addr, server.Proto, reqClient)
 		if err != nil {
+			forwarderFailures.Inc()
 			zlog.Info("forwarder query failed", "query", formatQuestion(req.Question[0]), "error", err.Error())
 			continue
 		}
@@ -93,6 +119,7 @@ func (f *Forwarder) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		// returns a different name/type/class would otherwise be cached
 		// under that question, poisoning lookups for unrelated names.
 		if !questionMatches(req.Question[0], resp.Question) {
+			forwarderResponseMismatch.Inc()
 			zlog.Info("forwarder dropped response with mismatched question",
 				"query", formatQuestion(req.Question[0]))
 			continue

--- a/middleware/hostsfile/hostsfile.go
+++ b/middleware/hostsfile/hostsfile.go
@@ -137,6 +137,7 @@ func (h *Hostsfile) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 
 	// Increment lookup counter
 	atomic.AddUint64(&db.stats.lookups, 1)
+	hostsfileLookups.Inc()
 
 	// Handle different query types
 	var answer []dns.RR
@@ -165,6 +166,7 @@ func (h *Hostsfile) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 
 	// Increment hit counter
 	atomic.AddUint64(&db.stats.hits, 1)
+	hostsfileHits.Inc()
 
 	// Build response. Bypass SetReply so we don't allocate a new
 	// Question slice: miekg/dns's SetReply copies req.Question; ours

--- a/middleware/hostsfile/metrics.go
+++ b/middleware/hostsfile/metrics.go
@@ -1,0 +1,22 @@
+package hostsfile
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/semihalev/sdns/internal/metric"
+)
+
+// Mirror of the in-memory db.stats counters so operators can read
+// hostsfile hit/lookup rates from Prometheus without polling the
+// admin Stats() endpoint. Both increments happen — the internal
+// counter is still used by Stats() callers; the metric counter is
+// for scrape.
+var (
+	hostsfileLookups = metric.NewCounter(nil, prometheus.CounterOpts{
+		Name: "dns_hostsfile_lookups_total",
+		Help: "Total lookups attempted against the hosts file",
+	})
+	hostsfileHits = metric.NewCounter(nil, prometheus.CounterOpts{
+		Name: "dns_hostsfile_hits_total",
+		Help: "Total lookups that matched a hosts file entry",
+	})
+)

--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -119,6 +119,7 @@ func (k *Kubernetes) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	}
 
 	atomic.AddUint64(&k.queries, 1)
+	kubernetesQueries.Inc()
 
 	if len(req.Question) == 0 {
 		ch.Next(ctx)
@@ -150,12 +151,15 @@ func (k *Kubernetes) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		if err := w.WriteMsg(msg); err != nil {
 			atomic.AddUint64(&k.errors, 1)
 			atomic.AddUint64(&k.writeErrors, 1)
+			kubernetesErrors.Inc()
+			kubernetesWriteErrors.Inc()
 			zlog.Error("Failed to write SERVFAIL for unsynced cluster query",
 				zlog.String("query", qname),
 				zlog.String("error", err.Error()))
 			return
 		}
 		atomic.AddUint64(&k.answered, 1)
+		kubernetesAnswered.Inc()
 		return
 	}
 
@@ -176,6 +180,8 @@ func (k *Kubernetes) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		if err := w.WriteMsg(msg); err != nil {
 			atomic.AddUint64(&k.errors, 1)
 			atomic.AddUint64(&k.writeErrors, 1)
+			kubernetesErrors.Inc()
+			kubernetesWriteErrors.Inc()
 			zlog.Error("Failed to write DNS response",
 				zlog.String("query", qname),
 				zlog.Int("qtype", int(q.Qtype)),
@@ -183,6 +189,7 @@ func (k *Kubernetes) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 			return
 		}
 		atomic.AddUint64(&k.answered, 1)
+		kubernetesAnswered.Inc()
 		return
 	}
 
@@ -197,6 +204,8 @@ func (k *Kubernetes) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	if err := w.WriteMsg(msg); err != nil {
 		atomic.AddUint64(&k.errors, 1)
 		atomic.AddUint64(&k.writeErrors, 1)
+		kubernetesErrors.Inc()
+		kubernetesWriteErrors.Inc()
 		zlog.Error("Failed to write DNS response",
 			zlog.String("query", qname),
 			zlog.Int("qtype", int(q.Qtype)),
@@ -204,6 +213,7 @@ func (k *Kubernetes) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		return
 	}
 	atomic.AddUint64(&k.answered, 1)
+	kubernetesAnswered.Inc()
 }
 
 // populateDemoData seeds representative services / pods for the

--- a/middleware/kubernetes/metrics.go
+++ b/middleware/kubernetes/metrics.go
@@ -1,0 +1,28 @@
+package kubernetes
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/semihalev/sdns/internal/metric"
+)
+
+// Prometheus exports for the existing internal counters. Dual-write
+// here keeps the existing Stats() / debug paths working unchanged
+// while giving operators a scrape-able view of pod-discovery health.
+var (
+	kubernetesQueries = metric.NewCounter(nil, prometheus.CounterOpts{
+		Name: "dns_kubernetes_queries_total",
+		Help: "Total queries served by the kubernetes middleware",
+	})
+	kubernetesAnswered = metric.NewCounter(nil, prometheus.CounterOpts{
+		Name: "dns_kubernetes_answered_total",
+		Help: "Total queries the kubernetes middleware answered authoritatively",
+	})
+	kubernetesErrors = metric.NewCounter(nil, prometheus.CounterOpts{
+		Name: "dns_kubernetes_errors_total",
+		Help: "Total kubernetes lookup or response-build errors",
+	})
+	kubernetesWriteErrors = metric.NewCounter(nil, prometheus.CounterOpts{
+		Name: "dns_kubernetes_write_errors_total",
+		Help: "Total writes to the client that failed (subset of dns_kubernetes_errors_total)",
+	})
+)

--- a/middleware/metrics/metrics.go
+++ b/middleware/metrics/metrics.go
@@ -12,14 +12,31 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/metric"
 	"github.com/semihalev/sdns/middleware"
 )
 
+// queries is the multi-label per-query counter. Closed cardinality
+// (qtypes ~30, rcodes ~24) so internal/metric is a fit; the hot path
+// is ~12 ns/op vs ~120 ns/op for the prior With(pooled-labels) call.
+//
+// Package-level rather than per-Metrics-instance because:
+//   - prometheus.MustRegister panics on duplicates, so re-creation
+//     wouldn't work anyway
+//   - metric.NewCounterVec auto-starts the flusher; doing it once
+//     at init keeps lifecycle simple
+//   - middleware.Setup wires exactly one instance in production
+var queries = metric.NewCounterVec(nil, prometheus.CounterOpts{
+	Name: "dns_queries_total",
+	Help: "How many DNS queries processed",
+}, []string{"qtype", "rcode"})
+
 // Metrics type.
 type Metrics struct {
-	queries *prometheus.CounterVec
-
-	// Domain metrics with concurrent access tracking
+	// Domain metrics with concurrent access tracking. Stays on
+	// direct prometheus.CounterVec because the label cardinality
+	// (per-domain) is unbounded — internal/metric is for closed
+	// label sets only.
 	domainMetricsEnabled bool
 	domainMetricsLimit   int // Max domains to track (memory limit)
 	domainQueries        *prometheus.CounterVec
@@ -32,17 +49,9 @@ type Metrics struct {
 // New return new metrics.
 func New(cfg *config.Config) *Metrics {
 	m := &Metrics{
-		queries: prometheus.NewCounterVec(
-			prometheus.CounterOpts{
-				Name: "dns_queries_total",
-				Help: "How many DNS queries processed",
-			},
-			[]string{"qtype", "rcode"},
-		),
 		domainMetricsEnabled: cfg.DomainMetrics,
 		domainMetricsLimit:   cfg.DomainMetricsLimit,
 	}
-	_ = prometheus.Register(m.queries)
 
 	// Initialize domain metrics if enabled
 	if m.domainMetricsEnabled {
@@ -77,14 +86,12 @@ func (m *Metrics) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 
 	question := ch.Request.Question[0]
 
-	// Update general metrics
-	labels := AcquireLabels()
-	defer ReleaseLabels(labels)
-
-	labels["qtype"] = dns.TypeToString[question.Qtype]
-	labels["rcode"] = dns.RcodeToString[ch.Writer.Rcode()]
-
-	m.queries.With(labels).Inc()
+	// Hot path: single WithLabelValues lookup against the COW map,
+	// per-CPU sharded atomic add. ~12 ns/op under 8-core contention.
+	queries.WithLabelValues(
+		dns.TypeToString[question.Qtype],
+		dns.RcodeToString[ch.Writer.Rcode()],
+	).Inc()
 
 	// Update domain metrics if enabled
 	if m.domainMetricsEnabled {
@@ -197,23 +204,6 @@ func (m *Metrics) maybeCleanupDomains() {
 		// Remove from Prometheus
 		m.domainQueries.DeleteLabelValues(domain)
 	}
-}
-
-var labelsPool sync.Pool
-
-// AcquireLabels returns a label from pool.
-func AcquireLabels() prometheus.Labels {
-	x := labelsPool.Get()
-	if x == nil {
-		return prometheus.Labels{"qtype": "", "rcode": ""}
-	}
-
-	return x.(prometheus.Labels)
-}
-
-// ReleaseLabels returns labels to pool.
-func ReleaseLabels(labels prometheus.Labels) {
-	labelsPool.Put(labels)
 }
 
 const name = "metrics"

--- a/middleware/ratelimit/ratelimit.go
+++ b/middleware/ratelimit/ratelimit.go
@@ -8,11 +8,22 @@ import (
 
 	"github.com/cespare/xxhash/v2"
 	"github.com/miekg/dns"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/semihalev/sdns/config"
 	"github.com/semihalev/sdns/internal/dnsutil"
+	"github.com/semihalev/sdns/internal/metric"
 	"github.com/semihalev/sdns/middleware"
 	"golang.org/x/time/rate"
 )
+
+// rateLimitExceeded counts queries rejected by the per-client
+// rate-limiter. Both the UDP-cookie-mismatch path and the plain-
+// limiter-Allow path contribute. Operators alert on a sustained
+// non-zero rate.
+var rateLimitExceeded = metric.NewCounter(nil, prometheus.CounterOpts{
+	Name: "dns_ratelimit_exceeded_total",
+	Help: "Total DNS queries rejected by the ratelimit middleware",
+})
 
 type limiter struct {
 	rl     *rate.Limiter
@@ -99,6 +110,7 @@ func (r *RateLimit) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 
 					if w.Proto() == "udp" {
 						if !l.rl.Allow() {
+							rateLimitExceeded.Inc()
 							ch.Cancel()
 							return
 						}
@@ -116,6 +128,7 @@ func (r *RateLimit) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	}
 
 	if !l.rl.Allow() {
+		rateLimitExceeded.Inc()
 		// no reply to client
 		ch.Cancel()
 		return

--- a/middleware/recovery/recovery.go
+++ b/middleware/recovery/recovery.go
@@ -7,10 +7,21 @@ import (
 	"runtime/debug"
 
 	"github.com/miekg/dns"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/metric"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/zlog/v2"
 )
+
+// panics counts caught panics in downstream middleware. A non-zero
+// rate is a critical signal — every panic is a bug that the recovery
+// middleware turned into a SERVFAIL for the client. Alert on rate(),
+// not on absolute value.
+var panics = metric.NewCounter(nil, prometheus.CounterOpts{
+	Name: "dns_recovery_panics_total",
+	Help: "Total panics caught by the recovery middleware",
+})
 
 // Recovery dummy type.
 type Recovery struct{}
@@ -27,6 +38,7 @@ func (r *Recovery) Name() string { return name }
 func (r *Recovery) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	defer func() {
 		if r := recover(); r != nil {
+			panics.Inc()
 			ch.CancelWithRcode(dns.RcodeServerFailure, false)
 
 			zlog.Error("Recovered in ServeDNS", "recover", r)

--- a/middleware/reflex/metrics.go
+++ b/middleware/reflex/metrics.go
@@ -3,31 +3,27 @@ package reflex
 import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/semihalev/sdns/internal/metric"
 )
 
 var (
 	// ReflexDetections counts suspected amplification attack sources.
-	ReflexDetections = promauto.NewCounterVec(
-		prometheus.CounterOpts{
-			Name: "reflex_detections_total",
-			Help: "Total suspected amplification attack detections by query type",
-		},
-		[]string{"qtype"},
-	)
+	// Single-label CounterVec — alloc-free hot path via internal/metric.
+	ReflexDetections = metric.NewCounterVec(nil, prometheus.CounterOpts{
+		Name: "reflex_detections_total",
+		Help: "Total suspected amplification attack detections by query type",
+	}, []string{"qtype"})
 
 	// ReflexBlocked counts blocked queries.
-	ReflexBlocked = promauto.NewCounter(
-		prometheus.CounterOpts{
-			Name: "reflex_blocked_total",
-			Help: "Total queries blocked due to amplification attack suspicion",
-		},
-	)
+	ReflexBlocked = metric.NewCounter(nil, prometheus.CounterOpts{
+		Name: "reflex_blocked_total",
+		Help: "Total queries blocked due to amplification attack suspicion",
+	})
 
-	// ReflexTrackedIPs shows current tracked IP count.
-	ReflexTrackedIPs = promauto.NewGauge(
-		prometheus.GaugeOpts{
-			Name: "reflex_tracked_ips",
-			Help: "Number of IPs currently being tracked",
-		},
-	)
+	// ReflexTrackedIPs shows current tracked IP count — Gauge stays on
+	// direct Prometheus (internal/metric is scalar-counter only).
+	ReflexTrackedIPs = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "reflex_tracked_ips",
+		Help: "Number of IPs currently being tracked",
+	})
 )

--- a/middleware/resolver/auto_trust_anchor.go
+++ b/middleware/resolver/auto_trust_anchor.go
@@ -372,6 +372,7 @@ func (r *Resolver) AutoTA() {
 					zlog.Warn("Trust anchor REVOKE bit present but no valid self-signed RRSIG — ignoring revocation", "keytag", tag)
 					continue
 				}
+				taRevoked.Inc()
 				zlog.Warn("Trust anchor revoked!", "keytag", tag)
 				tombstones[dnskeyMaterialFP(ta.DNSKey)] = &Tombstone{DNSKey: ta.DNSKey, FirstSeen: time.Now()}
 				newRevocation = true
@@ -408,6 +409,7 @@ func (r *Resolver) AutoTA() {
 		}
 
 		// found new ksk
+		taNewPending.Inc()
 		zlog.Warn("New trust anchor found! Pending for hold-down", "keytag", tag, "hold-down", "30d")
 		ta.State = StateAddPend
 		ta.FirstSeen = time.Now()
@@ -439,6 +441,7 @@ func (r *Resolver) AutoTA() {
 					// Previously-valid key disappeared. Enter Missing;
 					// per §4.2 the key remains a valid trust anchor
 					// until the remove hold-down expires.
+					taMissing.Inc()
 					zlog.Warn("Trust anchor missing! Please check it manually", "keytag", tag, "hold-down", "90d")
 					ta.State = StateMissing
 					ta.FirstSeen = time.Now()
@@ -454,6 +457,7 @@ func (r *Resolver) AutoTA() {
 				// reintroduced and should be allowed back through
 				// AddPend if the root republishes it.
 				if ta.State == StateMissing && time.Since(ta.FirstSeen) > 2160*time.Hour { // hold-down 90 days
+					taDeleted.Inc()
 					zlog.Warn("Trust anchor deleted after hold-down", "keytag", tag)
 					delete(kskCurrent, tag)
 				}
@@ -462,6 +466,7 @@ func (r *Resolver) AutoTA() {
 
 			if ta.State == StateAddPend && time.Since(ta.FirstSeen) > 720*time.Hour { // hold-down 30days
 				// now valid
+				taBecameValid.Inc()
 				zlog.Warn("Trust anchor now valid!", "keytag", tag)
 				ta.State = StateValid
 			}
@@ -473,6 +478,7 @@ func (r *Resolver) AutoTA() {
 				// — the absence was transient, and forcing another
 				// AddPend hold-down would strip trust for 30 days even
 				// though nothing about the key's authority changed.
+				taReappeared.Inc()
 				zlog.Info("Missing trust anchor reappeared — restored to Valid", "keytag", tag)
 				ta.State = StateValid
 			}

--- a/middleware/resolver/circuit_breaker.go
+++ b/middleware/resolver/circuit_breaker.go
@@ -46,7 +46,9 @@ func (cb *circuitBreaker) canQuery(server string) bool {
 		lastFailure := time.Unix(sf.lastFailure.Load(), 0)
 		if time.Since(lastFailure) > 30*time.Second {
 			// Reset after 30 seconds
-			sf.disabled.Store(false)
+			if sf.disabled.CompareAndSwap(true, false) {
+				circuitBreakerResets.Inc()
+			}
 			sf.count.Store(0)
 			return true
 		}
@@ -70,8 +72,8 @@ func (cb *circuitBreaker) recordFailure(server string) {
 	sf.lastFailure.Store(time.Now().Unix())
 
 	// Disable server after 5 consecutive failures
-	if count >= 5 && !sf.disabled.Load() {
-		sf.disabled.Store(true)
+	if count >= 5 && sf.disabled.CompareAndSwap(false, true) {
+		circuitBreakerTrips.Inc()
 		zlog.Warn("Circuit breaker tripped for DNS server", "server", server, "failures", count)
 	}
 }
@@ -87,6 +89,7 @@ func (cb *circuitBreaker) recordSuccess(server string) {
 		wasDisabled := sf.disabled.Swap(false)
 
 		if wasDisabled && oldCount > 0 {
+			circuitBreakerResets.Inc()
 			zlog.Info("Circuit breaker reset for DNS server", "server", server)
 		}
 	}

--- a/middleware/resolver/handler.go
+++ b/middleware/resolver/handler.go
@@ -148,6 +148,7 @@ func (h *DNSHandler) handle(ctx context.Context, req *dns.Msg) *dns.Msg {
 	}
 
 	if err != nil {
+		classifyResolverErr(err)
 		zlog.Info("Resolve query failed", "query", formatQuestion(q), "error", err.Error())
 
 		// Add Extended DNS Error information for recursor validation failures

--- a/middleware/resolver/metrics.go
+++ b/middleware/resolver/metrics.go
@@ -1,0 +1,121 @@
+package resolver
+
+import (
+	"context"
+	"errors"
+
+	"github.com/miekg/dns"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/semihalev/sdns/internal/dnsutil"
+	"github.com/semihalev/sdns/internal/metric"
+)
+
+// Resolution failure metrics. Classified at the central handler
+// error-return point so individual return sites stay clean. Closed
+// label sets — every reason is pre-registered below so the dynamic
+// path never hits a cold-create.
+var (
+	resolverFailures = metric.NewCounterVec(nil, prometheus.CounterOpts{
+		Name: "dns_resolver_failures_total",
+		Help: "Recursive resolution failures by reason",
+	}, []string{"reason"})
+
+	resolverFailTimeout     = resolverFailures.Register("timeout")
+	resolverFailNoReachable = resolverFailures.Register("no_reachable_auth")
+	resolverFailMaxDepth    = resolverFailures.Register("max_depth")
+	resolverFailNetwork     = resolverFailures.Register("network_error")
+	resolverFailOther       = resolverFailures.Register("other")
+
+	resolverDNSSECFailures = metric.NewCounterVec(nil, prometheus.CounterOpts{
+		Name: "dns_resolver_dnssec_failures_total",
+		Help: "DNSSEC validation failures by reason",
+	}, []string{"reason"})
+
+	resolverDNSSECBogus      = resolverDNSSECFailures.Register("bogus")
+	resolverDNSSECSigExpired = resolverDNSSECFailures.Register("sig_expired")
+	resolverDNSSECSigNotYet  = resolverDNSSECFailures.Register("sig_not_yet_valid")
+	resolverDNSSECKeyMissing = resolverDNSSECFailures.Register("dnskey_missing")
+	resolverDNSSECSigMissing = resolverDNSSECFailures.Register("rrsig_missing")
+	resolverDNSSECNSECMiss   = resolverDNSSECFailures.Register("nsec_missing")
+	resolverDNSSECUnsupAlg   = resolverDNSSECFailures.Register("unsupported_algorithm")
+	resolverDNSSECOther      = resolverDNSSECFailures.Register("other")
+
+	// Circuit breaker transitions. No per-server label — in resolver
+	// mode the auth-server set is unbounded (every zone's
+	// nameservers). The aggregate trip/reset rate is the operator
+	// signal; per-server diagnosis lives in the existing zlog lines
+	// at the trip/reset sites.
+	circuitBreakerTrips = metric.NewCounter(nil, prometheus.CounterOpts{
+		Name: "dns_circuit_breaker_trips_total",
+		Help: "Times the resolver circuit breaker opened (5 consecutive failures)",
+	})
+
+	circuitBreakerResets = metric.NewCounter(nil, prometheus.CounterOpts{
+		Name: "dns_circuit_breaker_resets_total",
+		Help: "Times an open circuit breaker closed (cool-down expired or success observed)",
+	})
+
+	// Trust-anchor RFC 5011 lifecycle events. Keyed by transition
+	// only — the per-keytag breakdown lives in the zlog lines next
+	// to each increment. Operators alert on revoked/missing rates.
+	trustAnchorLifecycle = metric.NewCounterVec(nil, prometheus.CounterOpts{
+		Name: "dns_trust_anchor_lifecycle_total",
+		Help: "RFC 5011 trust-anchor lifecycle transitions",
+	}, []string{"transition"})
+
+	taNewPending  = trustAnchorLifecycle.Register("new_pending")
+	taBecameValid = trustAnchorLifecycle.Register("became_valid")
+	taRevoked     = trustAnchorLifecycle.Register("revoked")
+	taMissing     = trustAnchorLifecycle.Register("missing")
+	taReappeared  = trustAnchorLifecycle.Register("reappeared")
+	taDeleted     = trustAnchorLifecycle.Register("deleted")
+)
+
+// classifyResolverErr increments the appropriate counter for a non-
+// nil resolver error. Timeout is checked first since context errors
+// don't carry an EDE code by themselves. DNSSEC-specific EDE codes
+// route to the dedicated DNSSEC vector; the rest land in the
+// generic failures vector. Sentinel errors that share
+// ExtendedErrorCodeOther (errMaxDepth, errParentDetection) get
+// distinguished via errors.Is.
+func classifyResolverErr(err error) {
+	if err == nil {
+		return
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		resolverFailTimeout.Inc()
+		return
+	}
+
+	code, _ := dnsutil.ErrorToEDE(err)
+	switch code {
+	case dns.ExtendedErrorCodeDNSBogus:
+		resolverDNSSECBogus.Inc()
+	case dns.ExtendedErrorCodeSignatureExpired:
+		resolverDNSSECSigExpired.Inc()
+	case dns.ExtendedErrorCodeSignatureNotYetValid:
+		resolverDNSSECSigNotYet.Inc()
+	case dns.ExtendedErrorCodeDNSKEYMissing:
+		resolverDNSSECKeyMissing.Inc()
+	case dns.ExtendedErrorCodeRRSIGsMissing:
+		resolverDNSSECSigMissing.Inc()
+	case dns.ExtendedErrorCodeNSECMissing:
+		resolverDNSSECNSECMiss.Inc()
+	case dns.ExtendedErrorCodeUnsupportedDNSKEYAlgorithm,
+		dns.ExtendedErrorCodeUnsupportedDSDigestType:
+		resolverDNSSECUnsupAlg.Inc()
+	case dns.ExtendedErrorCodeNoZoneKeyBitSet,
+		dns.ExtendedErrorCodeDNSSECIndeterminate:
+		resolverDNSSECOther.Inc()
+	case dns.ExtendedErrorCodeNoReachableAuthority:
+		resolverFailNoReachable.Inc()
+	case dns.ExtendedErrorCodeNetworkError:
+		resolverFailNetwork.Inc()
+	default:
+		if errors.Is(err, errMaxDepth) || errors.Is(err, errParentDetection) {
+			resolverFailMaxDepth.Inc()
+		} else {
+			resolverFailOther.Inc()
+		}
+	}
+}

--- a/sdns.go
+++ b/sdns.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/semihalev/sdns/api"
 	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/metric"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/sdns/server"
 	"github.com/semihalev/zlog/v2"
@@ -155,6 +156,10 @@ func runServer(cmd *cobra.Command, args []string) error {
 	case <-shutdownCtx.Done():
 		zlog.Warn("Server shutdown timeout exceeded")
 	}
+
+	// Drain the metric package's final flush so the last interval
+	// of counts reaches Prometheus before the process exits.
+	metric.Stop()
 
 	return nil
 }

--- a/server/doh/doh.go
+++ b/server/doh/doh.go
@@ -5,10 +5,51 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"strconv"
 	"strings"
 
 	"github.com/miekg/dns"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/semihalev/sdns/internal/metric"
 )
+
+// httpErrors counts DoH responses sent with a 4xx or 5xx status.
+// Labelled by status code (closed set: 400/405/415/500) so operators
+// can distinguish bad-request floods from server-side decode
+// failures. The 200-path is not counted here — that's what
+// dns_queries_total already measures.
+var (
+	httpErrors = metric.NewCounterVec(nil, prometheus.CounterOpts{
+		Name: "dns_doh_http_errors_total",
+		Help: "DoH responses returned with a 4xx or 5xx HTTP status, by code",
+	}, []string{"code"})
+
+	httpErr400 = httpErrors.Register("400")
+	httpErr405 = httpErrors.Register("405")
+	httpErr415 = httpErrors.Register("415")
+	httpErr500 = httpErrors.Register("500")
+)
+
+// writeHTTPError replaces http.Error + manual metric increments so
+// every error response goes through one bookkeeping site. Unknown
+// status codes fall through to the cold WithLabelValues path so the
+// metric stays correct without forcing every caller to update this
+// switch.
+func writeHTTPError(w http.ResponseWriter, code int) {
+	switch code {
+	case http.StatusBadRequest:
+		httpErr400.Inc()
+	case http.StatusMethodNotAllowed:
+		httpErr405.Inc()
+	case http.StatusUnsupportedMediaType:
+		httpErr415.Inc()
+	case http.StatusInternalServerError:
+		httpErr500.Inc()
+	default:
+		httpErrors.WithLabelValues(strconv.Itoa(code)).Inc()
+	}
+	http.Error(w, http.StatusText(code), code)
+}
 
 const (
 	minMsgHeaderSize = 12
@@ -30,12 +71,12 @@ func HandleWireFormat(handle func(*dns.Msg) *dns.Msg) http.HandlerFunc {
 		case http.MethodGet:
 			buf, err = base64.RawURLEncoding.DecodeString(r.URL.Query().Get("dns"))
 			if len(buf) == 0 || err != nil {
-				http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+				writeHTTPError(w, http.StatusBadRequest)
 				return
 			}
 		case http.MethodPost:
 			if r.Header.Get("Content-Type") != contentTypeDNS {
-				http.Error(w, http.StatusText(http.StatusUnsupportedMediaType), http.StatusUnsupportedMediaType)
+				writeHTTPError(w, http.StatusUnsupportedMediaType)
 				return
 			}
 
@@ -45,34 +86,34 @@ func HandleWireFormat(handle func(*dns.Msg) *dns.Msg) http.HandlerFunc {
 
 			buf, err = io.ReadAll(limitedReader)
 			if err != nil {
-				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				writeHTTPError(w, http.StatusInternalServerError)
 				return
 			}
 		default:
-			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			writeHTTPError(w, http.StatusMethodNotAllowed)
 			return
 		}
 
 		if len(buf) < minMsgHeaderSize {
-			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+			writeHTTPError(w, http.StatusBadRequest)
 			return
 		}
 
 		req := new(dns.Msg)
 		if err := req.Unpack(buf); err != nil {
-			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+			writeHTTPError(w, http.StatusBadRequest)
 			return
 		}
 
 		msg := handle(req)
 		if msg == nil {
-			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+			writeHTTPError(w, http.StatusBadRequest)
 			return
 		}
 
 		packed, err := msg.Pack()
 		if err != nil {
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			writeHTTPError(w, http.StatusInternalServerError)
 			return
 		}
 
@@ -88,21 +129,21 @@ func HandleJSON(handle func(*dns.Msg) *dns.Msg) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		// Only allow GET for JSON API
 		if r.Method != http.MethodGet {
-			http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+			writeHTTPError(w, http.StatusMethodNotAllowed)
 			return
 		}
 
 		query := r.URL.Query()
 		name := query.Get("name")
 		if name == "" {
-			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+			writeHTTPError(w, http.StatusBadRequest)
 			return
 		}
 		name = dns.Fqdn(name)
 
 		qtype := ParseQTYPE(query.Get("type"))
 		if qtype == dns.TypeNone {
-			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+			writeHTTPError(w, http.StatusBadRequest)
 			return
 		}
 
@@ -120,13 +161,13 @@ func HandleJSON(handle func(*dns.Msg) *dns.Msg) http.HandlerFunc {
 
 		msg := handle(req)
 		if msg == nil {
-			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+			writeHTTPError(w, http.StatusBadRequest)
 			return
 		}
 
 		jsonData, err := json.Marshal(NewMsg(msg))
 		if err != nil {
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			writeHTTPError(w, http.StatusInternalServerError)
 			return
 		}
 

--- a/server/metrics.go
+++ b/server/metrics.go
@@ -1,0 +1,47 @@
+package server
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/semihalev/sdns/internal/metric"
+)
+
+// listenerErrors counts listener Serve loops that exited with a
+// non-nil error. Bumped per protocol so operators can tell whether
+// UDP is degrading independently from TLS or DoH. Bounded label set
+// — the value is l.Proto() which is one of udp/tcp/tls/doh/doh3/doq.
+var (
+	listenerErrors = metric.NewCounterVec(nil, prometheus.CounterOpts{
+		Name: "dns_listener_errors_total",
+		Help: "Listener Serve loops that exited with an error, by transport",
+	}, []string{"proto"})
+
+	listenerErrUDP  = listenerErrors.Register("udp")
+	listenerErrTCP  = listenerErrors.Register("tcp")
+	listenerErrTLS  = listenerErrors.Register("tls")
+	listenerErrDoH  = listenerErrors.Register("doh")
+	listenerErrDoH3 = listenerErrors.Register("doh3")
+	listenerErrDoQ  = listenerErrors.Register("doq")
+)
+
+// recordListenerErr maps a Listener.Proto() string to the matching
+// pre-resolved counter. Unknown protocols fall through to the cold
+// WithLabelValues path so the metric stays correct even if a new
+// listener type lands without a corresponding handle here.
+func recordListenerErr(proto string) {
+	switch proto {
+	case "udp":
+		listenerErrUDP.Inc()
+	case "tcp":
+		listenerErrTCP.Inc()
+	case "tls":
+		listenerErrTLS.Inc()
+	case "doh":
+		listenerErrDoH.Inc()
+	case "doh3":
+		listenerErrDoH3.Inc()
+	case "doq":
+		listenerErrDoQ.Inc()
+	default:
+		listenerErrors.WithLabelValues(proto).Inc()
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -134,6 +134,7 @@ func (s *Server) Run(ctx context.Context) error {
 		go func(l Listener) {
 			defer s.running.Add(-1)
 			if err := l.Serve(ctx); err != nil {
+				recordListenerErr(l.Proto())
 				zlog.Error("listener stopped with error",
 					"proto", l.Proto(), "addr", l.Addr(), "error", err.Error())
 			}


### PR DESCRIPTION
## Summary

Adds **`internal/metric`** — a sharded-counter shim over Prometheus that flushes deltas on a background tick. Hot path is a per-CPU atomic add (~2-12 ns/op) vs ~120 ns/op for direct `prometheus.CounterVec.WithLabelValues` under 8-core contention.

Migrates every existing per-query counter to the new package and adds **23 new counters** covering decision points that were previously silent (policy enforcement, upstream health, DNSSEC validation outcomes, lifecycle events, server transport).

## Why

Counters on the per-query hot path call `WithLabelValues(...).Inc()` repeatedly. Under heavy concurrency the cache-line bouncing on a single atomic plus the per-call map lookup of `WithLabelValues` cost ~120 ns each — multiplied across every middleware on a busy SDNS process, that's real CPU. The new package brings it down by ~20× and makes it cheap enough to broaden coverage without thinking about per-metric cost.

## internal/metric

- `procPin` + per-CPU shard array (8 cache-line-padded atomics).
- Background flush goroutine ticks every 1s (configurable), sums shards, pushes delta to the underlying `prometheus.Counter` via `Add`. Prometheus' scraped value lags by ≤ one flush interval — invisible at the typical 15s scrape since `rate()` operates over windows that dwarf the flush.
- `CounterVec`: `atomic.Pointer[map]` (copy-on-write) instead of `sync.Map` — 22% faster read path, more predictable latency, smaller memory.
- Length-prefix-encoded keys (uvarint per label) + `unsafe.String` view from a `sync.Pool` buffer → alloc-free hit path even for multi-label vectors.
- Auto-starts on first `NewCounter` / `NewCounterVec`; `metric.Stop()` at shutdown drains the final flush.
- `Add` panics on negative delta (matches Prometheus counter contract).
- Arity validation prevents wrong-arity calls from collision-hitting cached keys.
- 25 tests, all green under `-race -count=3`.

## Migrated counters (wire-compatible — names + labels + values unchanged)

| Package | Counter |
|---|---|
| cache | hits, misses, evictions, prefetches, ecs_lookups |
| dns64 | synthesised, passthrough, a_lookup_failures, ptr_translated |
| reflex | detections, blocked |
| metrics | dns_queries_total |

Gauges (`dns_cache_size`, `dns_cache_hit_rate`, `reflex_tracked_ips`) and the dynamic-cardinality `dns_domain_queries_total` stay on direct Prometheus by design.

## New counters

**Policy / security**
- `dns_blocklist_hits_total`
- `dns_accesslist_denied_total`
- `dns_ratelimit_exceeded_total`
- `dns_forwarder_failures_total`
- `dns_forwarder_response_mismatch_total` *(potential poisoning signal)*
- `dns_failover_attempts_total` / `dns_failover_success_total`
- `dns_edns_errors_total{reason}`
- `dns_recovery_panics_total`

**Resolver**
- `dns_resolver_failures_total{reason}` *(timeout, no_reachable_auth, max_depth, network_error, other)*
- `dns_resolver_dnssec_failures_total{reason}` *(bogus, sig_expired, sig_not_yet_valid, dnskey_missing, rrsig_missing, nsec_missing, unsupported_algorithm, other)*
- `dns_circuit_breaker_trips_total` / `dns_circuit_breaker_resets_total`
- `dns_trust_anchor_lifecycle_total{transition}` *(new_pending, became_valid, revoked, missing, reappeared, deleted)*

**Server / transport**
- `dns_listener_errors_total{proto}`
- `dns_doh_http_errors_total{code}`

**Existing internal counter exports**
- `dns_hostsfile_lookups_total` / `dns_hostsfile_hits_total`
- `dns_kubernetes_queries_total` / `_answered_total` / `_errors_total` / `_write_errors_total`

## Benchmarks (8-CPU parallel, Apple M5)

```
                                              ns/op   allocs
─────────────────────────────────────────────────────────────
prometheus.CounterVec.WithLabelValues          129.6     0    (current SDNS pattern)
metric.CounterVec single-label hot              6.5      0    (~20x improvement)
metric.CounterVec multi-label hot              12.1      0    (alloc-free)
metric.Counter unlabeled                        1.6      0    (procPin shard)
```

## Test plan

- [x] `go test -race ./...` — all 34 packages green
- [x] `golangci-lint run ./...` — 0 issues
- [x] `internal/metric` covered by 25 tests including:
  - Concurrent Inc + flush race tests
  - Lifecycle (auto-start, Stop drains final flush, idempotent Stop, concurrent Stop)
  - SetFlushInterval validation (panics on 0/negative, panics if called after start, race-safe vs. start)
  - Multi-label collision resistance
  - Negative-delta panic
  - Arity-mismatch panic
- [x] Existing middleware tests pass with no modifications beyond replacing one test helper that read Prometheus values directly (now reads `Counter.Value()`, which is live and doesn't need a flush)