### PR TITLE
fix(dnssec): require wildcard-denial proof on positive answers (RFC 4035 §5.3.4)

### DIFF
--- a/middleware/resolver/dnssec/errors.go
+++ b/middleware/resolver/dnssec/errors.go
@@ -73,6 +73,10 @@ var (
 		Code:    dns.ExtendedErrorCodeDNSBogus,
 		Message: "NSEC3 opt-out validation failed",
 	}
+	ErrWildcardNoDenial = &dnsutil.EDEError{
+		Code:    dns.ExtendedErrorCodeDNSBogus,
+		Message: "Wildcard-expanded answer lacks NSEC/NSEC3 proof of no closer match",
+	}
 )
 
 // DNSKEYMissingForZone returns a DNSKEY-missing error tagged with zone.

--- a/middleware/resolver/dnssec/wildcard.go
+++ b/middleware/resolver/dnssec/wildcard.go
@@ -1,0 +1,89 @@
+package dnssec
+
+import (
+	"strings"
+
+	"github.com/miekg/dns"
+)
+
+// VerifyWildcardAnswer enforces the RFC 4035 §5.3.4 / RFC 5155 §8.8
+// requirement for positive answers synthesized from a wildcard.
+//
+// An RRSIG whose Labels field is smaller than the label count of the
+// RRset owner name signals that the RRset was expanded from a wildcard
+// (*.<closest-encloser>). miekg's RRSIG.Verify accepts such a signature
+// against any owner name deeper than the wildcard because it canonicalises
+// the owner back to "*.<closest-encloser>" before hashing. On its own that
+// lets an attacker replay a zone's legitimately-signed wildcard RRSIG over
+// a concrete name that actually exists and hand it back with AD=1 — a
+// forged-but-"authenticated" answer. RFC 4035 closes this by additionally
+// requiring proof that the owner name has no closer match than the
+// wildcard, i.e. that the "next closer" name does not exist.
+//
+// For every wildcard-expanded RRSIG in the Answer section this checks that
+// the Authority section carries an NSEC or NSEC3 covering the next closer
+// name. Those denial records live in the same response and have already
+// been cryptographically validated by VerifyRRSIG (they belong to the
+// signer zone and carry their own RRSIGs), so only their semantic coverage
+// is checked here. An attacker cannot satisfy the check by replaying a
+// genuine signed NSEC/NSEC3: no such record covers a name that exists.
+//
+// Callers must invoke this only after VerifyRRSIG has returned true for
+// resp; a false or error result means the answer must be treated as bogus.
+func VerifyWildcardAnswer(resp *dns.Msg) error {
+	var nsecSet, nsec3Set []dns.RR
+	for _, rr := range resp.Ns {
+		switch rr.(type) {
+		case *dns.NSEC:
+			nsecSet = append(nsecSet, rr)
+		case *dns.NSEC3:
+			nsec3Set = append(nsec3Set, rr)
+		}
+	}
+
+	for _, rr := range resp.Answer {
+		sig, ok := rr.(*dns.RRSIG)
+		if !ok {
+			continue
+		}
+
+		owner := strings.ToLower(dns.Fqdn(sig.Header().Name))
+		labels := dns.SplitDomainName(owner)
+		// Labels >= owner label count means an exact (non-wildcard) owner.
+		// A malformed over-count is rejected by RRSIG.Verify itself, so it
+		// never reaches here with ok=true; treat it as non-wildcard.
+		if int(sig.Labels) >= len(labels) {
+			continue
+		}
+
+		// Closest encloser is the last sig.Labels labels of the owner; the
+		// next closer name is one label longer, towards the owner name.
+		nextCloser := dns.Fqdn(strings.Join(labels[len(labels)-int(sig.Labels)-1:], "."))
+		if !nextCloserDenied(nextCloser, nsecSet, nsec3Set) {
+			return ErrWildcardNoDenial
+		}
+	}
+
+	return nil
+}
+
+// nextCloserDenied reports whether some NSEC or NSEC3 in the response
+// proves the next closer name does not exist.
+func nextCloserDenied(nextCloser string, nsecSet, nsec3Set []dns.RR) bool {
+	for _, rr := range nsecSet {
+		n := rr.(*dns.NSEC)
+		if nsecCovers(n.Header().Name, n.NextDomain, nextCloser) {
+			return true
+		}
+	}
+	for _, rr := range nsec3Set {
+		n := rr.(*dns.NSEC3)
+		if !nsec3Safe(n) {
+			continue
+		}
+		if n.Cover(nextCloser) {
+			return true
+		}
+	}
+	return false
+}

