### PR TITLE
fix(dnssec): validate insecure delegations served without a referral (+ AD on CD=1)

### DIFF
--- a/middleware/edns/edns.go
+++ b/middleware/edns/edns.go
@@ -144,7 +144,12 @@ func (e *EDNS) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	rw.cookie = cookie
 	rw.noedns = noedns
 	rw.nsid = nsid
-	rw.noad = !req.AuthenticatedData && !do
+	// Clear AD unless the client signalled it wants validation state (DO
+	// or AD bit set) AND did not set CD. RFC 4035 §3.2.3 / RFC 6840 §5.7:
+	// a CD=1 client opted out of trusting our validation, so AD must
+	// never be asserted to it — this is also the last-line backstop for
+	// the forwarder, which passes an upstream's AD bit through.
+	rw.noad = req.CheckingDisabled || (!req.AuthenticatedData && !do)
 
 	ch.Writer = rw
 	// Restore via defer so a downstream panic that a higher-up

--- a/middleware/edns/edns_test.go
+++ b/middleware/edns/edns_test.go
@@ -301,3 +301,44 @@ func TestEDNS_ForwardsECSGatedByClientNetworks(t *testing.T) {
 		t.Errorf("client outside allow-list should not see ECS forwarded, got %+v", got)
 	}
 }
+
+// adSetter replies with AuthenticatedData=true, simulating a validated
+// answer (or an upstream/forwarder response carrying AD).
+type adSetter struct{}
+
+func (a *adSetter) ServeDNS(ctx context.Context, ch *middleware.Chain) {
+	m := new(dns.Msg)
+	m.SetReply(ch.Request)
+	m.AuthenticatedData = true
+	_ = ch.Writer.WriteMsg(m)
+}
+func (a *adSetter) Name() string { return "ad-setter" }
+
+// TestEDNS_ClearsADForCheckingDisabled pins the RFC 4035 §3.2.3 / RFC 6840
+// §5.7 rule: a CD=1 client opted out of trusting our validation, so the AD
+// bit must never be asserted to it — even if a downstream handler (e.g. the
+// forwarder passing an upstream's bit through) set it.
+func TestEDNS_ClearsADForCheckingDisabled(t *testing.T) {
+	e := New(new(config.Config))
+	ch := middleware.NewChain([]middleware.Handler{e, &adSetter{}})
+
+	// CD=1 client (also DO=1) must receive AD=0.
+	req := new(dns.Msg)
+	req.SetQuestion("example.com.", dns.TypeA)
+	req.SetEdns0(4096, true) // DO=1
+	req.CheckingDisabled = true
+	mw := mock.NewWriter("udp", "127.0.0.1:0")
+	ch.Reset(mw, req)
+	ch.Next(context.Background())
+	assert.True(t, mw.Written())
+	assert.False(t, mw.Msg().AuthenticatedData, "AD must be cleared for a CD=1 client")
+
+	// Control: DO=1, CD=0 client keeps the validated AD bit.
+	req2 := new(dns.Msg)
+	req2.SetQuestion("example.com.", dns.TypeA)
+	req2.SetEdns0(4096, true) // DO=1
+	mw2 := mock.NewWriter("udp", "127.0.0.1:0")
+	ch.Reset(mw2, req2)
+	ch.Next(context.Background())
+	assert.True(t, mw2.Msg().AuthenticatedData, "AD must survive for a DO=1, CD=0 client")
+}

--- a/middleware/resolver/dnssec/nsec3.go
+++ b/middleware/resolver/dnssec/nsec3.go
@@ -214,6 +214,24 @@ func VerifyDelegation(delegation string, nsec []dns.RR) error {
 		}
 		return nil
 	}
+	return verifyDelegationTypes(types)
+}
+
+// VerifyDelegationExact verifies an insecure-delegation claim using only an
+// exact-match NSEC3 owner. It deliberately rejects opt-out coverage: an
+// opt-out span says an unsigned delegation may exist, but it does not prove
+// that this exact name is a delegation. Callers that already have a referral
+// NS RRset can use VerifyDelegation; no-referral downgrade checks need this
+// stricter form.
+func VerifyDelegationExact(delegation string, nsec []dns.RR) error {
+	types, err := findMatching(delegation, nsec)
+	if err != nil {
+		return err
+	}
+	return verifyDelegationTypes(types)
+}
+
+func verifyDelegationTypes(types []uint16) error {
 	if !typesSet(types, dns.TypeNS) {
 		return ErrNSECNSMissing
 	}

--- a/middleware/resolver/dnssec/nsec3_test.go
+++ b/middleware/resolver/dnssec/nsec3_test.go
@@ -268,3 +268,30 @@ func Test_VerifyDelegation(t *testing.T) {
 		t.Fatalf("VerifyDelegation failed with opt out delegation example from RFC5155: %s", err)
 	}
 }
