### PR TITLE
chore(release): bump version to 1.7.1 + security policy update

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ docker run -d --name sdns -p 53:53 -p 53:53/udp ghcr.io/semihalev/sdns:latest
 Pin to a specific version (recommended for production):
 
 ```shell
-$ docker run -d --name sdns -p 53:53 -p 53:53/udp ghcr.io/semihalev/sdns:1.7.0
+$ docker run -d --name sdns -p 53:53 -p 53:53/udp ghcr.io/semihalev/sdns:1.7.1
 ```
 
 #### Docker Compose

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,19 +2,27 @@
 
 ## Supported Versions
 
-Only the following version is currently being supported with security updates:
+Only the latest minor release line receives security updates:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.6.x   | :white\_check\_mark: |
-| < 1.6   | :x:                |
+| 1.7.x   | :white_check_mark: |
+| < 1.7   | :x:                |
 
 ## Reporting a Vulnerability
 
-We take security issues seriously. If you discover a security vulnerability in this project, please follow these steps:
+Please report security vulnerabilities **privately**. Do not open a public
+issue, pull request, or discussion for a vulnerability — that discloses the
+problem to attackers before a fix is available.
 
-1.  **Open an Issue**: Once you've made sure you're on the latest version and the vulnerability still exists, open an issue on our GitHub repository. Describe the vulnerability in detail, including the steps to reproduce if possible.
-2.  **Discussion**: After you report the vulnerability, we'll engage in a discussion with you on the issue to understand it better and evaluate its impact.
-3.  **Resolution**: We will address the security issue and release a new version with the necessary patches as soon as possible.
+1.  **Report privately**: Use GitHub's private vulnerability reporting —
+    ["Report a vulnerability"](https://github.com/semihalev/sdns/security/advisories/new)
+    under the repository's **Security** tab. Include a description, the
+    affected version(s), impact, and reproduction steps if possible.
+2.  **Discussion**: We'll work with you on the private advisory to confirm the
+    issue and assess its impact.
+3.  **Resolution**: We'll prepare a fix, release a patched version, and
+    coordinate public disclosure. Reporters are credited unless they ask to
+    remain anonymous.
 
-Your efforts to responsibly disclose your findings are sincerely appreciated and will be acknowledged.
+Your efforts to responsibly disclose your findings are sincerely appreciated.

--- a/sdns.go
+++ b/sdns.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const version = "1.7.0"
+const version = "1.7.1"
 
 var (
 	cfgPath    string


### PR DESCRIPTION
Prepares the **1.7.1** security/hardening patch release.

## Version bump
- `sdns.go`: `const version` 1.7.0 → 1.7.1
- README docker-run example tag 1.7.0 → 1.7.1

Intentionally **unchanged** (matching the 1.7.0 release pattern and `config.go`'s schema-version discipline):
- `config/config.go` `configver` and the README "Configuration (v1.7.0)" header — these track the **config-file schema**, which didn't change in 1.7.1. Bumping `configver` would warn every existing user of a version mismatch for no reason.
- README benchmark table (stays at last-measured release).
- "pre-1.7.0" prose and the affected-version test comment (accurate history).

## SECURITY.md
- Supported versions: **1.6.x → 1.7.x**.
- Reporting: replaced "open a GitHub issue" with **private vulnerability reporting** (GitHub Security Advisories). Telling reporters to disclose a resolver vuln in a public issue before a fix exists is the wrong default.

## What 1.7.1 ships (already merged)
- **DNSSEC**: validate RSA keys with exponents above crypto/rsa's 2³¹-1 ceiling (closes #495) — restored validation for the **`.lv` TLD** and mailbox.org.
- **Build**: Go toolchain pinned to **1.26.4**, clearing 5 reachable stdlib CVEs (`govulncheck` clean); snap was on Go 1.23.4.
- **Cache**: full-question verification on hit (xxhash collision / poisoning defense).
- **Resolver**: bounded circuit-breaker map (was an unbounded leak).
- **Server**: FORMERR on malformed QDCOUNT instead of panic/recover storm.
- **Blocklist**: hierarchical whitelist matching (lookup + add paths).
- **Config**: full-entropy DNS cookie secret.
- CI: codecov upload no longer fails the build; `doc.go` rewritten.

After merge: tag `v1.7.1` to trigger the goreleaser/Docker/snap release.