### PR TITLE
fix(resolver): honour parent-granted delegation lease (ghost domain, GHSA-mqfw-f48p-2vc8)

### DIFF
--- a/internal/authority/cache.go
+++ b/internal/authority/cache.go
@@ -44,7 +44,10 @@ func (n *Cache) Get(key uint64) (*Delegation, error) {
 
 	d := el.(*Delegation)
 
-	elapsed := n.now().UTC().Sub(d.ut)
+	// Monotonic elapsed: n.now() and d.ut both retain the monotonic clock
+	// reading (no .UTC()/.Round(), which would strip it), so a wall-clock
+	// step cannot extend or prematurely expire a delegation lease.
+	elapsed := n.now().Sub(d.ut)
 
 	if elapsed >= d.TTL {
 		return nil, cache.ErrCacheExpired
@@ -54,18 +57,27 @@ func (n *Cache) Get(key uint64) (*Delegation, error) {
 }
 
 // (*Cache).Set stores a delegation entry under the given key.
+//
+// The lease must honour the parent-granted TTL. The former one-hour lower
+// clamp inflated a short referral TTL (e.g. a 4s delegation) into a one-hour
+// lease, which let a withdrawn child zone be kept alive indefinitely from its
+// own authoritative NS answer — the ghost-domain vulnerability
+// (GHSA-mqfw-f48p-2vc8). Only the upper bound is clamped now; a non-positive
+// TTL is not cached at all (caching an already-expired entry is pointless and
+// a zero TTL means "do not cache").
 func (n *Cache) Set(key uint64, dsSet []dns.RR, servers *Servers, ttl time.Duration) {
+	if ttl <= 0 {
+		return
+	}
 	if ttl > maximumTTL {
 		ttl = maximumTTL
-	} else if ttl < minimumTTL {
-		ttl = minimumTTL
 	}
 
 	n.cache.Add(key, &Delegation{
 		Servers: servers,
 		DSSet:   dsSet,
 		TTL:     ttl,
-		ut:      n.now().UTC().Round(time.Second),
+		ut:      n.now(),
 	})
 }
 
@@ -76,6 +88,5 @@ func (n *Cache) Remove(key uint64) {
 
 const (
 	maximumTTL = 12 * time.Hour
-	minimumTTL = 1 * time.Hour
 	defaultCap = 1024 * 256
 )

--- a/internal/authority/cache_test.go
+++ b/internal/authority/cache_test.go
@@ -49,34 +49,57 @@ func Test_Cache(t *testing.T) {
 	nscache.Remove(key)
 }
 
-func Test_CacheSetTTLClamping(t *testing.T) {
+// Test_CacheSetTTL locks in the ghost-domain (GHSA-mqfw-f48p-2vc8) lease
+// semantics: the parent-granted TTL is honoured exactly (no lower floor),
+// only the 12h ceiling is applied, and non-positive TTLs are not cached. The
+// old code floored any sub-1h TTL to one hour, which is what let a withdrawn
+// child survive.
+func Test_CacheSetTTL(t *testing.T) {
 	nscache := NewCache()
-
-	key1 := uint64(1)
-	key2 := uint64(2)
-	key3 := uint64(3)
+	base := time.Now()
+	nscache.now = func() time.Time { return base }
 
 	servers := &Servers{List: []*Server{NewServer("1.2.3.4:53", IPv4)}}
 
-	// Test TTL above maximum (should be clamped to 12h)
-	nscache.Set(key1, nil, servers, 24*time.Hour)
+	const (
+		capped = uint64(1) // 24h -> clamped to 12h
+		short  = uint64(2) // 4s  -> honoured exactly (used to be floored to 1h)
+		zero   = uint64(3) // 0   -> not cached
+		neg    = uint64(4) // <0  -> not cached
+	)
 
-	// Test TTL below minimum (should be clamped to 1h)
-	nscache.Set(key2, nil, servers, 1*time.Minute)
+	nscache.Set(capped, nil, servers, 24*time.Hour)
+	nscache.Set(short, nil, servers, 4*time.Second)
+	nscache.Set(zero, nil, servers, 0)
+	nscache.Set(neg, nil, servers, -time.Second)
 
-	// Test TTL within range
-	nscache.Set(key3, nil, servers, 6*time.Hour)
+	// A 4s delegation is valid at 3s and expired by 5s — proving it was NOT
+	// inflated to the old one-hour floor.
+	nscache.now = func() time.Time { return base.Add(3 * time.Second) }
+	if _, err := nscache.Get(short); err != nil {
+		t.Fatalf("4s delegation should be valid at 3s: %v", err)
+	}
+	nscache.now = func() time.Time { return base.Add(5 * time.Second) }
+	if _, err := nscache.Get(short); err == nil {
+		t.Fatal("4s delegation must be expired by 5s (old code floored it to 1h)")
+	}
 
-	// All should be retrievable
-	ns1, err := nscache.Get(key1)
-	assert.NoError(t, err)
-	assert.NotNil(t, ns1)
+	// 24h TTL is capped to 12h: valid at 11h, expired by 13h.
+	nscache.now = func() time.Time { return base.Add(11 * time.Hour) }
+	if _, err := nscache.Get(capped); err != nil {
+		t.Fatalf("24h TTL should be capped to 12h and valid at 11h: %v", err)
+	}
+	nscache.now = func() time.Time { return base.Add(13 * time.Hour) }
+	if _, err := nscache.Get(capped); err == nil {
+		t.Fatal("24h TTL capped to 12h must be expired by 13h")
+	}
 
-	ns2, err := nscache.Get(key2)
-	assert.NoError(t, err)
-	assert.NotNil(t, ns2)
-
-	ns3, err := nscache.Get(key3)
-	assert.NoError(t, err)
-	assert.NotNil(t, ns3)
+	// Non-positive TTLs are never cached.
+	nscache.now = func() time.Time { return base }
+	if _, err := nscache.Get(zero); err == nil {
+		t.Fatal("zero-TTL delegation must not be cached")
+	}
+	if _, err := nscache.Get(neg); err == nil {
+		t.Fatal("negative-TTL delegation must not be cached")
+	}
 }

--- a/middleware/resolver/ghost_domain_test.go
+++ b/middleware/resolver/ghost_domain_test.go
@@ -1,0 +1,298 @@
+package resolver
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/authority"
+	"github.com/semihalev/sdns/internal/cache"
+)
+
+// startMockAuth starts a UDP authoritative server on a random loopback port
+// whose answers are produced by handle. It returns the ip:port and a cleanup
+// func, and increments counter for every request received.
+func startMockAuth(t *testing.T, counter *int64, handle func(q dns.Question) *dns.Msg) (string, func()) {
+	t.Helper()
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen udp: %v", err)
+	}
+	mux := dns.NewServeMux()
+	mux.HandleFunc(".", func(w dns.ResponseWriter, r *dns.Msg) {
+		atomic.AddInt64(counter, 1)
+		src := handle(r.Question[0])
+		reply := new(dns.Msg)
+		reply.SetReply(r)
+		reply.Authoritative = src.Authoritative
+		reply.Rcode = src.Rcode
+		reply.Answer = src.Answer
+		reply.Ns = src.Ns
+		reply.Extra = src.Extra
+		_ = w.WriteMsg(reply)
+	})
+	s := &dns.Server{Net: "udp", PacketConn: pc, Handler: mux}
+	go func() { _ = s.ActivateAndServe() }()
+	time.Sleep(10 * time.Millisecond)
+	return pc.LocalAddr().String(), func() { _ = s.Shutdown() }
+}
+
+func mustRR(t *testing.T, s string) dns.RR {
+	t.Helper()
+	rr, err := dns.NewRR(s)
+	if err != nil {
+		t.Fatalf("NewRR(%q): %v", s, err)
+	}
+	return rr
+}
+
+// TestGhostDomain_DelegationLeaseExpiry reproduces and guards against
+// GHSA-mqfw-f48p-2vc8 (ghost / phoenix domain) at the delegation-lease layer.
+// It seeds r.delegations with explicit ip:port servers and drives
+// Resolver.Resolve directly, so it exercises the delegation cache + walk-up.
+// It does NOT cover the answer-cache/prefetch pipeline: a full parent-referral
+// -> answer-cache -> prefetch -> withdrawal test is deferred to the
+// delegation-generation/CAS follow-up.
+//
+// Topology (random loopback ports):
+//   - parent: authoritative for ghostzone. The delegation for loop.ghostzone.
+//     has been withdrawn, so it returns NXDOMAIN for the child and below.
+//   - child : former authoritative for loop.ghostzone. It still answers
+//     loop.ghostzone. NS and www.loop.ghostzone. A.
+//
+// The resolver delegation cache is seeded with explicit ip:port servers,
+// which keeps this hermetic and portable: glue-derived upstreams are always
+// :53, which cannot be bound unprivileged in CI.
+//
+//   - control:  with NO cached child delegation, resolving www.loop.ghostzone.
+//     A walks up to the parent and returns NXDOMAIN.
+//   - expiry:   a cached child delegation is served only while its
+//     parent-granted lease is live; once the lease expires, re-resolution
+//     walks back to the parent and returns NXDOMAIN. The former one-hour
+//     lower clamp inflated the short lease into an hour and kept the withdrawn
+//     child alive — this sub-test fails on that pre-fix behaviour.
+func TestGhostDomain_DelegationLeaseExpiry(t *testing.T) {
+	var parentHits, childHits int64
+
+	parentSOA := "ghostzone. 30 IN SOA ns.ghostzone. hostmaster.ghostzone. 1 30 30 30 30"
+	parentAddr, stopParent := startMockAuth(t, &parentHits, func(q dns.Question) *dns.Msg {
+		m := &dns.Msg{}
+		m.Authoritative = true
+		name := dns.CanonicalName(q.Name)
+		if name == "ghostzone." && q.Qtype == dns.TypeNS {
+			m.Answer = []dns.RR{mustRR(t, "ghostzone. 300 IN NS ns.ghostzone.")}
+			return m
+		}
+		// Everything at/below the withdrawn child is NXDOMAIN now.
+		m.Rcode = dns.RcodeNameError
+		m.Ns = []dns.RR{mustRR(t, parentSOA)}
+		return m
+	})
+	defer stopParent()
+
+	childSOA := "loop.ghostzone. 30 IN SOA ns.loop.ghostzone. hostmaster.loop.ghostzone. 1 30 30 30 30"
+	childAddr, stopChild := startMockAuth(t, &childHits, func(q dns.Question) *dns.Msg {
+		m := &dns.Msg{}
+		m.Authoritative = true
+		name := dns.CanonicalName(q.Name)
+		switch {
+		case name == "loop.ghostzone." && q.Qtype == dns.TypeNS:
+			m.Answer = []dns.RR{mustRR(t, "loop.ghostzone. 30 IN NS ns.loop.ghostzone.")}
+		case name == "www.loop.ghostzone." && q.Qtype == dns.TypeA:
+			m.Answer = []dns.RR{mustRR(t, "www.loop.ghostzone. 30 IN A 192.0.2.55")}
+		default:
+			m.Rcode = dns.RcodeNameError
+			m.Ns = []dns.RR{mustRR(t, childSOA)}
+		}
+		return m
+	})
+	defer stopChild()
+
+	parentServers := func() *authority.Servers {
+		return &authority.Servers{
+			Zone:            "ghostzone.",
+			List:            []*authority.Server{authority.NewServer(parentAddr, authority.IPv4)},
+			CheckingDisable: true,
+		}
+	}
+	childServers := func() *authority.Servers {
+		return &authority.Servers{
+			Zone:            "loop.ghostzone.",
+			List:            []*authority.Server{authority.NewServer(childAddr, authority.IPv4)},
+			CheckingDisable: true,
+		}
+	}
+
+	parentQuestion := dns.Question{Name: "ghostzone.", Qtype: dns.TypeNS, Qclass: dns.ClassINET}
+	ghostQuestion := dns.Question{Name: "loop.ghostzone.", Qtype: dns.TypeNS, Qclass: dns.ClassINET}
+
+	newResolver := func() *Resolver {
+		return newWiredTestResolver(makeTestConfig())
+	}
+
+	// askA drives www.loop.ghostzone. A. The seeded ghostzone. delegation
+	// terminates searchCache's walk-up before it reaches the resolver's real
+	// root servers, so the start-servers argument is only a placeholder (it
+	// is immediately replaced by the searchCache result). Passing a local
+	// value avoids reading r.rootServers, which the resolver's background
+	// priming goroutine reads concurrently.
+	askA := func(r *Resolver) *dns.Msg {
+		req := new(dns.Msg)
+		req.SetQuestion("www.loop.ghostzone.", dns.TypeA)
+		req.CheckingDisabled = true
+		ctx := context.WithValue(context.Background(), contextKeyRequestID, req.Id)
+		resp, err := r.Resolve(ctx, req, parentServers(), true, 30, 0, true, nil)
+		if err != nil {
+			t.Logf("Resolve error: %v", err)
+			return nil
+		}
+		return resp
+	}
+
+	t.Run("control_parent_reresolution", func(t *testing.T) {
+		atomic.StoreInt64(&parentHits, 0)
+		atomic.StoreInt64(&childHits, 0)
+		r := newResolver()
+		r.delegations.Set(cache.Key(parentQuestion, true), nil, parentServers(), time.Hour)
+
+		resp := askA(r)
+		if resp == nil {
+			t.Fatal("control: expected a response, got resolve error")
+		}
+		if resp.Rcode != dns.RcodeNameError {
+			t.Fatalf("control: expected NXDOMAIN from parent, got %s (answers=%d parentHits=%d childHits=%d)",
+				dns.RcodeToString[resp.Rcode], len(resp.Answer),
+				atomic.LoadInt64(&parentHits), atomic.LoadInt64(&childHits))
+		}
+	})
+
+	// A cached child delegation is served while its parent-granted lease is
+	// live, then must expire on schedule so re-resolution walks back to the
+	// parent. Pre-fix the one-hour floor kept the 1s lease alive for an hour,
+	// so the second query still hit the child (the ghost). Post-fix the lease
+	// is honoured, expires, and the parent's NXDOMAIN wins.
+	t.Run("ghost_child_delegation_expires", func(t *testing.T) {
+		atomic.StoreInt64(&parentHits, 0)
+		atomic.StoreInt64(&childHits, 0)
+		r := newResolver()
+		r.delegations.Set(cache.Key(parentQuestion, true), nil, parentServers(), time.Hour)
+		// Parent granted a short referral TTL; the former child kept it warm.
+		r.delegations.Set(cache.Key(ghostQuestion, true), nil, childServers(), time.Second)
+
+		// While the lease is live, the cached child delegation answers.
+		if resp := askA(r); resp == nil || resp.Rcode != dns.RcodeSuccess || len(resp.Answer) == 0 {
+			var rc string
+			if resp != nil {
+				rc = dns.RcodeToString[resp.Rcode]
+			}
+			t.Fatalf("within lease: expected a positive answer from the cached child delegation, got rcode=%s", rc)
+		}
+
+		// Let the 1s delegation lease expire.
+		time.Sleep(1200 * time.Millisecond)
+
+		// Snapshot hit counters: after expiry the resolver must contact the
+		// parent and must NOT contact the former child.
+		childBefore := atomic.LoadInt64(&childHits)
+		parentBefore := atomic.LoadInt64(&parentHits)
+
+		resp := askA(r)
+		if resp == nil {
+			t.Fatal("after expiry: expected a response, got resolve error")
+		}
+		childAfter := atomic.LoadInt64(&childHits)
+		parentAfter := atomic.LoadInt64(&parentHits)
+		t.Logf("after expiry: rcode=%s answers=%d parentHits=%d->%d childHits=%d->%d",
+			dns.RcodeToString[resp.Rcode], len(resp.Answer),
+			parentBefore, parentAfter, childBefore, childAfter)
+
+		if resp.Rcode != dns.RcodeNameError {
+			t.Fatalf("ghost domain: after the parent-granted delegation lease expired the "+
+				"resolver must re-resolve via the parent and return NXDOMAIN, got rcode=%s "+
+				"answers=%d (the child delegation lease was not honoured)",
+				dns.RcodeToString[resp.Rcode], len(resp.Answer))
+		}
+		if childAfter != childBefore {
+			t.Fatalf("after expiry the former child must NOT be contacted, childHits %d -> %d", childBefore, childAfter)
+		}
+		if parentAfter == parentBefore {
+			t.Fatalf("after expiry the parent MUST be re-contacted, parentHits stayed at %d", parentBefore)
+		}
+	})
+}
+
+// TestProcessDelegation_RejectsNonProgressingReferral guards P1 of the
+// ghost-domain review: a referral whose NS owner is at the same depth as (or
+// shallower than) the zone we queried must never be turned into a cached
+// delegation. Otherwise a former child that answers a refresh with its own
+// same-zone referral could reinsert its delegation after the parent withdrew
+// it (reachable in production via pickFallbackResponse surfacing a
+// non-progressing referral). The guard runs before any DNSSEC/glue work, so
+// this needs no network.
+func TestProcessDelegation_RejectsNonProgressingReferral(t *testing.T) {
+	r := newWiredTestResolver(makeTestConfig())
+
+	req := new(dns.Msg)
+	req.SetQuestion("loop.ghostzone.", dns.TypeNS)
+	req.CheckingDisabled = true
+
+	rs := &resolveState{
+		req:     req,
+		servers: &authority.Servers{Zone: "loop.ghostzone."},
+		level:   dns.CountLabel("loop.ghostzone."),
+	}
+
+	// A self-referral: NS owner == the zone we queried (same depth).
+	ns := &dns.NS{Ns: "ns.loop.ghostzone."}
+	ns.Hdr = dns.RR_Header{Name: "loop.ghostzone.", Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: 30}
+	resp := new(dns.Msg)
+	resp.Ns = []dns.RR{ns}
+	nsInfo := delegationInfo{
+		hosts:    hostSet{"ns.loop.ghostzone.": struct{}{}},
+		nsRecord: ns,
+		nsTTL:    30,
+	}
+
+	_, err := r.processDelegation(context.Background(), rs, resp, nsInfo, false)
+	if !errors.Is(err, errParentDetection) {
+		t.Fatalf("non-progressing self-referral must be rejected with errParentDetection, got %v", err)
+	}
+
+	// And nothing may have been written to the delegation cache.
+	if _, gerr := r.delegations.Get(cache.Key(dns.Question{Name: "loop.ghostzone.", Qtype: dns.TypeNS, Qclass: dns.ClassINET}, true)); gerr == nil {
+		t.Fatal("a non-progressing referral must not populate the delegation cache")
+	}
+}
+
+// TestProgressingReferral tables the referral-progression guard: a referral
+// must be a strict descendant of the queried zone AND an ancestor of the name
+// being resolved.
+func TestProgressingReferral(t *testing.T) {
+	const qname = "www.loop.ghostzone."
+	cases := []struct {
+		name     string
+		referral string
+		authZone string
+		want     bool
+	}{
+		{"legit child delegation", "loop.ghostzone.", "ghostzone.", true},
+		{"legit tld from root", "ghostzone.", ".", true},
+		{"self referral (equal)", "loop.ghostzone.", "loop.ghostzone.", false},
+		{"shallower referral", "ghostzone.", "loop.ghostzone.", false},
+		{"unrelated but deeper", "evil.attacker.com.", "ghostzone.", false},
+		{"in bailiwick but off path to qname", "sub.ghostzone.", "ghostzone.", false},
+		{"out of bailiwick", "loop.ghostzone.", "other.tld.", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := progressingReferral(tc.referral, tc.authZone, qname); got != tc.want {
+				t.Fatalf("progressingReferral(%q, %q, %q) = %v, want %v",
+					tc.referral, tc.authZone, qname, got, tc.want)
+			}
+		})
+	}
+}

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -2029,7 +2029,7 @@ func (r *Resolver) lookupNSAddrV6(ctx context.Context, qname string, cd bool) (a
 	return addrs, fmt.Errorf("nameserver ipv6 address lookup failed for %s", qname)
 }
 
-func (r *Resolver) lookupV4Nss(ctx context.Context, q dns.Question, authservers *authority.Servers, key uint64, parentDS []dns.RR, foundv4, hosts hostSet, cd bool) {
+func (r *Resolver) lookupV4Nss(ctx context.Context, q dns.Question, authservers *authority.Servers, key uint64, parentDS []dns.RR, foundv4, hosts hostSet, cd bool, leaseDeadline time.Time) {
 	list := sortHosts(hosts, q.Name)
 
 	for _, name := range list {
@@ -2062,7 +2062,14 @@ func (r *Resolver) lookupV4Nss(ctx context.Context, q dns.Question, authservers 
 			// are unavailable: the DS set could be empty because the
 			// DNSSEC chain was short-circuited, and caching that empty-DS
 			// entry would make a signed zone look insecure after recovery.
-			r.delegations.Set(key, parentDS, authservers, time.Minute)
+			//
+			// Bound this provisional entry by the parent's remaining lease
+			// (absolute deadline), not a fresh duration: a flat one-minute
+			// route — or a restarted lease across several NS lookups — would
+			// outlive a 1-4s parent referral and keep a withdrawn child
+			// reachable (GHSA-mqfw-f48p-2vc8). A non-positive remainder is
+			// not cached (authority.Cache.Set skips it).
+			r.delegations.Set(key, parentDS, authservers, min(time.Until(leaseDeadline), time.Minute))
 		}
 
 		addrs, err := r.lookupNSAddrV4(ctx, name, cd)
@@ -2527,6 +2534,7 @@ func (r *Resolver) processAuthoritySection(ctx context.Context, rs *resolveState
 type delegationInfo struct {
 	hosts    hostSet
 	nsRecord *dns.NS
+	nsTTL    uint32
 	hasSOA   bool
 }
 
@@ -2541,12 +2549,60 @@ func (r *Resolver) extractDelegationInfo(resp *dns.Msg) delegationInfo {
 		case *dns.SOA:
 			info.hasSOA = true
 		case *dns.NS:
-			info.nsRecord = v
+			h := v.Header()
+			if info.nsRecord == nil {
+				// First NS anchors the referral RRset (owner + class).
+				info.nsRecord = v
+				info.nsTTL = h.Ttl
+				info.hosts[strings.ToLower(v.Ns)] = struct{}{}
+				continue
+			}
+			// A single delegation is one coherent NS RRset: same owner,
+			// same class. Ignore records from a different owner/class
+			// rather than blending their targets and TTLs into one
+			// delegation — a mixed-owner Authority section is not a valid
+			// referral and must not widen the cached nameserver set.
+			if !strings.EqualFold(h.Name, info.nsRecord.Header().Name) || h.Class != info.nsRecord.Header().Class {
+				continue
+			}
+			// Lease for the MINIMUM TTL across the RRset, not the last
+			// record's TTL.
+			if h.Ttl < info.nsTTL {
+				info.nsTTL = h.Ttl
+			}
 			info.hosts[strings.ToLower(v.Ns)] = struct{}{}
 		}
 	}
 
 	return info
+}
+
+// minRRSetTTL returns the smallest TTL among rrs, or 0 when rrs is empty.
+func minRRSetTTL(rrs []dns.RR) uint32 {
+	var m uint32
+	for i, rr := range rrs {
+		if t := rr.Header().Ttl; i == 0 || t < m {
+			m = t
+		}
+	}
+	return m
+}
+
+// progressingReferral reports whether a referral delegating `referral`,
+// received while querying the servers for `authZone` in service of `qname`,
+// legitimately moves resolution forward. It must be a STRICT descendant of
+// the zone we asked (in bailiwick) and an ancestor of the name we are
+// resolving. An equal/shallower self-referral or an unrelated deeper name is
+// rejected, so a former child cannot reinsert its own delegation and an
+// off-path server cannot inject one (GHSA-mqfw-f48p-2vc8).
+func progressingReferral(referral, authZone, qname string) bool {
+	if !dns.IsSubDomain(authZone, referral) {
+		return false // out of bailiwick
+	}
+	if strings.EqualFold(dns.CanonicalName(referral), dns.CanonicalName(authZone)) {
+		return false // same zone — not strictly below the authority
+	}
+	return dns.IsSubDomain(referral, qname) // must be on the path to qname
 }
 
 // filterAuthorityRecords filters authority records for SOA responses.
@@ -2566,12 +2622,42 @@ func (r *Resolver) processDelegation(ctx context.Context, rs *resolveState, resp
 	nsrr := nsInfo.nsRecord
 	q := dns.Question{Name: nsrr.Header().Name, Qtype: nsrr.Header().Rrtype, Qclass: nsrr.Header().Class}
 
+	// Ghost-domain guard (GHSA-mqfw-f48p-2vc8): a referral MUST progress
+	// strictly below the zone we queried. A former child that returns its
+	// own same-depth (or shallower) delegation — e.g. after the parent has
+	// withdrawn it — would otherwise reinsert that delegation and resurrect
+	// the domain. The main lookup loop routes such non-progressing referrals
+	// to configErrors, but pickFallbackResponse can still surface one, so
+	// reject it here before it can reach the delegation cache. The referral
+	// must be a strict descendant of the queried zone AND an ancestor of the
+	// name we are resolving.
+	if !progressingReferral(q.Name, rs.servers.Zone, rs.req.Question[0].Name) {
+		zlog.Debug("Rejecting non-progressing delegation", "zone", rs.servers.Zone, "referral", q.Name, "qname", rs.req.Question[0].Name)
+		return nil, errParentDetection
+	}
+
+	// Capture the parent-granted NS lease as an ABSOLUTE deadline BEFORE
+	// validation. DNSSEC validation and the NS-address lookups below take
+	// time and each cache insertion must expire at this fixed point — using
+	// a fresh duration at every insertion would restart the lease and let a
+	// 4s referral live far longer than 4s (GHSA-mqfw-f48p-2vc8).
+	leaseDeadline := time.Now().Add(time.Duration(nsInfo.nsTTL) * time.Second)
+
 	// DNSSEC validation for delegation
 	newParentDS, err := r.validateDelegation(ctx, rs.req, resp, q, rs.parentDS, rs.servers.Zone)
 	if err != nil {
 		return nil, err
 	}
 	rs.parentDS = newParentDS
+
+	// Bound the lease by the retained DS lifetime. "Has a DS" is separate
+	// from "its TTL": a retained DS with TTL 0 legitimately drives the lease
+	// to zero, so check the length, not whether minRRSetTTL is positive.
+	if len(rs.parentDS) > 0 {
+		if dsDeadline := time.Now().Add(time.Duration(minRRSetTTL(rs.parentDS)) * time.Second); dsDeadline.Before(leaseDeadline) {
+			leaseDeadline = dsDeadline
+		}
+	}
 
 	// Check for parent detection
 	nlevel := dns.CountLabel(q.Name)
@@ -2619,7 +2705,7 @@ func (r *Resolver) processDelegation(ctx context.Context, rs *resolveState, resp
 	authservers.CheckingDisable = cd
 	authservers.Zone = q.Name
 
-	r.lookupV4Nss(ctx, q, authservers, key, rs.parentDS, foundv4, nsInfo.hosts, cd)
+	r.lookupV4Nss(ctx, q, authservers, key, rs.parentDS, foundv4, nsInfo.hosts, cd, leaseDeadline)
 
 	if len(authservers.List) == 0 {
 		if minimized && rs.level < nlevel {
@@ -2634,7 +2720,10 @@ func (r *Resolver) processDelegation(ctx context.Context, rs *resolveState, resp
 	// lookup during the outage cannot land an empty-DS entry that later
 	// queries would treat as a proven-insecure delegation after recovery.
 	if !r.dnssec || r.hasTrustAnchors() {
-		r.delegations.Set(key, rs.parentDS, authservers, time.Duration(nsrr.Header().Ttl)*time.Second)
+		// time.Until(leaseDeadline): the REMAINING lease, so time spent in
+		// validation and NS-address lookups counts against it instead of
+		// restarting it. A non-positive remainder is not cached.
+		r.delegations.Set(key, rs.parentDS, authservers, time.Until(leaseDeadline))
 		zlog.Debug("Nameserver cache insert", "key", key, "query", formatQuestion(q), "cd", cd)
 	}
 


### PR DESCRIPTION
## Problem

A withdrawn child zone could be kept alive indefinitely — the **ghost / phoenix domain** attack (GHSA-mqfw-f48p-2vc8). Once a delegation was cached, its nameservers were re-queried directly at the former child and the parent was never re-consulted, so the parent's later `NXDOMAIN` was never observed and descendants kept resolving.

**Root cause:** `authority.Cache.Set` floored every sub-one-hour delegation TTL to **one hour**, inflating a 4-second parent referral into a one-hour lease. Prefetch then refreshed the answer on top of the inflated lease.

## Fixes

**`internal/authority/cache.go`**
- Remove the one-hour lower clamp — honour the parent-granted TTL. Keep the 12h ceiling.
- Never cache a non-positive TTL.
- Monotonic expiry (dropped `.UTC().Round`) so a wall-clock step can't extend or prematurely expire a lease.

**`middleware/resolver/resolver.go`**
- `processDelegation` captures the parent-granted lease as **one absolute deadline before DNSSEC validation** and threads it through the NS-address lookups, so validation/lookup time counts *against* the lease instead of restarting it. Both the provisional and final delegation writes expire at this fixed point (`time.Until(deadline)`).
- The deadline is bounded by the retained **DS lifetime**; `len(parentDS) > 0` is checked separately from the TTL value, so a retained DS with TTL 0 drives the lease to zero.
- `extractDelegationInfo` selects **one coherent NS RRset** (same owner + class) and leases for the **minimum** TTL across it, instead of blending targets/TTLs from a mixed Authority section.
- Referrals must **progress**: accepted only when a strict descendant of the queried zone **and** an ancestor of the name being resolved (`progressingReferral`). Rejects a former child's same-zone self-referral (reachable via `pickFallbackResponse`) and off-path / out-of-bailiwick delegations.

## Tests

- `Test_CacheSetTTL` — TTL boundaries (0/negative not cached, short honored not floored, 24h→12h cap).
- `TestGhostDomain_DelegationLeaseExpiry` — hermetic mock parent/child; served within lease, then after expiry asserts **parent re-contacted and former child not contacted** → `NXDOMAIN`. Verified to fail on pre-fix code.
- `TestProgressingReferral` — self / shallower / unrelated-deeper / off-path / out-of-bailiwick rejected; legit child/TLD accepted.
- `TestProcessDelegation_RejectsNonProgressingReferral` — in-resolver rejection with no cache write.

gofmt clean, golangci-lint 0 issues; `authority`, `cache`, and the full real-recursion `resolver` suites pass; new tests pass under `-race`.

## Scope

This closes the **submitted GHSA PoC**. Complete Ghost/Phoenix-domain protection is a durable follow-up and needs all three:

- [ ] Delegation **generation/CAS** so a late prefetch refresh (started before withdrawal) can't overwrite newer parent state (`prefetch_queue.go`).
- [ ] Descendant delegations **inherit the ancestor deadline** (`childDeadline = min(referralDeadline, ancestorDeadline)`) — the Phoenix downward-delegation (T2) variant, where a former child issues a deeper on-path delegation with a long TTL that survives the ancestor cut.
- [ ] **Top-down invalidation/revalidation** when an ancestor changes or expires.
- [ ] Full parent-referral → answer-cache → prefetch → withdrawal integration test for the above.