### PR TITLE
chore(release): bump version to 1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ docker run -d --name sdns -p 53:53 -p 53:53/udp ghcr.io/semihalev/sdns:latest
 Pin to a specific version (recommended for production):
 
 ```shell
-$ docker run -d --name sdns -p 53:53 -p 53:53/udp ghcr.io/semihalev/sdns:1.6.7
+$ docker run -d --name sdns -p 53:53 -p 53:53/udp ghcr.io/semihalev/sdns:1.7.0
 ```
 
 #### Docker Compose

--- a/sdns.go
+++ b/sdns.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const version = "1.6.7"
+const version = "1.7.0"
 
 var (
 	cfgPath    string


### PR DESCRIPTION
## Summary

Bumps the SDNS binary version to **1.7.0** so the next tagged release announces everything that has landed on main since 1.6.7.

## Changes

| File | Change |
|---|---|
| `sdns.go` | `const version = "1.6.7"` → `"1.7.0"` |
| `README.md` | docker run example tag bumped to `1.7.0` |
| `config/config.go` (configver) | already at `1.7.0` from PR #483 — no change |
| `contrib/linux/sdns.conf` | regenerated from the 1.7.0 binary; byte-identical to the existing copy (default config was kept mirrored through every feature PR) — no change |
| README benchmark table | **intentionally not bumped** — table stays at the last-measured release per repo convention |

## What this release ships

Merged since the 1.6.7 tag:

- **#483** EDNS Client Subnet forwarding, RFC 7871 Stage 1
- **#484** ECS-aware cache partitioning, Stage 2 — closes #417 (cache pollution)
- **#485** `internal/metric` sharded-counter shim + 23 new metrics (cache, dns64, resolver, dnssec, blocklist, accesslist, ratelimit, forwarder, failover, edns, recovery, listener, doh, circuit breaker, trust anchor, hostsfile, kubernetes) — hot path ~20× faster than direct `prometheus.CounterVec.WithLabelValues`
- **#486** DNS-over-HTTPS forwarder upstreams (RFC 8484), IP-literal and hostname URLs — closes #473

## Test plan

- [x] `go build ./...` — clean
- [x] `go test -race ./...` — all packages green