### PR TITLE
feat(dnsclient): own DNS exchange library, replace miekg-copy client

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/dnsclient"
 	"github.com/semihalev/zlog/v2"
 )
 
@@ -955,16 +957,14 @@ func generateConfig(path string) error {
 }
 
 func testIPv6Network() error {
-	client := &dns.Client{Net: "udp"}
-
 	req := new(dns.Msg)
 	req.SetQuestion(".", dns.TypeNS)
 
-	// root server
-	_, _, err := client.Exchange(req, net.JoinHostPort("2001:500:2::c", "53"))
-	if err != nil {
-		return err
-	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
 
-	return nil
+	// root server
+	client := dnsclient.Client{Proto: "udp", Timeout: 2 * time.Second}
+	_, _, err := client.Exchange(ctx, req, net.JoinHostPort("2001:500:2::c", "53"))
+	return err
 }

--- a/internal/dnsclient/buffer.go
+++ b/internal/dnsclient/buffer.go
@@ -1,0 +1,41 @@
+package dnsclient
+
+import "sync"
+
+// Size-bucketed buffer pools for efficient memory usage.
+var bufferPools = [4]sync.Pool{
+	{New: func() any { return new([512]byte) }},   // 0-512 bytes (most DNS over UDP)
+	{New: func() any { return new([1232]byte) }},  // 513-1232 bytes (EDNS0 UDP)
+	{New: func() any { return new([4096]byte) }},  // 1233-4096 bytes (typical TCP)
+	{New: func() any { return new([65535]byte) }}, // 4097-65535 bytes (max DNS)
+}
+
+// AcquireBuf returns a buffer from the appropriate pool.
+func AcquireBuf(size uint16) []byte {
+	switch {
+	case size <= 512:
+		return bufferPools[0].Get().(*[512]byte)[:size]
+	case size <= 1232:
+		return bufferPools[1].Get().(*[1232]byte)[:size]
+	case size <= 4096:
+		return bufferPools[2].Get().(*[4096]byte)[:size]
+	default:
+		return bufferPools[3].Get().(*[65535]byte)[:size]
+	}
+}
+
+// ReleaseBuf returns buf to the appropriate pool.
+func ReleaseBuf(buf []byte) {
+	switch cap(buf) {
+	case 512:
+		bufferPools[0].Put((*[512]byte)(buf[:512]))
+	case 1232:
+		bufferPools[1].Put((*[1232]byte)(buf[:1232]))
+	case 4096:
+		bufferPools[2].Put((*[4096]byte)(buf[:4096]))
+	case 65535:
+		bufferPools[3].Put((*[65535]byte)(buf[:65535]))
+	default:
+		// Buffer too large, let GC handle it
+	}
+}

--- a/internal/dnsclient/client.go
+++ b/internal/dnsclient/client.go
@@ -1,0 +1,121 @@
+package dnsclient
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// Client is a high-level, dial-per-Exchange DNS client for callers that
+// don't maintain their own connection pool — the forwarder, failover,
+// and the config IPv6 probe. The resolver hot path uses Conn directly
+// so it keeps its own pooling, circuit breaker and retry policy.
+//
+// The zero value with Proto unset behaves as plain UDP. The question-
+// section guard is on by default; the response transaction ID is always
+// validated.
+type Client struct {
+	Proto     string        // "udp" | "tcp" | "tcp-tls" | "doh"; empty means "udp"
+	Timeout   time.Duration // per-exchange dial+read+write budget; 0 means none
+	TLSConfig *tls.Config   // DoT (tcp-tls) server config
+	DoHURL    string        // DoH endpoint URL
+	DoHClient *http.Client  // DoH HTTP client (reused transport / HTTP2 pool)
+
+	// SkipQuestionCheck disables the response question-section guard.
+	// The guard is on by default; leave this false unless a caller has
+	// a specific reason to accept mismatched questions.
+	SkipQuestionCheck bool
+}
+
+// Exchange sends req to addr over c.Proto and returns the validated
+// response. A truncated UDP answer transparently retries over TCP.
+func (c *Client) Exchange(ctx context.Context, req *dns.Msg, addr string) (*dns.Msg, time.Duration, error) {
+	proto := c.Proto
+	if proto == "" {
+		proto = "udp"
+	}
+
+	if proto == "doh" {
+		t := time.Now()
+		resp, err := dohExchange(ctx, req, c.DoHURL, c.DoHClient)
+		rtt := time.Since(t)
+		if err != nil {
+			return nil, rtt, err
+		}
+		if !c.SkipQuestionCheck && len(req.Question) > 0 && !QuestionMatches(req.Question[0], resp.Question) {
+			return resp, rtt, ErrQuestion
+		}
+		return resp, rtt, nil
+	}
+
+	co, err := c.dial(ctx, proto, addr)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	c.setDeadline(ctx, co)
+
+	resp, rtt, err := co.Exchange(req)
+	_ = co.Close()
+	// (*Conn).Exchange already enforces the question guard. When a caller
+	// opts out, tolerate only that specific error and keep the response;
+	// every other error (ID mismatch, read failure) is still fatal.
+	toleratedQuestionMismatch := c.SkipQuestionCheck && errors.Is(err, ErrQuestion)
+	if err != nil && !toleratedQuestionMismatch {
+		return nil, rtt, err
+	}
+
+	if resp != nil && resp.Truncated && proto == "udp" {
+		tcp := *c
+		tcp.Proto = "tcp"
+		return tcp.Exchange(ctx, req, addr)
+	}
+
+	return resp, rtt, nil
+}
+
+// dial opens a connection to addr for proto and wraps it in a Conn.
+func (c *Client) dial(ctx context.Context, proto, addr string) (*Conn, error) {
+	d := net.Dialer{Timeout: c.Timeout}
+
+	switch proto {
+	case "tcp-tls":
+		conn, err := (&tls.Dialer{NetDialer: &d, Config: c.TLSConfig}).DialContext(ctx, "tcp", addr)
+		if err != nil {
+			return nil, err
+		}
+		return &Conn{Conn: conn}, nil
+	case "tcp":
+		conn, err := d.DialContext(ctx, "tcp", addr)
+		if err != nil {
+			return nil, err
+		}
+		return &Conn{Conn: conn}, nil
+	default: // udp
+		conn, err := d.DialContext(ctx, "udp", addr)
+		if err != nil {
+			return nil, err
+		}
+		return &Conn{Conn: conn}, nil
+	}
+}
+
+// setDeadline applies the tighter of c.Timeout and the context deadline
+// to the connection's read/write operations.
+func (c *Client) setDeadline(ctx context.Context, co *Conn) {
+	var deadline time.Time
+	if c.Timeout > 0 {
+		deadline = time.Now().Add(c.Timeout)
+	}
+	if d, ok := ctx.Deadline(); ok && (deadline.IsZero() || d.Before(deadline)) {
+		deadline = d
+	}
+	if !deadline.IsZero() {
+		_ = co.SetDeadline(deadline)
+	}
+}

--- a/internal/dnsclient/client_test.go
+++ b/internal/dnsclient/client_test.go
@@ -1,0 +1,293 @@
+package dnsclient
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"math/big"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// startServer launches a local DNS server on the given network ("udp"
+// or "tcp") driven by handler, returning its address and a stop func.
+func startServer(t *testing.T, network string, handler dns.HandlerFunc) (addr string, stop func()) {
+	t.Helper()
+	mux := dns.NewServeMux()
+	mux.HandleFunc(".", handler)
+	s := &dns.Server{Net: network, Handler: mux}
+
+	switch network {
+	case "udp":
+		pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen udp: %v", err)
+		}
+		s.PacketConn = pc
+		addr = pc.LocalAddr().String()
+	case "tcp":
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("listen tcp: %v", err)
+		}
+		s.Listener = ln
+		addr = ln.Addr().String()
+	default:
+		t.Fatalf("unsupported network %q", network)
+	}
+
+	go func() { _ = s.ActivateAndServe() }()
+	return addr, func() { _ = s.Shutdown() }
+}
+
+// startDoTServer launches a DNS-over-TLS server with a self-signed cert
+// and returns its address plus a *tls.Config that trusts the cert.
+func startDoTServer(t *testing.T, handler dns.HandlerFunc) (addr string, cfg *tls.Config, stop func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen tcp: %v", err)
+	}
+	addr = ln.Addr().String()
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		_ = ln.Close()
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "sdns-dnsclient-test"},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:     []string{"localhost"},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &priv.PublicKey, priv)
+	if err != nil {
+		_ = ln.Close()
+		t.Fatalf("create cert: %v", err)
+	}
+	leaf, err := x509.ParseCertificate(der)
+	if err != nil {
+		_ = ln.Close()
+		t.Fatalf("parse cert: %v", err)
+	}
+	pool := x509.NewCertPool()
+	pool.AddCert(leaf)
+
+	serverCfg := &tls.Config{
+		Certificates: []tls.Certificate{{Certificate: [][]byte{der}, PrivateKey: priv, Leaf: leaf}},
+		MinVersion:   tls.VersionTLS12,
+	}
+	mux := dns.NewServeMux()
+	mux.HandleFunc(".", handler)
+	// Hand the server a TLS-wrapped listener: miekg uses a provided
+	// Listener as-is, so it must already terminate TLS.
+	s := &dns.Server{Net: "tcp-tls", Listener: tls.NewListener(ln, serverCfg), Handler: mux}
+	go func() { _ = s.ActivateAndServe() }()
+	return addr, &tls.Config{ServerName: "localhost", RootCAs: pool, MinVersion: tls.VersionTLS12}, func() { _ = s.Shutdown() }
+}
+
+// answerExample replies to example.com. A with a fixed address and
+// echoes every other query as an empty NOERROR.
+func answerExample(w dns.ResponseWriter, r *dns.Msg) {
+	m := new(dns.Msg)
+	m.SetReply(r)
+	if len(r.Question) > 0 && r.Question[0].Qtype == dns.TypeA {
+		if rr, err := dns.NewRR(r.Question[0].Name + " 60 IN A 93.184.216.34"); err == nil {
+			m.Answer = []dns.RR{rr}
+		}
+	}
+	_ = w.WriteMsg(m)
+}
+
+func newReq() *dns.Msg {
+	req := new(dns.Msg)
+	req.SetQuestion("example.com.", dns.TypeA)
+	return req
+}
+
+func TestClientExchange_UDP(t *testing.T) {
+	addr, stop := startServer(t, "udp", answerExample)
+	defer stop()
+
+	c := &Client{Proto: "udp", Timeout: 2 * time.Second}
+	resp, _, err := c.Exchange(context.Background(), newReq(), addr)
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	if len(resp.Answer) != 1 {
+		t.Fatalf("expected 1 answer, got %d", len(resp.Answer))
+	}
+}
+
+func TestClientExchange_TCP(t *testing.T) {
+	addr, stop := startServer(t, "tcp", answerExample)
+	defer stop()
+
+	c := &Client{Proto: "tcp", Timeout: 2 * time.Second}
+	resp, _, err := c.Exchange(context.Background(), newReq(), addr)
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	if len(resp.Answer) != 1 {
+		t.Fatalf("expected 1 answer, got %d", len(resp.Answer))
+	}
+}
+
+func TestClientExchange_DoT(t *testing.T) {
+	addr, cfg, stop := startDoTServer(t, answerExample)
+	defer stop()
+
+	c := &Client{Proto: "tcp-tls", Timeout: 5 * time.Second, TLSConfig: cfg}
+	resp, _, err := c.Exchange(context.Background(), newReq(), addr)
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	if len(resp.Answer) != 1 {
+		t.Fatalf("expected 1 answer, got %d", len(resp.Answer))
+	}
+}
+
+// On UDP a wrong-ID reply is treated as a stray packet and skipped (it
+// might be a late reply to a timed-out query, or a spoof). With no
+// matching response, the exchange times out rather than accepting the
+// wrong answer or failing fast — matching miekg/dns.Client.
+func TestClientExchange_IDMismatch_UDPSkipsAndTimesOut(t *testing.T) {
+	addr, stop := startServer(t, "udp", func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Id = r.Id + 1 // wrong transaction ID
+		_ = w.WriteMsg(m)
+	})
+	defer stop()
+
+	c := &Client{Proto: "udp", Timeout: 300 * time.Millisecond}
+	resp, _, err := c.Exchange(context.Background(), newReq(), addr)
+	if err == nil {
+		t.Fatalf("expected a timeout, got resp %v", resp)
+	}
+	if errors.Is(err, dns.ErrId) {
+		t.Fatal("UDP must skip mismatched IDs, not fail fast with ErrId")
+	}
+	var ne net.Error
+	if !errors.As(err, &ne) || !ne.Timeout() {
+		t.Fatalf("expected a timeout error after skipping the stray packet, got %v", err)
+	}
+}
+
+// On a TCP stream there is a single in-flight response, so a mismatched
+// ID is a genuine protocol error and must fail fast with ErrId.
+func TestClientExchange_IDMismatch_TCP(t *testing.T) {
+	addr, stop := startServer(t, "tcp", func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Id = r.Id + 1 // wrong transaction ID
+		_ = w.WriteMsg(m)
+	})
+	defer stop()
+
+	c := &Client{Proto: "tcp", Timeout: 2 * time.Second}
+	_, _, err := c.Exchange(context.Background(), newReq(), addr)
+	if !errors.Is(err, dns.ErrId) {
+		t.Fatalf("expected ErrId on TCP, got %v", err)
+	}
+}
+
+func TestClientExchange_QuestionMismatch(t *testing.T) {
+	addr, stop := startServer(t, "udp", func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Question = []dns.Question{{Name: "victim.test.", Qtype: dns.TypeA, Qclass: dns.ClassINET}}
+		_ = w.WriteMsg(m)
+	})
+	defer stop()
+
+	c := &Client{Proto: "udp", Timeout: 2 * time.Second}
+	_, _, err := c.Exchange(context.Background(), newReq(), addr)
+	if !errors.Is(err, ErrQuestion) {
+		t.Fatalf("expected ErrQuestion, got %v", err)
+	}
+}
+
+func TestClientExchange_TruncationFallsBackToTCP(t *testing.T) {
+	// UDP server sets TC; TCP server returns the full answer. A correct
+	// client must retry over TCP and surface the TCP answer.
+	udpAddr, stopUDP := startServer(t, "udp", func(w dns.ResponseWriter, r *dns.Msg) {
+		m := new(dns.Msg)
+		m.SetReply(r)
+		m.Truncated = true
+		_ = w.WriteMsg(m)
+	})
+	defer stopUDP()
+
+	// The TCP listener must share the UDP address so the fallback dials
+	// the same host:port. Bind TCP to the UDP port explicitly.
+	host, port, _ := net.SplitHostPort(udpAddr)
+	ln, err := net.Listen("tcp", net.JoinHostPort(host, port))
+	if err != nil {
+		t.Fatalf("listen tcp on %s: %v", udpAddr, err)
+	}
+	mux := dns.NewServeMux()
+	mux.HandleFunc(".", answerExample)
+	s := &dns.Server{Net: "tcp", Listener: ln, Handler: mux}
+	go func() { _ = s.ActivateAndServe() }()
+	defer func() { _ = s.Shutdown() }()
+
+	c := &Client{Proto: "udp", Timeout: 2 * time.Second}
+	resp, _, err := c.Exchange(context.Background(), newReq(), udpAddr)
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	if resp.Truncated {
+		t.Fatal("expected the TCP (non-truncated) answer after fallback")
+	}
+	if len(resp.Answer) != 1 {
+		t.Fatalf("expected 1 answer from TCP fallback, got %d", len(resp.Answer))
+	}
+}
+
+func TestClientExchange_Timeout(t *testing.T) {
+	// Server that never replies.
+	addr, stop := startServer(t, "udp", func(w dns.ResponseWriter, r *dns.Msg) {})
+	defer stop()
+
+	c := &Client{Proto: "udp", Timeout: 200 * time.Millisecond}
+	_, _, err := c.Exchange(context.Background(), newReq(), addr)
+	if err == nil {
+		t.Fatal("expected a timeout error, got nil")
+	}
+}
+
+func BenchmarkClientExchangeUDP(b *testing.B) {
+	mux := dns.NewServeMux()
+	mux.HandleFunc(".", answerExample)
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		b.Fatalf("listen udp: %v", err)
+	}
+	s := &dns.Server{Net: "udp", PacketConn: pc, Handler: mux}
+	go func() { _ = s.ActivateAndServe() }()
+	defer func() { _ = s.Shutdown() }()
+	addr := pc.LocalAddr().String()
+
+	c := &Client{Proto: "udp", Timeout: 2 * time.Second}
+	ctx := context.Background()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, _, err := c.Exchange(ctx, newReq(), addr); err != nil {
+			b.Fatalf("exchange: %v", err)
+		}
+	}
+}

