### PR TITLE
1.7.1 hardening (round 2): toolchain CVEs, circuit-breaker leak, FORMERR guard, blocklist whitelist, cookie secret

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 COPY . /go/src/github.com/semihalev/sdns/
 

--- a/config/config.go
+++ b/config/config.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"time"
@@ -843,7 +842,7 @@ func Load(cfgfile, version string) (*Config, error) {
 	config := new(Config)
 
 	if _, err := os.Stat(cfgfile); os.IsNotExist(err) {
-		if path.Base(cfgfile) == "sdns.conf" {
+		if filepath.Base(cfgfile) == "sdns.conf" {
 			// compatibility for old default conf file
 			if _, err := os.Stat("sdns.toml"); os.IsNotExist(err) {
 				if err := generateConfig(cfgfile); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	"crypto/rand"
-	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"net"
@@ -880,14 +880,16 @@ func Load(cfgfile, version string) (*Config, error) {
 	}
 
 	if config.CookieSecret == "" {
-		var v uint64
-
-		err := binary.Read(rand.Reader, binary.BigEndian, &v)
-		if err != nil {
+		// 16 random bytes (128-bit) hex-encoded to a 32-char secret.
+		// The previous fmt.Sprintf("%16x", uint64) was *space*-padded,
+		// not zero-padded, so small random values produced low-entropy
+		// secrets like "              2a" — weakening DNS Cookie
+		// (RFC 7873) anti-spoofing.
+		secret := make([]byte, 16)
+		if _, err := rand.Read(secret); err != nil {
 			return nil, err
 		}
-
-		config.CookieSecret = fmt.Sprintf("%16x", v)
+		config.CookieSecret = hex.EncodeToString(secret)
 	}
 
 	if !config.IPv6Access {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/hex"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -494,4 +495,23 @@ func TestConfigWithIPv6Access(t *testing.T) {
 
 	// Clean up
 	os.RemoveAll(tmpDir) //nolint:gosec // G104 - test cleanup
+}
+
+// TestCookieSecretGenerated verifies the auto-generated DNS Cookie secret is
+// full-width hex (no space padding from the old fmt.Sprintf("%16x", ...)).
+func TestCookieSecretGenerated(t *testing.T) {
+	cfgFile := filepath.Join(t.TempDir(), "sdns.conf")
+	cfg, err := Load(cfgFile, "1.0.0")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.CookieSecret) != 32 {
+		t.Fatalf("CookieSecret length = %d, want 32", len(cfg.CookieSecret))
+	}
+	if strings.ContainsRune(cfg.CookieSecret, ' ') {
+		t.Fatalf("CookieSecret contains space padding: %q", cfg.CookieSecret)
+	}
+	if _, err := hex.DecodeString(cfg.CookieSecret); err != nil {
+		t.Fatalf("CookieSecret is not valid hex: %v", err)
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -77,3 +77,5 @@ require (
 )
 
 go 1.26.0
+
+toolchain go1.26.4

--- a/middleware/blocklist/blocklist.go
+++ b/middleware/blocklist/blocklist.go
@@ -287,7 +287,11 @@ func (b *BlockList) RemoveBatch(keys []string) int {
 func (b *BlockList) setLocked(key string) bool {
 	key = dns.CanonicalName(key)
 
-	if b.w[key] {
+	// Refuse to add a block the whitelist would shadow. Exists matches the
+	// whitelist across the hierarchy, so this must too — otherwise adding
+	// sub.example.com. while example.com. is whitelisted would report
+	// success and persist a block that can never take effect.
+	if matchHierarchy(key, b.w) {
 		return false
 	}
 

--- a/middleware/blocklist/blocklist.go
+++ b/middleware/blocklist/blocklist.go
@@ -314,17 +314,20 @@ func (b *BlockList) Exists(key string) bool {
 
 	key = dns.CanonicalName(key)
 
-	// Whitelisted names bypass both exact and wildcard block
-	// matches — the Set paths already refuse to *add* a block
-	// for a whitelisted name, but older lists or wildcard
-	// entries like "*.example.com." would otherwise still match
-	// an explicit whitelist of "important.example.com.".
-	if b.w[key] {
+	// Whitelist overrides every block (exact, parent, or wildcard). It is
+	// matched across the full hierarchy — exact name plus every parent —
+	// so it stays symmetric with the block walk below: just as blocking
+	// "example.com." covers "sub.example.com.", whitelisting "example.com."
+	// now exempts "sub.example.com." too. (Previously the whitelist matched
+	// the exact name only, so a parent whitelist silently failed to protect
+	// its subdomains from a parent/wildcard block.) This only ever exempts,
+	// so it can never introduce a new block that breaks resolution.
+	if matchHierarchy(key, b.w) {
 		return false
 	}
 
 	// Direct match - fastest path (exact name)
-	if _, ok := b.m[key]; ok {
+	if b.m[key] {
 		return true
 	}
 
@@ -347,16 +350,35 @@ func (b *BlockList) Exists(key string) bool {
 
 		if offset < len(key) {
 			suffix := key[offset:]
-			if _, ok := b.m[suffix]; ok {
-				return true
-			}
-			if _, ok := b.wild[suffix]; ok {
+			if b.m[suffix] || b.wild[suffix] {
 				return true
 			}
 		}
 	}
 
 	return false
+}
+
+// matchHierarchy reports whether name or any of its parent suffixes is a
+// key in m. Names are expected in canonical (lowercase, trailing-dot) form.
+func matchHierarchy(name string, m map[string]bool) bool {
+	if len(m) == 0 {
+		return false
+	}
+	if m[name] {
+		return true
+	}
+	offset := 0
+	for {
+		idx := strings.IndexByte(name[offset:], '.')
+		if idx == -1 {
+			return false
+		}
+		offset += idx + 1
+		if offset < len(name) && m[name[offset:]] {
+			return true
+		}
+	}
 }
 
 // (*BlockList).Length length returns the caches length.

--- a/middleware/blocklist/blocklist_test.go
+++ b/middleware/blocklist/blocklist_test.go
@@ -341,4 +341,10 @@ func Test_BlockList_WhitelistHierarchy(t *testing.T) {
 	// A different blocked subtree is unaffected by the whitelist.
 	b.Set("*.other.com.")
 	assert.True(t, b.Exists("x.other.com."), "unrelated subtree still blocked")
+
+	// Set must refuse a block the whitelist hierarchically shadows, rather
+	// than persist a block that can never take effect (Exists exempts it
+	// anyway). Symmetric with the hierarchical Exists whitelist match.
+	assert.False(t, b.Set("sub.example.com."), "Set must refuse a hierarchically-whitelisted name")
+	assert.False(t, b.Exists("sub.example.com."), "shadowed name stays exempt")
 }

--- a/middleware/blocklist/blocklist_test.go
+++ b/middleware/blocklist/blocklist_test.go
@@ -318,3 +318,27 @@ func Test_BlockList_NoStallDuringSave(t *testing.T) {
 		t.Fatal("ServeDNS-style RLock blocked while saveMu was held — disk I/O is back inside the map lock")
 	}
 }
+
+// Test_BlockList_WhitelistHierarchy verifies the whitelist is matched across
+// the domain hierarchy (symmetric with the block walk): whitelisting a parent
+// exempts its subdomains, and only ever exempts.
+func Test_BlockList_WhitelistHierarchy(t *testing.T) {
+	cfg := new(config.Config)
+	cfg.Nullroute = "0.0.0.0"
+	cfg.Nullroutev6 = "::0"
+	cfg.BlockListDir = filepath.Join(os.TempDir(), "sdns_temp_wl")
+	b := New(cfg)
+
+	b.Set("*.example.com.")
+	assert.True(t, b.Exists("sub.example.com."), "subdomain blocked before whitelist")
+
+	// Whitelist the parent — subtree is now exempt.
+	b.w[dns.CanonicalName("example.com.")] = true
+	assert.False(t, b.Exists("sub.example.com."), "parent whitelist must exempt subdomain")
+	assert.False(t, b.Exists("deep.sub.example.com."), "parent whitelist must exempt deep subdomain")
+	assert.False(t, b.Exists("example.com."), "whitelisted name itself exempt")
+
+	// A different blocked subtree is unaffected by the whitelist.
+	b.Set("*.other.com.")
+	assert.True(t, b.Exists("x.other.com."), "unrelated subtree still blocked")
+}

--- a/middleware/resolver/circuit_breaker.go
+++ b/middleware/resolver/circuit_breaker.go
@@ -95,21 +95,32 @@ func (cb *circuitBreaker) recordSuccess(server string) {
 	}
 }
 
-// cleanup removes old failure records periodically
+// cleanup removes old failure records periodically.
 func (cb *circuitBreaker) cleanup() {
 	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
 
 	for range ticker.C {
-		cb.mu.Lock()
-		now := time.Now().Unix()
-		for server, sf := range cb.failures {
-			// Remove entries older than 5 minutes with no recent failures
-			lastFailure := sf.lastFailure.Load()
-			if sf.count.Load() == 0 && now-lastFailure > 300 {
-				delete(cb.failures, server)
-			}
+		cb.cleanupOnce(time.Now().Unix())
+	}
+}
+
+// cleanupOnce evicts every entry with no failure in the last 5 minutes.
+//
+// Eviction must NOT be gated on count==0: count only returns to zero on a
+// recordSuccess, so a server that failed a few times (below the 5-failure
+// trip threshold) and was then never queried again would keep count>0 and
+// leak its map entry forever. A recursive resolver contacts an unbounded
+// set of authoritative IPs, so that is an unbounded-growth vector under
+// ordinary (and adversarial) traffic. Idle time alone is the correct
+// signal: any disable expires after 30s, so a 5-minute-idle entry is stale
+// regardless of its counter.
+func (cb *circuitBreaker) cleanupOnce(now int64) {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+	for server, sf := range cb.failures {
+		if now-sf.lastFailure.Load() > 300 {
+			delete(cb.failures, server)
 		}
-		cb.mu.Unlock()
 	}
 }

--- a/middleware/resolver/circuit_breaker_test.go
+++ b/middleware/resolver/circuit_breaker_test.go
@@ -338,3 +338,32 @@ func BenchmarkCircuitBreaker_RecordSuccess(b *testing.B) {
 		}
 	})
 }
+
+// TestCircuitBreaker_CleanupEvictsIdleWithFailures locks in the leak fix:
+// an entry that failed (count>0) but never recovered and went idle must be
+// evicted. The old cleanup gated on count==0 and would have leaked it.
+func TestCircuitBreaker_CleanupEvictsIdleWithFailures(t *testing.T) {
+	cb := newCircuitBreaker()
+	const server = "192.0.2.1:53"
+	cb.recordFailure(server) // count=1, below the 5-failure trip threshold
+
+	// Backdate the last failure beyond the 5-minute idle window.
+	cb.mu.RLock()
+	cb.failures[server].lastFailure.Store(time.Now().Unix() - 600)
+	cb.mu.RUnlock()
+
+	cb.cleanupOnce(time.Now().Unix())
+
+	cb.mu.RLock()
+	_, exists := cb.failures[server]
+	cb.mu.RUnlock()
+	assert.False(t, exists, "idle entry with count>0 must be evicted")
+
+	// A recently-failed entry must survive.
+	cb.recordFailure(server)
+	cb.cleanupOnce(time.Now().Unix())
+	cb.mu.RLock()
+	_, exists = cb.failures[server]
+	cb.mu.RUnlock()
+	assert.True(t, exists, "recently-failed entry must be kept")
+}

--- a/server/server.go
+++ b/server/server.go
@@ -68,6 +68,20 @@ func New(cfg *config.Config) *Server {
 
 // (*Server).ServeDNS serveDNS implements the Handle interface.
 func (s *Server) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
+	// A standard query carries exactly one question. Reject a malformed
+	// QDCOUNT here — at the single entry shared by every transport — with
+	// FORMERR, so downstream middlewares can index req.Question[0] without
+	// guarding. A 0-question packet would otherwise hit an unguarded
+	// req.Question[0] in several handlers and force a panic/recover/log
+	// cycle per packet (a cheap amplification vector that also pollutes
+	// the panic metric).
+	if len(r.Question) != 1 {
+		formerr := new(dns.Msg)
+		formerr.SetRcode(r, dns.RcodeFormatError)
+		_ = w.WriteMsg(formerr)
+		return
+	}
+
 	ch := s.chainPool.Get().(*middleware.Chain)
 	defer s.chainPool.Put(ch)
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -216,3 +216,20 @@ func Test_Server(t *testing.T) {
 	os.Remove(cert)    //nolint:gosec // G104 - test cleanup
 	os.Remove(privkey) //nolint:gosec // G104 - test cleanup
 }
+
+// Test_ServerEmptyQuestion verifies a malformed QDCOUNT (0 questions) is
+// answered with FORMERR at the entry point and never reaches — and panics —
+// a downstream handler that indexes req.Question[0].
+func Test_ServerEmptyQuestion(t *testing.T) {
+	s := New(&config.Config{})
+
+	req := new(dns.Msg) // no question
+	req.Id = dns.Id()
+	mw := mock.NewWriter("udp", "127.0.0.1:0")
+
+	assert.NotPanics(t, func() { s.ServeDNS(mw, req) })
+	assert.True(t, mw.Written())
+	if assert.NotNil(t, mw.Msg()) {
+		assert.Equal(t, dns.RcodeFormatError, mw.Msg().Rcode)
+	}
+}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -83,9 +83,9 @@ parts:
         *) echo "Unsupported architecture: ${CRAFT_ARCH_BUILD_FOR}"; exit 1 ;;
       esac
       
-      wget -q "https://go.dev/dl/go1.23.4.linux-${GOARCH}.tar.gz"
-      tar -C /usr/local -xzf "go1.23.4.linux-${GOARCH}.tar.gz"
-      rm "go1.23.4.linux-${GOARCH}.tar.gz"
+      wget -q "https://go.dev/dl/go1.26.4.linux-${GOARCH}.tar.gz"
+      tar -C /usr/local -xzf "go1.26.4.linux-${GOARCH}.tar.gz"
+      rm "go1.26.4.linux-${GOARCH}.tar.gz"
       
       export PATH=/usr/local/go/bin:$PATH
       export GOROOT=/usr/local/go


### PR DESCRIPTION
Five independent hardening/correctness fixes surfaced by a project-wide review (each is its own commit; happy to split).

## 1. `build`: pin Go toolchain to 1.26.4 — clears 5 reachable stdlib CVEs
`govulncheck` flagged 5 **reachable** stdlib advisories in the build toolchain (1.26.2): GO-2026-5037/5038/5039 (`crypto/x509`, `mime`, `net/textproto`) and GO-2026-4918/4971 (`net/http` HTTP/2, `net`) — reachable via the DoH server, DoT cert verification, the DoH-forwarder/blocklist HTTP clients, and the k8s client. All fixed in **go1.26.4**. Adds a `toolchain go1.26.4` directive, pins the Docker builder to `golang:1.26.4-alpine`, and bumps the snap build from the badly stale **Go 1.23.4** to 1.26.4. **After the bump, `govulncheck ./...` reports no vulnerabilities.**

## 2. `fix(resolver)`: circuit-breaker map grew unbounded
`cleanup` only evicted entries with `count==0`, but `count` resets to zero only on success — a server that failed a few times (below the 5-failure trip threshold) and was never queried again kept `count>0` and leaked its map slot forever. A recursive resolver sees an unbounded set of authoritative IPs → unbounded growth under ordinary/adversarial traffic. Now evicts on idle time alone (stale after 5 min; any disable expires in 30s).

## 3. `fix(server)`: FORMERR on malformed QDCOUNT instead of panic
A `QDCOUNT != 1` packet reached handlers (as112/blocklist/views/accesslog) that index `req.Question[0]` unguarded → panic/recover/log cycle per packet (cheap amplification + pollutes the panic metric). Rejected with FORMERR at `ServeDNS`, the single entry shared by all transports.

## 4. `fix(blocklist)`: whitelist now matches across the hierarchy
The block walk covers subdomains (blocking `example.com.` blocks `sub.example.com.`), but the whitelist matched the exact name only — whitelisting a parent silently failed to protect its subdomains from a parent/wildcard block. Made symmetric via a shared `matchHierarchy` helper. **Note:** this is a small *semantics* change (parent whitelist now exempts the subtree) — it only ever exempts, never adds a block, so it can't break resolution; flagging in case you prefer exact-only or most-specific-wins.

## 5. `fix(config)`: full-entropy DNS cookie secret
`fmt.Sprintf("%16x", uint64)` is *space*-padded, producing secrets like `"              2a"` and weakening DNS Cookie (RFC 7873) anti-spoofing. Now 16 random bytes hex-encoded (32 chars).

## Testing
New regression tests for #2–#5; `go build`, `go vet`, `go test -race` (config/blocklist/server/resolver-circuit-breaker), and `golangci-lint` all pass. `govulncheck ./...` clean.