### PR TITLE
fix(dnssec): false SERVFAILs for insecure names served by multi-zone authorities

### DIFF
--- a/middleware/resolver/dnssec/nsec3.go
+++ b/middleware/resolver/dnssec/nsec3.go
@@ -217,20 +217,6 @@ func VerifyDelegation(delegation string, nsec []dns.RR) error {
 	return verifyDelegationTypes(types)
 }
 
-// VerifyDelegationExact verifies an insecure-delegation claim using only an
-// exact-match NSEC3 owner. It deliberately rejects opt-out coverage: an
-// opt-out span says an unsigned delegation may exist, but it does not prove
-// that this exact name is a delegation. Callers that already have a referral
-// NS RRset can use VerifyDelegation; no-referral downgrade checks need this
-// stricter form.
-func VerifyDelegationExact(delegation string, nsec []dns.RR) error {
-	types, err := findMatching(delegation, nsec)
-	if err != nil {
-		return err
-	}
-	return verifyDelegationTypes(types)
-}
-
 func verifyDelegationTypes(types []uint16) error {
 	if !typesSet(types, dns.TypeNS) {
 		return ErrNSECNSMissing

--- a/middleware/resolver/dnssec/nsec3_test.go
+++ b/middleware/resolver/dnssec/nsec3_test.go
@@ -268,30 +268,3 @@ func Test_VerifyDelegation(t *testing.T) {
 		t.Fatalf("VerifyDelegation failed with opt out delegation example from RFC5155: %s", err)
 	}
 }
-
-func Test_VerifyDelegationExact(t *testing.T) {
-	records := []dns.RR{
-		makeNSEC3("a.b.com.", "b.b.com.", false, []uint16{dns.TypeNS}),
-	}
-	if err := VerifyDelegationExact("a.b.com.", records); err != nil {
-		t.Fatalf("VerifyDelegationExact failed for exact insecure delegation: %s", err)
-	}
-
-	records = []dns.RR{
-		makeNSEC3("a.b.com.", "b.b.com.", false, []uint16{dns.TypeNS, dns.TypeDS}),
-	}
-	if err := VerifyDelegationExact("a.b.com.", records); err == nil {
-		t.Fatal("VerifyDelegationExact accepted exact NSEC3 with DS bit set")
-	}
-
-	records = []dns.RR{
-		makeNSEC3("com.", "a.com.", false, []uint16{dns.TypeNS}),
-		makeNSEC3("a.com.", "e.com.", true, []uint16{dns.TypeNS}),
-	}
-	if err := VerifyDelegation("b.com.", records); err != nil {
-		t.Fatalf("test premise invalid: opt-out delegation should pass normal referral verifier: %s", err)
-	}
-	if err := VerifyDelegationExact("b.com.", records); err == nil {
-		t.Fatal("VerifyDelegationExact accepted NSEC3 opt-out without an exact delegation owner")
-	}
-}

--- a/middleware/resolver/dnssec/verify.go
+++ b/middleware/resolver/dnssec/verify.go
@@ -200,6 +200,20 @@ func VerifyRRSIG(signer string, keys map[uint16][]*dns.DNSKEY, msg *dns.Msg) (bo
 			}
 			name := strings.ToLower(r.Header().Name)
 			if !dnsutil.NameInZone(name, signerZone) {
+				if fromAuthority {
+					// Referral remnant: an upstream that also hosts
+					// ancestors of a CNAME target may append the
+					// target's zone-cut NS and DS-denial records —
+					// owned outside the signer zone — to a positive
+					// answer (issue #506). They are advisory (RFC
+					// 2181 §5.4.1 ranks authority data below answer
+					// data) and the caller re-resolves the target
+					// through its own validated recursion, so they
+					// are excluded from this signer's validation
+					// rather than failing it. Out-of-zone records in
+					// the ANSWER section stay fatal below.
+					continue
+				}
 				if collectErr == nil {
 					collectErr = ErrMissingSigned
 				}

--- a/middleware/resolver/dnssec/verify_referral_test.go
+++ b/middleware/resolver/dnssec/verify_referral_test.go
@@ -1,0 +1,140 @@
+package dnssec
+
+import (
+	"crypto"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// signRRSet signs rrset with key/priv and returns the RRSIG. The
+// validity window is now±6h so verifyOneSig's period check passes.
+func signRRSet(t *testing.T, key *dns.DNSKEY, priv crypto.PrivateKey, rrset []dns.RR) *dns.RRSIG {
+	t.Helper()
+
+	hdr := rrset[0].Header()
+	sig := &dns.RRSIG{
+		Hdr:         dns.RR_Header{Name: hdr.Name, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: hdr.Ttl},
+		TypeCovered: hdr.Rrtype,
+		Algorithm:   key.Algorithm,
+		Labels:      uint8(dns.CountLabel(hdr.Name)), //nolint:gosec // G115 - test names have few labels
+		OrigTtl:     hdr.Ttl,
+		Expiration:  uint32(time.Now().Add(6 * time.Hour).Unix()),  //nolint:gosec // G115 - RFC 4034 serial-arithmetic timestamp
+		Inception:   uint32(time.Now().Add(-6 * time.Hour).Unix()), //nolint:gosec // G115 - RFC 4034 serial-arithmetic timestamp
+		KeyTag:      key.KeyTag(),
+		SignerName:  key.Header().Name,
+	}
+	if err := sig.Sign(priv.(crypto.Signer), rrset); err != nil {
+		t.Fatalf("failed to sign %s %s: %s", hdr.Name, dns.TypeToString[hdr.Rrtype], err)
+	}
+	return sig
+}
+
+func makeZoneKey(t *testing.T, zone string) (*dns.DNSKEY, crypto.PrivateKey) {
+	t.Helper()
+
+	key := &dns.DNSKEY{
+		Hdr:       dns.RR_Header{Name: zone, Rrtype: dns.TypeDNSKEY, Class: dns.ClassINET, Ttl: 3600},
+		Flags:     257,
+		Protocol:  3,
+		Algorithm: dns.ECDSAP256SHA256,
+	}
+	priv, err := key.Generate(256)
+	if err != nil {
+		t.Fatalf("failed to generate zone key for %s: %s", zone, err)
+	}
+	return key, priv
+}
+
+// Test_VerifyRRSIG_ForeignReferralInAuthority reproduces issue #506
+// (variant 2, www.edpb.europa.eu): an authoritative server that hosts
+// both the signer zone and ancestors of the CNAME target answers with
+// a validly signed CNAME in ANSWER plus a referral for the target in
+// AUTHORITY — NS records for the target's zone cut and an NSEC proving
+// its insecure delegation, both owned by names OUTSIDE the signer zone
+// (on the wire the NSEC is signed by the parent zone, and that RRSIG's
+// owner is equally out-of-zone).
+//
+// Wire shape captured live from ans1.cw.net for
+// "www.edpb.europa.eu. IN AAAA":
+//
+//	;; ANSWER:    www.edpb.europa.eu. CNAME 51da….alb.prd.dhs.tech.ec.europa.eu.
+//	;;            www.edpb.europa.eu. RRSIG CNAME … edpb.europa.eu. …
+//	;; AUTHORITY: dhs.tech.ec.europa.eu. NS ns-520.awsdns-01.net.
+//	;;            dhs.tech.ec.europa.eu. NSEC dke.tech.ec.europa.eu. NS RRSIG NSEC
+//	;;            dhs.tech.ec.europa.eu. RRSIG NSEC … europa.eu. …
+//
+// The referral remnant is advisory (RFC 2181 §5.4.1 ranks it below
+// answer data; the resolver re-resolves the CNAME target through its
+// own validated recursion), so it must not bogus the answer: the
+// in-zone CNAME validates and VerifyRRSIG must succeed. The buggy
+// collect() guard instead hard-fails with ErrMissingSigned.
+func Test_VerifyRRSIG_ForeignReferralInAuthority(t *testing.T) {
+	signerZone := "edpb.example."
+	key, priv := makeZoneKey(t, signerZone)
+	keys := map[uint16][]*dns.DNSKEY{key.KeyTag(): {key}}
+
+	cname := &dns.CNAME{
+		Hdr:    dns.RR_Header{Name: "www.edpb.example.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+		Target: "51da7994.alb.prd.dhs.tech.ec.example.",
+	}
+	cnameSig := signRRSet(t, key, priv, []dns.RR{cname})
+
+	// Referral remnant for the CNAME target's zone cut — owner names
+	// live under ec.example., outside the signer zone.
+	foreignNS := &dns.NS{
+		Hdr: dns.RR_Header{Name: "dhs.tech.ec.example.", Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: 7200},
+		Ns:  "ns-520.awsdns-01.example.",
+	}
+	foreignNSEC := &dns.NSEC{
+		Hdr:        dns.RR_Header{Name: "dhs.tech.ec.example.", Rrtype: dns.TypeNSEC, Class: dns.ClassINET, Ttl: 1800},
+		NextDomain: "dke.tech.ec.example.",
+		TypeBitMap: []uint16{dns.TypeNS, dns.TypeRRSIG, dns.TypeNSEC},
+	}
+
+	msg := new(dns.Msg)
+	msg.SetQuestion("www.edpb.example.", dns.TypeAAAA)
+	msg.Answer = []dns.RR{cname, cnameSig}
+	msg.Ns = []dns.RR{foreignNS, foreignNSEC}
+
+	ok, err := VerifyRRSIG(signerZone, keys, msg)
+	if err != nil {
+		t.Fatalf("BUG REPRODUCED (issue #506 variant 2): a validly signed CNAME answer "+
+			"was rejected because the authority section carries the upstream's referral "+
+			"remnant for the CNAME target (out-of-zone NS+NSEC): %s", err)
+	}
+	if !ok {
+		t.Fatal("expected the in-zone CNAME RRset to validate")
+	}
+}
+
+// Test_VerifyRRSIG_ForeignRecordInAnswerStaysBogus pins the guard the
+// referral fix must NOT relax: an unsigned out-of-zone RRset inside the
+// ANSWER section is attacker-piggybacked data riding on a signed
+// response (RFC 4035 §3.2.3) and must keep failing validation.
+func Test_VerifyRRSIG_ForeignRecordInAnswerStaysBogus(t *testing.T) {
+	signerZone := "edpb.example."
+	key, priv := makeZoneKey(t, signerZone)
+	keys := map[uint16][]*dns.DNSKEY{key.KeyTag(): {key}}
+
+	cname := &dns.CNAME{
+		Hdr:    dns.RR_Header{Name: "www.edpb.example.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+		Target: "51da7994.alb.prd.dhs.tech.ec.example.",
+	}
+	cnameSig := signRRSet(t, key, priv, []dns.RR{cname})
+
+	// Unsigned foreign A record spliced into the ANSWER section.
+	foreignA := &dns.A{
+		Hdr: dns.RR_Header{Name: "51da7994.alb.prd.dhs.tech.ec.example.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+		A:   []byte{192, 0, 2, 66},
+	}
+
+	msg := new(dns.Msg)
+	msg.SetQuestion("www.edpb.example.", dns.TypeAAAA)
+	msg.Answer = []dns.RR{cname, cnameSig, foreignA}
+
+	if _, err := VerifyRRSIG(signerZone, keys, msg); err == nil {
+		t.Fatal("an unsigned out-of-zone RRset in the ANSWER section must stay bogus")
+	}
+}

--- a/middleware/resolver/optout_delegation_test.go
+++ b/middleware/resolver/optout_delegation_test.go
@@ -1,0 +1,197 @@
+package resolver
+
+import (
+	"context"
+	"crypto"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/middleware"
+)
+
+// makeZoneKeyRes generates a KSK for zone; signRRSetRes signs rrset
+// with it using a now±6h validity window.
+func makeZoneKeyRes(t *testing.T, zone string) (*dns.DNSKEY, crypto.PrivateKey) {
+	t.Helper()
+
+	key := &dns.DNSKEY{
+		Hdr:       dns.RR_Header{Name: zone, Rrtype: dns.TypeDNSKEY, Class: dns.ClassINET, Ttl: 3600},
+		Flags:     257,
+		Protocol:  3,
+		Algorithm: dns.ECDSAP256SHA256,
+	}
+	priv, err := key.Generate(256)
+	if err != nil {
+		t.Fatalf("failed to generate zone key for %s: %s", zone, err)
+	}
+	return key, priv
+}
+
+func signRRSetRes(t *testing.T, key *dns.DNSKEY, priv crypto.PrivateKey, rrset []dns.RR) *dns.RRSIG {
+	t.Helper()
+
+	hdr := rrset[0].Header()
+	sig := &dns.RRSIG{
+		Hdr:         dns.RR_Header{Name: hdr.Name, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: hdr.Ttl},
+		TypeCovered: hdr.Rrtype,
+		Algorithm:   key.Algorithm,
+		Labels:      uint8(dns.CountLabel(hdr.Name)), //nolint:gosec // G115 - test names have few labels
+		OrigTtl:     hdr.Ttl,
+		Expiration:  uint32(time.Now().Add(6 * time.Hour).Unix()),  //nolint:gosec // G115 - RFC 4034 serial-arithmetic timestamp
+		Inception:   uint32(time.Now().Add(-6 * time.Hour).Unix()), //nolint:gosec // G115 - RFC 4034 serial-arithmetic timestamp
+		KeyTag:      key.KeyTag(),
+		SignerName:  key.Header().Name,
+	}
+	if err := sig.Sign(priv.(crypto.Signer), rrset); err != nil {
+		t.Fatalf("failed to sign %s %s: %s", hdr.Name, dns.TypeToString[hdr.Rrtype], err)
+	}
+	return sig
+}
+
+// cannedDNSSECStore serves pre-built DS / DNSKEY responses to
+// subQuery so the delegation-proof helpers run without network.
+type cannedDNSSECStore struct {
+	byQtype map[uint16]*dns.Msg
+}
+
+func (s *cannedDNSSECStore) Get(req *dns.Msg) (*dns.Msg, bool) {
+	if m, ok := s.byQtype[req.Question[0].Qtype]; ok {
+		return m.Copy(), true
+	}
+	return nil, false
+}
+
+func (s *cannedDNSSECStore) SetFromResponse(resp *dns.Msg, keyCD bool) {}
+
+// Test_provenInsecureDelegation_OptOutSpan reproduces issue #506
+// (variant 1, tether.edge.apple): a signed parent zone that uses
+// NSEC3 OPT-OUT and serves an unsigned child zone from the SAME
+// nameservers, so no referral is crossed on the wire and answer()
+// falls back to provenInsecureDelegation.
+//
+// In an opt-out zone an unsigned delegation has NO exact-match NSEC3
+// by definition (RFC 5155 §6) — the authenticated DS-NODATA proof is
+// the covering opt-out NSEC3. Wire shape captured live from
+// c.ns.apple.com for "edge.apple. IN DS" (apex NSEC3, flags=1):
+//
+//	;; AUTHORITY: apple. SOA …
+//	;;            TMJ4….apple. NSEC3 1 1 0 - 3FVF…  NS SOA TXT RRSIG DNSKEY NSEC3PARAM TYPE63
+//	;;            TMJ4….apple. RRSIG NSEC3 … apple. …
+//
+// Conformant validators (Unbound, BIND, delv) treat names under an
+// opt-out span as insecure, so provenInsecureDelegation must accept
+// the proof. Requiring an exact match here can never succeed for an
+// opt-out zone and turns every shared-authority answer under it into
+// a false SERVFAIL.
+func Test_provenInsecureDelegation_OptOutSpan(t *testing.T) {
+	parent := "parent-optout.test."
+	key, priv := makeZoneKeyRes(t, parent)
+	parentDS := []dns.RR{key.ToDS(dns.SHA256)}
+
+	apexHash := dns.HashName(parent, dns.SHA1, 0, "")
+
+	// Pick a child label whose NSEC3 hash sorts after the apex hash so
+	// the single apex NSEC3 (NextDomain at the top of the hash space)
+	// covers the child's hash, mirroring the captured .apple response.
+	var child string
+	for _, label := range []string{"edge", "cdn", "img", "sub", "zone", "app", "dev", "net"} {
+		h := dns.HashName(label+"."+parent, dns.SHA1, 0, "")
+		if h > apexHash && h < strings.Repeat("V", 32) {
+			child = label + "." + parent
+			break
+		}
+	}
+	if child == "" {
+		t.Fatal("no candidate child label hashed into the covered span")
+	}
+	qname := "tether." + child
+
+	apexNSEC3 := &dns.NSEC3{
+		Hdr:        dns.RR_Header{Name: apexHash + "." + parent, Rrtype: dns.TypeNSEC3, Class: dns.ClassINET, Ttl: 3600},
+		Hash:       dns.SHA1,
+		Flags:      1, // opt-out
+		Iterations: 0,
+		SaltLength: 0,
+		Salt:       "",
+		HashLength: 20,
+		NextDomain: strings.Repeat("V", 32),
+		TypeBitMap: []uint16{dns.TypeNS, dns.TypeSOA, dns.TypeRRSIG, dns.TypeDNSKEY, dns.TypeNSEC3PARAM},
+	}
+	nsec3Sig := signRRSetRes(t, key, priv, []dns.RR{apexNSEC3})
+
+	dsResp := new(dns.Msg)
+	dsResp.SetQuestion(child, dns.TypeDS)
+	dsResp.Response = true
+	dsResp.Ns = []dns.RR{apexNSEC3, nsec3Sig}
+
+	keyResp := new(dns.Msg)
+	keyResp.SetQuestion(parent, dns.TypeDNSKEY)
+	keyResp.Response = true
+	keyResp.Answer = []dns.RR{key}
+
+	r := &Resolver{}
+	var store middleware.Store = &cannedDNSSECStore{byQtype: map[uint16]*dns.Msg{
+		dns.TypeDS:     dsResp,
+		dns.TypeDNSKEY: keyResp,
+	}}
+	r.store.Store(&store)
+
+	if !r.provenInsecureDelegation(context.Background(), parent, qname, parentDS) {
+		t.Fatalf("BUG REPRODUCED (issue #506 variant 1): the authenticated opt-out "+
+			"NSEC3 proof of the insecure delegation %s was rejected — every "+
+			"shared-authority answer under an opt-out parent zone becomes a false "+
+			"SERVFAIL", child)
+	}
+}
+
+// Test_provenInsecureDelegation_StrippedSignaturesStayBogus pins the
+// downgrade guard the opt-out fix must NOT relax: for a name that
+// exists as ordinary signed data in the parent zone (an attacker
+// stripping RRSIGs off it), the DS NODATA proof carries an
+// exact-match NSEC3 WITHOUT the NS bit — that is not a delegation,
+// and provenInsecureDelegation must keep failing closed.
+func Test_provenInsecureDelegation_StrippedSignaturesStayBogus(t *testing.T) {
+	parent := "parent-optout.test."
+	key, priv := makeZoneKeyRes(t, parent)
+	parentDS := []dns.RR{key.ToDS(dns.SHA256)}
+
+	child := "edge." + parent
+	childHash := dns.HashName(child, dns.SHA1, 0, "")
+
+	// Exact-match NSEC3 for the child: in-zone data (A/AAAA), no NS bit.
+	exactNSEC3 := &dns.NSEC3{
+		Hdr:        dns.RR_Header{Name: childHash + "." + parent, Rrtype: dns.TypeNSEC3, Class: dns.ClassINET, Ttl: 3600},
+		Hash:       dns.SHA1,
+		Flags:      1,
+		Iterations: 0,
+		SaltLength: 0,
+		Salt:       "",
+		HashLength: 20,
+		NextDomain: strings.Repeat("V", 32),
+		TypeBitMap: []uint16{dns.TypeA, dns.TypeAAAA, dns.TypeRRSIG},
+	}
+	nsec3Sig := signRRSetRes(t, key, priv, []dns.RR{exactNSEC3})
+
+	dsResp := new(dns.Msg)
+	dsResp.SetQuestion(child, dns.TypeDS)
+	dsResp.Response = true
+	dsResp.Ns = []dns.RR{exactNSEC3, nsec3Sig}
+
+	keyResp := new(dns.Msg)
+	keyResp.SetQuestion(parent, dns.TypeDNSKEY)
+	keyResp.Response = true
+	keyResp.Answer = []dns.RR{key}
+
+	r := &Resolver{}
+	var store middleware.Store = &cannedDNSSECStore{byQtype: map[uint16]*dns.Msg{
+		dns.TypeDS:     dsResp,
+		dns.TypeDNSKEY: keyResp,
+	}}
+	r.store.Store(&store)
+
+	if r.provenInsecureDelegation(context.Background(), parent, "tether."+child, parentDS) {
+		t.Fatal("a non-delegation name with stripped signatures must stay bogus")
+	}
+}

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -799,6 +799,16 @@ func (r *Resolver) answer(ctx context.Context, req, resp *dns.Msg, parentDS []dn
 					lastErr = verr
 					continue
 				}
+				if ok {
+					// VerifyRRSIG tolerates out-of-zone authority
+					// records (referral remnants for a CNAME target)
+					// by excluding them from validation. Drop them
+					// here so the AD bit never covers unvalidated
+					// data (RFC 4035 §3.2.3); the CNAME chase
+					// re-resolves the target through its own
+					// validated recursion anyway.
+					resp.Ns = dnsutil.FilterRRsToZone(resp.Ns, signer)
+				}
 				resp.AuthenticatedData = ok
 				settled = true
 				break
@@ -1726,7 +1736,7 @@ func (r *Resolver) provenInsecureDelegation(ctx context.Context, zone, qname str
 	for n := zoneCount + 1; n <= len(labels); n++ {
 		candidate := dns.Fqdn(strings.Join(labels[len(labels)-n:], "."))
 
-		dsset, insecure, err := r.authenticatedDelegationDS(ctx, curSigner, candidate, curDS, false)
+		dsset, insecure, err := r.authenticatedDelegationDS(ctx, curSigner, candidate, curDS)
 		if err != nil {
 			return false
 		}
@@ -1750,11 +1760,17 @@ func (r *Resolver) provenInsecureDelegation(ctx context.Context, zone, qname str
 // the validation explicitly; using the normal CD=0 path here can re-enter the
 // same missing-signature fallback and loop on the very proof being requested.
 //
-// allowOptOut is only safe for real referral handling where the response
-// already carried an NS RRset for child. No-referral checks must reject NSEC3
-// opt-out because opt-out proves a delegation may exist, not that this exact
-// owner is one.
-func (r *Resolver) authenticatedDelegationDS(ctx context.Context, signer, child string, parentDS []dns.RR, allowOptOut bool) (dsset []dns.RR, insecure bool, err error) {
+// NSEC3 opt-out coverage is accepted as the DS-denial proof, matching the
+// referral path and other validators (RFC 5155 §6): in an opt-out zone an
+// unsigned delegation has no exact-match NSEC3 by definition, so demanding
+// one turns every legitimate name under the span into a false SERVFAIL
+// (issue #506). This cannot be abused to downgrade signed data: a name that
+// exists in the parent has an exact-match NSEC3 even in opt-out zones, and
+// dnssec.VerifyDelegation tries the exact match first — signature stripping
+// then fails on the missing NS bit. Forged names inside an opt-out span are
+// accepted as insecure, which is the documented opt-out tradeoff every
+// validator shares (RFC 5155 §12.2).
+func (r *Resolver) authenticatedDelegationDS(ctx context.Context, signer, child string, parentDS []dns.RR) (dsset []dns.RR, insecure bool, err error) {
 	dsResp, err := r.lookupDS(ctx, child, true)
 	if err != nil {
 		return nil, false, err
@@ -1777,12 +1793,7 @@ func (r *Resolver) authenticatedDelegationDS(ctx context.Context, signer, child 
 	}
 
 	if nsec3Set := dnsutil.FilterRRsToZone(dnsutil.ExtractRRSet(dsResp.Ns, "", dns.TypeNSEC3), signer); len(nsec3Set) > 0 {
-		if allowOptOut {
-			err = dnssec.VerifyDelegation(child, nsec3Set)
-		} else {
-			err = dnssec.VerifyDelegationExact(child, nsec3Set)
-		}
-		if err != nil {
+		if err := dnssec.VerifyDelegation(child, nsec3Set); err != nil {
 			return nil, false, err
 		}
 		return nil, true, nil
@@ -2692,7 +2703,7 @@ func (r *Resolver) validateDelegation(ctx context.Context, req, resp *dns.Msg, q
 			// so no authenticated delegation proof is possible or needed.
 			return parentDS, nil
 		}
-		newDSRR, _, err := r.authenticatedDelegationDS(ctx, parentSigner, q.Name, effectiveParentDS, true)
+		newDSRR, _, err := r.authenticatedDelegationDS(ctx, parentSigner, q.Name, effectiveParentDS)
 		if err != nil {
 			zlog.Warn("DNSSEC verify failed (delegation)", "query", formatQuestion(q), "error", err.Error())
 			return nil, err


### PR DESCRIPTION
Closes #506.

## Root cause

Both reported variants come from the same situation: some of the affected domains' nameservers are authoritative for **several zones of the resolution chain at once**, and only those servers produce response shapes the validator rejected. Which server answers is nondeterministic, so the failures look like a cold-cache race; once one query fails, the SERVFAIL is held by the negative cache (`expire` TTL), matching the reported "latching".

**Variant 1 — `tether.edge.apple` (`Response is missing required RRSIG records`).** `.apple` and `edge.apple` share nameservers (`c/d.ns.apple.com`). When the delegation walk hits a shared server, it answers the full qname authoritatively — no referral is crossed — so `answer()` falls back to `provenInsecureDelegation`. That path demanded an **exact-match NSEC3** for `edge.apple`, but `.apple` is an NSEC3 **opt-out** zone (flags=1, verified on the wire): an unsigned delegation there has no exact-match NSEC3 by definition (RFC 5155 §6), so the proof could never succeed. When `apple-ns.pch.net` (TLD-only) answers instead, a real referral is crossed and the opt-out-tolerant referral path accepts it — hence the intermittency.

**Variant 2 — `www.edpb.europa.eu` (`RRsets covered by RRSIG are missing`).** `ans1/ans2.cw.net` host both `edpb.europa.eu` and `europa.eu`/`ec.europa.eu` ancestors, and append a referral for the CNAME target to the authority section of the positive answer (`dhs.tech.ec.europa.eu NS` + NSEC + RRSIG by `europa.eu`). `VerifyRRSIG`, validating under signer `edpb.europa.eu`, treated those out-of-zone owners as bogus and rejected the validly signed CNAME. The two `europarl` nameservers return the CNAME alone — hence the intermittency.

## Fix

- `provenInsecureDelegation` accepts opt-out NSEC3 coverage (`dnssec.VerifyDelegation`), matching the referral path, Unbound/BIND, and RFC 5155. Downgrade attacks stay blocked: names that exist in the parent always have an exact-match NSEC3 (tried first), and signature stripping fails on the missing NS bit. The now-constant `allowOptOut` parameter and orphaned `VerifyDelegationExact` are removed.
- `VerifyRRSIG` skips out-of-zone **authority** records instead of failing (advisory referral remnants, RFC 2181 §5.4.1; the target is re-resolved through its own validated recursion). Out-of-zone records in the **answer** section remain fatal.
- `answer()` strips the remnants after successful validation so the AD bit never covers unvalidated data (RFC 4035 §3.2.3).

## Tests

Deterministic regression tests built from captured wire shapes (no live network), written first and failing on the unfixed code with the issue's exact error strings:

- `Test_provenInsecureDelegation_OptOutSpan` — canned, cryptographically valid opt-out DS-denial proof mirroring `c.ns.apple.com`.
- `Test_VerifyRRSIG_ForeignReferralInAuthority` — signed CNAME + foreign referral remnant mirroring `ans1.cw.net`.

Each is paired with a guard test pinning the protections the fix must not relax:

- `Test_provenInsecureDelegation_StrippedSignaturesStayBogus` — exact-match NSEC3 without the NS bit stays bogus.
- `Test_VerifyRRSIG_ForeignRecordInAnswerStaysBogus` — unsigned foreign RRset in the ANSWER section stays bogus.

## Verification

Live cold-start reproduction (fresh cache per run, A/AAAA/TYPE65 fired concurrently at startup):

| build | tether.edge.apple | www.edpb.europa.eu |
|---|---|---|
| before | 5/6 runs SERVFAIL | 2/3 runs SERVFAIL |
| after | 9/9 runs clean (27/27 NOERROR) | 9/9 runs clean (27/27 NOERROR) |

Full `make test` passes; touched packages re-run with `-race`; `gofmt` and `golangci-lint` clean.