--- a/internal/dnsclient/conn.go
+++ b/internal/dnsclient/conn.go
@@ -1,0 +1,205 @@
+// Package dnsclient owns SDNS's upstream DNS transport: wire framing,
+// buffer pooling, dialing, deadlines and exchange policy (ID match,
+// question-section guard, UDP->TCP truncation fallback). It is written
+// clean-room and depends on github.com/miekg/dns only as the message
+// codec (dns.Msg / Pack / Unpack), not as a transport.
+package dnsclient
+
+import (
+	"encoding/binary"
+	"errors"
+	"io"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+const headerSize = 12
+
+// ErrQuestion is returned by (*Conn).Exchange when the response's
+// question section does not match the outstanding request. Accepting a
+// mismatched question lets a malicious upstream plant a cache entry
+// under an unrelated name (issue #469).
+var ErrQuestion = errors.New("dns: response question did not match request")
+
+// Conn represents a connection to a DNS server. It wraps a net.Conn
+// (either a connected UDP socket or a TCP/TLS stream) and tracks the
+// negotiated UDP receive size.
+type Conn struct {
+	net.Conn        // underlying connection
+	UDPSize  uint16 // minimum receive buffer for UDP messages
+}
+
+// Exchange performs a synchronous query over co: it writes m, reads the
+// response, and validates the transaction ID and question section. The
+// caller is responsible for dialing co and setting any deadline before
+// calling Exchange.
+func (co *Conn) Exchange(m *dns.Msg) (r *dns.Msg, rtt time.Duration, err error) {
+	opt := m.IsEdns0()
+	// If EDNS0 advertises a receive size, honour it for the UDP buffer.
+	if opt != nil && opt.UDPSize() >= dns.MinMsgSize {
+		co.UDPSize = opt.UDPSize()
+	}
+	if opt == nil && co.UDPSize < dns.MinMsgSize {
+		co.UDPSize = dns.MinMsgSize
+	}
+
+	t := time.Now()
+
+	if err = co.WriteMsg(m); err != nil {
+		return nil, 0, err
+	}
+
+	if _, ok := co.Conn.(net.PacketConn); ok {
+		// UDP: a connected socket can still surface a stray or late
+		// datagram — a reply to an earlier query that already timed out,
+		// or a packet spoofed from the peer address. Skip mismatched IDs
+		// and keep reading until the matching response or the read
+		// deadline, matching miekg/dns.Client so a single stray packet
+		// can't fail a healthy upstream. The caller's read deadline bounds
+		// the loop.
+		for {
+			r, err = co.ReadMsg()
+			if err != nil || r.Id == m.Id {
+				break
+			}
+		}
+	} else {
+		// TCP/TLS is a stream with a single in-flight response, so a
+		// mismatched ID is a genuine protocol error, not a stray packet.
+		r, err = co.ReadMsg()
+		if err == nil && r.Id != m.Id {
+			err = dns.ErrId
+		}
+	}
+	if err == nil && len(m.Question) > 0 && !QuestionMatches(m.Question[0], r.Question) {
+		err = ErrQuestion
+	}
+
+	rtt = time.Since(t)
+
+	return r, rtt, err
+}
+
+// QuestionMatches reports whether the response's question section
+// answers the outstanding request question. DNS names are compared
+// case-insensitively because they are not case-sensitive on the wire.
+func QuestionMatches(req dns.Question, resp []dns.Question) bool {
+	if len(resp) != 1 {
+		return false
+	}
+	r := resp[0]
+	return r.Qtype == req.Qtype && r.Qclass == req.Qclass && strings.EqualFold(r.Name, req.Name)
+}
+
+// ReadMsg reads a single DNS message from co. The buffer is always
+// returned to the pool, even on a timed-out UDP read or a truncated
+// TCP read, so failed upstream reads never leak the buffer. On success
+// only the bytes actually read are unpacked — feeding Unpack the
+// trailing capacity of a pooled UDP buffer would let stale bytes from a
+// previous use bleed into the parsed message.
+func (co *Conn) ReadMsg() (*dns.Msg, error) {
+	var (
+		p   []byte
+		n   int
+		err error
+	)
+
+	if _, ok := co.Conn.(net.PacketConn); ok {
+		p = AcquireBuf(co.UDPSize)
+		n, err = co.Read(p)
+	} else {
+		var length uint16
+		length, err = readUint16(co.Conn)
+		if err != nil {
+			return nil, err
+		}
+		p = AcquireBuf(length)
+		n, err = io.ReadFull(co.Conn, p)
+	}
+
+	if err != nil {
+		ReleaseBuf(p)
+		return nil, err
+	} else if n < headerSize {
+		ReleaseBuf(p)
+		return nil, dns.ErrShortRead
+	}
+
+	m := new(dns.Msg)
+	if err := m.Unpack(p[:n]); err != nil {
+		ReleaseBuf(p)
+		// Still hand the message back so a caller that only checks err
+		// can ignore it; a caller that wants the partial result has it.
+		return m, err
+	}
+	ReleaseBuf(p)
+	return m, nil
+}
+
+// Read implements net.Conn. For a UDP connection it reads a single
+// datagram. For a stream connection it reads the 2-byte length prefix
+// (RFC 1035 §4.2.2) and then exactly that many bytes into p.
+func (co *Conn) Read(p []byte) (n int, err error) {
+	if co.Conn == nil {
+		return 0, dns.ErrConnEmpty
+	}
+
+	if _, ok := co.Conn.(net.PacketConn); ok {
+		return co.Conn.Read(p)
+	}
+
+	length, err := readUint16(co.Conn)
+	if err != nil {
+		return 0, err
+	}
+	if int(length) > len(p) {
+		return 0, io.ErrShortBuffer
+	}
+
+	return io.ReadFull(co.Conn, p[:length])
+}
+
+// WriteMsg packs m into a pooled buffer and writes it to co.
+func (co *Conn) WriteMsg(m *dns.Msg) (err error) {
+	size := uint16(m.Len()) + 1 //nolint:gosec // G115 - DNS message size is bounded
+
+	out := AcquireBuf(size)
+	defer ReleaseBuf(out)
+
+	out, err = m.PackBuffer(out)
+	if err != nil {
+		return err
+	}
+	_, err = co.Write(out)
+	return err
+}
+
+// Write implements net.Conn. For UDP it writes p as a single datagram.
+// For a stream connection it prefixes p with its 2-byte length.
+func (co *Conn) Write(p []byte) (int, error) {
+	if len(p) > dns.MaxMsgSize {
+		return 0, errors.New("message too large")
+	}
+
+	if _, ok := co.Conn.(net.PacketConn); ok {
+		return co.Conn.Write(p)
+	}
+
+	var l [2]byte
+	binary.BigEndian.PutUint16(l[:], uint16(len(p))) //nolint:gosec // G115 - DNS message size is bounded
+
+	buffers := net.Buffers{l[:], p}
+	n, err := buffers.WriteTo(co.Conn)
+	return int(n), err
+}
+
+func readUint16(r io.Reader) (uint16, error) {
+	var b [2]byte
+	if _, err := io.ReadFull(r, b[:]); err != nil {
+		return 0, err
+	}
+	return binary.BigEndian.Uint16(b[:]), nil
+}

--- a/internal/dnsclient/conn_test.go
+++ b/internal/dnsclient/conn_test.go
@@ -1,0 +1,190 @@
+package dnsclient
+
+import (
+	"errors"
+	"io"
+	"net"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// fakePacketConn is a net.Conn that also satisfies net.PacketConn (so
+// (*Conn).Read takes its UDP branch) and hands back a fixed datagram.
+// readN lets a test report fewer bytes than it copied into the caller's
+// buffer, simulating a pooled buffer whose tail still holds stale data.
+type fakePacketConn struct {
+	net.PacketConn // nil — only the promoted method set is needed for the type assertion
+	readData       []byte
+	readN          int
+}
+
+func (f *fakePacketConn) Read(p []byte) (int, error) {
+	copy(p, f.readData)
+	return f.readN, nil
+}
+func (f *fakePacketConn) Write(p []byte) (int, error) { return len(p), nil }
+func (f *fakePacketConn) RemoteAddr() net.Addr        { return nil }
+
+func TestReadMsg_ShortRead(t *testing.T) {
+	co := &Conn{Conn: &fakePacketConn{readData: []byte{1, 2, 3, 4}, readN: 4}, UDPSize: 512}
+	_, err := co.ReadMsg()
+	if err != dns.ErrShortRead {
+		t.Fatalf("expected ErrShortRead, got %v", err)
+	}
+}
+
+// TestReadMsg_UnpacksOnlyBytesRead exercises the p[:n] fix: the pooled
+// buffer holds a complete, valid message, but the connection reports a
+// short read that cuts off the final rdata bytes. ReadMsg must unpack
+// only the bytes actually received (and so reject the truncated record)
+// rather than reading the stale tail of the buffer as valid rdata.
+func TestReadMsg_UnpacksOnlyBytesRead(t *testing.T) {
+	msg := new(dns.Msg)
+	msg.SetQuestion("example.com.", dns.TypeTXT)
+	msg.Response = true
+	rr, err := dns.NewRR("example.com. 60 IN TXT \"this-is-a-long-txt-record-used-to-pad-the-rdata\"")
+	if err != nil {
+		t.Fatalf("build TXT RR: %v", err)
+	}
+	msg.Answer = []dns.RR{rr}
+
+	full, err := msg.Pack()
+	if err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+
+	// The datagram is three bytes short of the full message — those
+	// bytes land inside the TXT rdata. With the fix, only full[:n] is
+	// unpacked and the truncated record is rejected. Without it, the
+	// trailing bytes (still present in the buffer) would be parsed as
+	// valid rdata.
+	n := len(full) - 3
+	co := &Conn{Conn: &fakePacketConn{readData: full, readN: n}, UDPSize: 4096}
+
+	if _, err := co.ReadMsg(); err == nil {
+		t.Fatal("expected an unpack error from the truncated datagram, got nil")
+	}
+}
+
+// fakeSeqPacketConn satisfies net.PacketConn and returns a queued
+// sequence of datagrams on successive Reads, so a test can feed a stray
+// mismatched-ID packet ahead of the real response.
+type fakeSeqPacketConn struct {
+	net.PacketConn
+	datagrams [][]byte
+	idx       int
+}
+
+func (f *fakeSeqPacketConn) Read(p []byte) (int, error) {
+	if f.idx >= len(f.datagrams) {
+		return 0, io.EOF // no more datagrams; stands in for a read deadline
+	}
+	d := f.datagrams[f.idx]
+	f.idx++
+	return copy(p, d), nil
+}
+func (f *fakeSeqPacketConn) Write(p []byte) (int, error) { return len(p), nil }
+func (f *fakeSeqPacketConn) RemoteAddr() net.Addr        { return nil }
+
+// TestExchange_UDP_SkipsMismatchedID is the regression guard for the
+// forwarder/failover path: a connected UDP socket may surface a stray
+// datagram (a late reply to a timed-out query, or a spoof) before the
+// real answer. Exchange must skip the mismatched ID and keep reading,
+// matching miekg/dns.Client, rather than failing the whole exchange on
+// the first stray packet.
+func TestExchange_UDP_SkipsMismatchedID(t *testing.T) {
+	req := new(dns.Msg)
+	req.SetQuestion("example.com.", dns.TypeA)
+	req.Id = 0x1234
+
+	stray := new(dns.Msg)
+	stray.SetQuestion("example.com.", dns.TypeA)
+	stray.Response = true
+	stray.Id = 0x9999 // mismatched — a reply to some earlier query
+	strayWire, err := stray.Pack()
+	if err != nil {
+		t.Fatalf("pack stray: %v", err)
+	}
+
+	real := new(dns.Msg)
+	real.SetQuestion("example.com.", dns.TypeA)
+	real.Response = true
+	real.Id = 0x1234 // matches the request
+	rr, _ := dns.NewRR("example.com. 60 IN A 93.184.216.34")
+	real.Answer = []dns.RR{rr}
+	realWire, err := real.Pack()
+	if err != nil {
+		t.Fatalf("pack real: %v", err)
+	}
+
+	co := &Conn{
+		Conn:    &fakeSeqPacketConn{datagrams: [][]byte{strayWire, realWire}},
+		UDPSize: 512,
+	}
+	resp, _, err := co.Exchange(req)
+	if err != nil {
+		t.Fatalf("expected the stray packet to be skipped, got error: %v", err)
+	}
+	if resp.Id != req.Id {
+		t.Fatalf("expected matching response id %#x, got %#x", req.Id, resp.Id)
+	}
+	if len(resp.Answer) != 1 {
+		t.Fatalf("expected the real answer, got %d records", len(resp.Answer))
+	}
+}
+
+// fakeStreamConn is a net.Conn (not a net.PacketConn, so (*Conn).ReadMsg
+// takes its stream branch) that replays a fixed byte script across Reads
+// and then reports EOF — letting a test deliver a length prefix followed
+// by a short body.
+type fakeStreamConn struct {
+	net.Conn
+	data []byte
+	pos  int
+}
+
+func (f *fakeStreamConn) Read(p []byte) (int, error) {
+	if f.pos >= len(f.data) {
+		return 0, io.EOF
+	}
+	n := copy(p, f.data[f.pos:])
+	f.pos += n
+	return n, nil
+}
+
+// TestReadMsg_TCPPartialRead_PropagatesError guards against the shadowed-
+// err regression: the 2-byte length prefix promises 100 bytes but the
+// stream delivers only 50 then EOF, so io.ReadFull returns
+// ErrUnexpectedEOF. ReadMsg must propagate that read error instead of
+// swallowing it and falling through to a short-read/unpack error.
+func TestReadMsg_TCPPartialRead_PropagatesError(t *testing.T) {
+	data := append([]byte{0x00, 0x64}, make([]byte, 50)...) // length=100, body=50
+	co := &Conn{Conn: &fakeStreamConn{data: data}}
+
+	_, err := co.ReadMsg()
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("expected ErrUnexpectedEOF to propagate, got %v", err)
+	}
+}
+
+// FuzzReadMsg feeds arbitrary bytes through the UDP read path to ensure
+// the framing never panics regardless of the wire contents.
+func FuzzReadMsg(f *testing.F) {
+	f.Add([]byte{})
+	f.Add([]byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11})
+	seed := new(dns.Msg)
+	seed.SetQuestion("example.com.", dns.TypeA)
+	if b, err := seed.Pack(); err == nil {
+		f.Add(b)
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		size := len(data)
+		if size == 0 || size > 65535 {
+			size = 512
+		}
+		co := &Conn{Conn: &fakePacketConn{readData: data, readN: len(data)}, UDPSize: uint16(size)} //nolint:gosec // bounded above
+		_, _ = co.ReadMsg()
+	})
+}

