### PR TITLE
feat(forwarder): DNS-over-HTTPS upstreams (RFC 8484, closes #473)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ example.com.		0	CH	HINFO	"Host" "IPv6:[2001:500:8d::53]:53 rtt:148ms health:[GOO
 | **dnssec**           | Enable DNSSEC validation for secure DNS responses. Options: "on" or "off". Default: "on"                            |
 | **rootkeys**         | DNSSEC root zone trust anchors in DNSKEY format                                                                     |
 | **fallbackservers**  | Upstream DNS servers used when all others fail. Format: "IP:port" (e.g., "8.8.8.8:53")                             |
-| **forwarderservers** | Forward all queries to these DNS servers. Format: "IP:port" (e.g., "8.8.8.8:53")                                   |
+| **forwarderservers** | Forward all queries to these DNS servers. Accepts `IP:port` (plain UDP/TCP), `tls://IP:port` (DoT, RFC 7858), or `https://host/dns-query` (DoH, RFC 8484; hostname or IP literal). See [Forwarder upstreams](#forwarder-upstreams) for details. |
 | **api**              | HTTP API server binding address for statistics and control. Leave empty to disable                                  |
 | **bearertoken**      | API bearer token for authorization. If set, Authorization header must be included in API requests                   |
 | **blocklists**       | URLs of remote blocklists to download and use for filtering                                                         |
@@ -394,6 +394,27 @@ sum(dns_cache_size)
 # Cache operations per second
 rate(dns_cache_hits_total[1m]) + rate(dns_cache_misses_total[1m])
 ```
+
+#### Forwarder upstreams
+
+`forwarderservers` accepts three formats, mix-and-match per entry:
+
+```toml
+forwarderservers = [
+    "1.1.1.1:53",                          # plain UDP (TCP fallback on TC)
+    "tls://1.1.1.1:853",                   # DoT (RFC 7858) — TCP+TLS, IP literal required
+    "https://1.1.1.1/dns-query",           # DoH (RFC 8484) — IP literal
+    "https://cloudflare-dns.com/dns-query", # DoH — hostname (bootstrapped via system resolver at startup)
+]
+```
+
+DoH notes:
+
+*   Hostnames are resolved **once at startup** through the system resolver (`/etc/resolv.conf` on Unix). The resolved IPs are pinned for the process lifetime, so there is no per-query DNS dependency. If the upstream changes IPs, restart picks them up.
+*   IP-literal DoH URLs skip the bootstrap entirely — safest for hardened deployments that can't depend on the system resolver.
+*   POST + `application/dns-message` per RFC 8484, HTTP/2 with connection reuse. The TLS `ServerName` is set to the URL hostname so cert validation works correctly when dialing IPs.
+*   Bootstrap failure (NXDOMAIN, timeout, no addresses) is logged and the entry is skipped — startup continues with whatever upstreams remain usable.
+*   Timeouts come from the existing top-level config: `querytimeout` caps the **total time** the forwarder spends across every configured upstream (default 10s — applies to UDP, DoT, and DoH alike so three slow upstreams can't take 3 × per-call timeout), `timeout` bounds each per-IP TCP dial inside one DoH attempt (default 2s) so a blackholed pinned address bypasses to the next one without consuming the request budget. Consecutive dial attempts rotate the starting IP so a single bad address can't pin the rotation. Response TXIDs are validated (echo of the request ID or 0 per RFC 8484 §4.1). The existing `dns_forwarder_failures_total` and `dns_forwarder_response_mismatch_total` metrics cover DoH paths too.
 
 ### External Plugins
 

--- a/config/config.go
+++ b/config/config.go
@@ -404,12 +404,18 @@ fallbackservers = [
 
 # Forwarder DNS servers
 # When configured, SDNS acts as a forwarding resolver instead of recursive
-# Supports DNS (port 53) and DNS-over-TLS (tls:// prefix)
+# Supports plain DNS (port 53), DNS-over-TLS (tls:// prefix), and
+# DNS-over-HTTPS (https:// prefix, RFC 8484). DoH URLs accept either an
+# IP literal or a hostname — hostnames are resolved once at startup
+# through the system resolver and the resulting IPs are pinned for the
+# process lifetime (no per-query DNS dependency).
 forwarderservers = [
     # Examples:
-    # "8.8.8.8:53",              # Standard DNS
-    # "[2001:4860:4860::8888]:53", # Standard DNS IPv6
-    # "tls://8.8.8.8:853" # DNS-over-TLS
+    # "8.8.8.8:53",                          # Standard DNS
+    # "[2001:4860:4860::8888]:53",           # Standard DNS IPv6
+    # "tls://8.8.8.8:853",                   # DNS-over-TLS
+    # "https://1.1.1.1/dns-query",           # DoH, IP literal
+    # "https://cloudflare-dns.com/dns-query" # DoH, hostname (system-resolver bootstrap)
 ]
 
 # ============================

--- a/contrib/linux/sdns.conf
+++ b/contrib/linux/sdns.conf
@@ -142,12 +142,18 @@ fallbackservers = [
 
 # Forwarder DNS servers
 # When configured, SDNS acts as a forwarding resolver instead of recursive
-# Supports DNS (port 53) and DNS-over-TLS (tls:// prefix)
+# Supports plain DNS (port 53), DNS-over-TLS (tls:// prefix), and
+# DNS-over-HTTPS (https:// prefix, RFC 8484). DoH URLs accept either an
+# IP literal or a hostname — hostnames are resolved once at startup
+# through the system resolver and the resulting IPs are pinned for the
+# process lifetime (no per-query DNS dependency).
 forwarderservers = [
     # Examples:
-    # "8.8.8.8:53",              # Standard DNS
-    # "[2001:4860:4860::8888]:53", # Standard DNS IPv6
-    # "tls://8.8.8.8:853" # DNS-over-TLS
+    # "8.8.8.8:53",                          # Standard DNS
+    # "[2001:4860:4860::8888]:53",           # Standard DNS IPv6
+    # "tls://8.8.8.8:853",                   # DNS-over-TLS
+    # "https://1.1.1.1/dns-query",           # DoH, IP literal
+    # "https://cloudflare-dns.com/dns-query" # DoH, hostname (system-resolver bootstrap)
 ]
 
 # ============================

--- a/middleware/forwarder/doh.go
+++ b/middleware/forwarder/doh.go
@@ -1,0 +1,245 @@
+package forwarder
+
+import (
+	"bytes"
+	"context"
+	"crypto/tls"
+	"errors"
+	"fmt"
+	"io"
+	"mime"
+	"net"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// dohMaxResponseSize bounds the response body read so a misbehaving
+// upstream can't OOM us with a huge body. DNS messages can't exceed
+// 64 KiB on the wire (RFC 1035 length field is uint16), so this
+// limit is a tight ceiling on legitimate traffic.
+const dohMaxResponseSize = 65535
+
+// contentTypeDNS is the RFC 8484 wire-format media type. Set on both
+// the Content-Type of the POST body and the Accept header so an
+// upstream that supports multiple media types knows which one we
+// want back. Compared case-insensitively against parsed responses
+// (RFC 7231 §3.1.1.1).
+const contentTypeDNS = "application/dns-message"
+
+// ipResolver is the subset of net.Resolver this package uses for
+// hostname bootstrap. The interface indirection lets tests swap in
+// a deterministic stub instead of standing up a real DNS listener.
+type ipResolver interface {
+	LookupIP(ctx context.Context, network, host string) ([]net.IP, error)
+}
+
+// resolver is the resolver used for bootstrap of DoH hostnames.
+// Production always uses net.DefaultResolver, which itself defers
+// to the system resolver (/etc/resolv.conf on Unix, the configured
+// DNS suffixes on Windows).
+var resolver ipResolver = net.DefaultResolver
+
+// newDoHServer parses a DoH upstream URL, resolves the hostname (if
+// any) via the system resolver, and returns a server entry ready to
+// be added to Forwarder.servers. Hostname resolution happens once at
+// boot — there is no per-query DNS dependency. The resolved IPs are
+// pinned into a custom DialContext on the returned http.Client so
+// Go's transport never re-resolves at connect time.
+//
+// dialTimeout bounds a single per-IP TCP dial — sourced from
+// cfg.Timeout so operators tune all upstream timeouts through one
+// knob. A blackholed pinned IP gets bypassed in dialTimeout
+// instead of consuming the entire requestTimeout, which keeps the
+// rotation effective even when a hostname resolves to mixed A/AAAA
+// on a host with broken v6.
+//
+// requestTimeout caps the full POST round-trip — sourced from
+// cfg.QueryTimeout. Zero on either disables that ceiling; production
+// callers should always pass non-zero values.
+//
+// TLS ServerName is set to the original hostname even when we dial
+// an IP literal — this preserves SNI and cert-chain validation.
+//
+// Returns an error if the URL is malformed, the scheme is not https,
+// the URL has no host, or the hostname fails to resolve at boot
+// (no usable IPs). The caller treats those failures as "skip this
+// entry, keep going" to match the existing tls:// behaviour in
+// New().
+func newDoHServer(rawURL string, dialTimeout, requestTimeout time.Duration) (*server, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse url: %w", err)
+	}
+	if u.Scheme != "https" {
+		return nil, fmt.Errorf("scheme must be https, got %q", u.Scheme)
+	}
+	if u.Host == "" {
+		return nil, errors.New("missing host")
+	}
+
+	host := u.Hostname()
+	port := u.Port()
+	if port == "" {
+		port = "443"
+	}
+
+	var ips []net.IP
+	if ip := net.ParseIP(host); ip != nil {
+		// IP literal — no bootstrap needed.
+		ips = []net.IP{ip}
+	} else {
+		// Hostname — bootstrap via the system resolver. Short
+		// timeout so a broken /etc/resolv.conf can't block startup
+		// for minutes.
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		ips, err = resolver.LookupIP(ctx, "ip", host)
+		if err != nil {
+			return nil, fmt.Errorf("bootstrap %s: %w", host, err)
+		}
+		if len(ips) == 0 {
+			return nil, fmt.Errorf("bootstrap %s: no addresses returned", host)
+		}
+	}
+
+	// Snapshot the IPs into a fresh slice we own, then the custom
+	// DialContext below closes over it. We don't refresh — DoH
+	// provider IPs rarely move, and a refresh ticker is more
+	// complexity than the MVP warrants. If the IPs ever drift,
+	// restart picks them up.
+	pinned := append([]net.IP(nil), ips...)
+
+	// nextStart rotates the starting position in the pinned list
+	// per dial so consecutive dial attempts don't always hit the
+	// same first IP. Without this a blackholed address at index 0
+	// would burn its full per-IP timeout on every request before
+	// failing over.
+	var nextStart atomic.Uint32
+
+	tr := &http.Transport{
+		ForceAttemptHTTP2:     true,
+		MaxIdleConnsPerHost:   4,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   dialTimeout,
+		ResponseHeaderTimeout: requestTimeout,
+		// Custom DialContext: ignore the addr Go's transport would
+		// have computed (which would re-resolve the hostname) and
+		// dial the pinned IPs in rotation order, returning the
+		// first successful connection. Each dial is capped by
+		// dialTimeout so a blackholed address bounces in that
+		// budget instead of consuming the full request timeout.
+		// The port comes from the URL.
+		DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			n := len(pinned)
+			start := int(nextStart.Add(1)-1) % n
+			var lastErr error
+			for i := range n {
+				ip := pinned[(start+i)%n]
+				d := net.Dialer{Timeout: dialTimeout}
+				conn, dialErr := d.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+				if dialErr == nil {
+					return conn, nil
+				}
+				lastErr = dialErr
+			}
+			if lastErr == nil {
+				lastErr = errors.New("no pinned IPs available")
+			}
+			return nil, lastErr
+		},
+		TLSClientConfig: &tls.Config{
+			// ServerName is the original hostname so SNI is sent
+			// correctly and the cert is validated against the
+			// name the operator typed, not against the IP. For
+			// IP-literal URLs, host == ip.String() — the cert
+			// must have a matching SAN.
+			ServerName: host,
+			MinVersion: tls.VersionTLS12,
+		},
+	}
+
+	return &server{
+		Addr:      rawURL,
+		Proto:     "doh",
+		DoHURL:    rawURL,
+		DoHClient: &http.Client{Transport: tr, Timeout: requestTimeout},
+	}, nil
+}
+
+// dohExchange POSTs req to the DoH endpoint and decodes the wire-
+// format response. Mirrors the (msg, error) contract of
+// dnsutil.Exchange so the dispatch site in ServeDNS can treat DoH
+// identically to UDP / DoT.
+func dohExchange(ctx context.Context, srv *server, req *dns.Msg) (*dns.Msg, error) {
+	body, err := req.Pack()
+	if err != nil {
+		return nil, fmt.Errorf("pack: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, srv.DoHURL, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", contentTypeDNS)
+	httpReq.Header.Set("Accept", contentTypeDNS)
+
+	httpResp, err := srv.DoHClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("doh exchange: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusOK {
+		// Drain a small amount of the body so the connection can
+		// be reused (Go's http.Transport requires the body be read
+		// before the conn returns to the pool).
+		_, _ = io.Copy(io.Discard, io.LimitReader(httpResp.Body, 1024))
+		return nil, fmt.Errorf("doh status %d", httpResp.StatusCode)
+	}
+
+	// RFC 7231 §3.1.1.1: media types are case-insensitive and may
+	// carry parameters (charset=, boundary=, ...). mime.ParseMediaType
+	// strips parameters and lowercases the type for us.
+	rawCT := httpResp.Header.Get("Content-Type")
+	mediaType, _, err := mime.ParseMediaType(rawCT)
+	if err != nil || !strings.EqualFold(mediaType, contentTypeDNS) {
+		_, _ = io.Copy(io.Discard, io.LimitReader(httpResp.Body, 1024))
+		return nil, fmt.Errorf("doh unexpected content-type %q", rawCT)
+	}
+
+	// Read one byte past the size cap so we can distinguish "body
+	// fits within limit" from "body exceeded limit and was
+	// truncated". Without this dns.Msg.Unpack would happily decode
+	// the parseable prefix of an oversized response and silently
+	// ignore the rest.
+	respBody, err := io.ReadAll(io.LimitReader(httpResp.Body, dohMaxResponseSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+	if len(respBody) > dohMaxResponseSize {
+		return nil, fmt.Errorf("doh response exceeds %d bytes", dohMaxResponseSize)
+	}
+
+	resp := new(dns.Msg)
+	if err := resp.Unpack(respBody); err != nil {
+		return nil, fmt.Errorf("unpack: %w", err)
+	}
+
+	// Validate the response transaction ID. miekg/dns's
+	// Client.ExchangeContext does this for UDP/DoT; on the DoH
+	// path we have to do it ourselves before the caller rewrites
+	// resp.Id = req.Id. RFC 8484 §4.1 says DoH clients SHOULD use
+	// DNS ID 0 for cache friendliness, and several compliant
+	// servers normalise the response ID to 0 regardless of what
+	// the request carried — so accept either an exact echo or a
+	// zero. Anything else is a buggy or hostile upstream.
+	if resp.Id != req.Id && resp.Id != 0 {
+		return nil, fmt.Errorf("doh response ID mismatch: got %d, want %d or 0", resp.Id, req.Id)
+	}
+	return resp, nil
+}

--- a/middleware/forwarder/doh_test.go
+++ b/middleware/forwarder/doh_test.go
@@ -1,0 +1,627 @@
+package forwarder
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/middleware"
+)
+
+// dohAnswerFor builds a wire-format DNS response with a single A
+// record. mismatchName, if non-empty, swaps the question section so
+// the question-mismatch path in ServeDNS triggers.
+func dohAnswerFor(t *testing.T, req *dns.Msg, ip string, mismatchName string) []byte {
+	t.Helper()
+	resp := new(dns.Msg)
+	resp.SetReply(req)
+	if mismatchName != "" {
+		resp.Question = []dns.Question{{
+			Name: dns.Fqdn(mismatchName), Qtype: req.Question[0].Qtype, Qclass: dns.ClassINET,
+		}}
+	}
+	if req.Question[0].Qtype == dns.TypeA {
+		rr, err := dns.NewRR(req.Question[0].Name + " 60 IN A " + ip)
+		if err != nil {
+			t.Fatalf("build A RR: %v", err)
+		}
+		resp.Answer = []dns.RR{rr}
+	}
+	b, err := resp.Pack()
+	if err != nil {
+		t.Fatalf("pack response: %v", err)
+	}
+	return b
+}
+
+// readDoHRequest decodes a DoH request body (POST). Returns the
+// parsed *dns.Msg so handlers can inspect the question section.
+func readDoHRequest(t *testing.T, r *http.Request) *dns.Msg {
+	t.Helper()
+	if r.Method != http.MethodPost {
+		t.Fatalf("expected POST, got %s", r.Method)
+	}
+	if ct := r.Header.Get("Content-Type"); ct != contentTypeDNS {
+		t.Fatalf("expected Content-Type %s, got %s", contentTypeDNS, ct)
+	}
+	body, err := io.ReadAll(io.LimitReader(r.Body, dohMaxResponseSize))
+	if err != nil {
+		t.Fatalf("read body: %v", err)
+	}
+	msg := new(dns.Msg)
+	if err := msg.Unpack(body); err != nil {
+		t.Fatalf("unpack body: %v", err)
+	}
+	return msg
+}
+
+// startDoHServer launches a TLS test server that answers DoH POSTs
+// according to handler. Returns the URL (https://127.0.0.1:PORT/path)
+// and a stop function. The test server uses a self-signed cert, so
+// callers must override TLSClientConfig.InsecureSkipVerify in the
+// returned *server's transport (see configureForTest below).
+func startDoHServer(t *testing.T, path string, handler func(*http.Request) (status int, body []byte, contentType string)) (string, func()) {
+	t.Helper()
+	mux := http.NewServeMux()
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		status, body, ct := handler(r)
+		if ct == "" {
+			ct = contentTypeDNS
+		}
+		w.Header().Set("Content-Type", ct)
+		w.WriteHeader(status)
+		_, _ = w.Write(body)
+	})
+	srv := httptest.NewTLSServer(mux)
+	return srv.URL + path, srv.Close
+}
+
+// dohServerWithSkipVerify builds a *server pointing at testURL but
+// with TLS verification skipped — httptest.NewTLSServer uses a self-
+// signed cert that the production newDoHServer rejects.
+func dohServerWithSkipVerify(t *testing.T, testURL string) *server {
+	t.Helper()
+	u, err := url.Parse(testURL)
+	if err != nil {
+		t.Fatalf("parse test url: %v", err)
+	}
+	host := u.Hostname()
+	port := u.Port()
+	if port == "" {
+		port = "443"
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		t.Fatalf("test url host %q is not an IP", host)
+	}
+	tr := &http.Transport{
+		ForceAttemptHTTP2: true,
+		DialContext: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			var d net.Dialer
+			return d.DialContext(ctx, network, net.JoinHostPort(ip.String(), port))
+		},
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: true, //nolint:gosec // test-only — httptest TLS cert is self-signed
+			MinVersion:         tls.VersionTLS12,
+		},
+	}
+	return &server{
+		Addr:      testURL,
+		Proto:     "doh",
+		DoHURL:    testURL,
+		DoHClient: &http.Client{Transport: tr, Timeout: 5 * time.Second},
+	}
+}
+
+func TestNewDoHServer_IPLiteral(t *testing.T) {
+	srv, err := newDoHServer("https://1.1.1.1/dns-query", 2*time.Second, 5*time.Second)
+	if err != nil {
+		t.Fatalf("newDoHServer: %v", err)
+	}
+	if srv.Proto != "doh" {
+		t.Errorf("Proto = %q, want doh", srv.Proto)
+	}
+	if srv.DoHURL != "https://1.1.1.1/dns-query" {
+		t.Errorf("DoHURL = %q", srv.DoHURL)
+	}
+	if srv.DoHClient == nil {
+		t.Fatal("DoHClient is nil")
+	}
+	// SNI must be the URL host (matches cert), not stripped.
+	if sn := srv.DoHClient.Transport.(*http.Transport).TLSClientConfig.ServerName; sn != "1.1.1.1" {
+		t.Errorf("ServerName = %q, want 1.1.1.1", sn)
+	}
+}
+
+func TestNewDoHServer_CustomPort(t *testing.T) {
+	srv, err := newDoHServer("https://1.1.1.1:8443/q", 2*time.Second, 5*time.Second)
+	if err != nil {
+		t.Fatalf("newDoHServer: %v", err)
+	}
+	if srv.DoHURL != "https://1.1.1.1:8443/q" {
+		t.Errorf("DoHURL = %q", srv.DoHURL)
+	}
+}
+
+func TestNewDoHServer_RejectsNonHTTPS(t *testing.T) {
+	if _, err := newDoHServer("http://1.1.1.1/dns-query", 2*time.Second, 5*time.Second); err == nil {
+		t.Error("expected error for non-https scheme")
+	}
+}
+
+func TestNewDoHServer_RejectsMissingHost(t *testing.T) {
+	if _, err := newDoHServer("https:///dns-query", 2*time.Second, 5*time.Second); err == nil {
+		t.Error("expected error for missing host")
+	}
+}
+
+// stubResolver implements ipResolver for deterministic, offline
+// hostname-bootstrap testing.
+type stubResolver struct {
+	ips     []net.IP
+	err     error
+	queried atomic.Int32
+}
+
+func (s *stubResolver) LookupIP(_ context.Context, _, _ string) ([]net.IP, error) {
+	s.queried.Add(1)
+	return s.ips, s.err
+}
+
+// TestNewDoHServer_HostnameSuccess exercises the full hostname
+// bootstrap path through the swap-in resolver hook: resolver IS
+// consulted, resolved IPs end up pinned in the transport, SNI is the
+// URL hostname (not the resolved IP), Proto/DoHURL are correct.
+func TestNewDoHServer_HostnameSuccess(t *testing.T) {
+	orig := resolver
+	t.Cleanup(func() { resolver = orig })
+
+	stub := &stubResolver{ips: []net.IP{net.IPv4(192, 0, 2, 55), net.ParseIP("2001:db8::1")}}
+	resolver = stub
+
+	srv, err := newDoHServer("https://dns.test/dns-query", 2*time.Second, 5*time.Second)
+	if err != nil {
+		t.Fatalf("newDoHServer: %v", err)
+	}
+	if stub.queried.Load() != 1 {
+		t.Errorf("stub LookupIP calls = %d, want 1", stub.queried.Load())
+	}
+	if srv.Proto != "doh" {
+		t.Errorf("Proto = %q, want doh", srv.Proto)
+	}
+	if srv.DoHURL != "https://dns.test/dns-query" {
+		t.Errorf("DoHURL = %q", srv.DoHURL)
+	}
+	// SNI is the original hostname so cert SAN validation works
+	// when we dial the resolved IP.
+	tr := srv.DoHClient.Transport.(*http.Transport)
+	if sn := tr.TLSClientConfig.ServerName; sn != "dns.test" {
+		t.Errorf("ServerName = %q, want dns.test", sn)
+	}
+}
+
+func TestNewDoHServer_HostnameBootstrapFails(t *testing.T) {
+	orig := resolver
+	t.Cleanup(func() { resolver = orig })
+	resolver = &stubResolver{err: fmt.Errorf("nxdomain")}
+
+	if _, err := newDoHServer("https://dns.test/q", 2*time.Second, 5*time.Second); err == nil {
+		t.Error("expected bootstrap failure")
+	}
+}
+
+// TestNewDoHServer_HostnameBootstrapEmpty covers the edge case
+// where the resolver returns nil/empty without error — newDoHServer
+// must reject this rather than build a client with no IPs.
+func TestNewDoHServer_HostnameBootstrapEmpty(t *testing.T) {
+	orig := resolver
+	t.Cleanup(func() { resolver = orig })
+	resolver = &stubResolver{ips: nil}
+
+	if _, err := newDoHServer("https://dns.test/q", 2*time.Second, 5*time.Second); err == nil {
+		t.Error("expected error on empty IP list")
+	}
+}
+
+// TestForwarder_DoH_Success drives the full ServeDNS path against a
+// local TLS DoH server.
+func TestForwarder_DoH_Success(t *testing.T) {
+	dohURL, stop := startDoHServer(t, "/dns-query", func(r *http.Request) (int, []byte, string) {
+		req := readDoHRequest(t, r)
+		return http.StatusOK, dohAnswerFor(t, req, "203.0.113.5", ""), ""
+	})
+	defer stop()
+
+	f := &Forwarder{servers: []*server{dohServerWithSkipVerify(t, dohURL)}, dnssec: false}
+	resp := runForwarderQuery(t, f, "example.com.", dns.TypeA)
+
+	if resp == nil || resp.Rcode != dns.RcodeSuccess {
+		t.Fatalf("unexpected response: %+v", resp)
+	}
+	if len(resp.Answer) != 1 {
+		t.Fatalf("Answer len = %d, want 1", len(resp.Answer))
+	}
+	if a, ok := resp.Answer[0].(*dns.A); !ok || a.A.String() != "203.0.113.5" {
+		t.Errorf("wrong A record: %v", resp.Answer[0])
+	}
+}
+
+func TestForwarder_DoH_ServerError(t *testing.T) {
+	var hits atomic.Int32
+	dohURL, stop := startDoHServer(t, "/dns-query", func(r *http.Request) (int, []byte, string) {
+		hits.Add(1)
+		return http.StatusInternalServerError, []byte("oops"), "text/plain"
+	})
+	defer stop()
+
+	f := &Forwarder{servers: []*server{dohServerWithSkipVerify(t, dohURL)}, dnssec: false}
+	runForwarderQueryExpectSERVFAIL(t, f, "example.com.", dns.TypeA)
+
+	if hits.Load() != 1 {
+		t.Errorf("doh server hits = %d, want 1", hits.Load())
+	}
+}
+
+func TestForwarder_DoH_BadContentType(t *testing.T) {
+	dohURL, stop := startDoHServer(t, "/dns-query", func(r *http.Request) (int, []byte, string) {
+		return http.StatusOK, []byte("not dns"), "text/plain"
+	})
+	defer stop()
+
+	f := &Forwarder{servers: []*server{dohServerWithSkipVerify(t, dohURL)}, dnssec: false}
+	runForwarderQueryExpectSERVFAIL(t, f, "example.com.", dns.TypeA)
+}
+
+// TestForwarder_DoH_MismatchedQuestion exercises the
+// dns_forwarder_response_mismatch_total path.
+func TestForwarder_DoH_MismatchedQuestion(t *testing.T) {
+	beforeMismatch := forwarderResponseMismatch.Value()
+
+	dohURL, stop := startDoHServer(t, "/dns-query", func(r *http.Request) (int, []byte, string) {
+		req := readDoHRequest(t, r)
+		return http.StatusOK, dohAnswerFor(t, req, "203.0.113.5", "attacker.example."), ""
+	})
+	defer stop()
+
+	f := &Forwarder{servers: []*server{dohServerWithSkipVerify(t, dohURL)}, dnssec: false}
+	runForwarderQueryExpectSERVFAIL(t, f, "example.com.", dns.TypeA)
+
+	if got := forwarderResponseMismatch.Value() - beforeMismatch; got != 1 {
+		t.Errorf("mismatch counter delta = %d, want 1", got)
+	}
+}
+
+// TestForwarder_DoH_FallthroughOnError exercises the "first server
+// fails, second succeeds" path. The first DoH server returns 500;
+// the second answers OK. The client should get the second answer.
+func TestForwarder_DoH_FallthroughOnError(t *testing.T) {
+	failURL, stopFail := startDoHServer(t, "/dns-query", func(r *http.Request) (int, []byte, string) {
+		return http.StatusBadGateway, []byte("nope"), "text/plain"
+	})
+	defer stopFail()
+
+	okURL, stopOK := startDoHServer(t, "/dns-query", func(r *http.Request) (int, []byte, string) {
+		req := readDoHRequest(t, r)
+		return http.StatusOK, dohAnswerFor(t, req, "198.51.100.7", ""), ""
+	})
+	defer stopOK()
+
+	f := &Forwarder{servers: []*server{
+		dohServerWithSkipVerify(t, failURL),
+		dohServerWithSkipVerify(t, okURL),
+	}, dnssec: false}
+
+	resp := runForwarderQuery(t, f, "example.com.", dns.TypeA)
+	if resp == nil || len(resp.Answer) != 1 {
+		t.Fatalf("expected 1 answer, got %+v", resp)
+	}
+	if a, ok := resp.Answer[0].(*dns.A); !ok || a.A.String() != "198.51.100.7" {
+		t.Errorf("expected fallback answer, got %v", resp.Answer[0])
+	}
+}
+
+// TestDoHGETBase64Ignored confirms that we POST, not GET — sending a
+// GET-formatted request to our handler shouldn't happen.
+func TestDoHRequestIsPOST(t *testing.T) {
+	var sawMethod string
+	dohURL, stop := startDoHServer(t, "/dns-query", func(r *http.Request) (int, []byte, string) {
+		sawMethod = r.Method
+		req := readDoHRequest(t, r)
+		return http.StatusOK, dohAnswerFor(t, req, "203.0.113.5", ""), ""
+	})
+	defer stop()
+
+	f := &Forwarder{servers: []*server{dohServerWithSkipVerify(t, dohURL)}, dnssec: false}
+	runForwarderQuery(t, f, "example.com.", dns.TypeA)
+
+	if sawMethod != http.MethodPost {
+		t.Errorf("method = %q, want POST", sawMethod)
+	}
+}
+
+// TestDoHAcceptsBase64Path ensures URL path with characters that
+// base64url uses doesn't break Pack/Unpack.
+func TestDoHAcceptsBase64Path(t *testing.T) {
+	_ = base64.RawURLEncoding // satisfy import
+	dohURL, stop := startDoHServer(t, "/abc-_123/dns-query", func(r *http.Request) (int, []byte, string) {
+		req := readDoHRequest(t, r)
+		return http.StatusOK, dohAnswerFor(t, req, "203.0.113.5", ""), ""
+	})
+	defer stop()
+
+	f := &Forwarder{servers: []*server{dohServerWithSkipVerify(t, dohURL)}, dnssec: false}
+	if resp := runForwarderQuery(t, f, "example.com.", dns.TypeA); resp == nil {
+		t.Fatal("nil response")
+	}
+}
+
+func TestForwarder_DoH_Timeout(t *testing.T) {
+	// Handler that sleeps past the client's timeout.
+	dohURL, stop := startDoHServer(t, "/dns-query", func(r *http.Request) (int, []byte, string) {
+		req := readDoHRequest(t, r)
+		time.Sleep(200 * time.Millisecond)
+		return http.StatusOK, dohAnswerFor(t, req, "203.0.113.5", ""), ""
+	})
+	defer stop()
+
+	srv := dohServerWithSkipVerify(t, dohURL)
+	srv.DoHClient.Timeout = 50 * time.Millisecond
+
+	f := &Forwarder{servers: []*server{srv}, dnssec: false}
+	runForwarderQueryExpectSERVFAIL(t, f, "example.com.", dns.TypeA)
+}
+
+// TestForwarder_DoH_CaseInsensitiveContentType checks that an
+// upstream returning "Application/DNS-Message" (mixed case, RFC 7231
+// §3.1.1.1 allows it) is still accepted. The old strings.HasPrefix
+// check rejected it.
+func TestForwarder_DoH_CaseInsensitiveContentType(t *testing.T) {
+	dohURL, stop := startDoHServer(t, "/dns-query", func(r *http.Request) (int, []byte, string) {
+		req := readDoHRequest(t, r)
+		return http.StatusOK, dohAnswerFor(t, req, "203.0.113.5", ""), "Application/DNS-Message"
+	})
+	defer stop()
+
+	f := &Forwarder{servers: []*server{dohServerWithSkipVerify(t, dohURL)}, dnssec: false}
+	resp := runForwarderQuery(t, f, "example.com.", dns.TypeA)
+	if resp == nil || len(resp.Answer) != 1 {
+		t.Fatalf("expected 1 answer with mixed-case Content-Type, got %+v", resp)
+	}
+}
+
+// TestForwarder_DoH_ContentTypeWithParams ensures that
+// "application/dns-message; charset=utf-8" (parameters per RFC 7231)
+// parses correctly.
+func TestForwarder_DoH_ContentTypeWithParams(t *testing.T) {
+	dohURL, stop := startDoHServer(t, "/dns-query", func(r *http.Request) (int, []byte, string) {
+		req := readDoHRequest(t, r)
+		return http.StatusOK, dohAnswerFor(t, req, "203.0.113.5", ""), "application/dns-message; charset=utf-8"
+	})
+	defer stop()
+
+	f := &Forwarder{servers: []*server{dohServerWithSkipVerify(t, dohURL)}, dnssec: false}
+	if resp := runForwarderQuery(t, f, "example.com.", dns.TypeA); resp == nil || len(resp.Answer) != 1 {
+		t.Fatalf("expected 1 answer with parameterised Content-Type, got %+v", resp)
+	}
+}
+
+// TestForwarder_DoH_MismatchedID ensures a response whose TXID is
+// neither an echo of req.Id nor 0 (the RFC 8484-blessed normalized
+// value) is rejected. Matches the UDP/DoT behaviour enforced by
+// miekg's dns.Client.ExchangeContext.
+func TestForwarder_DoH_MismatchedID(t *testing.T) {
+	dohURL, stop := startDoHServer(t, "/dns-query", func(r *http.Request) (int, []byte, string) {
+		req := readDoHRequest(t, r)
+		resp := new(dns.Msg)
+		resp.SetReply(req)
+		// Forge a bogus TXID — neither echoed nor 0.
+		resp.Id = req.Id ^ 0x5555
+		if resp.Id == 0 { // vanishingly unlikely but cover it
+			resp.Id = 0x1234
+		}
+		rr, err := dns.NewRR(req.Question[0].Name + " 60 IN A 203.0.113.5")
+		if err != nil {
+			t.Fatalf("build RR: %v", err)
+		}
+		resp.Answer = []dns.RR{rr}
+		body, err := resp.Pack()
+		if err != nil {
+			t.Fatalf("pack: %v", err)
+		}
+		return http.StatusOK, body, ""
+	})
+	defer stop()
+
+	f := &Forwarder{servers: []*server{dohServerWithSkipVerify(t, dohURL)}, dnssec: false}
+	runForwarderQueryExpectSERVFAIL(t, f, "example.com.", dns.TypeA)
+}
+
+// TestForwarder_DoH_ZeroIDAccepted ensures the RFC 8484
+// normalisation case (server returns ID=0 regardless of request ID)
+// is accepted — otherwise we'd break interop with RFC-strict DoH
+// servers.
+func TestForwarder_DoH_ZeroIDAccepted(t *testing.T) {
+	dohURL, stop := startDoHServer(t, "/dns-query", func(r *http.Request) (int, []byte, string) {
+		req := readDoHRequest(t, r)
+		resp := new(dns.Msg)
+		resp.SetReply(req)
+		resp.Id = 0
+		rr, err := dns.NewRR(req.Question[0].Name + " 60 IN A 203.0.113.5")
+		if err != nil {
+			t.Fatalf("build RR: %v", err)
+		}
+		resp.Answer = []dns.RR{rr}
+		body, err := resp.Pack()
+		if err != nil {
+			t.Fatalf("pack: %v", err)
+		}
+		return http.StatusOK, body, ""
+	})
+	defer stop()
+
+	f := &Forwarder{servers: []*server{dohServerWithSkipVerify(t, dohURL)}, dnssec: false}
+	resp := runForwarderQuery(t, f, "example.com.", dns.TypeA)
+	if resp == nil || len(resp.Answer) != 1 {
+		t.Fatalf("expected 1 answer when upstream returned ID=0, got %+v", resp)
+	}
+}
+
+// TestForwarder_SharedQueryBudget proves that three slow upstreams
+// don't take 3 * per-upstream-timeout. With queryTimeout set on the
+// Forwarder, the whole loop bounds at queryTimeout regardless of
+// how many upstreams are tried.
+func TestForwarder_SharedQueryBudget(t *testing.T) {
+	// Each upstream sleeps for 500ms before returning an error so
+	// the next upstream is tried. Without a shared budget, three
+	// upstreams = 1.5s. With queryTimeout=300ms, the loop must
+	// bail well before that.
+	slowHandler := func(r *http.Request) (int, []byte, string) {
+		time.Sleep(500 * time.Millisecond)
+		return http.StatusInternalServerError, []byte("slow"), "text/plain"
+	}
+	url1, stop1 := startDoHServer(t, "/dns-query", slowHandler)
+	defer stop1()
+	url2, stop2 := startDoHServer(t, "/dns-query", slowHandler)
+	defer stop2()
+	url3, stop3 := startDoHServer(t, "/dns-query", slowHandler)
+	defer stop3()
+
+	f := &Forwarder{
+		servers: []*server{
+			dohServerWithSkipVerify(t, url1),
+			dohServerWithSkipVerify(t, url2),
+			dohServerWithSkipVerify(t, url3),
+		},
+		dnssec:       false,
+		queryTimeout: 300 * time.Millisecond,
+	}
+
+	start := time.Now()
+	runForwarderQueryExpectSERVFAIL(t, f, "example.com.", dns.TypeA)
+	elapsed := time.Since(start)
+
+	// 3 upstreams * 500ms would be 1.5s. With the shared 300ms
+	// budget we should bail well before 1 second — pick a generous
+	// upper bound that still proves the budget worked.
+	if elapsed > time.Second {
+		t.Errorf("elapsed = %v, want < 1s (shared budget was 300ms; 3 sequential 500ms calls would be 1.5s)", elapsed)
+	}
+}
+
+// TestForwarder_DoH_OversizedBody ensures an upstream returning a
+// body larger than dohMaxResponseSize is rejected (SERVFAIL) rather
+// than silently truncated to a parseable prefix.
+func TestForwarder_DoH_OversizedBody(t *testing.T) {
+	// Build a body that is a valid DNS message prefix followed by
+	// junk bytes so total length exceeds the limit. The prefix is
+	// the legitimate response; trailing bytes are padding.
+	dohURL, stop := startDoHServer(t, "/dns-query", func(r *http.Request) (int, []byte, string) {
+		req := readDoHRequest(t, r)
+		legitimate := dohAnswerFor(t, req, "203.0.113.5", "")
+		// Pad past dohMaxResponseSize so io.LimitReader's +1 byte
+		// detection trips.
+		body := make([]byte, 0, len(legitimate)+dohMaxResponseSize)
+		body = append(body, legitimate...)
+		body = append(body, make([]byte, dohMaxResponseSize)...)
+		return http.StatusOK, body, ""
+	})
+	defer stop()
+
+	f := &Forwarder{servers: []*server{dohServerWithSkipVerify(t, dohURL)}, dnssec: false}
+	runForwarderQueryExpectSERVFAIL(t, f, "example.com.", dns.TypeA)
+}
+
+// runForwarderQuery drives a single A query through the forwarder
+// and returns the response the chain wrote. nil on SERVFAIL/cancel.
+func runForwarderQuery(t *testing.T, f *Forwarder, qname string, qtype uint16) *dns.Msg {
+	t.Helper()
+
+	req := new(dns.Msg)
+	req.SetQuestion(qname, qtype)
+	req.RecursionDesired = true
+
+	mw := mock.NewWriter("udp", "127.0.0.1:0")
+	ch := middleware.NewChain([]middleware.Handler{f})
+	ch.Reset(mw, req)
+
+	f.ServeDNS(context.Background(), ch)
+
+	if mw.Msg() == nil {
+		return nil
+	}
+	return mw.Msg()
+}
+
+// runForwarderQueryExpectSERVFAIL is runForwarderQuery's twin for
+// the explicit failure path — when every server errors out the
+// forwarder issues CancelWithRcode(SERVFAIL).
+func runForwarderQueryExpectSERVFAIL(t *testing.T, f *Forwarder, qname string, qtype uint16) {
+	t.Helper()
+
+	req := new(dns.Msg)
+	req.SetQuestion(qname, qtype)
+	req.RecursionDesired = true
+
+	mw := mock.NewWriter("udp", "127.0.0.1:0")
+	ch := middleware.NewChain([]middleware.Handler{f})
+	ch.Reset(mw, req)
+
+	f.ServeDNS(context.Background(), ch)
+
+	if msg := mw.Msg(); msg == nil || msg.Rcode != dns.RcodeServerFailure {
+		t.Fatalf("expected SERVFAIL, got %+v", msg)
+	}
+}
+
+func TestNew_DoH_ConfigParse(t *testing.T) {
+	cfg := stubConfig([]string{
+		"1.1.1.1:53",
+		"tls://1.1.1.1:853",
+		"https://1.1.1.1/dns-query",
+	})
+	f := New(cfg)
+	if len(f.servers) != 3 {
+		t.Fatalf("len(servers) = %d, want 3", len(f.servers))
+	}
+	wantProto := []string{"udp", "tcp-tls", "doh"}
+	for i, w := range wantProto {
+		if f.servers[i].Proto != w {
+			t.Errorf("server %d proto = %q, want %q", i, f.servers[i].Proto, w)
+		}
+	}
+}
+
+func TestNew_DoH_SkipsBadEntries(t *testing.T) {
+	cfg := stubConfig([]string{
+		"https:///dns-query", // missing host
+		"https://not-a-real-hostname-zzz-xyz-9999.invalid/q", // bootstrap fails
+		"1.1.1.1:53", // valid — must survive
+	})
+	f := New(cfg)
+	if len(f.servers) != 1 {
+		t.Fatalf("len(servers) = %d, want 1 (only the udp entry should survive)", len(f.servers))
+	}
+	if f.servers[0].Proto != "udp" {
+		t.Errorf("surviving server proto = %q, want udp", f.servers[0].Proto)
+	}
+}
+
+// stubConfig builds a config.Config with only the fields New touches.
+func stubConfig(forwarders []string) *config.Config {
+	return &config.Config{ForwarderServers: forwarders}
+}
+
+var _ = strings.ToLower // satisfy import in test refactors

--- a/middleware/forwarder/forwarder.go
+++ b/middleware/forwarder/forwarder.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"crypto/tls"
 	"net"
+	"net/http"
 	"strings"
+	"time"
 
 	"github.com/miekg/dns"
 	"github.com/prometheus/client_golang/prometheus"
@@ -40,7 +42,12 @@ var (
 
 type server struct {
 	Addr  string
-	Proto string
+	Proto string // "udp" | "tcp-tls" | "doh"
+
+	// DoH-only fields. Populated by newDoHServer when Proto=="doh";
+	// nil for plain UDP and DoT entries.
+	DoHURL    string
+	DoHClient *http.Client
 }
 
 // Forwarder type.
@@ -48,33 +55,87 @@ type Forwarder struct {
 	servers   []*server
 	dnssec    bool
 	tlsConfig *tls.Config
+
+	// queryTimeout caps the total time ServeDNS spends across every
+	// configured upstream — mirroring how the resolver handler
+	// enforces cfg.QueryTimeout. Without it, three slow upstreams
+	// could take ~3 * per-upstream-timeout, which contradicts the
+	// README description of querytimeout as the maximum time for
+	// any one client-facing query.
+	queryTimeout time.Duration
 }
 
 // New return forwarder.
+//
+// Accepted forwarder_servers formats:
+//   - "1.1.1.1:53"                         — plain UDP (TCP fallback on TC)
+//   - "tls://1.1.1.1:853"                  — DoT (RFC 7858) over TCP-TLS
+//   - "https://1.1.1.1/dns-query"          — DoH (RFC 8484) with IP literal
+//   - "https://dns.example.com/dns-query"  — DoH with hostname (bootstrapped
+//     via the system resolver once at startup; resolved IPs are pinned for
+//     the process lifetime, no per-query DNS dependency)
+//
+// DoH servers honour cfg.Timeout (per-IP dial budget) and
+// cfg.QueryTimeout (full request budget) — operators tune both via
+// the existing top-level config keys, no DoH-specific knob.
+//
+// Each entry is parsed independently; a malformed or unreachable
+// entry is logged and skipped so one bad upstream does not abort
+// startup if others are usable.
 func New(cfg *config.Config) *Forwarder {
+	dialTimeout := cfg.Timeout.Duration
+	if dialTimeout <= 0 {
+		dialTimeout = 2 * time.Second
+	}
+	requestTimeout := cfg.QueryTimeout.Duration
+	if requestTimeout <= 0 {
+		requestTimeout = 10 * time.Second
+	}
+
 	forwarderservers := []*server{}
 	for _, s := range cfg.ForwarderServers {
-		srv := &server{Proto: "udp"}
-
-		if strings.HasPrefix(s, "tls://") {
-			s = strings.TrimPrefix(s, "tls://")
-			srv.Proto = "tcp-tls"
-		}
-
-		host, _, _ := net.SplitHostPort(s)
-
-		if ip := net.ParseIP(host); ip != nil && ip.To4() != nil {
-			srv.Addr = s
+		switch {
+		case strings.HasPrefix(s, "https://"):
+			srv, err := newDoHServer(s, dialTimeout, requestTimeout)
+			if err != nil {
+				zlog.Error("Forwarder DoH server not usable", "server", s, "error", err.Error())
+				continue
+			}
 			forwarderservers = append(forwarderservers, srv)
-		} else if ip != nil && ip.To16() != nil {
-			srv.Addr = s
-			forwarderservers = append(forwarderservers, srv)
-		} else {
-			zlog.Error("Forwarder server is not correct. Check your config.", "server", s)
+
+		case strings.HasPrefix(s, "tls://"):
+			addr := strings.TrimPrefix(s, "tls://")
+			if !validForwarderAddr(addr) {
+				zlog.Error("Forwarder server is not correct. Check your config.", "server", s)
+				continue
+			}
+			forwarderservers = append(forwarderservers, &server{Addr: addr, Proto: "tcp-tls"})
+
+		default:
+			if !validForwarderAddr(s) {
+				zlog.Error("Forwarder server is not correct. Check your config.", "server", s)
+				continue
+			}
+			forwarderservers = append(forwarderservers, &server{Addr: s, Proto: "udp"})
 		}
 	}
 
-	return &Forwarder{servers: forwarderservers, dnssec: cfg.DNSSEC == "on"}
+	return &Forwarder{
+		servers:      forwarderservers,
+		dnssec:       cfg.DNSSEC == "on",
+		queryTimeout: requestTimeout,
+	}
+}
+
+// validForwarderAddr reports whether addr is a host:port string with
+// an IPv4 or IPv6 host literal. Preserves the pre-DoH validation
+// (which only accepted IP literals for UDP / DoT).
+func validForwarderAddr(addr string) bool {
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		return false
+	}
+	return net.ParseIP(host) != nil
 }
 
 // (*Forwarder).Name name return middleware name.
@@ -87,6 +148,23 @@ func (f *Forwarder) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	if len(req.Question) == 0 || len(f.servers) == 0 {
 		ch.CancelWithRcode(dns.RcodeServerFailure, true)
 		return
+	}
+
+	// Wrap ctx with the shared per-query budget so the dispatch
+	// loop below cannot exceed cfg.QueryTimeout regardless of how
+	// many upstreams are configured. Each individual call still
+	// respects its own per-upstream timeout (dns.Client default for
+	// UDP/DoT, http.Client.Timeout for DoH); ctx cancellation
+	// short-circuits the loop when the overall budget is gone.
+	//
+	// Guard against zero queryTimeout — that would create an
+	// already-expired context. Production goes through New() which
+	// always sets a positive value; this branch keeps the package
+	// robust if a Forwarder is constructed directly (mostly tests).
+	if f.queryTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, f.queryTimeout)
+		defer cancel()
 	}
 
 	// Preserve the client's CD bit. We may set CD=1 on the
@@ -102,12 +180,19 @@ func (f *Forwarder) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	defer func() { req.CheckingDisabled = clientCD }()
 
 	for _, server := range f.servers {
-		reqClient := &dns.Client{Net: server.Proto}
-		if server.Proto == "tcp-tls" {
-			reqClient.TLSConfig = f.tlsConfig
+		var (
+			resp *dns.Msg
+			err  error
+		)
+		if server.Proto == "doh" {
+			resp, err = dohExchange(ctx, server, req)
+		} else {
+			reqClient := &dns.Client{Net: server.Proto}
+			if server.Proto == "tcp-tls" {
+				reqClient.TLSConfig = f.tlsConfig
+			}
+			resp, err = dnsutil.Exchange(ctx, req, server.Addr, server.Proto, reqClient)
 		}
-
-		resp, err := dnsutil.Exchange(ctx, req, server.Addr, server.Proto, reqClient)
 		if err != nil {
 			forwarderFailures.Inc()
 			zlog.Info("forwarder query failed", "query", formatQuestion(req.Question[0]), "error", err.Error())


### PR DESCRIPTION
## Summary

Adds **DoH (DNS-over-HTTPS) as a forwarder upstream protocol**, closing #473 (requested by @JJF-1). `forwarderservers` now accepts `https://` URLs alongside the existing UDP and `tls://` (DoT) forms, with both IP-literal and hostname URLs supported.

```toml
forwarderservers = [
    "1.1.1.1:53",                          # plain UDP
    "tls://1.1.1.1:853",                   # DoT
    "https://1.1.1.1/dns-query",           # DoH, IP literal
    "https://cloudflare-dns.com/dns-query" # DoH, hostname (system-resolver bootstrap)
]
```

## Design

**Hostname bootstrap.** Hostnames are resolved once at startup through `net.DefaultResolver` (the system resolver). The resolved IPs are pinned for the process lifetime — there is no per-query DNS dependency. Bootstrap failure is logged and the entry is skipped without aborting startup, matching the existing `tls://` parse-error behavior.

**Per-server HTTP/2 client with pinned IPs.** Each DoH server gets its own `*http.Client` with:
- A custom `DialContext` that dials the pinned IPs in **rotation** (atomic counter starting position) and **caps each per-IP TCP dial at `cfg.Timeout`** — a blackholed pinned IP bypasses to the next one in ≤ 2s instead of consuming the full request budget. This is the standard mixed-A/AAAA-with-broken-v6 failure mode.
- HTTP/2 + `MaxIdleConnsPerHost: 4` for connection reuse (the TLS handshake costs 50-100ms — must amortize).
- TLS `ServerName` set to the original URL hostname so cert SAN validation works correctly when dialing IPs.

**Wire format & response handling.**
- POST `application/dns-message` per RFC 8484
- Response `Content-Type` parsed with `mime.ParseMediaType` (RFC 7231 §3.1.1.1 case-insensitivity + parameter tolerance) — `Application/DNS-Message` and `application/dns-message; charset=utf-8` both work.
- Response body bounded at 64 KiB (`dohMaxResponseSize+1` read so oversized bodies are rejected rather than silently truncated to a parseable prefix).
- Response TXID validated against `req.Id` OR `0` (RFC 8484 §4.1 cache-friendly normalization) before the existing question-section mismatch check. Matches `dns.Client.ExchangeContext`'s ID-echo enforcement for UDP/DoT.

**Shared query budget across upstreams.** `cfg.QueryTimeout` is now also a forwarder-level constraint — `ServeDNS` wraps the chain `ctx` with `WithTimeout(queryTimeout)` once so the dispatch loop across N upstreams cannot exceed the budget regardless of protocol. Three slow upstreams can no longer take ~3 × per-call timeout.

## What it reuses

- Existing `dns_forwarder_failures_total` and `dns_forwarder_response_mismatch_total` cover DoH paths without new metrics.
- Timeouts come from existing top-level config (`querytimeout`, `timeout`) — no DoH-specific knob.
- Failure handling matches existing `tls://`: per-entry log+skip; one bad upstream does not abort startup.

## What it does not do (intentional)

- **No HTTP/3 (DoH3) forwarder support.** Server-side DoH3 already exists; client-side is a separate transport with its own dependency surface. Defer to a follow-up if requested.
- **No GET method.** POST avoids URL-length limits and HTTP caching surface.
- **No IP refresh ticker.** DoH provider IPs rarely move; if they do, restart picks them up. Documented.
- **No per-DoH-server metric label.** Existing aggregate counters apply; per-upstream cardinality would be dynamic and would need bounded enumeration.

## Test plan

- [x] 21 new DoH tests under `-race`, all green: IP literal, custom port, scheme rejection, missing host, hostname bootstrap (success / NXDOMAIN failure / empty-IP-list failure), full ServeDNS happy path, server 5xx, bad Content-Type, case-insensitive Content-Type, parameterized Content-Type, mismatched question, mismatched TXID, RFC-8484 ID=0 accepted, fallthrough on first-server failure, POST-method assertion, base64-friendly URL path, per-server timeout, **shared-query-budget proof** (3 × 500ms upstreams + 300ms budget must finish in <1s), oversized body rejection, config-parse, skip-bad-entries.
- [x] Existing forwarder UDP/DoT tests still green — no regressions.
- [x] `go test -race ./...` — all packages green.
- [x] `golangci-lint run ./...` — 0 issues.