--- a/middleware/resolver/dnssec/wildcard_test.go
+++ b/middleware/resolver/dnssec/wildcard_test.go
@@ -1,0 +1,158 @@
+package dnssec
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// wildcardSig builds an RRSIG covering an RRset at owner whose Labels field
+// reflects a wildcard with the given label count (e.g. labels=2 for
+// *.example.com.).
+func wildcardSig(owner string, labels uint8) *dns.RRSIG {
+	sig := &dns.RRSIG{Labels: labels, TypeCovered: dns.TypeA}
+	sig.Hdr = dns.RR_Header{Name: dns.Fqdn(owner), Rrtype: dns.TypeRRSIG, Class: dns.ClassINET}
+	return sig
+}
+
+func nsec(owner, next string) *dns.NSEC {
+	n := &dns.NSEC{NextDomain: dns.Fqdn(next)}
+	n.Hdr = dns.RR_Header{Name: dns.Fqdn(owner), Rrtype: dns.TypeNSEC, Class: dns.ClassINET}
+	return n
+}
+
+func aRR(owner string) *dns.A {
+	a := &dns.A{}
+	a.Hdr = dns.RR_Header{Name: dns.Fqdn(owner), Rrtype: dns.TypeA, Class: dns.ClassINET}
+	return a
+}
+
+// TestVerifyWildcardAnswer_ReplayForged locks in the fix for the wildcard
+// positive-answer replay: a signed wildcard RRSIG (Labels=2, i.e.
+// *.example.com.) presented over the concrete name secure.example.com. with
+// NO NSEC proof of non-existence must be rejected as bogus.
+func TestVerifyWildcardAnswer_ReplayForged(t *testing.T) {
+	msg := new(dns.Msg)
+	msg.Answer = []dns.RR{
+		aRR("secure.example.com."),
+		wildcardSig("secure.example.com.", 2),
+	}
+	// No NSEC/NSEC3 in the authority section.
+	if err := VerifyWildcardAnswer(msg); err != ErrWildcardNoDenial {
+		t.Fatalf("expected ErrWildcardNoDenial for a wildcard answer with no denial proof, got %v", err)
+	}
+}
+
+// TestVerifyWildcardAnswer_ReplayWithNonCoveringNSEC ensures a replayed but
+// non-covering NSEC (as an attacker can only supply for a name that exists)
+// does not satisfy the proof.
+func TestVerifyWildcardAnswer_ReplayWithNonCoveringNSEC(t *testing.T) {
+	msg := new(dns.Msg)
+	msg.Answer = []dns.RR{
+		aRR("secure.example.com."),
+		wildcardSig("secure.example.com.", 2),
+	}
+	// An NSEC that exists in the zone but does not cover secure.example.com.
+	msg.Ns = []dns.RR{nsec("aaa.example.com.", "bbb.example.com.")}
+	if err := VerifyWildcardAnswer(msg); err != ErrWildcardNoDenial {
+		t.Fatalf("non-covering NSEC must not satisfy the wildcard denial, got %v", err)
+	}
+}
+
+// TestVerifyWildcardAnswer_LegitimateWithNSEC verifies a genuine wildcard
+// answer accompanied by an NSEC covering the next closer name is accepted.
+func TestVerifyWildcardAnswer_LegitimateWithNSEC(t *testing.T) {
+	msg := new(dns.Msg)
+	msg.Answer = []dns.RR{
+		aRR("secure.example.com."),
+		wildcardSig("secure.example.com.", 2),
+	}
+	// next closer for wildcard *.example.com. over secure.example.com. is
+	// secure.example.com. itself; an NSEC covering it proves non-existence.
+	msg.Ns = []dns.RR{nsec("labrador.example.com.", "terrier.example.com.")}
+	if err := VerifyWildcardAnswer(msg); err != nil {
+		t.Fatalf("legitimate wildcard answer with covering NSEC should verify, got %v", err)
+	}
+}
+
+// TestVerifyWildcardAnswer_DeepNextCloser verifies the next closer name is
+// computed one label below the closest encloser, not the full owner name.
+func TestVerifyWildcardAnswer_DeepNextCloser(t *testing.T) {
+	msg := new(dns.Msg)
+	// Owner a.b.example.com. expanded from *.example.com. (Labels=2).
+	// Closest encloser = example.com.; next closer = b.example.com.
+	msg.Answer = []dns.RR{
+		aRR("a.b.example.com."),
+		wildcardSig("a.b.example.com.", 2),
+	}
+	// NSEC covering b.example.com. proves nothing closer than the wildcard.
+	msg.Ns = []dns.RR{nsec("aa.example.com.", "c.example.com.")}
+	if err := VerifyWildcardAnswer(msg); err != nil {
+		t.Fatalf("deep next-closer proof should verify, got %v", err)
+	}
+
+	// Same answer but the NSEC covers the owner a.b.example.com. while
+	// leaving the next closer b.example.com. on the owner boundary
+	// (not covered), so the closest-encloser proof is incomplete and
+	// must be rejected.
+	msg.Ns = []dns.RR{nsec("b.example.com.", "c.example.com.")}
+	if err := VerifyWildcardAnswer(msg); err != ErrWildcardNoDenial {
+		t.Fatalf("owner-only coverage must not satisfy the next-closer proof, got %v", err)
+	}
+}
+
+// TestVerifyWildcardAnswer_NonWildcard confirms an exact-owner answer (no
+// wildcard expansion) needs no denial proof.
+func TestVerifyWildcardAnswer_NonWildcard(t *testing.T) {
+	msg := new(dns.Msg)
+	msg.Answer = []dns.RR{
+		aRR("secure.example.com."),
+		wildcardSig("secure.example.com.", 3), // Labels == owner label count
+	}
+	if err := VerifyWildcardAnswer(msg); err != nil {
+		t.Fatalf("non-wildcard answer should not require a denial proof, got %v", err)
+	}
+}
+
+// TestVerifyWildcardAnswer_NSEC3 verifies the NSEC3 next-closer proof path.
+func TestVerifyWildcardAnswer_NSEC3(t *testing.T) {
+	msg := new(dns.Msg)
+	msg.Answer = []dns.RR{
+		aRR("secure.example.com."),
+		wildcardSig("secure.example.com.", 2),
+	}
+	// Build an NSEC3 whose hashed-owner interval covers the next closer
+	// name (secure.example.com.). Compute the real hash so Cover matches.
+	const salt = "aabbccdd"
+	h := dns.HashName("secure.example.com.", dns.SHA1, 0, salt)
+	// Owner just below the target hash, next just above, so it covers it.
+	n3 := &dns.NSEC3{
+		Hash:       dns.SHA1,
+		Iterations: 0,
+		Salt:       salt,
+		NextDomain: bumpHash(h, +1),
+	}
+	n3.Hdr = dns.RR_Header{Name: bumpHash(h, -1) + ".example.com.", Rrtype: dns.TypeNSEC3, Class: dns.ClassINET}
+	msg.Ns = []dns.RR{n3}
+	if err := VerifyWildcardAnswer(msg); err != nil {
+		t.Fatalf("wildcard answer with covering NSEC3 should verify, got %v", err)
+	}
+}
+
+// bumpHash returns the base32hex-encoded label h shifted by delta in its
+// last character, producing a neighbour hash for building covering NSEC3
+// intervals in tests.
+func bumpHash(h string, delta int) string {
+	const alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUV"
+	b := []byte(h)
+	idx := len(alphabet) - 1
+	for i := range len(alphabet) {
+		if alphabet[i] == b[len(b)-1] {
+			idx = i
+			break
+		}
+	}
+	idx = (idx + delta + len(alphabet)) % len(alphabet)
+	b[len(b)-1] = alphabet[idx]
+	return string(b)
+}

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -808,6 +808,18 @@ func (r *Resolver) answer(ctx context.Context, req, resp *dns.Msg, parentDS []dn
 					// re-resolves the target through its own
 					// validated recursion anyway.
 					resp.Ns = dnsutil.FilterRRsToZone(resp.Ns, signer)
+
+					// RFC 4035 §5.3.4: a wildcard-expanded answer is only
+					// authentic if the response also proves the owner name
+					// has no closer match than the wildcard. Otherwise a
+					// zone's legitimately-signed wildcard RRSIG can be
+					// replayed over a concrete name that really exists and
+					// returned with AD=1. The NSEC/NSEC3 proof consulted
+					// here was validated by verifyDNSSEC above.
+					if werr := dnssec.VerifyWildcardAnswer(resp); werr != nil {
+						zlog.Warn("DNSSEC verify failed (wildcard answer)", "query", formatQuestion(q), "error", werr.Error())
+						return nil, werr
+					}
 				}
 				resp.AuthenticatedData = ok
 				settled = true