--- a/internal/dnsclient/doh.go
+++ b/internal/dnsclient/doh.go
@@ -1,0 +1,95 @@
+package dnsclient
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"strings"
+
+	"github.com/miekg/dns"
+)
+
+// dohMaxResponseSize bounds the response body read so a misbehaving
+// upstream can't OOM us with a huge body. DNS messages can't exceed
+// 64 KiB on the wire (RFC 1035 length field is uint16), so this limit
+// is a tight ceiling on legitimate traffic.
+const dohMaxResponseSize = 65535
+
+// contentTypeDNS is the RFC 8484 wire-format media type. Set on both
+// the Content-Type of the POST body and the Accept header so an
+// upstream that supports multiple media types knows which one we want
+// back. Compared case-insensitively against parsed responses
+// (RFC 7231 §3.1.1.1).
+const contentTypeDNS = "application/dns-message"
+
+// dohExchange POSTs req to a DoH endpoint (RFC 8484) and decodes the
+// wire-format response. The http.Client is supplied by the caller and
+// reused across queries — it carries the pinned-IP transport / HTTP2
+// connection pool, so it must never be constructed per call.
+func dohExchange(ctx context.Context, req *dns.Msg, url string, client *http.Client) (*dns.Msg, error) {
+	body, err := req.Pack()
+	if err != nil {
+		return nil, fmt.Errorf("pack: %w", err)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", contentTypeDNS)
+	httpReq.Header.Set("Accept", contentTypeDNS)
+
+	httpResp, err := client.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("doh exchange: %w", err)
+	}
+	defer httpResp.Body.Close()
+
+	if httpResp.StatusCode != http.StatusOK {
+		// Drain a small amount of the body so the connection can be
+		// reused (Go's http.Transport requires the body be read before
+		// the conn returns to the pool).
+		_, _ = io.Copy(io.Discard, io.LimitReader(httpResp.Body, 1024))
+		return nil, fmt.Errorf("doh status %d", httpResp.StatusCode)
+	}
+
+	// RFC 7231 §3.1.1.1: media types are case-insensitive and may carry
+	// parameters (charset=, boundary=, ...). mime.ParseMediaType strips
+	// parameters and lowercases the type for us.
+	rawCT := httpResp.Header.Get("Content-Type")
+	mediaType, _, err := mime.ParseMediaType(rawCT)
+	if err != nil || !strings.EqualFold(mediaType, contentTypeDNS) {
+		_, _ = io.Copy(io.Discard, io.LimitReader(httpResp.Body, 1024))
+		return nil, fmt.Errorf("doh unexpected content-type %q", rawCT)
+	}
+
+	// Read one byte past the size cap so we can distinguish "body fits
+	// within limit" from "body exceeded limit and was truncated".
+	// Without this dns.Msg.Unpack would happily decode the parseable
+	// prefix of an oversized response and silently ignore the rest.
+	respBody, err := io.ReadAll(io.LimitReader(httpResp.Body, dohMaxResponseSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("read body: %w", err)
+	}
+	if len(respBody) > dohMaxResponseSize {
+		return nil, fmt.Errorf("doh response exceeds %d bytes", dohMaxResponseSize)
+	}
+
+	resp := new(dns.Msg)
+	if err := resp.Unpack(respBody); err != nil {
+		return nil, fmt.Errorf("unpack: %w", err)
+	}
+
+	// Validate the response transaction ID. RFC 8484 §4.1 says DoH
+	// clients SHOULD use DNS ID 0 for cache friendliness, and several
+	// compliant servers normalise the response ID to 0 regardless of
+	// what the request carried — so accept either an exact echo or a
+	// zero. Anything else is a buggy or hostile upstream.
+	if resp.Id != req.Id && resp.Id != 0 {
+		return nil, fmt.Errorf("doh response ID mismatch: got %d, want %d or 0", resp.Id, req.Id)
+	}
+	return resp, nil
+}

--- a/internal/dnsclient/doh_test.go
+++ b/internal/dnsclient/doh_test.go
@@ -1,0 +1,99 @@
+package dnsclient
+
+import (
+	"context"
+	"crypto/tls"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// dohResponseFor builds a wire-format reply to req. mismatchName, when
+// non-empty, swaps the question section to trigger the question guard.
+func dohResponseFor(t *testing.T, req *dns.Msg, mismatchName string) []byte {
+	t.Helper()
+	resp := new(dns.Msg)
+	resp.SetReply(req)
+	if mismatchName != "" {
+		resp.Question = []dns.Question{{Name: dns.Fqdn(mismatchName), Qtype: req.Question[0].Qtype, Qclass: dns.ClassINET}}
+	}
+	if rr, err := dns.NewRR(req.Question[0].Name + " 60 IN A 93.184.216.34"); err == nil {
+		resp.Answer = []dns.RR{rr}
+	}
+	b, err := resp.Pack()
+	if err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+	return b
+}
+
+// startDoHTestServer launches a TLS DoH server and returns a Client
+// wired to trust it.
+func startDoHTestServer(t *testing.T, handler func(w http.ResponseWriter, r *http.Request)) (*Client, func()) {
+	t.Helper()
+	srv := httptest.NewTLSServer(http.HandlerFunc(handler))
+	httpClient := &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true, MinVersion: tls.VersionTLS12}, //nolint:gosec // test-only self-signed cert
+		},
+	}
+	c := &Client{Proto: "doh", DoHURL: srv.URL + "/dns-query", DoHClient: httpClient}
+	return c, srv.Close
+}
+
+func TestClientExchange_DoH(t *testing.T) {
+	req := newReq()
+	c, stop := startDoHTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		in := new(dns.Msg)
+		if err := in.Unpack(body); err != nil {
+			t.Errorf("unpack request: %v", err)
+		}
+		w.Header().Set("Content-Type", contentTypeDNS)
+		_, _ = w.Write(dohResponseFor(t, in, ""))
+	})
+	defer stop()
+
+	resp, _, err := c.Exchange(context.Background(), req, "")
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	if len(resp.Answer) != 1 {
+		t.Fatalf("expected 1 answer, got %d", len(resp.Answer))
+	}
+}
+
+func TestClientExchange_DoHQuestionMismatch(t *testing.T) {
+	req := newReq()
+	c, stop := startDoHTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		in := new(dns.Msg)
+		_ = in.Unpack(body)
+		w.Header().Set("Content-Type", contentTypeDNS)
+		_, _ = w.Write(dohResponseFor(t, in, "victim.test"))
+	})
+	defer stop()
+
+	_, _, err := c.Exchange(context.Background(), req, "")
+	if !errors.Is(err, ErrQuestion) {
+		t.Fatalf("expected ErrQuestion, got %v", err)
+	}
+}
+
+func TestClientExchange_DoHBadStatus(t *testing.T) {
+	c, stop := startDoHTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadGateway)
+	})
+	defer stop()
+
+	_, _, err := c.Exchange(context.Background(), newReq(), "")
+	if err == nil {
+		t.Fatal("expected an error for non-200 status, got nil")
+	}
+}

