### PR TITLE
fix(dnssec): two intermittent AD-loss vectors (cache poisoning + prefetch downgrade)

### DIFF
--- a/middleware/cache/prefetch_dnssec_test.go
+++ b/middleware/cache/prefetch_dnssec_test.go
@@ -1,0 +1,127 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/middleware"
+	"github.com/semihalev/sdns/middleware/edns"
+)
+
+// ednsPrefetchQueryer is a faithful stand-in for the real prefetch
+// sub-pipeline: it runs the refresh request through the actual edns
+// middleware (which the real prefetchSub includes — edns is not
+// ClientOnly) over a terminal handler that emits a signed answer. edns
+// strips RRSIGs and clears AD whenever the request lacks DO, exactly as
+// it does in production, so this exercises the real downgrade path.
+type ednsPrefetchQueryer struct {
+	e *edns.EDNS
+}
+
+func (q *ednsPrefetchQueryer) Query(ctx context.Context, req *dns.Msg) (*dns.Msg, error) {
+	// Terminal handler: the "resolver" returns a DNSSEC-signed,
+	// authenticated answer (A + its covering RRSIG, AD=1).
+	terminal := middleware.HandlerFunc(func(ctx context.Context, ch *middleware.Chain) {
+		resp := new(dns.Msg)
+		resp.SetReply(ch.Request)
+		resp.AuthenticatedData = true
+		resp.Answer = []dns.RR{
+			&dns.A{
+				Hdr: dns.RR_Header{Name: "secure.example.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+				A:   []byte{192, 0, 2, 10},
+			},
+			&dns.RRSIG{
+				Hdr:         dns.RR_Header{Name: "secure.example.", Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 300},
+				TypeCovered: dns.TypeA,
+				Algorithm:   13,
+				Labels:      2,
+				OrigTtl:     300,
+				Expiration:  4102444800, // 2100-01-01, fixed; edns never verifies the sig
+				Inception:   1577836800, // 2020-01-01
+				KeyTag:      12345,
+				SignerName:  "example.",
+				Signature:   "dummysig",
+			},
+		}
+		_ = ch.Writer.WriteMsg(resp)
+		ch.Cancel()
+	})
+
+	ch := middleware.NewChain([]middleware.Handler{q.e, terminal})
+	w := mock.NewWriter("udp", "127.0.0.1:0")
+	ch.Reset(w, req)
+	ch.Next(ctx)
+	return w.Msg(), nil
+}
+
+// TestPrefetchKeepsDNSSECForDO0Trigger proves a DO=0 client triggering a
+// prefetch must not downgrade a signed entry. The cache is keyed on CD
+// (not DO) and stores the COMPLETE answer, stripping DNSSEC per-client at
+// serve time. The prefetch sub-pipeline runs edns, so unless the worker
+// forces DO=1 a DO=0 trigger would refresh through edns, strip the RRSIG,
+// clear AD, and overwrite the entry — every later DO=1 client then loses
+// AD until expiry. With the DO=1 fix the refreshed entry keeps RRSIG+AD.
+func TestPrefetchKeepsDNSSECForDO0Trigger(t *testing.T) {
+	c := New(&config.Config{
+		CacheSize: 1024,
+		Expire:    60,
+		Prefetch:  50,
+	})
+	defer c.Stop()
+
+	c.SetPrefetchQueryer(&ednsPrefetchQueryer{e: edns.New(&config.Config{})})
+
+	// The triggering client query carries DO=0 (no EDNS DO bit) — a plain
+	// stub/forwarder, the common case that races prefetch on a hot name.
+	trigger := new(dns.Msg)
+	trigger.SetQuestion("secure.example.", dns.TypeA)
+
+	// A hot CD=0 entry already in cache (about to be refreshed).
+	old := new(dns.Msg)
+	old.SetReply(trigger)
+	old.Answer = []dns.RR{&dns.A{
+		Hdr: dns.RR_Header{Name: "secure.example.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 1},
+		A:   []byte{192, 0, 2, 1},
+	}}
+	key := CacheKey{Question: trigger.Question[0], CD: false}.Hash()
+	entry := NewCacheEntryWithKey(old, 5*time.Second, 0, key)
+	c.positive.Set(key, entry)
+
+	if !c.prefetchQueue.Add(PrefetchRequest{
+		Request: trigger.Copy(),
+		Key:     key,
+		Cache:   c,
+		Entry:   entry,
+	}) {
+		t.Fatal("Add returned false; queue rejected the request")
+	}
+
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		got, ok := c.positive.Get(key)
+		if ok && got != entry {
+			// Refreshed. The stored answer must still carry the RRSIG
+			// and the AD bit — proving the DO=0 trigger did not strip
+			// DNSSEC via the prefetch sub-pipeline's edns layer.
+			hasRRSIG := false
+			for _, rr := range got.msg.Answer {
+				if _, ok := rr.(*dns.RRSIG); ok {
+					hasRRSIG = true
+				}
+			}
+			if !hasRRSIG {
+				t.Fatalf("prefetch dropped the RRSIG: a DO=0 trigger downgraded the signed entry")
+			}
+			if !got.msg.AuthenticatedData {
+				t.Fatalf("prefetch cleared the AD bit: a DO=0 trigger downgraded the signed entry")
+			}
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("prefetch worker did not replace the cache entry")
+}

--- a/middleware/cache/prefetch_queue.go
+++ b/middleware/cache/prefetch_queue.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/dnsutil"
 	"github.com/semihalev/zlog/v2"
 )
 
@@ -101,6 +102,21 @@ func (pq *PrefetchQueue) processPrefetch(req PrefetchRequest) {
 	// (CD bit, EDNS options) don't bleed into the shared Request
 	// held by other callers or into the stored entry's question.
 	prefetchReq := req.Request.Copy()
+
+	// Force DO=1 on the refresh. The cache stores the COMPLETE answer
+	// (RRSIGs + AD) and is keyed on CD, not DO — DNSSEC is stripped
+	// per-client at serve time by edns. On the external path the cache
+	// sits below edns and stores the full answer; the prefetch sub-
+	// pipeline runs edns, so copying a DO=0 trigger's bit would let edns
+	// strip the refresh and overwrite the entry with an AD-less answer
+	// that downgrades every later DO=1 client. Mirror the internal
+	// NS/DS lookups, which always query with DO set. CD is preserved
+	// from the copy (it is the cache key and the validation opt-out).
+	if opt := prefetchReq.IsEdns0(); opt != nil {
+		opt.SetDo(true)
+	} else {
+		prefetchReq.SetEdns0(dnsutil.DefaultMsgSize, true)
+	}
 
 	// Route through the cache-less prefetch sub-pipeline so the
 	// refresh reaches the upstream resolver/forwarder instead of

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -1504,20 +1504,13 @@ func (r *Resolver) searchCache(q dns.Question, cd bool, origin string) (servers 
 		return ns.Servers, ns.DSSet, dns.CompareDomainName(origin, q.Name)
 	}
 
-	if !cd {
-		key := cache.Key(q, true)
-		ns, err := r.delegations.Get(key)
-
-		if err == nil && len(ns.DSSet) == 0 {
-			if atomic.LoadUint32(&ns.Servers.ErrorCount) >= 10 {
-				r.delegations.Remove(key)
-				q.Name = origin
-				return r.searchCache(q, cd, origin)
-			}
-			zlog.Debug("Nameserver cache hit", "key", key, "query", formatQuestion(q), "cd", true)
-			return ns.Servers, ns.DSSet, dns.CompareDomainName(origin, q.Name)
-		}
-	}
+	// A CD=0 query must NEVER borrow a CD=1 delegation. Delegations are
+	// keyed on the client's CD bit (see processDelegation), so a
+	// proven-insecure CD=0 delegation already lives in this same CD=0
+	// bucket and was returned above. The CD=1 bucket holds only
+	// unvalidated results (CD=1 clients and internal NS/DS lookups);
+	// serving one of those here would strip AD from a signed zone whose
+	// DS lookup transiently returned empty.
 
 	next, end := dns.NextLabel(q.Name, 0)
 
@@ -2044,9 +2037,8 @@ func (r *Resolver) lookupV4Nss(ctx context.Context, q dns.Question, authservers 
 		if hasList && (!r.dnssec || r.hasTrustAnchors()) {
 			// Temporary cache before lookup. Skip when trust anchors
 			// are unavailable: the DS set could be empty because the
-			// DNSSEC chain was short-circuited, and caching that
-			// would poison CD=false lookups after recovery (CD=false
-			// searchCache falls back to CD=true empty-DS entries).
+			// DNSSEC chain was short-circuited, and caching that empty-DS
+			// entry would make a signed zone look insecure after recovery.
 			r.delegations.Set(key, parentDS, authservers, time.Minute)
 		}
 
@@ -2579,11 +2571,20 @@ func (r *Resolver) processDelegation(ctx context.Context, rs *resolveState, resp
 		return resp, errParentDetection
 	}
 
-	// Determine checking disabled state
+	// Determine checking disabled state for the downstream NS-address /
+	// DS sub-lookups (an insecure delegation must not fail them closed).
 	cd := rs.req.CheckingDisabled || len(rs.parentDS) == 0
 
-	// Try nameserver cache
-	key := cache.Key(q, cd)
+	// Key the delegation cache on the CLIENT's CD bit only — never on the
+	// delegation's own insecure-ness. searchCache always looks up with
+	// rs.req.CheckingDisabled (see the resolve() seed), so a proven-insecure
+	// delegation reached by a CD=0 query belongs in the CD=0 bucket where
+	// that lookup finds it. Folding len(parentDS)==0 into the key would file
+	// it under CD=1 instead — and a transient/unvalidated CD=1 delegation
+	// (client or internal NS/DS lookup) could then be served to CD=0 queries,
+	// silently stripping AD from a genuinely signed zone.
+	keyCD := rs.req.CheckingDisabled
+	key := cache.Key(q, keyCD)
 	if cached, err := r.delegations.Get(key); err == nil {
 		return r.resolveWithCachedNameservers(ctx, rs, cached, key, q, cd)
 	}
@@ -2606,10 +2607,9 @@ func (r *Resolver) processDelegation(ctx context.Context, rs *resolveState, resp
 		return nil, errNoReachableAuth
 	}
 
-	// Cache delegations. Skip when trust anchors are unavailable so
-	// a CD=true lookup during the outage cannot land an empty-DS
-	// entry that CD=false queries would reuse via searchCache after
-	// recovery (see searchCache CD=false → CD=true empty-DS reuse).
+	// Cache delegations. Skip when trust anchors are unavailable so a
+	// lookup during the outage cannot land an empty-DS entry that later
+	// queries would treat as a proven-insecure delegation after recovery.
 	if !r.dnssec || r.hasTrustAnchors() {
 		r.delegations.Set(key, rs.parentDS, authservers, time.Duration(nsrr.Header().Ttl)*time.Second)
 		zlog.Debug("Nameserver cache insert", "key", key, "query", formatQuestion(q), "cd", cd)

--- a/middleware/resolver/searchcache_poison_test.go
+++ b/middleware/resolver/searchcache_poison_test.go
@@ -1,0 +1,61 @@
+package resolver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/authority"
+	"github.com/semihalev/sdns/internal/cache"
+)
+
+// Test_searchCache_CD1DelegationMustNotPoisonCD0 reproduces the AD-loss
+// cache-poisoning bug.
+//
+// Internal resolutions (NS-address lookups via the Queryer, DS lookups via
+// subQuery) inherit cd=true when resolving an insecure delegation
+// (cd := req.CheckingDisabled || len(parentDS)==0). Under CD=1,
+// validateDelegation returns a raw, UNVALIDATED findDS result — which is an
+// empty DSSet on a transient/flaky lookup — and processDelegation caches it
+// under the cd=true key. If the nameserver/DS being resolved lives in a
+// genuinely SIGNED zone (e.g. com.), that secure zone ends up cached as
+// cd=true with an empty DSSet.
+//
+// searchCache then lets a CD=0 query consume that CD=1 empty-DSSet entry
+// (resolver.go: "if !cd { ... if len(ns.DSSet)==0 { return } }"), so the
+// secure zone is served to validating clients with no DS chain — every
+// answer under it loses the AD bit until the entry expires.
+//
+// This test asserts the correct invariant: a CD=0 query must never be
+// served an unvalidated CD=1 delegation. It FAILS on the buggy code (the
+// CD=1 com. entry is returned) and passes once the cross-CD share is fixed.
+func Test_searchCache_CD1DelegationMustNotPoisonCD0(t *testing.T) {
+	r := &Resolver{delegations: authority.NewCache()}
+	r.rootServers = &authority.Servers{
+		Zone: ".",
+		List: []*authority.Server{authority.NewServer("198.51.100.1:53", authority.IPv4)},
+	}
+
+	// Simulate the poisoned state: com. (a signed TLD) cached under the
+	// cd=true key with an EMPTY DSSet, as an unvalidated CD=1 internal
+	// resolution would leave it after a transient no-DS lookup.
+	comNS := dns.Question{Name: "com.", Qtype: dns.TypeNS, Qclass: dns.ClassINET}
+	poison := &authority.Servers{
+		Zone: "com.",
+		List: []*authority.Server{authority.NewServer("192.0.2.66:53", authority.IPv4)},
+	}
+	r.delegations.Set(cache.Key(comNS, true), nil /* empty DSSet */, poison, time.Minute)
+
+	// A CD=0 client query under com. With no validated CD=0 delegation
+	// cached, it must fall through to the root and re-establish a
+	// validated chain — NOT borrow the unvalidated CD=1 com. delegation.
+	q := dns.Question{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	servers, parentDS, _ := r.searchCache(q, false, q.Name)
+
+	if servers != nil && len(servers.List) > 0 && servers.List[0].Addr == "192.0.2.66:53" {
+		t.Fatalf("BUG REPRODUCED: a CD=0 query was served the unvalidated CD=1 com. "+
+			"delegation (insecure downgrade) — servers=%s parentDS=%v; "+
+			"expected the root servers and a freshly validated chain",
+			servers.List[0].Addr, parentDS)
+	}
+}


### PR DESCRIPTION
Fixes two independent causes of intermittent AD-bit loss observed on a live resolver: signed zones (e.g. `com.`, `org.`, `tr.`) sporadically served to validating clients without the `ad` flag, recovering on their own after a while. Both are transient cache-state bugs, not validation-logic bugs.

## 1. Resolver delegation cache: CD=0 queries borrowing CD=1 delegations

`searchCache` (the resolve seed) looks up delegations with the client's `rs.req.CheckingDisabled`, but `processDelegation` stored them under `cd := req.CheckingDisabled || len(parentDS)==0` — so a CD=0 query resolving an insecure delegation filed it in the **CD=1** bucket. A `searchCache` block bridged that mismatch by letting a CD=0 lookup borrow a CD=1 empty-DSSet entry.

That fallback leaked **unvalidated** CD=1 results — a CD=1 client, or an internal NS-address / DS lookup that ran CD=1 and got a transient empty DS — into CD=0 answers, caching a genuinely signed zone as insecure and stripping AD across its whole subtree until the entry expired.

**Fix:** key delegations on the client's CD bit only (the same bit `searchCache` reads) and remove the cross-CD fallback. A proven-insecure CD=0 delegation now lives in the CD=0 bucket where it is found directly; the CD=1 bucket holds only unvalidated results and is never read by validating clients.

## 2. Cache prefetch: DO=0 trigger downgrading a signed entry

The answer cache stores the complete response (RRSIGs + AD) and is keyed on CD, not DO; DNSSEC is stripped per-client at serve time by `edns`. On the external path the cache sits below `edns`, so it stores the full answer.

The prefetch sub-pipeline runs `edns` (it is not `ClientOnly`), and the worker refreshed with a copy of the triggering client's request. When a DO=0 client raced a hot signed entry across the prefetch threshold, the refresh went through `edns` with DO=0 — stripping the RRSIGs and clearing AD — and overwrote the entry. Every later DO=1 client then got the stripped answer and lost AD until the TTL expired.

**Fix:** force DO=1 on the prefetch refresh, mirroring the external store path and the internal NS/DS lookups. CD is preserved from the copy (cache key + validation opt-out).

## Tests
- `Test_searchCache_CD1DelegationMustNotPoisonCD0` — reproduces the cross-CD delegation leak.
- `TestPrefetchKeepsDNSSECForDO0Trigger` — integration test running a DO=0-triggered refresh through the real `edns` layer, asserting the stored entry keeps its RRSIG and AD bit.

Both are genuine regression tests (red before the fix, green after). Full `go test ./... -race` passes; `gofmt` clean; `golangci-lint` 0 issues.

## Live verification
Branch deployed to a production resolver and monitored on a 15-minute AD-flag sweep across 63 signed TLDs for several days spanning multiple full cache rotations (including longest-TTL TLD NS/DS entries): every signed TLD stayed `ad`-clean, no recurrence.

## Scope
Also audited the other cross-CD / DO-downgrade surfaces (answer cache reads, negative cache, glue/NS-address caches, `subQuery` DS/DNSKEY, internal NS/CNAME/DNAME lookups) and confirmed no further AD-loss vectors: the answer cache has no cross-CD fallback, and every internal lookup that gets cached already forces DO=1. The NS-address glue cache is CD-agnostic by design but is not a validation-chain input, so it cannot silently drop AD.