### PR TITLE
fix(resolver): inherit ancestor delegation deadline across nested cuts (Phoenix T2, GHSA-mqfw-f48p-2vc8)

### DIFF
--- a/internal/authority/cache.go
+++ b/internal/authority/cache.go
@@ -9,12 +9,17 @@ import (
 
 // Delegation represents a cache entry holding the authoritative
 // servers for a zone plus the DS RRset that proves the delegation.
+//
+// ExpiresAt is a single immutable absolute expiry (monotonic clock
+// retained). Storing the absolute deadline — rather than a duration
+// re-anchored at insertion — is what lets a descendant delegation inherit
+// an ancestor's shorter lease without a scheduler pause between "compute
+// remaining" and "store" silently re-inflating it (GHSA-mqfw-f48p-2vc8,
+// Phoenix downward-delegation variant).
 type Delegation struct {
-	Servers *Servers
-	DSSet   []dns.RR
-	TTL     time.Duration
-
-	ut time.Time
+	Servers   *Servers
+	DSSet     []dns.RR
+	ExpiresAt time.Time
 }
 
 // Cache type.
@@ -44,19 +49,16 @@ func (n *Cache) Get(key uint64) (*Delegation, error) {
 
 	d := el.(*Delegation)
 
-	// Monotonic elapsed: n.now() and d.ut both retain the monotonic clock
-	// reading (no .UTC()/.Round(), which would strip it), so a wall-clock
-	// step cannot extend or prematurely expire a delegation lease.
-	elapsed := n.now().Sub(d.ut)
-
-	if elapsed >= d.TTL {
+	// now() and ExpiresAt both retain the monotonic clock reading, so a
+	// wall-clock step cannot extend or prematurely expire the lease.
+	if !n.now().Before(d.ExpiresAt) {
 		return nil, cache.ErrCacheExpired
 	}
 
 	return d, nil
 }
 
-// (*Cache).Set stores a delegation entry under the given key.
+// (*Cache).Set stores a delegation entry that expires ttl from now.
 //
 // The lease must honour the parent-granted TTL. The former one-hour lower
 // clamp inflated a short referral TTL (e.g. a 4s delegation) into a one-hour
@@ -73,11 +75,32 @@ func (n *Cache) Set(key uint64, dsSet []dns.RR, servers *Servers, ttl time.Durat
 		ttl = maximumTTL
 	}
 
+	n.store(key, dsSet, servers, n.now().Add(ttl))
+}
+
+// (*Cache).SetUntil stores a delegation with an ABSOLUTE expiry, capped at
+// the 12h ceiling. Resolver writes use this so a parent-granted deadline —
+// possibly inherited from a shorter-lived ancestor — is stored verbatim
+// rather than reconstructed from time.Until(deadline): any delay (including a
+// scheduler pause) between computing the remaining duration and Set's
+// now.Add(ttl) would otherwise restart the lease.
+func (n *Cache) SetUntil(key uint64, dsSet []dns.RR, servers *Servers, expiresAt time.Time) {
+	now := n.now()
+	if !expiresAt.After(now) {
+		return
+	}
+	if ceiling := now.Add(maximumTTL); expiresAt.After(ceiling) {
+		expiresAt = ceiling
+	}
+
+	n.store(key, dsSet, servers, expiresAt)
+}
+
+func (n *Cache) store(key uint64, dsSet []dns.RR, servers *Servers, expiresAt time.Time) {
 	n.cache.Add(key, &Delegation{
-		Servers: servers,
-		DSSet:   dsSet,
-		TTL:     ttl,
-		ut:      n.now(),
+		Servers:   servers,
+		DSSet:     dsSet,
+		ExpiresAt: expiresAt,
 	})
 }
 

--- a/internal/authority/cache_test.go
+++ b/internal/authority/cache_test.go
@@ -103,3 +103,65 @@ func Test_CacheSetTTL(t *testing.T) {
 		t.Fatal("negative-TTL delegation must not be cached")
 	}
 }
