### PR TITLE
chore(release): bump version to 1.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ docker run -d --name sdns -p 53:53 -p 53:53/udp ghcr.io/semihalev/sdns:latest
 Pin to a specific version (recommended for production):
 
 ```shell
-$ docker run -d --name sdns -p 53:53 -p 53:53/udp ghcr.io/semihalev/sdns:1.7.1
+$ docker run -d --name sdns -p 53:53 -p 53:53/udp ghcr.io/semihalev/sdns:1.7.2
 ```
 
 #### Docker Compose

--- a/sdns.go
+++ b/sdns.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const version = "1.7.1"
+const version = "1.7.2"
 
 var (
 	cfgPath    string


### PR DESCRIPTION
Bumps the version to **1.7.2** for the next release off main.

- `sdns.go`: const version `1.7.1` → `1.7.2`
- README docker-run example tag → `1.7.2`

`configver` / README config header / benchmark table unchanged (no schema change).

## What 1.7.2 ships (already merged to main)
- **DNSSEC: validate insecure delegations served without a referral** (#501) — fixes SERVFAIL for any signed zone whose nameservers live in an unsigned in-bailiwick subzone (e.g. the whole `.tr` TLD; `comcast.net`/`tx.comcast.net`). Authenticated, downgrade-safe (CD=1-raw DS lookup + explicit verify, verify-before-unsupported-digest, opt-out rejected for the no-referral case).
- **Clear the AD bit for CD=1 clients** (#501) — RFC 4035 §3.2.3 / §5.7.
- **Own DNS exchange library** (#500) — replaces the miekg-copy client with `internal/dnsclient` (UDP/TCP/DoT/DoH), trimming the resolver/forwarder client paths.

Builds as `sdns v1.7.2`; whole-repo `go test`, `go vet`, `golangci-lint`, and `govulncheck` all clean.

After merge: tag `v1.7.2` to trigger the release.