+
+func Test_VerifyDelegationExact(t *testing.T) {
+	records := []dns.RR{
+		makeNSEC3("a.b.com.", "b.b.com.", false, []uint16{dns.TypeNS}),
+	}
+	if err := VerifyDelegationExact("a.b.com.", records); err != nil {
+		t.Fatalf("VerifyDelegationExact failed for exact insecure delegation: %s", err)
+	}
+
+	records = []dns.RR{
+		makeNSEC3("a.b.com.", "b.b.com.", false, []uint16{dns.TypeNS, dns.TypeDS}),
+	}
+	if err := VerifyDelegationExact("a.b.com.", records); err == nil {
+		t.Fatal("VerifyDelegationExact accepted exact NSEC3 with DS bit set")
+	}
+
+	records = []dns.RR{
+		makeNSEC3("com.", "a.com.", false, []uint16{dns.TypeNS}),
+		makeNSEC3("a.com.", "e.com.", true, []uint16{dns.TypeNS}),
+	}
+	if err := VerifyDelegation("b.com.", records); err != nil {
+		t.Fatalf("test premise invalid: opt-out delegation should pass normal referral verifier: %s", err)
+	}
+	if err := VerifyDelegationExact("b.com.", records); err == nil {
+		t.Fatal("VerifyDelegationExact accepted NSEC3 opt-out without an exact delegation owner")
+	}
+}

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -760,8 +760,15 @@ func (r *Resolver) answer(ctx context.Context, req, resp *dns.Msg, parentDS []dn
 			// signatures are acceptable (insecure delegation) or a
 			// real DNSSEC failure (signed zone).
 			if r.isZoneSecure(ctx, q.Name, parentDS, zone) {
-				zlog.Warn("DNSSEC verify failed (answer)", "query", formatQuestion(q), "error", dnssec.ErrNoSignatures.Error())
-				return nil, dnssec.ErrNoSignatures
+				// The zone we queried is signed, but qname may live in an
+				// unsigned child delegated below it that this same server
+				// answered authoritatively (no referral crossed). Accept
+				// the unsigned data only if an insecure delegation between
+				// zone and qname is cryptographically proven.
+				if !r.provenInsecureDelegation(ctx, zone, q.Name, parentDS) {
+					zlog.Warn("DNSSEC verify failed (answer)", "query", formatQuestion(q), "error", dnssec.ErrNoSignatures.Error())
+					return nil, dnssec.ErrNoSignatures
+				}
 			}
 		} else {
 			origDSRR := parentDS
@@ -845,9 +852,15 @@ func (r *Resolver) authority(ctx context.Context, req, resp *dns.Msg, parentDS [
 		signers := r.findRRSIGSigners(resp, q.Name, false)
 		if len(signers) == 0 {
 			if r.isZoneSecure(ctx, q.Name, parentDS, zone) {
-				err := dnssec.ErrNoSignatures
-				zlog.Warn("DNSSEC verify failed (NXDOMAIN)", "query", formatQuestion(q), "error", err.Error())
-				return nil, err
+				// As in answer(): a negative response with no proof is
+				// only acceptable when qname sits under a proven insecure
+				// delegation below the signed zone we queried (the same
+				// shared-authority, no-referral case).
+				if !r.provenInsecureDelegation(ctx, zone, q.Name, parentDS) {
+					err := dnssec.ErrNoSignatures
+					zlog.Warn("DNSSEC verify failed (NXDOMAIN)", "query", formatQuestion(q), "error", err.Error())
+					return nil, err
+				}
 			}
 		} else {
 			origDSRR := parentDS
@@ -1685,6 +1698,112 @@ func (r *Resolver) isZoneSecure(ctx context.Context, qname string, parentDS []dn
 	return hasSupportedDS(parentDS)
 }
 
+// provenInsecureDelegation reports whether qname falls under a
+// cryptographically proven insecure delegation lying strictly below
+// `zone` — the deepest zone whose DS chain `parentDS` establishes.
+//
+// It exists for the case where one server is authoritative for both a
+// signed parent and an unsigned child delegated from it, and answers a
+// name in the child authoritatively — so the resolver crosses no referral
+// and answer()/authority() never run validateDelegation's proof. Without
+// this, the child's legitimately-unsigned records are misread as a signed
+// zone missing its RRSIGs and bogused out (SERVFAIL).
+//
+// It walks each zone-cut candidate from just below `zone` toward qname.
+// At a cut with a usable, validated DS it descends (secure). At the first
+// cut with no DS it returns true ONLY when a signed NSEC/NSEC3 proves an
+// insecure delegation (NS bit, no DS, no SOA) — exactly
+// dnssec.VerifyDelegation. A name that merely lacks a DS without that
+// delegation proof (an attacker stripping signatures off ordinary data in
+// the signed parent) yields false and stays bogus, so this can never be
+// used to downgrade. Any lookup/validation error also fails closed.
+func (r *Resolver) provenInsecureDelegation(ctx context.Context, zone, qname string, parentDS []dns.RR) bool {
+	zone = strings.ToLower(dns.Fqdn(zone))
+	qname = strings.ToLower(dns.Fqdn(qname))
+	if zone == "" || strings.EqualFold(qname, zone) || !dnsutil.NameInZone(qname, zone) {
+		return false
+	}
+
+	labels := dns.SplitDomainName(qname)
+	zoneCount := dns.CountLabel(zone)
+	curDS := parentDS
+	curSigner := zone
+
+	// Candidates from just below `zone` (least specific) toward qname.
+	for n := zoneCount + 1; n <= len(labels); n++ {
+		candidate := dns.Fqdn(strings.Join(labels[len(labels)-n:], "."))
+
+		dsset, insecure, err := r.authenticatedDelegationDS(ctx, curSigner, candidate, curDS, false)
+		if err != nil {
+			return false
+		}
+		if insecure {
+			return true
+		}
+		if len(dsset) > 0 {
+			// Secure delegation — descend and keep checking.
+			curDS = dsset
+			curSigner = candidate
+			continue
+		}
+		return false
+	}
+	return false
+}
+
+// authenticatedDelegationDS returns the authenticated DS RRset for child, or
+// insecure=true when the authenticated parent proof says child is an insecure
+// delegation. The DS lookup itself runs with CD=1 because this helper performs
+// the validation explicitly; using the normal CD=0 path here can re-enter the
+// same missing-signature fallback and loop on the very proof being requested.
+//
+// allowOptOut is only safe for real referral handling where the response
+// already carried an NS RRset for child. No-referral checks must reject NSEC3
+// opt-out because opt-out proves a delegation may exist, not that this exact
+// owner is one.
+func (r *Resolver) authenticatedDelegationDS(ctx context.Context, signer, child string, parentDS []dns.RR, allowOptOut bool) (dsset []dns.RR, insecure bool, err error) {
+	dsResp, err := r.lookupDS(ctx, child, true)
+	if err != nil {
+		return nil, false, err
+	}
+
+	ok, verr := r.verifyDNSSEC(ctx, signer, child, dsResp, parentDS)
+	if verr != nil {
+		return nil, false, verr
+	}
+	if !ok {
+		return nil, false, dnssec.ErrDSRecords
+	}
+
+	dsset = dnsutil.ExtractRRSet(dsResp.Answer, child, dns.TypeDS)
+	if len(dsset) > 0 {
+		if !hasSupportedDS(dsset) {
+			return dsset, true, nil
+		}
+		return dsset, false, nil
+	}
+
+	if nsec3Set := dnsutil.FilterRRsToZone(dnsutil.ExtractRRSet(dsResp.Ns, "", dns.TypeNSEC3), signer); len(nsec3Set) > 0 {
+		if allowOptOut {
+			err = dnssec.VerifyDelegation(child, nsec3Set)
+		} else {
+			err = dnssec.VerifyDelegationExact(child, nsec3Set)
+		}
+		if err != nil {
+			return nil, false, err
+		}
+		return nil, true, nil
+	}
+	if nsecSet := dnsutil.FilterRRsToZone(dnsutil.ExtractRRSet(dsResp.Ns, "", dns.TypeNSEC), signer); len(nsecSet) > 0 {
+		if err := dnssec.VerifyDelegationNSEC(child, nsecSet); err != nil {
+			return nil, false, err
+		}
+		return nil, true, nil
+	}
+
+	return nil, false, dnssec.ErrNSECMissingCoverage
+}
+
 // hasSupportedDS reports whether dsset contains at least one DS record
 // that this validator can actually use — both its digest type and the
 // DNSKEY algorithm it advertises must be supported. An unsupported-only
@@ -2433,7 +2552,7 @@ func (r *Resolver) processDelegation(ctx context.Context, rs *resolveState, resp
 	q := dns.Question{Name: nsrr.Header().Name, Qtype: nsrr.Header().Rrtype, Qclass: nsrr.Header().Class}
 
 	// DNSSEC validation for delegation
-	newParentDS, err := r.validateDelegation(ctx, rs.req, resp, q, rs.parentDS)
+	newParentDS, err := r.validateDelegation(ctx, rs.req, resp, q, rs.parentDS, rs.servers.Zone)
 	if err != nil {
 		return nil, err
 	}
@@ -2526,7 +2645,7 @@ func (r *Resolver) processDelegation(ctx context.Context, rs *resolveState, resp
 }
 
 // validateDelegation performs DNSSEC validation for delegation.
-func (r *Resolver) validateDelegation(ctx context.Context, req, resp *dns.Msg, q dns.Question, parentDS []dns.RR) ([]dns.RR, error) {
+func (r *Resolver) validateDelegation(ctx context.Context, req, resp *dns.Msg, q dns.Question, parentDS []dns.RR, zone string) ([]dns.RR, error) {
 	if req.CheckingDisabled {
 		// CD=1: the client has opted out of DNSSEC validation.
 		// answer() and authority() already wrap their enforcement in
@@ -2554,37 +2673,31 @@ func (r *Resolver) validateDelegation(ctx context.Context, req, resp *dns.Msg, q
 		return nil, dnssec.ErrTrustAnchorsUnavailable
 	}
 
+	effectiveParentDS := parentDS
+	parentSigner := strings.ToLower(dns.Fqdn(zone))
+	if parentSigner == "" {
+		parentSigner = rootzone
+	}
+	if parentSigner == rootzone && len(effectiveParentDS) == 0 {
+		effectiveParentDS = r.dsRRFromRootKeys()
+	}
+
 	signers := r.findRRSIGSigners(resp, q.Name, false)
 	signerFound := len(signers) > 0
 
-	if !signerFound && hasSupportedDS(parentDS) && req.Question[0].Qtype == dns.TypeDS {
-		// A DS query under a signed parent must come back signed.
-		// Guard with hasSupportedDS so parent chains of only
-		// unsupported DS records (unknown digest or DNSKEY algorithm)
-		// fall through to the insecure treatment below instead of
-		// SERVFAIL-ing on data the validator can't use anyway.
-		zlog.Warn("DNSSEC verify failed (delegation)", "query", formatQuestion(q), "error", dnssec.ErrDSRecords.Error())
-		return nil, dnssec.ErrDSRecords
-	}
-
-	origDSRR := parentDS
+	origDSRR := effectiveParentDS
 	if !signerFound {
-		// No RRSIGs in the referral. Fall through the DS-lookup path
-		// with an empty signer so findDS still attempts to walk the
-		// parent chain; this matches the pre-refactor behaviour.
-		newDSRR, err := r.findDS(ctx, "", q.Name, parentDS, false)
+		if !hasSupportedDS(effectiveParentDS) {
+			// Parent is insecure (or only has unsupported DS material),
+			// so no authenticated delegation proof is possible or needed.
+			return parentDS, nil
+		}
+		newDSRR, _, err := r.authenticatedDelegationDS(ctx, parentSigner, q.Name, effectiveParentDS, true)
 		if err != nil {
+			zlog.Warn("DNSSEC verify failed (delegation)", "query", formatQuestion(q), "error", err.Error())
 			return nil, err
 		}
-		parentDS = newDSRR
-		if hasSupportedDS(parentDS) {
-			// Parent chain declares the child is signed with usable DS
-			// but no RRSIG is present — bogus. Every DS unsupported is
-			// insecure per RFC 6840 §5.2 and falls through below.
-			zlog.Warn("DNSSEC verify failed (delegation)", "query", formatQuestion(q), "error", dnssec.ErrDSRecords.Error())
-			return nil, dnssec.ErrDSRecords
-		}
-		return parentDS, nil
+		return newDSRR, nil
 	}
 
 	// Try each candidate signer (most specific first) until one
@@ -2610,7 +2723,7 @@ func (r *Resolver) validateDelegation(ctx context.Context, req, resp *dns.Msg, q
 			continue
 		}
 		if len(candidateDSRR) == 0 {
-			if r.isZoneSecure(ctx, q.Name, origDSRR, "") {
+			if r.isZoneSecure(ctx, q.Name, origDSRR, zone) {
 				lastErr = dnssec.ErrDSRecords
 				continue
 			}

--- a/middleware/resolver/resolver_test.go
+++ b/middleware/resolver/resolver_test.go
@@ -328,11 +328,12 @@ func Test_resolverFindSigner(t *testing.T) {
 	assert.NotNil(t, resp)
 }
 
-// Test_resolverBogusZone verifies that a zone with DS records but broken
-// signatures (bogus DNSSEC) is correctly rejected per RFC 4035 §5.5.
-// comcast.net. has DS at the net. delegation but its DNSKEY RRSIGs do not
-// cryptographically verify — the resolver must return SERVFAIL.
-func Test_resolverBogusZone(t *testing.T) {
+// Test_resolverSharedAuthorityUnsignedChild verifies a signed parent that is
+// served by the same authorities as an unsigned delegated child. comcast.net.
+// is signed, while tx.comcast.net. has an authenticated NSEC at the parent
+// side with NS present and DS/SOA absent; the child data is legitimately
+// unsigned even though no referral is crossed on the wire.
+func Test_resolverSharedAuthorityUnsignedChild(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -344,9 +345,11 @@ func Test_resolverBogusZone(t *testing.T) {
 	cfg := makeTestConfig()
 	r := newWiredTestResolver(cfg)
 
-	_, err := r.Resolve(ctx, req, r.rootServers, true, 30, 0, false, nil)
+	resp, err := r.Resolve(ctx, req, r.rootServers, true, 30, 0, false, nil)
 
-	assert.Error(t, err)
+	assert.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.False(t, resp.AuthenticatedData)
 }
 
 func Test_resolverRootKeys(t *testing.T) {


### PR DESCRIPTION
## The bug

When **one server is authoritative for both a signed parent and an unsigned child** delegated from it (e.g. `tr.` + `ns.tr.`, `comcast.net.` + `tx.comcast.net.`), it answers names in the child **authoritatively — no referral is crossed**. SDNS then attributed the answer to the signed parent, saw no RRSIGs, and **SERVFAIL'd** the child's legitimately-unsigned data as "a signed zone missing its signatures."

Impact: **every signed zone whose nameservers live in an unsigned in-bailiwick subzone breaks** — and the parent flaps in/out of validation as the NS-address cache expires. Confirmed live: `dig ns44.ns.tr A +dnssec` → SERVFAIL on v1.7.1; the whole `.tr` TLD intermittently lost the AD bit.

## The fix

`answer()`/`authority()` now consult **`provenInsecureDelegation`**, which walks each zone cut between the signed zone and the queried name and accepts unsigned data **only when an insecure delegation is cryptographically proven**.

DS authentication is centralized in **`authenticatedDelegationDS`**, designed to be fail-closed and downgrade-safe:
- **No recursive re-entry** — the DS lookup runs **CD=1 (raw)** and is validated explicitly afterward, so it can't fall back into the missing-signature path and loop on the proof it's fetching.
- **No unauthenticated-DS downgrade** — `verifyDNSSEC` runs **before** the unsupported-digest check, so a forged unsigned DS with an unsupported algorithm can't downgrade a signed child.
- **No opt-out downgrade** — no-referral checks use **`VerifyDelegationExact`** (requires an exact NSEC3 delegation owner: NS set, DS/SOA clear; rejects opt-out coverage). Referral handling keeps opt-out, since it already carries an NS RRset.

`validateDelegation`'s no-signers path now authenticates the DS/no-DS proof through the same helper (instead of trusting a raw `findDS` result) and seeds the root trust anchor for top-level delegations.

## Also: clear AD for CD=1 clients (RFC 4035 §3.2.3 / RFC 6840 §5.7)
A CD=1 client opted out of trusting our validation, so AD must never be asserted to it. The `edns` egress strip keyed only on DO/AD, so a CD=1 client could receive AD=1 — including an upstream's bit passed through by the forwarder. Now cleared whenever CD is set (last-line backstop for all paths).

## Testing
- `Test_VerifyDelegationExact` — pins the opt-out rejection (opt-out passes the referral verifier, fails the exact one).
- `Test_resolverSharedAuthorityUnsignedChild` — live regression (`tx.comcast.net` → NoError, AD=false).
- `TestEDNS_ClearsADForCheckingDisabled` — AD stripped on CD=1, preserved on the CD=0 control.
- Whole-repo `go test` passes; `go vet` and `golangci-lint` clean.

Reviewed via an adversarial 4-facet deep-dive of the DNSSEC verify flow (signature/key core, NSEC/NSEC3 proofs, chain-of-trust, cache/AD) — these fixes close the findings; the crypto core, denial-of-existence proofs, and cache/AD interaction were verified sound.