+
+// Test_CacheSetUntil locks in the absolute-deadline semantics that the
+// Phoenix T2 inheritance fix depends on: the supplied deadline is stored
+// verbatim (never re-anchored), past/equal deadlines are not cached, and the
+// 12h ceiling still applies.
+func Test_CacheSetUntil(t *testing.T) {
+	nscache := NewCache()
+	base := time.Now()
+	nscache.now = func() time.Time { return base }
+
+	servers := &Servers{List: []*Server{NewServer("1.2.3.4:53", IPv4)}}
+
+	const (
+		exact  = uint64(1) // stored verbatim
+		past   = uint64(2) // before now -> not cached
+		atNow  = uint64(3) // equal to now -> not cached
+		capped = uint64(4) // beyond 12h -> capped
+	)
+
+	deadline := base.Add(10 * time.Second)
+	nscache.SetUntil(exact, nil, servers, deadline)
+	nscache.SetUntil(past, nil, servers, base.Add(-time.Second))
+	nscache.SetUntil(atNow, nil, servers, base)
+	nscache.SetUntil(capped, nil, servers, base.Add(24*time.Hour))
+
+	// The absolute deadline is stored exactly as supplied.
+	d, err := nscache.Get(exact)
+	if err != nil {
+		t.Fatalf("SetUntil entry should be cached: %v", err)
+	}
+	if !d.ExpiresAt.Equal(deadline) {
+		t.Fatalf("ExpiresAt = %v, want the supplied deadline %v (re-anchored?)", d.ExpiresAt, deadline)
+	}
+
+	// Valid strictly before the deadline, expired exactly at it.
+	nscache.now = func() time.Time { return deadline.Add(-time.Nanosecond) }
+	if _, err := nscache.Get(exact); err != nil {
+		t.Fatalf("entry should be valid just before its deadline: %v", err)
+	}
+	nscache.now = func() time.Time { return deadline }
+	if _, err := nscache.Get(exact); err == nil {
+		t.Fatal("entry must be expired exactly at its deadline")
+	}
+
+	// Past and now-equal deadlines are never cached.
+	nscache.now = func() time.Time { return base }
+	if _, err := nscache.Get(past); err == nil {
+		t.Fatal("past deadline must not be cached")
+	}
+	if _, err := nscache.Get(atNow); err == nil {
+		t.Fatal("deadline equal to now must not be cached")
+	}
+
+	// A deadline beyond the ceiling is capped to now+12h.
+	d, err = nscache.Get(capped)
+	if err != nil {
+		t.Fatalf("capped entry should be cached: %v", err)
+	}
+	if want := base.Add(12 * time.Hour); !d.ExpiresAt.Equal(want) {
+		t.Fatalf("ExpiresAt = %v, want ceiling %v", d.ExpiresAt, want)
+	}
+}

