### PR TITLE
1.7.1 hardening: cache full-key verification, CI fix, doc.go rewrite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,9 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           files: coverage.out
-          fail_ci_if_error: true
+          # Coverage upload is informational; a Codecov outage or a
+          # missing token (e.g. on fork PRs) must not fail the build.
+          fail_ci_if_error: false
           token: ${{ secrets.CODECOV_TOKEN }}
 
   lint:

--- a/doc.go
+++ b/doc.go
@@ -1,77 +1,105 @@
 /*
-Package main implements SDNS - a high-performance, recursive DNS resolver server with DNSSEC support.
+Package main is the entry point for SDNS, a high-performance, privacy-focused
+recursive DNS resolver with full DNSSEC validation.
 
-SDNS is a privacy-focused DNS server that provides:
+# Overview
 
-  - High-performance recursive DNS resolution with aggressive caching
-  - Full DNSSEC validation and verification support
-  - DNS-over-HTTPS (DoH) and DNS-over-QUIC (DoQ) protocols
-  - Privacy-preserving features including query minimization (RFC 7816)
-  - Flexible middleware architecture for extending functionality
-  - Built-in blocklist and allowlist support
-  - Rate limiting and access control
-  - Metrics and monitoring via Prometheus
-  - Automatic root trust anchor updates (RFC 5011)
+SDNS resolves queries iteratively from the root, validating DNSSEC along the
+chain of trust, and caches aggressively. It can also run as a forwarding
+resolver. Queries are served over plain DNS (UDP and TCP) as well as the
+encrypted transports DNS-over-TLS (DoT), DNS-over-HTTPS (DoH, including
+HTTP/3), and DNS-over-QUIC (DoQ). A separate HTTP API exposes Prometheus
+metrics and operational endpoints (blocklist management, cache purge).
 
-Architecture:
+# Feature highlights
 
-SDNS uses a middleware-based architecture where each component processes DNS queries
-in a chain. The middleware order is important and defined as:
+  - Iterative recursive resolution with DNSSEC validation, NSEC/NSEC3
+    denial-of-existence proofs, and RFC 5011 automatic root trust-anchor
+    maintenance.
+  - QNAME minimization (RFC 7816) for query privacy.
+  - High-performance caching: positive and negative caches, prefetch of
+    popular entries, and EDNS Client Subnet (ECS, RFC 7871) aware keying.
+  - Forwarding to upstream resolvers over UDP, TCP, DoT, and DoH.
+  - Filtering and policy: blocklists with pattern matching, IP access
+    lists, per-client views, and per-client/global rate limiting.
+  - Amplification/reflection (spoofed-source) attack detection.
+  - DNS64 (RFC 6147), AS112 (RFC 7534), CHAOS telemetry, local hosts-file
+    answers, and optional Kubernetes service discovery.
+  - Observability via Prometheus metrics and dnstap query logging.
 
- 1. Recovery - Panic recovery and error handling
- 2. Loop - Detection and prevention of query loops
- 3. Metrics - Prometheus metrics collection with optional per-domain tracking
- 4. Dnstap - Binary DNS message logging (dnstap format)
- 5. AccessList - IP-based access control
- 6. RateLimit - Query rate limiting per client
- 7. EDNS - EDNS0 support and processing
- 8. AccessLog - Query logging
- 9. Chaos - Chaos TXT query responses
- 10. HostsFile - Local hosts file resolution
- 11. BlockList - Domain blocking with pattern matching
- 12. AS112 - RFC 7534 AS112 redirection
- 13. Cache - High-performance query caching
- 14. Failover - Upstream server failover
- 15. Resolver - Recursive DNS resolution with DNSSEC
- 16. Forwarder - Forward queries to upstream servers
+# Architecture
 
-Configuration:
+SDNS processes every query through an ordered middleware chain. Each
+middleware either answers the query, mutates the request/response, or passes
+control to the next middleware via the chain. The order is significant and is
+the single source of truth in gen.go's middlewareList; gen.go generates
+registry.go, whose init registers each middleware with the middleware package.
+Middlewares self-declare their dependencies through marker interfaces (e.g.
+StoreProvider, QueryerSetter), so adding one means adding an entry to
+middlewareList plus an implementation — no central wiring switch to edit.
 
-SDNS uses a configuration file (default: sdns.conf) that supports:
+The chain order is:
 
-  - Server binding addresses for DNS, DoH, and DoQ
-  - TLS certificate configuration
-  - Middleware-specific settings
-  - Upstream resolver configuration
-  - Cache size and TTL settings
-  - Logging levels and output
+ 1. recovery   - Panic recovery for the handler chain.
+ 2. metrics    - Prometheus metrics, with optional per-domain tracking.
+ 3. dnstap     - Binary DNS message logging in dnstap format.
+ 4. accesslist - IP-based access control for clients.
+ 5. ratelimit  - Per-client and global query rate limiting.
+ 6. reflex     - DNS amplification/reflection (spoofed-source) detection.
+ 7. edns       - EDNS0 processing: option/version handling, DO and CD bits,
+    and UDP buffer-size negotiation.
+ 8. accesslog  - Per-query logging.
+ 9. chaos      - CHAOS-class version and telemetry responses.
+ 10. hostsfile - Answers served from a local hosts file.
+ 11. views     - Per-client static answers selected by source-IP CIDR.
+ 12. blocklist - Domain blocking with pattern matching.
+ 13. as112     - RFC 7534 handling for private-use reverse zones.
+ 14. kubernetes- Kubernetes service DNS (optional).
+ 15. dns64     - RFC 6147 AAAA synthesis for IPv6-only clients.
+ 16. cache     - Positive/negative caching with prefetch and ECS awareness.
+ 17. failover  - Fallback when the primary resolution path fails.
+ 18. resolver  - Iterative recursive resolution with DNSSEC validation.
+ 19. forwarder - Forwarding to upstream resolvers (UDP/TCP/DoT/DoH).
 
-Usage:
+# Configuration
+
+SDNS reads a TOML configuration file (default: sdns.conf). If the file does
+not exist, a documented default is generated on first run. The file controls
+listen addresses for each transport, TLS certificates, upstream and root
+servers, cache sizing and TTL bounds, DNSSEC and privacy options, the HTTP
+API, and per-middleware settings.
+
+# Usage
 
 	sdns [flags]
 	sdns [command]
 
-Available Commands:
+Commands:
 
-	help        Help about any command
-	version     Print version information
+	version   Print version and build information.
+	help      Help about any command.
 
 Flags:
 
-	-c, --config string   Location of config file (default "sdns.conf")
-	-h, --help           Help for sdns
+	-c, --config string   Path to the config file; generated if absent
+	                      (default "sdns.conf").
+	-t, --test            Validate the config file and exit (0 valid, 1 invalid).
+	-h, --help            Help for sdns.
 
-Example:
+Examples:
 
-	# Start with default config
+	# Start with the default config (generated if missing).
 	sdns
 
-	# Start with custom config
+	# Start with a specific config file.
 	sdns -c /etc/sdns/sdns.conf
 
-	# Show version
+	# Validate a config without starting the server.
+	sdns -t -c /etc/sdns/sdns.conf
+
+	# Print version information.
 	sdns version
 
-For more information, visit https://sdns.dev
+Project home and documentation: https://github.com/semihalev/sdns
 */
 package main // import "github.com/semihalev/sdns"

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -513,6 +513,16 @@ func (c *Cache) handleCacheHit(ctx context.Context, ch *middleware.Chain, entry 
 	w := ch.Writer
 	req := ch.Request
 
+	// Full-key verification (defends against xxhash64 key collisions).
+	// The cache key is a non-cryptographic 64-bit hash of the query
+	// preimage, so a collision — accidental, or attacker-searched on a
+	// chosen qname — would otherwise serve one query's answer to another.
+	// Returning false treats it as a miss so the chain resolves normally.
+	// This is the single chokepoint for every hit (scoped and shared).
+	if len(req.Question) == 0 || !entryMatchesQuestion(entry, req.Question[0]) {
+		return false
+	}
+
 	// Rate limiting applies to external client queries only.
 	// Internal sub-queries (CNAME chase, DNAME target, NS lookup)
 	// carry BufferWriter.Internal()==true via the responseWriter

--- a/middleware/cache/store.go
+++ b/middleware/cache/store.go
@@ -85,7 +85,32 @@ func entryMatchesQuestion(entry *CacheEntry, q dns.Question) bool {
 		return false
 	}
 	eq := entry.msg.Question[0]
-	return eq.Qtype == q.Qtype && eq.Qclass == q.Qclass && strings.EqualFold(eq.Name, q.Name)
+	return eq.Qtype == q.Qtype && eq.Qclass == q.Qclass && equalNameASCIIFold(eq.Name, q.Name)
+}
+
+// equalNameASCIIFold reports whether two DNS names are equal under
+// ASCII-only case folding — exactly the normalization the cache key uses
+// (internal/cache.Key lowercases A–Z and nothing else). strings.EqualFold
+// would be broader (full Unicode case folding), so two names the key hash
+// treats as distinct could compare equal here and weaken the collision
+// check; matching the hash's folding keeps the verification exact.
+func equalNameASCIIFold(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		ca, cb := a[i], b[i]
+		if ca >= 'A' && ca <= 'Z' {
+			ca += 'a' - 'A'
+		}
+		if cb >= 'A' && cb <= 'Z' {
+			cb += 'a' - 'A'
+		}
+		if ca != cb {
+			return false
+		}
+	}
+	return true
 }
 
 // Get returns a materialised cached response for req. Reply