### PR DESCRIPTION
## Problem

A positive answer was marked `AuthenticatedData=true` on RRSIG verification alone. miekg's `RRSIG.Verify` accepts a wildcard RRSIG (`Labels` < owner label count) against **any** deeper owner, because it canonicalises the owner back to `*.<closest-encloser>` before hashing (`dnssec.go` L402/L624 in v1.1.72).

On its own that lets an attacker replay a zone's legitimately-signed wildcard RRSIG over a concrete name that really exists and return it with **AD=1** — a forged but "authenticated" answer. Example: a zone signs `*.example.com. A 1.2.3.4` and `secure.example.com. A 5.6.7.8`; an attacker returns `secure.example.com. A 1.2.3.4` carrying the wildcard RRSIG. `ValidateSigner`/`findDS`/RRSIG all pass, and SDNS returned it with AD=1. A compliant validator rejects it because the attacker cannot supply an NSEC proving `secure.example.com` is absent.

## Fix

RFC 4035 §5.3.4 requires a wildcard-expanded positive answer to also prove the owner name has no closer match than the wildcard, i.e. that the **next closer** name does not exist.

`VerifyWildcardAnswer` (new `middleware/resolver/dnssec/wildcard.go`) enforces this: for every wildcard-expanded RRSIG in the Answer section it requires an NSEC/NSEC3 in the Authority section covering the next closer name. Those denial records are already cryptographically validated by `VerifyRRSIG` (same signer zone, own RRSIGs) before this runs, so only their semantic coverage is checked here. A replayed *genuine* NSEC cannot satisfy the check — no NSEC covers a name that exists.

Wired into `answer()` right after the signer validates and before AD is set; fails closed (SERVFAIL, EDE DNSBogus) when the proof is absent.

The negative paths (`authority()`, NSEC/NSEC3 name-error and NODATA) already carried the wildcard proofs; only the positive answer path was missing it.

## Tests

New unit tests in `wildcard_test.go`:
- replay attack with no denial proof → rejected
- non-covering NSEC and owner-only (non-next-closer) coverage → rejected
- legitimate wildcard answer with covering NSEC → accepted
- deep next-closer (`a.b.example.com` from `*.example.com`) → accepted
- NSEC3 next-closer proof → accepted
- non-wildcard answer → no proof required

`gofmt`, `golangci-lint` (0 issues), and the full `middleware/resolver/...` suite pass (the end-to-end resolver DNSSEC tests exercise real validation — no false SERVFAILs introduced).