--- a/middleware/resolver/phoenix_t2_test.go
+++ b/middleware/resolver/phoenix_t2_test.go
@@ -1,0 +1,305 @@
+package resolver
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/authority"
+	"github.com/semihalev/sdns/internal/cache"
+)
+
+// TestPhoenixT2_NestedDelegationInheritsAncestorDeadline is the Phase-1a
+// regression for the Phoenix downward-delegation (T2) variant of
+// GHSA-mqfw-f48p-2vc8.
+//
+// Topology (one loopback listener per zone; TEST-NET-1 glue remapped to those
+// listeners via r.resolveTarget, since loopback glue is rejected and the UDP
+// fast path uses a pre-parsed address):
+//
+//	root         delegates ghostzone.        NS TTL 3s   (the SHORT ancestor cut)
+//	ghostzone.   delegates sub.ghostzone.    NS TTL 12h  (a LONG nested referral)
+//	sub.ghostzone. answers www.sub.ghostzone. A
+//
+// The nested sub.ghostzone. delegation must NOT be cached for 12h: it inherits
+// the 3s ghostzone cut. We assert the nested ExpiresAt is never after the
+// ancestor's — the strong, deterministic form of the invariant.
+func TestPhoenixT2_NestedDelegationInheritsAncestorDeadline(t *testing.T) {
+	var ignore int64
+
+	// Generic authoritative behaviour for DS/AAAA so DNSSEC-off (CD=1) chain
+	// walks and background v6 lookups don't error the resolution.
+	softNeg := func(zone string) *dns.Msg {
+		m := &dns.Msg{}
+		m.Authoritative = true
+		m.Ns = []dns.RR{mustRR(t, zone+" 30 IN SOA ns."+zone+" hostmaster."+zone+" 1 30 30 30 30")}
+		return m
+	}
+
+	// sub.ghostzone. — authoritative leaf.
+	subAddr, stopSub := startMockAuth(t, &ignore, func(q dns.Question) *dns.Msg {
+		if q.Qtype == dns.TypeA && dns.CanonicalName(q.Name) == "www.sub.ghostzone." {
+			m := &dns.Msg{}
+			m.Authoritative = true
+			m.Answer = []dns.RR{mustRR(t, "www.sub.ghostzone. 300 IN A 192.0.2.55")}
+			return m
+		}
+		return softNeg("sub.ghostzone.")
+	})
+	defer stopSub()
+
+	// ghostzone. — delegates sub.ghostzone. with a LONG (12h) NS TTL.
+	ghostAddr, stopGhost := startMockAuth(t, &ignore, func(q dns.Question) *dns.Msg {
+		if q.Qtype == dns.TypeDS {
+			return softNeg("ghostzone.")
+		}
+		if dns.IsSubDomain("sub.ghostzone.", dns.CanonicalName(q.Name)) || dns.CanonicalName(q.Name) == "sub.ghostzone." {
+			m := &dns.Msg{} // referral (AA=false)
+			m.Ns = []dns.RR{mustRR(t, "sub.ghostzone. 43200 IN NS ns.sub.ghostzone.")}
+			m.Extra = []dns.RR{mustRR(t, "ns.sub.ghostzone. 43200 IN A 192.0.2.13")}
+			return m
+		}
+		return softNeg("ghostzone.")
+	})
+	defer stopGhost()
+
+	// root — delegates ghostzone. with a SHORT (3s) NS TTL.
+	rootAddr, stopRoot := startMockAuth(t, &ignore, func(q dns.Question) *dns.Msg {
+		if dns.CanonicalName(q.Name) == "." && q.Qtype == dns.TypeNS {
+			m := &dns.Msg{}
+			m.Authoritative = true
+			m.Answer = []dns.RR{mustRR(t, ". 3600 IN NS a.root.")}
+			return m
+		}
+		if q.Qtype == dns.TypeDS {
+			return softNeg(".")
+		}
+		if dns.IsSubDomain("ghostzone.", dns.CanonicalName(q.Name)) || dns.CanonicalName(q.Name) == "ghostzone." {
+			m := &dns.Msg{} // referral
+			m.Ns = []dns.RR{mustRR(t, "ghostzone. 3 IN NS ns.ghostzone.")}
+			m.Extra = []dns.RR{mustRR(t, "ns.ghostzone. 3 IN A 192.0.2.11")}
+			return m
+		}
+		return softNeg(".")
+	})
+	defer stopRoot()
+
+	// Remap TEST-NET-1 glue to the loopback listeners.
+	remap := map[string]string{
+		"192.0.2.11:53": ghostAddr,
+		"192.0.2.13:53": subAddr,
+	}
+	mapper := func(addr string) string {
+		if to, ok := remap[addr]; ok {
+			return to
+		}
+		return addr
+	}
+
+	// Build the resolver with the root pointed at the mock via config (no
+	// post-construction write to r.rootServers → no priming race), then
+	// install the mapper atomically.
+	base := makeTestConfig()
+	cfg := *base
+	cfg.RootServers = []string{rootAddr}
+	cfg.Root6Servers = nil
+	// DNSSEC off keeps this hermetic: with glue provided there are then no
+	// DNSKEY/DS/NS-address sub-lookups that could escape resolveTarget and
+	// hit the real network. (The advisory PoC likewise runs dnssec=off; the
+	// inheritance under test is orthogonal to validation.)
+	cfg.DNSSEC = "off"
+	r := newWiredTestResolver(&cfg)
+	r.resolveTarget.Store(&mapper)
+
+	req := new(dns.Msg)
+	req.SetQuestion("www.sub.ghostzone.", dns.TypeA)
+	req.CheckingDisabled = true
+	ctx := context.WithValue(context.Background(), contextKeyRequestID, req.Id)
+
+	resp, err := r.Resolve(ctx, req, r.rootServers, true, 30, 0, true, nil)
+	if err != nil {
+		t.Fatalf("resolve failed: %v", err)
+	}
+	if resp.Rcode != dns.RcodeSuccess || len(resp.Answer) == 0 {
+		t.Fatalf("expected a positive answer, got rcode=%s answers=%d", dns.RcodeToString[resp.Rcode], len(resp.Answer))
+	}
+
+	// Inspect the cached cuts (CD=1 bucket).
+	ghostDeleg, gerr := r.delegations.Get(cache.Key(dns.Question{Name: "ghostzone.", Qtype: dns.TypeNS, Qclass: dns.ClassINET}, true))
+	if gerr != nil {
+		t.Fatalf("ghostzone. delegation not cached: %v", gerr)
+	}
+	subDeleg, serr := r.delegations.Get(cache.Key(dns.Question{Name: "sub.ghostzone.", Qtype: dns.TypeNS, Qclass: dns.ClassINET}, true))
+	if serr != nil {
+		t.Fatalf("sub.ghostzone. delegation not cached: %v", serr)
+	}
+
+	t.Logf("ghostzone ExpiresAt=%s  sub ExpiresAt=%s  (Δ=%s)",
+		ghostDeleg.ExpiresAt, subDeleg.ExpiresAt, subDeleg.ExpiresAt.Sub(ghostDeleg.ExpiresAt))
+
+	// The nested cut must never outlive its ancestor, despite the 12h
+	// referral. In this topology the inherited deadline is stored verbatim
+	// (SetUntil, no re-anchoring), so the two must be EXACTLY equal — any
+	// drift means the deadline was recomputed or the wrong minimum won.
+	if !subDeleg.ExpiresAt.Equal(ghostDeleg.ExpiresAt) {
+		t.Fatalf("Phoenix T2: nested sub.ghostzone. cut (ExpiresAt=%s) != ancestor ghostzone. "+
+			"(ExpiresAt=%s) — the inherited deadline was re-anchored or the 12h child referral won",
+			subDeleg.ExpiresAt, ghostDeleg.ExpiresAt)
+	}
+	// And it must be far below the 12h it advertised.
+	if subDeleg.ExpiresAt.After(time.Now().Add(time.Hour)) {
+		t.Fatalf("Phoenix T2: nested cut cached for far longer than the ancestor lease: ExpiresAt=%s", subDeleg.ExpiresAt)
+	}
+}
+
+// TestPhoenixT2_CachedHitCarriesCurrentReferralDeadline covers the cached-hit
+// branch of processDelegation: a referral is received but the delegation is
+// ALREADY in the cache (a concurrent resolution inserted it while this one was
+// in flight). The freshly observed referral deadline must still bound the
+// descent — "the shortest applicable cut always wins" — rather than being
+// discarded in favour of the (longer) cached lease.
+//
+// The race is made deterministic by seeding a 2h ghostzone. entry from inside
+// the root mock handler: searchCache has already run (cache was empty), so the
+// insert lands exactly between the root query and processDelegation's cache
+// check. The root referral carries a 3s NS TTL, so:
+//
+//	effective deadline = min(2h cached, 3s current referral) = 3s
+//
+// and the nested sub.ghostzone. delegation inserted during the descent must
+// expire within seconds, not hours.
+func TestPhoenixT2_CachedHitCarriesCurrentReferralDeadline(t *testing.T) {
+	var ignore int64
+	var rPtr atomic.Pointer[Resolver]
+
+	softNeg := func(zone string) *dns.Msg {
+		m := &dns.Msg{}
+		m.Authoritative = true
+		m.Ns = []dns.RR{mustRR(t, zone+" 30 IN SOA ns."+zone+" hostmaster."+zone+" 1 30 30 30 30")}
+		return m
+	}
+
+	// sub.ghostzone. — authoritative leaf.
+	subAddr, stopSub := startMockAuth(t, &ignore, func(q dns.Question) *dns.Msg {
+		if q.Qtype == dns.TypeA && dns.CanonicalName(q.Name) == "www.sub.ghostzone." {
+			m := &dns.Msg{}
+			m.Authoritative = true
+			m.Answer = []dns.RR{mustRR(t, "www.sub.ghostzone. 300 IN A 192.0.2.55")}
+			return m
+		}
+		return softNeg("sub.ghostzone.")
+	})
+	defer stopSub()
+
+	// ghostzone. — delegates sub.ghostzone. with a LONG (12h) NS TTL.
+	ghostAddr, stopGhost := startMockAuth(t, &ignore, func(q dns.Question) *dns.Msg {
+		if q.Qtype == dns.TypeDS {
+			return softNeg("ghostzone.")
+		}
+		if dns.IsSubDomain("sub.ghostzone.", dns.CanonicalName(q.Name)) || dns.CanonicalName(q.Name) == "sub.ghostzone." {
+			m := &dns.Msg{}
+			m.Ns = []dns.RR{mustRR(t, "sub.ghostzone. 43200 IN NS ns.sub.ghostzone.")}
+			m.Extra = []dns.RR{mustRR(t, "ns.sub.ghostzone. 43200 IN A 192.0.2.13")}
+			return m
+		}
+		return softNeg("ghostzone.")
+	})
+	defer stopGhost()
+
+	ghostKey := cache.Key(dns.Question{Name: "ghostzone.", Qtype: dns.TypeNS, Qclass: dns.ClassINET}, true)
+
+	// root — delegates ghostzone. with a SHORT (3s) NS TTL, and seeds the
+	// delegation cache with a LONG (2h) ghostzone. entry while doing so.
+	rootAddr, stopRoot := startMockAuth(t, &ignore, func(q dns.Question) *dns.Msg {
+		if dns.CanonicalName(q.Name) == "." && q.Qtype == dns.TypeNS {
+			m := &dns.Msg{}
+			m.Authoritative = true
+			m.Answer = []dns.RR{mustRR(t, ". 3600 IN NS a.root.")}
+			return m
+		}
+		if q.Qtype == dns.TypeDS {
+			return softNeg(".")
+		}
+		if dns.IsSubDomain("ghostzone.", dns.CanonicalName(q.Name)) || dns.CanonicalName(q.Name) == "ghostzone." {
+			// The concurrent insert: while our referral is on the wire, another
+			// resolution finishes and caches ghostzone. for 2h.
+			if r := rPtr.Load(); r != nil {
+				if _, err := r.delegations.Get(ghostKey); err != nil {
+					seeded := &authority.Servers{
+						Zone:            "ghostzone.",
+						CheckingDisable: true,
+						List:            []*authority.Server{authority.NewServer("192.0.2.11:53", authority.IPv4)},
+					}
+					r.delegations.Set(ghostKey, nil, seeded, 2*time.Hour)
+				}
+			}
+			m := &dns.Msg{}
+			m.Ns = []dns.RR{mustRR(t, "ghostzone. 3 IN NS ns.ghostzone.")}
+			m.Extra = []dns.RR{mustRR(t, "ns.ghostzone. 3 IN A 192.0.2.11")}
+			return m
+		}
+		return softNeg(".")
+	})
+	defer stopRoot()
+
+	remap := map[string]string{
+		"192.0.2.11:53": ghostAddr,
+		"192.0.2.13:53": subAddr,
+	}
+	mapper := func(addr string) string {
+		if to, ok := remap[addr]; ok {
+			return to
+		}
+		return addr
+	}
+
+	base := makeTestConfig()
+	cfg := *base
+	cfg.RootServers = []string{rootAddr}
+	cfg.Root6Servers = nil
+	cfg.DNSSEC = "off"
+	r := newWiredTestResolver(&cfg)
+	r.resolveTarget.Store(&mapper)
+	rPtr.Store(r)
+
+	req := new(dns.Msg)
+	req.SetQuestion("www.sub.ghostzone.", dns.TypeA)
+	req.CheckingDisabled = true
+	ctx := context.WithValue(context.Background(), contextKeyRequestID, req.Id)
+
+	resp, err := r.Resolve(ctx, req, r.rootServers, true, 30, 0, true, nil)
+	if err != nil {
+		t.Fatalf("resolve failed: %v", err)
+	}
+	if resp.Rcode != dns.RcodeSuccess || len(resp.Answer) == 0 {
+		t.Fatalf("expected a positive answer, got rcode=%s answers=%d", dns.RcodeToString[resp.Rcode], len(resp.Answer))
+	}
+
+	// The cached branch must actually have been taken: the seeded 2h entry
+	// survives untouched (a fresh insert would have replaced it with ~3s).
+	ghostDeleg, gerr := r.delegations.Get(ghostKey)
+	if gerr != nil {
+		t.Fatalf("ghostzone. delegation not cached: %v", gerr)
+	}
+	if ghostDeleg.ExpiresAt.Before(time.Now().Add(time.Hour)) {
+		t.Fatalf("test harness: seeded 2h ghostzone. entry was replaced (ExpiresAt=%s) — "+
+			"the cached-hit branch was not exercised", ghostDeleg.ExpiresAt)
+	}
+
+	// The descent below the cached hit must carry the CURRENT 3s referral
+	// deadline, not the 2h cached lease.
+	subDeleg, serr := r.delegations.Get(cache.Key(dns.Question{Name: "sub.ghostzone.", Qtype: dns.TypeNS, Qclass: dns.ClassINET}, true))
+	if serr != nil {
+		t.Fatalf("sub.ghostzone. delegation not cached: %v", serr)
+	}
+
+	t.Logf("seeded ghostzone ExpiresAt=%s  sub ExpiresAt=%s", ghostDeleg.ExpiresAt, subDeleg.ExpiresAt)
+
+	if subDeleg.ExpiresAt.After(time.Now().Add(time.Minute)) {
+		t.Fatalf("Phoenix T2 cached-hit: nested sub.ghostzone. cut cached until %s — the freshly "+
+			"observed 3s referral deadline was discarded in favour of the 2h cached lease",
+			subDeleg.ExpiresAt)
+	}
+}

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -43,6 +43,15 @@ type Resolver struct {
 	outboundUDPv4 []*net.UDPAddr
 	outboundUDPv6 []*net.UDPAddr
 
+	// resolveTarget, when set, remaps an upstream server address to a dial
+	// target just before exchange dials it. Production leaves it nil (the
+	// UDP fast path is untouched); hermetic tests Store a mapper to redirect
+	// TEST-NET-1 (192.0.2.0/24) glue to loopback listeners so a real
+	// root->parent->child->sub referral chain can be driven in-process. It
+	// is atomic because the background priming goroutine dials concurrently
+	// with a test setting the mapper — a plain field would race.
+	resolveTarget atomic.Pointer[func(addr string) string]
+
 	// glue addrs cache
 	glueV4 *cache.Cache
 	glueV6 *cache.Cache
@@ -108,6 +117,28 @@ type resolveState struct {
 	isRoot    bool
 	extra     []bool
 	requestID uint16
+
+	// cutDeadline is the absolute expiry of the shallowest delegation on
+	// the path descended so far (zero = unbounded, at/above root). A newly
+	// established delegation inherits it via min, so a deep sub-delegation
+	// can never outlive an ancestor cut — the Phoenix downward-delegation
+	// (T2) protection (GHSA-mqfw-f48p-2vc8).
+	cutDeadline time.Time
+}
+
+// minNonZero returns the earlier of two deadlines, treating a zero time as
+// "unbounded" (so it never wins). Zero for both returns zero.
+func minNonZero(a, b time.Time) time.Time {
+	switch {
+	case a.IsZero():
+		return b
+	case b.IsZero():
+		return a
+	case a.Before(b):
+		return a
+	default:
+		return b
+	}
 }
 
 type hostSet map[string]struct{}
@@ -270,7 +301,11 @@ func (r *Resolver) resolve(ctx context.Context, rs *resolveState) (*dns.Msg, err
 	q := rs.req.Question[0]
 
 	if rs.isRoot {
-		rs.servers, rs.parentDS, rs.level = r.searchCache(q, rs.req.CheckingDisabled, q.Name)
+		m := r.searchCache(q, rs.req.CheckingDisabled, q.Name)
+		rs.servers, rs.parentDS, rs.level = m.servers, m.parentDS, m.level
+		// Seed the cut deadline from the deepest cached delegation so any
+		// delegation established below it inherits this bound.
+		rs.cutDeadline = minNonZero(rs.cutDeadline, m.deadline)
 	}
 
 	// RFC 7816 query minimization. There are some concerns in RFC.
@@ -1290,11 +1325,21 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, proto string,
 
 	co := AcquireConn()
 
+	// Dial target. In production resolveTarget is nil, so dialAddr == the
+	// server's own address and the UDP fast path below is unchanged. A test
+	// mapper can redirect an advertised address (e.g. TEST-NET-1 glue) to a
+	// loopback listener; when it remaps, we take the string-dial path so the
+	// remapped address is honoured instead of the pre-parsed UDPAddr.
+	dialAddr := server.Addr
+	if m := r.resolveTarget.Load(); m != nil {
+		dialAddr = (*m)(server.Addr)
+	}
+
 	switch {
 	case pooledConn != nil:
 		// Use the pooled TCP connection.
 		co.Conn = pooledConn.Conn
-	case proto == "udp" && server.UDPAddr != nil:
+	case proto == "udp" && server.UDPAddr != nil && dialAddr == server.Addr:
 		// Fast UDP path: net.DialUDP with pre-parsed addresses skips
 		// DialContext's resolveAddrList + dialParallel + internal
 		// context.WithDeadline, which together account for most of
@@ -1309,7 +1354,7 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, proto string,
 	default:
 		// TCP / fallback path: use the full Dialer machinery.
 		d := r.newDialer(ctx, rs, proto, server.IPVersion)
-		co.Conn, err = d.DialContext(ctx, proto, server.Addr)
+		co.Conn, err = d.DialContext(ctx, proto, dialAddr)
 		releaseDialer(d)
 		if err != nil {
 			zlog.Debug("Dial failed to upstream server", "query", formatQuestion(q), "upstream", server.Addr,
@@ -1499,7 +1544,18 @@ func (r *Resolver) newDialer(ctx context.Context, rs *resolveState, proto string
 	return d
 }
 
-func (r *Resolver) searchCache(q dns.Question, cd bool, origin string) (servers *authority.Servers, parentDS []dns.RR, level int) {
+// delegationMatch is the result of a delegation-cache walk: the servers to
+// use, the DS set proving the delegation, the descent level, and the absolute
+// expiry of the matched cut (zero for the root, which is unbounded). The
+// deadline seeds resolveState.cutDeadline so descendants inherit it.
+type delegationMatch struct {
+	servers  *authority.Servers
+	parentDS []dns.RR
+	level    int
+	deadline time.Time
+}
+
+func (r *Resolver) searchCache(q dns.Question, cd bool, origin string) delegationMatch {
 	if q.Qtype == dns.TypeDS {
 		// DS queries are answered by parent zone, move up one label
 		next, end := dns.NextLabel(q.Name, 0)
@@ -1523,7 +1579,12 @@ func (r *Resolver) searchCache(q dns.Question, cd bool, origin string) (servers 
 			return r.searchCache(q, cd, origin)
 		}
 		zlog.Debug("Nameserver cache hit", "key", key, "query", formatQuestion(q), "cd", cd)
-		return ns.Servers, ns.DSSet, dns.CompareDomainName(origin, q.Name)
+		return delegationMatch{
+			servers:  ns.Servers,
+			parentDS: ns.DSSet,
+			level:    dns.CompareDomainName(origin, q.Name),
+			deadline: ns.ExpiresAt,
+		}
 	}
 
 	// A CD=0 query must NEVER borrow a CD=1 delegation. Delegations are
@@ -1537,7 +1598,8 @@ func (r *Resolver) searchCache(q dns.Question, cd bool, origin string) (servers 
 	next, end := dns.NextLabel(q.Name, 0)
 
 	if end {
-		return r.rootServers, nil, 0 // reached root zone, use root servers
+		// Reached root zone: use root servers (unbounded — zero deadline).
+		return delegationMatch{servers: r.rootServers, level: 0}
 	}
 
 	q.Name = q.Name[next:]
@@ -2029,7 +2091,7 @@ func (r *Resolver) lookupNSAddrV6(ctx context.Context, qname string, cd bool) (a
 	return addrs, fmt.Errorf("nameserver ipv6 address lookup failed for %s", qname)
 }
 
-func (r *Resolver) lookupV4Nss(ctx context.Context, q dns.Question, authservers *authority.Servers, key uint64, parentDS []dns.RR, foundv4, hosts hostSet, cd bool, leaseDeadline time.Time) {
+func (r *Resolver) lookupV4Nss(ctx context.Context, q dns.Question, authservers *authority.Servers, key uint64, parentDS []dns.RR, foundv4, hosts hostSet, cd bool, cutDeadline time.Time) {
 	list := sortHosts(hosts, q.Name)
 
 	for _, name := range list {
@@ -2063,13 +2125,14 @@ func (r *Resolver) lookupV4Nss(ctx context.Context, q dns.Question, authservers 
 			// DNSSEC chain was short-circuited, and caching that empty-DS
 			// entry would make a signed zone look insecure after recovery.
 			//
-			// Bound this provisional entry by the parent's remaining lease
-			// (absolute deadline), not a fresh duration: a flat one-minute
-			// route — or a restarted lease across several NS lookups — would
-			// outlive a 1-4s parent referral and keep a withdrawn child
-			// reachable (GHSA-mqfw-f48p-2vc8). A non-positive remainder is
-			// not cached (authority.Cache.Set skips it).
-			r.delegations.Set(key, parentDS, authservers, min(time.Until(leaseDeadline), time.Minute))
+			// Bound this provisional entry by the (inherited) cut deadline,
+			// stored as an absolute expiry — a flat one-minute route, or a
+			// lease restarted across several NS lookups, would outlive a
+			// 1-4s parent referral and keep a withdrawn child reachable
+			// (GHSA-mqfw-f48p-2vc8). Cap it at one minute so a long-lived cut
+			// still refreshes the provisional set promptly. A past deadline
+			// is not cached (SetUntil skips it).
+			r.delegations.SetUntil(key, parentDS, authservers, minNonZero(cutDeadline, time.Now().Add(time.Minute)))
 		}
 
 		addrs, err := r.lookupNSAddrV4(ctx, name, cd)
@@ -2636,12 +2699,13 @@ func (r *Resolver) processDelegation(ctx context.Context, rs *resolveState, resp
 		return nil, errParentDetection
 	}
 
-	// Capture the parent-granted NS lease as an ABSOLUTE deadline BEFORE
-	// validation. DNSSEC validation and the NS-address lookups below take
-	// time and each cache insertion must expire at this fixed point — using
-	// a fresh duration at every insertion would restart the lease and let a
-	// 4s referral live far longer than 4s (GHSA-mqfw-f48p-2vc8).
-	leaseDeadline := time.Now().Add(time.Duration(nsInfo.nsTTL) * time.Second)
+	// Capture ONE observation instant BEFORE validation and derive both the
+	// NS and DS deadlines from it. Using a fresh time.Now() after validation
+	// would add the validation latency back onto a short DS lease; anchoring
+	// both to observedAt makes each insertion expire at a fixed point rather
+	// than restarting the lease (GHSA-mqfw-f48p-2vc8).
+	observedAt := time.Now()
+	leaseDeadline := observedAt.Add(time.Duration(nsInfo.nsTTL) * time.Second)
 
 	// DNSSEC validation for delegation
 	newParentDS, err := r.validateDelegation(ctx, rs.req, resp, q, rs.parentDS, rs.servers.Zone)
@@ -2654,10 +2718,16 @@ func (r *Resolver) processDelegation(ctx context.Context, rs *resolveState, resp
 	// from "its TTL": a retained DS with TTL 0 legitimately drives the lease
 	// to zero, so check the length, not whether minRRSetTTL is positive.
 	if len(rs.parentDS) > 0 {
-		if dsDeadline := time.Now().Add(time.Duration(minRRSetTTL(rs.parentDS)) * time.Second); dsDeadline.Before(leaseDeadline) {
+		if dsDeadline := observedAt.Add(time.Duration(minRRSetTTL(rs.parentDS)) * time.Second); dsDeadline.Before(leaseDeadline) {
 			leaseDeadline = dsDeadline
 		}
 	}
+
+	// Inherit the ancestor cut: a descendant delegation can never outlive
+	// the shallowest delegation on its path (Phoenix T2). This absolute
+	// deadline is stored verbatim (SetUntil), never reconstructed from a
+	// duration, so it cannot be re-inflated by scheduling delay.
+	childDeadline := minNonZero(leaseDeadline, rs.cutDeadline)
 
 	// Check for parent detection
 	nlevel := dns.CountLabel(q.Name)
@@ -2695,6 +2765,12 @@ func (r *Resolver) processDelegation(ctx context.Context, rs *resolveState, resp
 	keyCD := rs.req.CheckingDisabled
 	key := cache.Key(q, keyCD)
 	if cached, err := r.delegations.Get(key); err == nil {
+		// Carry the CURRENT referral's deadline into the cached descent.
+		// The cached entry may hold a longer lease than the referral we just
+		// observed (e.g. it was inserted before the parent shortened its NS
+		// TTL); resolveWithCachedNameservers combines this with
+		// cached.ExpiresAt so the shortest applicable cut always wins.
+		rs.cutDeadline = childDeadline
 		return r.resolveWithCachedNameservers(ctx, rs, cached, key, q, cd)
 	}
 
@@ -2705,7 +2781,7 @@ func (r *Resolver) processDelegation(ctx context.Context, rs *resolveState, resp
 	authservers.CheckingDisable = cd
 	authservers.Zone = q.Name
 
-	r.lookupV4Nss(ctx, q, authservers, key, rs.parentDS, foundv4, nsInfo.hosts, cd, leaseDeadline)
+	r.lookupV4Nss(ctx, q, authservers, key, rs.parentDS, foundv4, nsInfo.hosts, cd, childDeadline)
 
 	if len(authservers.List) == 0 {
 		if minimized && rs.level < nlevel {
@@ -2720,10 +2796,9 @@ func (r *Resolver) processDelegation(ctx context.Context, rs *resolveState, resp
 	// lookup during the outage cannot land an empty-DS entry that later
 	// queries would treat as a proven-insecure delegation after recovery.
 	if !r.dnssec || r.hasTrustAnchors() {
-		// time.Until(leaseDeadline): the REMAINING lease, so time spent in
-		// validation and NS-address lookups counts against it instead of
-		// restarting it. A non-positive remainder is not cached.
-		r.delegations.Set(key, rs.parentDS, authservers, time.Until(leaseDeadline))
+		// Store the absolute (inherited) deadline verbatim. A past deadline
+		// is not cached (SetUntil skips it).
+		r.delegations.SetUntil(key, rs.parentDS, authservers, childDeadline)
 		zlog.Debug("Nameserver cache insert", "key", key, "query", formatQuestion(q), "cd", cd)
 	}
 
@@ -2749,10 +2824,12 @@ func (r *Resolver) processDelegation(ctx context.Context, rs *resolveState, resp
 		return nil, errMaxDepth
 	}
 
-	// Continue resolution with new servers
+	// Continue resolution with new servers. Descend the inherited cut
+	// deadline so any deeper delegation is bounded by this one.
 	rs.servers = authservers
 	rs.level = nlevel
 	rs.isRoot = false
+	rs.cutDeadline = childDeadline
 	return r.resolve(ctx, rs)
 }
 
@@ -2929,5 +3006,8 @@ func (r *Resolver) resolveWithCachedNameservers(ctx context.Context, rs *resolve
 	rs.servers = cached.Servers
 	rs.parentDS = cached.DSSet
 	rs.isRoot = false
+	// Inherit the cached cut's deadline (defensive min, not overwrite) so a
+	// delegation established below it cannot outlive it.
+	rs.cutDeadline = minNonZero(rs.cutDeadline, cached.ExpiresAt)
 	return r.resolve(ctx, rs)
 }

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -391,9 +391,18 @@ func (r *Resolver) groupLookup(ctx context.Context, rs *resolveState, req *dns.M
 	key := strconv.FormatUint(cache.Key(q), 10) + "|" + servers.Zone +
 		"|" + string(cd) + "|" + strconv.FormatUint(servers.Fingerprint(), 10)
 
+	// The leader closure can outlive this caller: TimedDoChan returns on
+	// ctx timeout/cancel and Forgets the key while the closure keeps
+	// running. After we return, req resumes its lifecycle upstack — the
+	// response re-attaches the request OPT and the edns writer mutates it
+	// in place — so an abandoned leader copying req (lookup's per-server
+	// CopyTo) would race on caller-owned memory. Hand the closure its own
+	// private copy, made here while we still exclusively own req.
+	leaderReq := req.Copy()
+
 	// Use TimedDoChan for automatic timeout handling
 	result, shared, err := r.sfGroup.TimedDoChan(ctx, key, func() (any, error) {
-		return r.lookup(ctx, rs, req, servers)
+		return r.lookup(ctx, rs, leaderReq, servers)
 	})
 
 	if err != nil {

--- a/middleware/resolver/resolver_test.go
+++ b/middleware/resolver/resolver_test.go
@@ -31,7 +31,8 @@ func Test_resolver(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, len(resp.Answer) > 0, true)
 
-	servers, _, _ := r.searchCache(req.Question[0], req.CheckingDisabled, "google.com.")
+	m := r.searchCache(req.Question[0], req.CheckingDisabled, "google.com.")
+	servers := m.servers
 	assert.Equal(t, true, len(servers.List) > 0)
 	atomic.AddUint32(&servers.ErrorCount, 4)
 

--- a/middleware/resolver/searchcache_poison_test.go
+++ b/middleware/resolver/searchcache_poison_test.go
@@ -50,7 +50,8 @@ func Test_searchCache_CD1DelegationMustNotPoisonCD0(t *testing.T) {
 	// cached, it must fall through to the root and re-establish a
 	// validated chain — NOT borrow the unvalidated CD=1 com. delegation.
 	q := dns.Question{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
-	servers, parentDS, _ := r.searchCache(q, false, q.Name)
+	m := r.searchCache(q, false, q.Name)
+	servers, parentDS := m.servers, m.parentDS
 
 	if servers != nil && len(servers.List) > 0 && servers.List[0].Addr == "192.0.2.66:53" {
 		t.Fatalf("BUG REPRODUCED: a CD=0 query was served the unvalidated CD=1 com. "+


### PR DESCRIPTION
## Summary

Follow-up to #513: closes the Phoenix downward-delegation (T2) variant of the ghost-domain attack, plus a data race in the singleflight lookup path found while verifying under `-race`.

### Deadline inheritance (T2)

A nested delegation could outlive the parent lease that granted it — a 3s ancestor referral followed by a 12h nested referral left the deeper entry alive after the ancestor expired, and `searchCache` serves the deepest match.

- `authority.Delegation` now stores a single immutable absolute expiry (`ExpiresAt`); new `Cache.SetUntil` stores a parent-granted deadline verbatim (never reconstructed from a duration, so scheduler delay cannot re-inflate the lease). `Set(ttl)` keeps its API for duration-based callers.
- Resolution threads the shallowest deadline on the path through `resolveState.cutDeadline`: `searchCache` returns the matched entry's expiry, `processDelegation` computes `min(local lease, ancestor cut)` from a single pre-validation observation instant, and the cached-hit branch carries the freshly observed referral deadline into the descent — the shortest applicable cut always wins.

### Singleflight request race

The `groupLookup` singleflight closure captured the caller's request. A leader goroutine can outlive its caller (`TimedDoChan` timeout → `Forget`), after which the edns `ResponseWriter` mutates the request's re-attached OPT while the abandoned leader is still copying the request per server. The closure now receives a private copy made while the caller exclusively owns the request.

## Tests

- `TestPhoenixT2_NestedDelegationInheritsAncestorDeadline` — real referral chain through mock authorities (TEST-NET glue, per-resolver dial-target seam); nested cut must **exactly equal** the ancestor deadline.
- `TestPhoenixT2_CachedHitCarriesCurrentReferralDeadline` — deterministic concurrent-insert race; fails without the cached-hit fix (nested cut cached 2h instead of 3s).
- `Test_CacheSetUntil` — deadline stored verbatim, past/equal deadlines rejected, 12h ceiling.
- Full `middleware/resolver` + `internal/authority` suites green under `-race` (3/3 runs; the data race previously reproduced in 2/5 full-suite runs).
- `gofmt` clean, `golangci-lint` 0 issues.