--- a/middleware/cache/store.go
+++ b/middleware/cache/store.go
@@ -43,11 +43,17 @@ func (s *Store) Lookup(req *dns.Msg) (*CacheEntry, bool) {
 	if len(req.Question) == 0 {
 		return nil, false
 	}
-	return s.LookupByKey(CacheKey{Question: req.Question[0], CD: req.CheckingDisabled}.Hash())
+	q := req.Question[0]
+	return s.LookupByKeyVerified(CacheKey{Question: q, CD: req.CheckingDisabled}.Hash(), q)
 }
 
 // LookupByKey is the pre-keyed form of Lookup, used by hot paths
 // inside the cache middleware that already computed the key.
+//
+// Callers MUST verify the returned entry's question against the request
+// (use LookupByKeyVerified, or compare via entryMatchesQuestion): the map
+// key is a non-cryptographic 64-bit xxhash of the key preimage, so a hash
+// collision would otherwise serve one query's answer to another.
 func (s *Store) LookupByKey(key uint64) (*CacheEntry, bool) {
 	if entry, ok := s.positive.Get(key); ok {
 		return entry, true
@@ -56,6 +62,30 @@ func (s *Store) LookupByKey(key uint64) (*CacheEntry, bool) {
 		return entry, true
 	}
 	return nil, false
+}
+
+// LookupByKeyVerified is LookupByKey plus a full-key check: it confirms the
+// stored entry's question matches q before returning it. Without this, two
+// distinct questions whose preimages collide under xxhash64 would silently
+// serve each other's answers — and because qnames are attacker-chosen, a
+// collision can be searched for offline and used to poison the cache.
+func (s *Store) LookupByKeyVerified(key uint64, q dns.Question) (*CacheEntry, bool) {
+	entry, ok := s.LookupByKey(key)
+	if !ok || !entryMatchesQuestion(entry, q) {
+		return nil, false
+	}
+	return entry, true
+}
+
+// entryMatchesQuestion reports whether entry's stored question equals q:
+// type and class exactly, name case-insensitively (RFC 4343 — matching the
+// key hash, which lowercases the name in its preimage).
+func entryMatchesQuestion(entry *CacheEntry, q dns.Question) bool {
+	if entry == nil || entry.msg == nil || len(entry.msg.Question) == 0 {
+		return false
+	}
+	eq := entry.msg.Question[0]
+	return eq.Qtype == q.Qtype && eq.Qclass == q.Qclass && strings.EqualFold(eq.Name, q.Name)
 }
 
 // Get returns a materialised cached response for req. Reply

--- a/middleware/cache/store_test.go
+++ b/middleware/cache/store_test.go
@@ -35,6 +35,43 @@ func newTestSuccessResp(name string) *dns.Msg {
 	return resp
 }
 
+// TestLookupByKeyVerifiedRejectsCollision plants two distinct questions
+// under the SAME key — deterministically simulating an xxhash64 collision —
+// and confirms full-key verification serves only the matching question.
+// Without it, an attacker who searches a colliding qname could poison the
+// cache (the cache previously returned an entry on a bare hash match).
+func TestLookupByKeyVerifiedRejectsCollision(t *testing.T) {
+	s := newTestStore(t)
+
+	const collidingKey = uint64(0xC0FFEE)
+	respA := newTestSuccessResp("a.example.")
+	s.positive.Set(collidingKey, NewCacheEntryWithKey(respA, time.Minute, 0, collidingKey))
+
+	qA := dns.Question{Name: "a.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	qB := dns.Question{Name: "b.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+
+	if _, ok := s.LookupByKeyVerified(collidingKey, qB); ok {
+		t.Fatal("collision: mismatched question must be a miss")
+	}
+	if _, ok := s.LookupByKeyVerified(collidingKey, qA); !ok {
+		t.Fatal("matching question must hit")
+	}
+	// Name comparison is case-insensitive (RFC 4343), matching the key hash.
+	qAUpper := dns.Question{Name: "A.EXAMPLE.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	if _, ok := s.LookupByKeyVerified(collidingKey, qAUpper); !ok {
+		t.Fatal("name match must be case-insensitive")
+	}
+	// Type and class must match exactly.
+	for _, q := range []dns.Question{
+		{Name: "a.example.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET},
+		{Name: "a.example.", Qtype: dns.TypeA, Qclass: dns.ClassCHAOS},
+	} {
+		if _, ok := s.LookupByKeyVerified(collidingKey, q); ok {
+			t.Fatalf("mismatched %v must be a miss", q)
+		}
+	}
+}
+
 // TestStoreGetLookupRoundTrip covers Store.Lookup and Store.Get via
 // SetFromResponse — the three public facade methods every caller
 // outside the middleware goes through.

--- a/middleware/cache/store_test.go
+++ b/middleware/cache/store_test.go
@@ -180,3 +180,21 @@ func TestCachePurgePublicAPI(t *testing.T) {
 		t.Fatal("entry should be purged")
 	}
 }
+
+// TestEqualNameASCIIFold verifies the cache-key verification folds ASCII
+// case only — matching internal/cache.Key — and does NOT do Unicode folding
+// (which strings.EqualFold would), so it can't accept names the key hash
+// treats as distinct.
+func TestEqualNameASCIIFold(t *testing.T) {
+	if !equalNameASCIIFold("a.Example.COM.", "A.example.com.") {
+		t.Fatal("ASCII case must fold equal")
+	}
+	if equalNameASCIIFold("a.example.com.", "b.example.com.") {
+		t.Fatal("different names must not be equal")
+	}
+	// U+017F (ſ, 2 bytes UTF-8) Unicode-folds to 's', but must NOT fold
+	// here — different byte length, and the key hash treats it as distinct.
+	if equalNameASCIIFold("ſ.example.", "s.example.") {
+		t.Fatal("must not Unicode-fold (would diverge from the key hash)")
+	}
+}


### PR DESCRIPTION
Three focused improvements identified in a project-wide review (each is an independent commit; happy to split into separate PRs if preferred).

## 1. `fix(cache)`: verify full question on cache hit
The cache map key is a non-cryptographic 64-bit xxhash of the query preimage, and entries were returned on a **bare key match** with no comparison of the stored question. Two distinct queries whose preimages collide would silently serve each other's answers — and since qnames are attacker-chosen, a collision can be searched offline and used to **poison the cache**.

Fix: `Store.LookupByKeyVerified` (= `LookupByKey` + `entryMatchesQuestion`: exact type/class, case-insensitive name per RFC 4343). `Store.Lookup`/`Get` (resolver sub-queries, prefetch) verify directly; the cache-middleware hot path verifies once at `handleCacheHit` — the single chokepoint every scoped and shared hit passes through — and falls through to normal resolution on a mismatch. New test `TestLookupByKeyVerifiedRejectsCollision` plants two questions under one key to exercise the defense deterministically.

## 2. `ci`: don't fail the build on codecov upload errors
The coverage upload step runs only on `ubuntu-latest` with `fail_ci_if_error: true`, so a Codecov outage or missing token (e.g. fork PRs) failed the whole ubuntu job while macOS/Windows passed — the recurring red `Test (ubuntu-latest)` check seen across recent PRs. Coverage upload is informational → `fail_ci_if_error: false`.

## 3. `docs(doc.go)`: rewrite stale package documentation
The package godoc listed a nonexistent "Loop" middleware and omitted `reflex`, `views`, `as112`, `kubernetes`, and `dns64`; its described chain no longer matched `gen.go`. Rewritten to reflect the real 19-middleware order, the served transports (UDP/TCP/DoT/DoH/DoH3/DoQ), the actual feature set, the self-wiring registry, and the real CLI.

## Testing
`go build ./...`, `go vet`, `go test -race ./middleware/cache/`, and `golangci-lint run` all pass.