--- a/internal/dnsutil/helpers.go
+++ b/internal/dnsutil/helpers.go
@@ -2,7 +2,6 @@
 package dnsutil
 
 import (
-	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"net/netip"
@@ -186,24 +185,6 @@ func isDNSSEC(rr dns.RR) bool {
 		return true
 	}
 	return false
-}
-
-// Exchange exchange dns request with TCP fallback.
-func Exchange(ctx context.Context, req *dns.Msg, addr string, net string, client *dns.Client) (*dns.Msg, error) {
-	localClient := dns.Client{Net: net}
-	if client != nil {
-		// Copy to avoid mutating the caller's client (e.g. when we retry over TCP).
-		localClient = *client
-		localClient.Net = net
-	}
-
-	resp, _, err := localClient.ExchangeContext(ctx, req, addr)
-
-	if err == nil && resp.Truncated && net == "udp" {
-		return Exchange(ctx, req, addr, "tcp", client)
-	}
-
-	return resp, err
 }
 
 // NotSupported response to writer an empty notimplemented message.

--- a/middleware/failover/failover.go
+++ b/middleware/failover/failover.go
@@ -9,6 +9,7 @@ import (
 	"github.com/miekg/dns"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/dnsclient"
 	"github.com/semihalev/sdns/internal/dnsutil"
 	"github.com/semihalev/sdns/internal/metric"
 	"github.com/semihalev/sdns/middleware"
@@ -97,9 +98,10 @@ func (w *ResponseWriter) WriteMsg(m *dns.Msg) error {
 	req.SetEdns0(dnsutil.DefaultMsgSize, true)
 	req.CheckingDisabled = m.CheckingDisabled
 
+	client := dnsclient.Client{Proto: "udp"}
 	for _, server := range w.f.servers {
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		resp, err := dnsutil.Exchange(ctx, req, server, "udp", nil)
+		resp, _, err := client.Exchange(ctx, req, server)
 		cancel()
 		if err != nil {
 			zlog.Info("Failover query failed", "query", formatQuestion(req.Question[0]), "error", err.Error())

--- a/middleware/forwarder/doh.go
+++ b/middleware/forwarder/doh.go
@@ -1,21 +1,15 @@
 package forwarder
 
 import (
-	"bytes"
 	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io"
-	"mime"
 	"net"
 	"net/http"
 	"net/url"
-	"strings"
 	"sync/atomic"
 	"time"
-
-	"github.com/miekg/dns"
 )
 
 // dohMaxResponseSize bounds the response body read so a misbehaving
@@ -169,77 +163,4 @@ func newDoHServer(rawURL string, dialTimeout, requestTimeout time.Duration) (*se
 		DoHURL:    rawURL,
 		DoHClient: &http.Client{Transport: tr, Timeout: requestTimeout},
 	}, nil
-}
-
-// dohExchange POSTs req to the DoH endpoint and decodes the wire-
-// format response. Mirrors the (msg, error) contract of
-// dnsutil.Exchange so the dispatch site in ServeDNS can treat DoH
-// identically to UDP / DoT.
-func dohExchange(ctx context.Context, srv *server, req *dns.Msg) (*dns.Msg, error) {
-	body, err := req.Pack()
-	if err != nil {
-		return nil, fmt.Errorf("pack: %w", err)
-	}
-
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, srv.DoHURL, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("build request: %w", err)
-	}
-	httpReq.Header.Set("Content-Type", contentTypeDNS)
-	httpReq.Header.Set("Accept", contentTypeDNS)
-
-	httpResp, err := srv.DoHClient.Do(httpReq)
-	if err != nil {
-		return nil, fmt.Errorf("doh exchange: %w", err)
-	}
-	defer httpResp.Body.Close()
-
-	if httpResp.StatusCode != http.StatusOK {
-		// Drain a small amount of the body so the connection can
-		// be reused (Go's http.Transport requires the body be read
-		// before the conn returns to the pool).
-		_, _ = io.Copy(io.Discard, io.LimitReader(httpResp.Body, 1024))
-		return nil, fmt.Errorf("doh status %d", httpResp.StatusCode)
-	}
-
-	// RFC 7231 §3.1.1.1: media types are case-insensitive and may
-	// carry parameters (charset=, boundary=, ...). mime.ParseMediaType
-	// strips parameters and lowercases the type for us.
-	rawCT := httpResp.Header.Get("Content-Type")
-	mediaType, _, err := mime.ParseMediaType(rawCT)
-	if err != nil || !strings.EqualFold(mediaType, contentTypeDNS) {
-		_, _ = io.Copy(io.Discard, io.LimitReader(httpResp.Body, 1024))
-		return nil, fmt.Errorf("doh unexpected content-type %q", rawCT)
-	}
-
-	// Read one byte past the size cap so we can distinguish "body
-	// fits within limit" from "body exceeded limit and was
-	// truncated". Without this dns.Msg.Unpack would happily decode
-	// the parseable prefix of an oversized response and silently
-	// ignore the rest.
-	respBody, err := io.ReadAll(io.LimitReader(httpResp.Body, dohMaxResponseSize+1))
-	if err != nil {
-		return nil, fmt.Errorf("read body: %w", err)
-	}
-	if len(respBody) > dohMaxResponseSize {
-		return nil, fmt.Errorf("doh response exceeds %d bytes", dohMaxResponseSize)
-	}
-
-	resp := new(dns.Msg)
-	if err := resp.Unpack(respBody); err != nil {
-		return nil, fmt.Errorf("unpack: %w", err)
-	}
-
-	// Validate the response transaction ID. miekg/dns's
-	// Client.ExchangeContext does this for UDP/DoT; on the DoH
-	// path we have to do it ourselves before the caller rewrites
-	// resp.Id = req.Id. RFC 8484 §4.1 says DoH clients SHOULD use
-	// DNS ID 0 for cache friendliness, and several compliant
-	// servers normalise the response ID to 0 regardless of what
-	// the request carried — so accept either an exact echo or a
-	// zero. Anything else is a buggy or hostile upstream.
-	if resp.Id != req.Id && resp.Id != 0 {
-		return nil, fmt.Errorf("doh response ID mismatch: got %d, want %d or 0", resp.Id, req.Id)
-	}
-	return resp, nil
 }

--- a/middleware/forwarder/forwarder.go
+++ b/middleware/forwarder/forwarder.go
@@ -3,6 +3,7 @@ package forwarder
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"net"
 	"net/http"
 	"strings"
@@ -11,7 +12,7 @@ import (
 	"github.com/miekg/dns"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/semihalev/sdns/config"
-	"github.com/semihalev/sdns/internal/dnsutil"
+	"github.com/semihalev/sdns/internal/dnsclient"
 	"github.com/semihalev/sdns/internal/metric"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/zlog/v2"
@@ -63,6 +64,13 @@ type Forwarder struct {
 	// README description of querytimeout as the maximum time for
 	// any one client-facing query.
 	queryTimeout time.Duration
+
+	// dialTimeout is the per-upstream dial+read budget for UDP/DoT
+	// exchanges, sourced from cfg.Timeout. It mirrors the historical
+	// per-query timeout that the stock dns.Client default imposed, so
+	// one slow upstream cannot eat the whole queryTimeout budget. DoH
+	// upstreams carry their own timeout on the reused http.Client.
+	dialTimeout time.Duration
 }
 
 // New return forwarder.
@@ -124,6 +132,7 @@ func New(cfg *config.Config) *Forwarder {
 		servers:      forwarderservers,
 		dnssec:       cfg.DNSSEC == "on",
 		queryTimeout: requestTimeout,
+		dialTimeout:  dialTimeout,
 	}
 }
 
@@ -180,33 +189,34 @@ func (f *Forwarder) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	defer func() { req.CheckingDisabled = clientCD }()
 
 	for _, server := range f.servers {
-		var (
-			resp *dns.Msg
-			err  error
-		)
-		if server.Proto == "doh" {
-			resp, err = dohExchange(ctx, server, req)
-		} else {
-			reqClient := &dns.Client{Net: server.Proto}
-			if server.Proto == "tcp-tls" {
-				reqClient.TLSConfig = f.tlsConfig
-			}
-			resp, err = dnsutil.Exchange(ctx, req, server.Addr, server.Proto, reqClient)
-		}
-		if err != nil {
-			forwarderFailures.Inc()
-			zlog.Info("forwarder query failed", "query", formatQuestion(req.Question[0]), "error", err.Error())
-			continue
+		// Build a lightweight client per upstream. For DoH this
+		// references the reused, pinned-IP http.Client created at
+		// startup (never per query); for DoT it picks up the
+		// forwarder's TLS config dynamically. The question-section
+		// guard and ID match live inside Exchange.
+		client := dnsclient.Client{Proto: server.Proto, Timeout: f.dialTimeout}
+		switch server.Proto {
+		case "doh":
+			client.DoHURL = server.DoHURL
+			client.DoHClient = server.DoHClient
+		case "tcp-tls":
+			client.TLSConfig = f.tlsConfig
 		}
 
-		// Reject responses whose question section does not match the
-		// outstanding query. A malicious or misbehaving upstream that
-		// returns a different name/type/class would otherwise be cached
-		// under that question, poisoning lookups for unrelated names.
-		if !questionMatches(req.Question[0], resp.Question) {
-			forwarderResponseMismatch.Inc()
-			zlog.Info("forwarder dropped response with mismatched question",
-				"query", formatQuestion(req.Question[0]))
+		resp, _, err := client.Exchange(ctx, req, server.Addr)
+		if err != nil {
+			// A mismatched question section is a security signal
+			// (potential cache poisoning), not a generic upstream
+			// failure — count it separately. Every other error is a
+			// plain forwarder failure.
+			if errors.Is(err, dnsclient.ErrQuestion) {
+				forwarderResponseMismatch.Inc()
+				zlog.Info("forwarder dropped response with mismatched question",
+					"query", formatQuestion(req.Question[0]))
+			} else {
+				forwarderFailures.Inc()
+				zlog.Info("forwarder query failed", "query", formatQuestion(req.Question[0]), "error", err.Error())
+			}
 			continue
 		}
 
@@ -231,17 +241,6 @@ func (f *Forwarder) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 
 func formatQuestion(q dns.Question) string {
 	return strings.ToLower(q.Name) + " " + dns.ClassToString[q.Qclass] + " " + dns.TypeToString[q.Qtype]
-}
-
-// questionMatches reports whether the response's question section answers the
-// outstanding request question. The name comparison is case-insensitive
-// because DNS names are not case-sensitive on the wire.
-func questionMatches(req dns.Question, resp []dns.Question) bool {
-	if len(resp) != 1 {
-		return false
-	}
-	r := resp[0]
-	return r.Qtype == req.Qtype && r.Qclass == req.Qclass && strings.EqualFold(r.Name, req.Name)
 }
 
 const name = "forwarder"

--- a/middleware/resolver/client.go
+++ b/middleware/resolver/client.go
@@ -1,225 +1,24 @@
 package resolver
 
-// Originally this Client from github.com/miekg/dns
-// Adapted for resolver package usage by Semih Alev.
+// The DNS transport (Conn, wire framing, buffer pool and the
+// question-section guard) lives in internal/dnsclient. The resolver
+// keeps its own connection/buffer pooling, circuit breaker, RTT
+// tracking and retry policy on top of these primitives, so it consumes
+// them through these aliases rather than owning the transport code.
 
-import (
-	"encoding/binary"
-	"errors"
-	"io"
-	"net"
-	"strings"
-	"sync"
-	"time"
+import "github.com/semihalev/sdns/internal/dnsclient"
 
-	"github.com/miekg/dns"
+// Conn is the resolver's DNS connection type. It is an alias for
+// dnsclient.Conn so existing resolver call sites (utils.go pooling,
+// resolver.exchange) and tests continue to use the unqualified name.
+type Conn = dnsclient.Conn
+
+// ErrQuestion is returned by (*Conn).Exchange when the response's
+// question section does not match the outstanding request (issue #469).
+var ErrQuestion = dnsclient.ErrQuestion
+
+// AcquireBuf and ReleaseBuf expose the shared size-bucketed buffer pool.
+var (
+	AcquireBuf = dnsclient.AcquireBuf
+	ReleaseBuf = dnsclient.ReleaseBuf
 )
-
-const (
-	headerSize = 12
-)
-
-// ErrQuestion is returned by Conn.Exchange when the response's question
-// section does not match the outstanding request. Accepting a mismatched
-// question lets a malicious upstream plant a cache entry under an unrelated
-// name (issue #469).
-var ErrQuestion = errors.New("dns: response question did not match request")
-
-// Conn A Conn represents a connection to a DNS server.
-type Conn struct {
-	net.Conn        // a net.Conn holding the connection
-	UDPSize  uint16 // minimum receive buffer for UDP messages
-}
-
-// (*Conn).Exchange exchange performs a synchronous query.
-func (co *Conn) Exchange(m *dns.Msg) (r *dns.Msg, rtt time.Duration, err error) {
-
-	opt := m.IsEdns0()
-	// If EDNS0 is used use that for size.
-	if opt != nil && opt.UDPSize() >= dns.MinMsgSize {
-		co.UDPSize = opt.UDPSize()
-	}
-
-	if opt == nil && co.UDPSize < dns.MinMsgSize {
-		co.UDPSize = dns.MinMsgSize
-	}
-
-	t := time.Now()
-
-	if err = co.WriteMsg(m); err != nil {
-		return nil, 0, err
-	}
-
-	r, err = co.ReadMsg()
-	if err == nil && r.Id != m.Id {
-		err = dns.ErrId
-	}
-	if err == nil && len(m.Question) > 0 && !questionMatches(m.Question[0], r.Question) {
-		err = ErrQuestion
-	}
-
-	rtt = time.Since(t)
-
-	return r, rtt, err
-}
-
-// questionMatches reports whether the response's question section answers the
-// outstanding request question. DNS names are compared case-insensitively
-// because they are not case-sensitive on the wire.
-func questionMatches(req dns.Question, resp []dns.Question) bool {
-	if len(resp) != 1 {
-		return false
-	}
-	r := resp[0]
-	return r.Qtype == req.Qtype && r.Qclass == req.Qclass && strings.EqualFold(r.Name, req.Name)
-}
-
-// (*Conn).ReadMsg readMsg reads a message from the connection co.
-// If the received message contains a TSIG record the transaction signature
-// is verified. This method always tries to return the message, however if an
-// error is returned there are no guarantees that the returned message is a
-// valid representation of the packet read.
-func (co *Conn) ReadMsg() (*dns.Msg, error) {
-	var (
-		p   []byte
-		n   int
-		err error
-	)
-
-	if _, ok := co.Conn.(net.PacketConn); ok {
-		p = AcquireBuf(co.UDPSize)
-		n, err = co.Read(p)
-	} else {
-		var length uint16
-		if err := binary.Read(co.Conn, binary.BigEndian, &length); err != nil {
-			return nil, err
-		}
-
-		p = AcquireBuf(length)
-		n, err = io.ReadFull(co.Conn, p)
-	}
-
-	// Return the buffer to the pool regardless of outcome — UDP
-	// timeouts and truncated TCP reads are common and used to leak
-	// the buffer on every failed upstream read.
-	defer ReleaseBuf(p)
-
-	if err != nil {
-		return nil, err
-	} else if n < headerSize {
-		return nil, dns.ErrShortRead
-	}
-
-	m := new(dns.Msg)
-	if err := m.Unpack(p); err != nil {
-		// If an error was returned, we still want to allow the user to use
-		// the message, but naively they can just check err if they don't want
-		// to use an erroneous message
-		return m, err
-	}
-	return m, err
-}
-
-// (*Conn).Read read implements the net.Conn read method.
-func (co *Conn) Read(p []byte) (n int, err error) {
-	if co.Conn == nil {
-		return 0, dns.ErrConnEmpty
-	}
-
-	if _, ok := co.Conn.(net.PacketConn); ok {
-		// UDP connection
-		return co.Conn.Read(p)
-	}
-
-	var length uint16
-	if err := binary.Read(co.Conn, binary.BigEndian, &length); err != nil {
-		return 0, err
-	}
-	if int(length) > len(p) {
-		return 0, io.ErrShortBuffer
-	}
-
-	return io.ReadFull(co.Conn, p[:length])
-}
-
-// (*Conn).WriteMsg writeMsg sends a message through the connection co.
-// If the message m contains a TSIG record the transaction
-// signature is calculated.
-func (co *Conn) WriteMsg(m *dns.Msg) (err error) {
-	size := uint16(m.Len()) + 1 //nolint:gosec // G115 - DNS message size is bounded
-
-	out := AcquireBuf(size)
-	defer ReleaseBuf(out)
-
-	out, err = m.PackBuffer(out)
-	if err != nil {
-		return err
-	}
-	_, err = co.Write(out)
-	return err
-}
-
-// (*Conn).Write write implements the net.Conn Write method.
-func (co *Conn) Write(p []byte) (int, error) {
-	if len(p) > dns.MaxMsgSize {
-		return 0, errors.New("message too large")
-	}
-
-	if _, ok := co.Conn.(net.PacketConn); ok {
-		return co.Conn.Write(p)
-	}
-
-	l := make([]byte, 2)
-	binary.BigEndian.PutUint16(l, uint16(len(p))) //nolint:gosec // G115 - DNS message size is bounded
-
-	n, err := (&net.Buffers{l, p}).WriteTo(co.Conn)
-	return int(n), err
-}
-
-// Size-bucketed buffer pools for efficient memory usage.
-var bufferPools = [4]sync.Pool{
-	{New: func() any { b := make([]byte, 512); return &b }},   // 0-512 bytes (most DNS over UDP)
-	{New: func() any { b := make([]byte, 1232); return &b }},  // 513-1232 bytes (EDNS0 UDP)
-	{New: func() any { b := make([]byte, 4096); return &b }},  // 1233-4096 bytes (typical TCP)
-	{New: func() any { b := make([]byte, 65535); return &b }}, // 4097-65535 bytes (max DNS)
-}
-
-// AcquireBuf returns a buffer from the appropriate pool.
-func AcquireBuf(size uint16) []byte {
-	var poolIdx int
-	switch {
-	case size <= 512:
-		poolIdx = 0
-	case size <= 1232:
-		poolIdx = 1
-	case size <= 4096:
-		poolIdx = 2
-	default:
-		poolIdx = 3
-	}
-
-	x := bufferPools[poolIdx].Get()
-	buf := *(x.(*[]byte))
-	return buf[:size]
-}
-
-// ReleaseBuf returns buf to the appropriate pool.
-func ReleaseBuf(buf []byte) {
-	c := cap(buf)
-	var poolIdx int
-	switch {
-	case c <= 512:
-		poolIdx = 0
-	case c <= 1232:
-		poolIdx = 1
-	case c <= 4096:
-		poolIdx = 2
-	case c <= 65535:
-		poolIdx = 3
-	default:
-		// Buffer too large, let GC handle it
-		return
-	}
-
-	bufferPools[poolIdx].Put(&buf)
-}


### PR DESCRIPTION
## What

Introduces `internal/dnsclient` — an owned, clean-room DNS exchange library that owns the transport (wire framing, buffer pooling, dialing, deadlines, ID/question validation, UDP→TCP truncation fallback) and depends on `github.com/miekg/dns` only as the message codec (`dns.Msg`/`Pack`/`Unpack`), not as a transport.

It replaces five divergent, mostly-unhardened exchange paths:
- `middleware/resolver/client.go` — was a literal copy of miekg's `Conn` ("Originally this Client from github.com/miekg/dns")
- `middleware/forwarder` — stock `dns.Client` per query + a separate hand-rolled DoH path
- `middleware/failover` and the `config` IPv6 probe — via `dnsutil.Exchange`, which built a fresh `dns.Client` per call

The resolver keeps its own connection/buffer pooling, circuit breaker, RTT tracking and retry policy on top of these primitives (it consumes `Conn` via a type alias; `resolver.go` is untouched). The forwarder/failover/config paths now get pooled buffers and the issue-#469 question-section guard they previously lacked.

## Transports

UDP, TCP, DoT (`tcp-tls`), and DoH (RFC 8484) behind one `Client`. No upstream DoQ (server-only today); the transport split leaves room for it.

## Hardening / correctness

- **Question-section guard (#469)** is now applied uniformly (was duplicated in two places, missing in others).
- **Unpack only the bytes read** (`p[:n]`) so a short UDP datagram can't bleed stale pooled-buffer tail into the parsed message.
- **UDP ID-mismatch loop** — matches `miekg/dns.Client`: skip stray/late/spoofed datagrams and keep reading until the matching response or the read deadline, so one stray packet can't fail a healthy upstream. TCP keeps strict `ErrId` (single in-flight response on a stream).
- **TCP read errors propagate** correctly (no swallowed `io.ReadFull` error).

## Performance

This is a **consolidation + hardening** change, not a zero-allocation rewrite: returning `*dns.Msg` is floored by `Unpack` (~25 allocs for a typical signed response), which no transport change can avoid while keeping `dns.Msg`. What it does optimize on the hot path:
- size-bucketed buffer pools backed by `*[N]byte` arrays — no slice-header allocation per `Acquire`/`Release`
- `binary.Read` (reflection) replaced with a small `io.ReadFull` length-prefix helper

A/B against `main` on a 50k-query workload shows the resolver hot path is **neutral** (no regression from the cutover).

## Testing

- `internal/dnsclient` unit tests per transport (UDP/TCP/DoT/DoH) covering ID mismatch, question mismatch, truncation→TCP fallback, short-read, timeout, DoH bad-status/content-type
- `FuzzReadMsg` over the framing
- regression guards for the UDP stray-ID skip and TCP read-error propagation
- `go test -race` green across `dnsclient`, `resolver`, `forwarder`, `failover`, `config`; `golangci-lint` clean