### PR TITLE
fix(cache,resolver): bind cached answers to their delegation cut and CAS the prefetch write-back (GHSA-mqfw-f48p-2vc8)

### DIFF
--- a/docs/security/ghost-phoenix-durable-design.md
+++ b/docs/security/ghost-phoenix-durable-design.md
@@ -1,0 +1,117 @@
+# Durable Ghost/Phoenix-Domain Protection
+
+Status: authoritative implementation specification  
+Advisory: GHSA-mqfw-f48p-2vc8
+
+This document replaces the earlier scratchpad design and its tentative
+numeric-version, RR-rewrite, and eager-generation alternatives.
+
+## Security invariants
+
+1. A learned delegation expires at one immutable absolute `ExpiresAt` and
+   cannot outlive any ancestor delegation used to reach it.
+2. A cached response cannot be served past the shortest learned delegation
+   cut observed while producing its request tree.
+3. An asynchronous prefetch result can replace only the exact answer-cache
+   entry that triggered it.
+4. Zero `time.Time` means unbounded and is used only where no learned
+   delegation applies (root/configured, forwarder, and local-answer paths).
+
+All expiry arithmetic retains Go's monotonic clock reading. Protocol
+timestamps may use UTC; cache lifetime arithmetic must use `time.Now()`
+without `UTC`, `In`, or other monotonic-stripping transformations.
+
+## Locked design
+
+### Delegation deadlines
+
+`authority.Delegation` stores `ExpiresAt time.Time`. Resolver writes use
+`SetUntil` so an inherited deadline is stored verbatim rather than converted
+back to a duration and re-anchored.
+
+Resolution state carries `(cutDeadline, cutKey)`. A local referral is combined
+with its ancestor as:
+
+```text
+(childDeadline, childKey) = minCut(ancestorDeadline, ancestorKey,
+                                   localDeadline, localKey)
+```
+
+Zero deadlines are unbounded. Equal deadlines keep the first identity, so a
+descendant that inherits the exact ancestor expiry retains the ancestor key.
+`searchCache` returns a small result containing servers, DS, level, deadline,
+and delegation key.
+
+### Answer binding
+
+`CacheEntry` stores immutable `cutUntil` and `cutKey` fields. Resolver RRsets
+are not rewritten before insertion. Read-time effective lifetime is:
+
+```text
+min(stored + ttl, cutUntil)
+```
+
+`ToMsg`, `TTL`, and `IsExpired` use that effective lifetime, including when
+the delegation cut is shorter than the configured five-second minimum TTL.
+
+The pooled `middleware.Chain.ResponseMeta` atomically folds the earliest
+immutable `(deadline, key)` pair across resolver, CNAME, and internal-subquery
+legs. Cache write-back occurs after synchronous CNAME chasing, then reads the
+winning pair. Direct resolver `subQuery` writes use the same metadata.
+
+### Late asynchronous writes
+
+`PrefetchRequest.Entry` is the exact triggering `*CacheEntry`. Prefetch
+write-back uses pointer identity under the cache segment lock:
+
+```text
+ReplaceIfCurrent(key, expected=req.Entry, replacement)
+```
+
+If another result has replaced or removed that entry, the refresh is dropped.
+A prefetched SERVFAIL never replaces a valid positive entry. Expiry cleanup
+uses conditional deletion so a stale reader cannot delete a newer value.
+
+Phase 2 intentionally covers asynchronous prefetch refreshes. The ordinary
+external cache-miss path uses per-key request deduplication and is outside this
+pointer-CAS refresh contract. If a future asynchronous writer bypasses that
+path, it must capture an explicit expected entry/token before it is allowed to
+publish.
+
+### Phase 3
+
+Active pre-expiry invalidation remains deferred. `cutKey` is carried and stored
+now so a future generation design has stable lineage identity, but no mutable
+generation registry or O(n) subtree sweep is part of Phases 1–2. Mid-lease
+re-delegation is therefore bounded by the parent-granted lease; unchanged,
+withdrawn, and re-delegated parent state is observed when that deadline is
+reached.
+
+## Delivered phases and acceptance coverage
+
+| Phase | Delivered behavior | Primary regression |
+|---|---|---|
+| #513 | Parent lease honored; no one-hour floor; non-positive TTL skipped; progressing referrals only; coherent NS RRset; minimum NS/DS TTL | `ghost_domain_test.go`, `authority/cache_test.go` |
+| 1a | Descendants inherit the shortest immutable ancestor deadline | `phoenix_t2_test.go` |
+| 1b | Positive, negative, CD, ECS, CNAME, forwarder/local-zero answer-cache binding | `cache/cutuntil_test.go` |
+| 2 | Pointer-CAS late-prefetch protection and full withdrawal pipeline | `ghost_answer_prefetch_test.go`, `cache/cutuntil_test.go` |
+| deferred 3 | Optional active pre-expiry generation invalidation | Not implemented |
+
+The critical acceptance set is:
+
+1. Short ancestor plus 12-hour nested referral: exact inherited expiration.
+2. Long answer under a short cut, including the five-second minimum-TTL floor.
+3. CNAME chain crossing two cuts: the shortest deadline and its key win.
+4. Forwarder/local answers with a zero deadline remain unbounded, including
+   after pooled-chain reuse.
+5. Delayed prefetch cannot replace a newer parent NXDOMAIN.
+6. At the deadline, unchanged, withdrawn, and re-delegated parent states are
+   re-observed; the former child is not used after re-delegation/withdrawal.
+7. Concurrent metadata folding, replacement, expiry deletion, and queue
+   shutdown pass under the Go race detector.
+
+## References
+
+- [Phoenix Domain (NDSS 2023)](https://www.ndss-symposium.org/wp-content/uploads/2023-5-paper.pdf)
+- [IETF NS revalidation draft](https://datatracker.ietf.org/doc/html/draft-ietf-dnsop-ns-revalidation-13)
+- [ISC/BIND parent-derived expiry note](https://kb.isc.org/docs/aa-00620)

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -149,6 +149,50 @@ func (c *Cache) Remove(key uint64) {
 	c.data.Del(key)
 }
 
+// CompareAndSwap stores value under key only if the value currently
+// stored is identical (==, i.e. pointer identity for pointer-typed
+// values) to old. Returns false — storing nothing — when the key is
+// absent or holds a different value. The check-and-set runs under the
+// key's segment write lock, so a concurrent Add/Remove cannot
+// interleave between the compare and the swap.
+//
+// This is the late-write guard for asynchronous refreshes
+// (GHSA-mqfw-f48p-2vc8): a stale in-flight result may only replace
+// the exact entry it set out to refresh, never state that landed
+// after it started.
+func (c *Cache) CompareAndSwap(key uint64, old, value any) bool {
+	seg := c.data.data.getSegment(key)
+	seg.rwlock.Lock()
+	defer seg.rwlock.Unlock()
+
+	cur, ok := seg.data.Get(key)
+	if !ok || cur != old {
+		return false
+	}
+	seg.data.Put(key, value)
+	return true
+}
+
+// CompareAndDelete removes key only if its current value is identical to old.
+// Expiry cleanup uses this instead of an unconditional Remove: a fresh value
+// may be published after the reader loaded the expired entry, and that newer
+// value must not be deleted by the stale reader.
+func (c *Cache) CompareAndDelete(key uint64, old any) bool {
+	seg := c.data.data.getSegment(key)
+	seg.rwlock.Lock()
+	defer seg.rwlock.Unlock()
+
+	cur, ok := seg.data.Get(key)
+	if !ok || cur != old {
+		return false
+	}
+	if !seg.data.Del(key) {
+		return false
+	}
+	c.data.data.count.Add(-1)
+	return true
+}
+
 // Len returns current size
 func (c *Cache) Len() int {
 	return int(c.data.Len())

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -47,6 +47,41 @@ func TestCacheRemove(t *testing.T) {
 	assert.False(t, found, "Item should not be found after removal")
 }
 
+func TestCacheConditionalReplaceAndDelete(t *testing.T) {
+	type value struct{ generation int }
+
+	c := New(4)
+	old := &value{generation: 1}
+	newer := &value{generation: 2}
+	other := &value{generation: 3}
+	c.Add(1, old)
+
+	if c.CompareAndSwap(1, other, newer) {
+		t.Fatal("CompareAndSwap succeeded with a stale expected pointer")
+	}
+	if !c.CompareAndSwap(1, old, newer) {
+		t.Fatal("CompareAndSwap rejected the current pointer")
+	}
+	if got, ok := c.Get(1); !ok || got != newer {
+		t.Fatalf("replacement = %#v, %v; want newer pointer", got, ok)
+	}
+
+	// This is the expiry-cleanup race: a reader that loaded old before the
+	// replacement must not delete newer after it is published.
+	if c.CompareAndDelete(1, old) {
+		t.Fatal("CompareAndDelete removed a newer replacement")
+	}
+	if !c.CompareAndDelete(1, newer) {
+		t.Fatal("CompareAndDelete rejected the current pointer")
+	}
+	if _, ok := c.Get(1); ok {
+		t.Fatal("current pointer was not deleted")
+	}
+	if got := c.Len(); got != 0 {
+		t.Fatalf("cache length = %d after conditional delete, want 0", got)
+	}
+}
+
 func TestCacheLRUEviction(t *testing.T) {
 	// Note: RadicalCache is not LRU, it clears segments for performance
 	// This test verifies size limits are maintained

--- a/middleware/autowire_test.go
+++ b/middleware/autowire_test.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/config"
@@ -46,8 +47,8 @@ func (h *clientOnlyHandler) ClientOnly() bool                        { return tr
 // nopStore implements Store.
 type nopStore struct{}
 
-func (nopStore) Get(*dns.Msg) (*dns.Msg, bool)  { return nil, false }
-func (nopStore) SetFromResponse(*dns.Msg, bool) {}
+func (nopStore) Get(*dns.Msg) (*dns.Msg, bool)             { return nil, false }
+func (nopStore) SetFromResponse(*dns.Msg, bool, time.Time) {}
 
 func TestAutoWire_NilSafe(t *testing.T) {
 	var p *Pipeline

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -390,6 +390,19 @@ func (c *Cache) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		}
 	}
 
+	// Establish the request tree's ResponseMeta sink: the resolver
+	// (downstream, possibly in a nested sub-pipeline sharing this
+	// ctx) records the delegation-cut deadline into it, and WriteMsg
+	// reads it back to bound the cache entry (GHSA-mqfw-f48p-2vc8).
+	// Reuse an existing ctx meta so nested pipelines fold into the
+	// outermost request's sink; otherwise back it with this chain's
+	// pooled Meta field (zeroed on Chain.Reset).
+	meta := middleware.ResponseMetaFrom(ctx)
+	if meta == nil {
+		meta = &ch.Meta
+		ctx = middleware.WithResponseMeta(ctx, meta)
+	}
+
 	// Use pooled response writer. Restore via defer so a
 	// downstream panic that gets recovered upstream still
 	// unwraps this chain before it returns to the pool; a
@@ -407,11 +420,13 @@ func (c *Cache) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	// the insert key without re-reading the OPT (which by then
 	// may have been mutated by the edns wrapper on the response).
 	rw.clientScope = clientScope
+	rw.meta = meta
 	ch.Writer = rw
 	defer func() {
 		ch.Writer = w
 		rw.ctx = nil
 		rw.clientScope = netip.Prefix{}
+		rw.meta = nil
 		c.writerPool.Put(rw)
 	}()
 
@@ -683,6 +698,12 @@ type ResponseWriter struct {
 	// — that's how pre-Stage-2 traffic and SCOPE=0 responses keep
 	// the same cache shape they had before.
 	clientScope netip.Prefix
+	// meta is the request tree's ResponseMeta sink, stashed by
+	// Cache.ServeDNS. By the time WriteMsg runs, the resolver
+	// downstream has folded the delegation-cut deadline into it;
+	// the insert bounds the entry with that deadline. Nil when the
+	// writer is used outside ServeDNS.
+	meta *middleware.ResponseMeta
 }
 
 // (*ResponseWriter).WriteMsg writeMsg implements the ResponseWriter interface.
@@ -699,6 +720,21 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 		return w.ResponseWriter.WriteMsg(res)
 	}
 
+	// Complete any synchronous CNAME chase before reading ResponseMeta and
+	// publishing the cache entry. A target leg can cross a different (shorter)
+	// delegation cut; storing first would bind the outer CNAME only to its own
+	// longer cut and violate the request-tree "shortest cut wins" invariant.
+	// filterCacheableAnswer below still retains only records belonging to the
+	// original question, so this does not merge the target RRset into the outer
+	// cache entry.
+	ctx := w.ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if depth := cnameChaseDepth(ctx); depth < maxCnameChaseDepth {
+		res = w.cache.additionalAnswer(withCnameChaseDepth(ctx, depth+1), res)
+	}
+
 	// Classify, filter, and store via Store. Key is derived from
 	// the response's CD bit — today's behaviour and the contract
 	// the cache dedup leader and follower agree on.
@@ -710,34 +746,32 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 	// client (with or without ECS) hits the same entry. SCOPE>0
 	// means the answer is geo-tailored and gets a scoped key,
 	// clamped to the policy ceiling so cardinality stays bounded.
+	// The delegation-cut bound for this response, folded into the
+	// meta sink by the resolver while producing it. Zero (no meta,
+	// or no learned delegation on the path) leaves the entry
+	// unbounded — forwarder and local answers keep today's shape.
+	var (
+		cutUntil time.Time
+		cutKey   uint64
+	)
+	if w.meta != nil {
+		cutUntil, cutKey = w.meta.Cut()
+	}
+
 	if w.clientScope.IsValid() {
 		if respScope, ok := ecs.ReadResponseScope(res); ok {
 			clamped := w.cache.ecsPolicy.ClampScope(respScope, w.clientScope)
 			scopedKey := CacheKey{Question: q, CD: res.CheckingDisabled, Scope: clamped}.Hash()
-			w.cache.store.SetFromResponseScoped(scopedKey, res)
+			w.cache.store.SetFromResponseScoped(scopedKey, res, cutUntil, cutKey)
 		} else {
 			// No SCOPE in response (or SCOPE=0): authority says
 			// "global"; cache shared so future non-ECS clients hit.
 			key := CacheKey{Question: q, CD: res.CheckingDisabled}.Hash()
-			w.cache.store.SetFromResponseWithKey(key, res)
+			w.cache.store.SetFromResponseWithKey(key, res, cutUntil, cutKey)
 		}
 	} else {
 		key := CacheKey{Question: q, CD: res.CheckingDisabled}.Hash()
-		w.cache.store.SetFromResponseWithKey(key, res)
-	}
-
-	// Resolve CNAME chains before sending to client (matching V1
-	// behavior). Depth counter replaces the pre-Phase-3d
-	// !w.Internal() guard; the active request ctx was stashed on
-	// this writer by Cache.ServeDNS so WriteMsg can read it
-	// without the caller plumbing ctx through the
-	// dns.ResponseWriter interface.
-	ctx := w.ctx
-	if ctx == nil {
-		ctx = context.Background()
-	}
-	if depth := cnameChaseDepth(ctx); depth < maxCnameChaseDepth {
-		res = w.cache.additionalAnswer(withCnameChaseDepth(ctx, depth+1), res)
+		w.cache.store.SetFromResponseWithKey(key, res, cutUntil, cutKey)
 	}
 
 	return w.ResponseWriter.WriteMsg(res)

--- a/middleware/cache/cache_ecs_test.go
+++ b/middleware/cache/cache_ecs_test.go
@@ -231,7 +231,7 @@ func TestECSCache_PreStage2EntriesStillHit(t *testing.T) {
 	req.SetQuestion("legacy.example.", dns.TypeA)
 	pre := reply(req, "192.0.2.50", 0)
 	sharedKey := internalcache.Key(req.Question[0], false)
-	c.store.SetFromResponseWithKey(sharedKey, pre)
+	c.store.SetFromResponseWithKey(sharedKey, pre, time.Time{}, 0)
 
 	// Plain client lookup hits without an upstream call.
 	h := &echoHandler{aRecord: "should-not-be-used", scopeBits: 0}
@@ -259,7 +259,7 @@ func TestECSCache_SupernetHit(t *testing.T) {
 	scope, err := netip.ParsePrefix("203.0.112.0/22")
 	require.NoError(t, err)
 	key := CacheKey{Question: req.Question[0], CD: false, Scope: scope}.Hash()
-	c.store.SetFromResponseScoped(key, reply(req, "10.1.1.1", 22))
+	c.store.SetFromResponseScoped(key, reply(req, "10.1.1.1", 22), time.Time{}, 0)
 
 	// Client at 203.0.113.42 — its /24 is 203.0.113.0, which falls
 	// inside 203.0.112.0/22. Lookup probes /24 (miss), /23 (miss),
@@ -329,13 +329,13 @@ func TestECSCache_PurgeRemovesScopedEntries(t *testing.T) {
 	for _, addr := range []string{"203.0.113.0/24", "198.51.100.0/24"} {
 		scope := netip.MustParsePrefix(addr)
 		key := CacheKey{Question: req.Question[0], CD: false, Scope: scope}.Hash()
-		c.store.SetFromResponseScoped(key, reply(req, "10.0.0.1", 24))
+		c.store.SetFromResponseScoped(key, reply(req, "10.0.0.1", 24), time.Time{}, 0)
 		if _, ok := c.store.LookupByKey(key); !ok {
 			t.Fatalf("scoped seed for %s did not land in cache", addr)
 		}
 	}
 	sharedKey := CacheKey{Question: req.Question[0], CD: false}.Hash()
-	c.store.SetFromResponseWithKey(sharedKey, reply(req, "10.0.0.99", 0))
+	c.store.SetFromResponseWithKey(sharedKey, reply(req, "10.0.0.99", 0), time.Time{}, 0)
 
 	c.store.Purge(req.Question[0])
 
@@ -622,7 +622,7 @@ func TestECSCache_PurgeIsCaseInsensitive(t *testing.T) {
 	req.SetQuestion("Mixed.Example.", dns.TypeA)
 	scope := netip.MustParsePrefix("203.0.113.0/24")
 	key := CacheKey{Question: req.Question[0], CD: false, Scope: scope}.Hash()
-	c.store.SetFromResponseScoped(key, reply(req, "10.0.0.1", 24))
+	c.store.SetFromResponseScoped(key, reply(req, "10.0.0.1", 24), time.Time{}, 0)
 	require.Truef(t, func() bool { _, ok := c.store.LookupByKey(key); return ok }(),
 		"seed did not land in cache")
 
@@ -667,7 +667,7 @@ func TestECSCache_CacheLimitTTLCapsScopedWrites(t *testing.T) {
 
 	scope := netip.MustParsePrefix("203.0.113.0/24")
 	key := CacheKey{Question: req.Question[0], CD: false, Scope: scope}.Hash()
-	c.store.SetFromResponseScoped(key, resp)
+	c.store.SetFromResponseScoped(key, resp, time.Time{}, 0)
 
 	entry, ok := c.store.LookupByKey(key)
 	require.True(t, ok, "scoped seed did not land in cache")
@@ -679,7 +679,7 @@ func TestECSCache_CacheLimitTTLCapsScopedWrites(t *testing.T) {
 	// Unscoped writes must NOT be capped — the cap is per
 	// CacheConfig.ECSMaxTTL gated by `scoped == true`.
 	plainKey := CacheKey{Question: req.Question[0], CD: false}.Hash()
-	c.store.SetFromResponseWithKey(plainKey, resp)
+	c.store.SetFromResponseWithKey(plainKey, resp, time.Time{}, 0)
 	plain, ok := c.store.LookupByKey(plainKey)
 	require.True(t, ok)
 	if plain.ttl <= cfg.ECS.CacheLimitTTL.Duration {

--- a/middleware/cache/cache_integration_test.go
+++ b/middleware/cache/cache_integration_test.go
@@ -209,17 +209,15 @@ func TestCache_Prefetch(t *testing.T) {
 	}
 
 	cache := New(cfg)
-	defer cache.Stop()
 
-	// Stop the prefetch workers before firing the query so the
-	// claim CAS set by cache.ServeDNS stays observable — otherwise
-	// a worker picks the item up, fails (no prefetchQueryer is
-	// wired in unit-test setup), and the deferred
-	// releasePrefetchClaim flips prefetch back to false before the
-	// test reads it. The queue's buffered channel still accepts
-	// the Add; no worker drains it, which is what we want.
-	cache.prefetchQueue.cancel()
-	cache.prefetchQueue.wg.Wait()
+	// Replace the live worker pool with a live zero-worker queue before
+	// firing the query so the claim CAS set by cache.ServeDNS stays
+	// observable. A stopped queue correctly rejects Add; relying on a
+	// canceled queue to keep accepting work would recreate the shutdown
+	// send/close race this test must not require.
+	cache.prefetchQueue.Stop()
+	cache.prefetchQueue = NewPrefetchQueue(0, 1, cache.metrics)
+	defer cache.Stop()
 
 	// Create a short-lived cache entry manually
 	req := new(dns.Msg)

--- a/middleware/cache/cutuntil_test.go
+++ b/middleware/cache/cutuntil_test.go
@@ -1,0 +1,477 @@
+package cache
+
+import (
+	"context"
+	"net/netip"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/middleware"
+)
+
+var _ middleware.CutStore = (*Store)(nil)
+
+func cutTestMsg(name string, rcode int, answerTTL uint32) *dns.Msg {
+	m := new(dns.Msg)
+	m.SetQuestion(name, dns.TypeA)
+	m.Rcode = rcode
+	m.Response = true
+	if rcode == dns.RcodeSuccess {
+		m.Answer = []dns.RR{&dns.A{
+			Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: answerTTL},
+			A:   []byte{192, 0, 2, 1},
+		}}
+	}
+	return m
+}
+
+func cutTestNXMsg(name string, ttl uint32) *dns.Msg {
+	m := cutTestMsg(name, dns.RcodeNameError, 0)
+	m.Ns = []dns.RR{&dns.SOA{
+		Hdr:     dns.RR_Header{Name: "example.", Rrtype: dns.TypeSOA, Class: dns.ClassINET, Ttl: ttl},
+		Ns:      "ns.example.",
+		Mbox:    "hostmaster.example.",
+		Serial:  1,
+		Refresh: 60,
+		Retry:   60,
+		Expire:  60,
+		Minttl:  ttl,
+	}}
+	return m
+}
+
+type cutTestQueryer struct {
+	handlers []middleware.Handler
+}
+
+func (q *cutTestQueryer) Query(ctx context.Context, req *dns.Msg) (*dns.Msg, error) {
+	w := mock.NewWriter("tcp", "127.0.0.1:0")
+	ch := middleware.NewChain(q.handlers)
+	ch.Reset(w, req)
+	ch.Next(ctx)
+	if !w.Written() {
+		return nil, middleware.ErrNoResponse
+	}
+	return w.Msg(), nil
+}
+
+// TestCacheEntry_CutUntil locks in the effective-lifetime math for the
+// answer-cache ghost fix (GHSA-mqfw-f48p-2vc8): an entry's lifetime is
+// min(stored+ttl, cutUntil), enforced at read time.
+func TestCacheEntry_CutUntil(t *testing.T) {
+	req := new(dns.Msg)
+	req.SetQuestion("example.org.", dns.TypeA)
+
+	// Cut shorter than the TTL: the cut wins.
+	e := NewCacheEntry(cutTestMsg("example.org.", dns.RcodeSuccess, 300), 300*time.Second, 0)
+	e.cutUntil = time.Now().Add(2 * time.Second)
+
+	if e.IsExpired() {
+		t.Fatal("entry must be valid before its cut deadline")
+	}
+	if ttl := e.TTL(); ttl > 2 {
+		t.Fatalf("TTL() = %d, must be capped by the 2s cut, not the 300s TTL", ttl)
+	}
+	msg := e.ToMsg(req)
+	if msg == nil {
+		t.Fatal("ToMsg must materialise before the cut deadline")
+	}
+	if got := msg.Answer[0].Header().Ttl; got > 2 {
+		t.Fatalf("served TTL = %d, must be capped by the 2s cut", got)
+	}
+
+	// Past the cut: expired despite ~300s of TTL remaining.
+	e.cutUntil = time.Now().Add(-time.Millisecond)
+	if !e.IsExpired() {
+		t.Fatal("entry must expire at its cut deadline even with TTL remaining")
+	}
+	if e.ToMsg(req) != nil {
+		t.Fatal("ToMsg must refuse to serve past the cut deadline")
+	}
+	if e.TTL() != 0 {
+		t.Fatal("TTL() must be 0 past the cut deadline")
+	}
+
+	// Zero cut: plain TTL behaviour unchanged.
+	e.cutUntil = time.Time{}
+	if e.IsExpired() || e.TTL() == 0 || e.ToMsg(req) == nil {
+		t.Fatal("zero cutUntil must leave plain TTL behaviour unchanged")
+	}
+
+	// Cut longer than the TTL: the TTL wins.
+	short := NewCacheEntry(cutTestMsg("example.org.", dns.RcodeSuccess, 1), time.Second, 0)
+	short.cutUntil = time.Now().Add(time.Hour)
+	if ttl := short.TTL(); ttl > 1 {
+		t.Fatalf("TTL() = %d, a long cut must not extend a short TTL", ttl)
+	}
+}
+
+// TestStore_CutUntil_OverridesMinTTLFloor: the configured MinTTL floor
+// (5s) inflates stored TTLs, which is exactly how a ghost answer under
+// a short cut would outlive its delegation. The cut bound is enforced
+// at read time, so it wins over the floor.
+func TestStore_CutUntil_OverridesMinTTLFloor(t *testing.T) {
+	s := NewStore(
+		NewPositiveCache(1024, minTTL, maxTTL, &CacheMetrics{}),
+		NewNegativeCache(1024, minTTL, time.Hour, &CacheMetrics{}),
+		CacheConfig{},
+	)
+
+	resp := cutTestMsg("ghost.example.", dns.RcodeSuccess, 1)
+	key := CacheKey{Question: resp.Question[0], CD: false}.Hash()
+
+	// A cut already in the past: the entry may be stored, but must
+	// never be served — even though the MinTTL floor lifted its TTL
+	// to 5s.
+	s.SetFromResponseWithKey(key, resp, time.Now().Add(-time.Millisecond), 0)
+
+	req := new(dns.Msg)
+	req.SetQuestion("ghost.example.", dns.TypeA)
+	if _, ok := s.Get(req); ok {
+		t.Fatal("answer served past its delegation cut (MinTTL floor overrode the cut)")
+	}
+
+	// A future cut inside the floor: served, but with the cut-capped TTL.
+	s.SetFromResponseWithKey(key, resp, time.Now().Add(2*time.Second), 0)
+	msg, ok := s.Get(req)
+	if !ok {
+		t.Fatal("entry with a future cut must be served")
+	}
+	if got := msg.Answer[0].Header().Ttl; got > 2 {
+		t.Fatalf("served TTL = %d, must be capped by the 2s cut despite the 5s MinTTL floor", got)
+	}
+}
+
+func TestStore_CutUntil_CoversNegativeCDAndECS(t *testing.T) {
+	s := NewStore(
+		NewPositiveCache(1024, minTTL, maxTTL, &CacheMetrics{}),
+		NewNegativeCache(1024, minTTL, time.Hour, &CacheMetrics{}),
+		CacheConfig{},
+	)
+
+	t.Run("negative answer", func(t *testing.T) {
+		const cutKey = uint64(0x101)
+		resp := cutTestNXMsg("missing.example.", 300)
+		key := CacheKey{Question: resp.Question[0], CD: false}.Hash()
+		cut := time.Now().Add(2 * time.Second)
+		s.SetFromResponseWithKey(key, resp, cut, cutKey)
+
+		entry, ok := s.LookupByKey(key)
+		if !ok {
+			t.Fatal("negative answer was not cached")
+		}
+		if !entry.cutUntil.Equal(cut) || entry.cutKey != cutKey {
+			t.Fatalf("negative cut = (%v, %#x), want (%v, %#x)", entry.cutUntil, entry.cutKey, cut, cutKey)
+		}
+
+		s.SetFromResponseWithKey(key, resp, time.Now().Add(-time.Millisecond), cutKey)
+		if _, ok := s.LookupByKey(key); ok {
+			t.Fatal("negative answer survived past its delegation cut")
+		}
+	})
+
+	t.Run("CD buckets", func(t *testing.T) {
+		resp := cutTestMsg("cd.example.", dns.RcodeSuccess, 300)
+		falseCut, trueCut := time.Now().Add(time.Minute), time.Now().Add(2*time.Minute)
+		const falseKey, trueKey = uint64(0x201), uint64(0x202)
+		s.SetFromResponseWithCut(resp, false, falseCut, falseKey)
+		s.SetFromResponseWithCut(resp, true, trueCut, trueKey)
+
+		for _, tc := range []struct {
+			cd       bool
+			deadline time.Time
+			cutKey   uint64
+		}{{false, falseCut, falseKey}, {true, trueCut, trueKey}} {
+			req := new(dns.Msg)
+			req.SetQuestion("cd.example.", dns.TypeA)
+			req.CheckingDisabled = tc.cd
+			entry, ok := s.Lookup(req)
+			if !ok {
+				t.Fatalf("CD=%v entry missing", tc.cd)
+			}
+			if !entry.cutUntil.Equal(tc.deadline) || entry.cutKey != tc.cutKey {
+				t.Fatalf("CD=%v cut = (%v, %#x), want (%v, %#x)", tc.cd, entry.cutUntil, entry.cutKey, tc.deadline, tc.cutKey)
+			}
+		}
+	})
+
+	t.Run("ECS scoped", func(t *testing.T) {
+		resp := cutTestMsg("ecs.example.", dns.RcodeSuccess, 300)
+		key := CacheKey{Question: resp.Question[0], CD: false, Scope: netip.MustParsePrefix("192.0.2.0/24")}.Hash()
+		cut := time.Now().Add(2 * time.Second)
+		const cutKey = uint64(0x301)
+		s.SetFromResponseScoped(key, resp, cut, cutKey)
+		entry, ok := s.LookupByKey(key)
+		if !ok {
+			t.Fatal("ECS-scoped entry missing")
+		}
+		if !entry.cutUntil.Equal(cut) || entry.cutKey != cutKey {
+			t.Fatalf("ECS cut = (%v, %#x), want (%v, %#x)", entry.cutUntil, entry.cutKey, cut, cutKey)
+		}
+		s.SetFromResponseScoped(key, resp, time.Now().Add(-time.Millisecond), cutKey)
+		if _, ok := s.LookupByKey(key); ok {
+			t.Fatal("ECS-scoped entry survived past its delegation cut")
+		}
+	})
+}
+
+// TestStore_ReplaceIfCurrent locks in the pointer-CAS late-write
+// semantics (GHSA-mqfw-f48p-2vc8, late prefetch overwrite): a refresh
+// may only replace the exact entry it captured, and a SERVFAIL refresh
+// may never displace a positive entry.
+func TestStore_ReplaceIfCurrent(t *testing.T) {
+	s := NewStore(
+		NewPositiveCache(1024, minTTL, maxTTL, &CacheMetrics{}),
+		NewNegativeCache(1024, minTTL, time.Hour, &CacheMetrics{}),
+		CacheConfig{},
+	)
+
+	q := dns.Question{Name: "cas.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	key := CacheKey{Question: q, CD: false}.Hash()
+
+	s.SetFromResponseWithKey(key, cutTestMsg("cas.example.", dns.RcodeSuccess, 60), time.Time{}, 0)
+	claimed, ok := s.LookupByKey(key)
+	if !ok {
+		t.Fatal("seed entry missing")
+	}
+
+	// Nil expected never stores.
+	if s.ReplaceIfCurrent(key, nil, cutTestMsg("cas.example.", dns.RcodeSuccess, 60), time.Time{}, 0) {
+		t.Fatal("ReplaceIfCurrent with nil expected must be a no-op")
+	}
+
+	// Current entry matches: refresh lands.
+	if !s.ReplaceIfCurrent(key, claimed, cutTestMsg("cas.example.", dns.RcodeSuccess, 120), time.Time{}, 0) {
+		t.Fatal("refresh of the still-current entry must succeed")
+	}
+	replaced, _ := s.LookupByKey(key)
+	if replaced == claimed {
+		t.Fatal("entry was not replaced")
+	}
+
+	// Stale expected (the entry it captured is gone): refresh dropped.
+	// This is the late-prefetch-overwrite guard — `claimed` plays the
+	// role of the entry a slow prefetch captured before newer state
+	// (here `replaced`, in reality a withdrawal NXDOMAIN) landed.
+	if s.ReplaceIfCurrent(key, claimed, cutTestMsg("cas.example.", dns.RcodeSuccess, 60), time.Time{}, 0) {
+		t.Fatal("a stale refresh must not overwrite newer state")
+	}
+	if cur, _ := s.LookupByKey(key); cur != replaced {
+		t.Fatal("newer entry was clobbered by the stale refresh")
+	}
+
+	// SERVFAIL refresh never displaces a positive entry.
+	if s.ReplaceIfCurrent(key, replaced, cutTestMsg("cas.example.", dns.RcodeServerFailure, 0), time.Time{}, 0) {
+		t.Fatal("a SERVFAIL refresh must never displace a positive entry")
+	}
+	if _, ok := s.LookupByKey(key); !ok {
+		t.Fatal("positive entry lost after SERVFAIL refresh attempt")
+	}
+
+	// SERVFAIL-to-SERVFAIL refresh within the negative cache works.
+	negQ := dns.Question{Name: "neg.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	negKey := CacheKey{Question: negQ, CD: false}.Hash()
+	s.SetFromResponseWithKey(negKey, cutTestMsg("neg.example.", dns.RcodeServerFailure, 0), time.Time{}, 0)
+	negEntry, ok := s.LookupByKey(negKey)
+	if !ok {
+		t.Fatal("negative seed entry missing")
+	}
+	if !s.ReplaceIfCurrent(negKey, negEntry, cutTestMsg("neg.example.", dns.RcodeServerFailure, 0), time.Time{}, 0) {
+		t.Fatal("refresh of a still-current negative entry must succeed")
+	}
+}
+
+func TestStore_ReplaceIfCurrent_ConcurrentSingleWinner(t *testing.T) {
+	s := NewStore(
+		NewPositiveCache(1024, minTTL, maxTTL, &CacheMetrics{}),
+		NewNegativeCache(1024, minTTL, time.Hour, &CacheMetrics{}),
+		CacheConfig{},
+	)
+
+	q := dns.Question{Name: "cas-race.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	key := CacheKey{Question: q, CD: false}.Hash()
+	s.SetFromResponseWithKey(key, cutTestMsg(q.Name, dns.RcodeSuccess, 60), time.Time{}, 0)
+	expected, ok := s.LookupByKey(key)
+	if !ok {
+		t.Fatal("seed entry missing")
+	}
+
+	start := make(chan struct{})
+	var winners atomic.Int32
+	var wg sync.WaitGroup
+	for range 128 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			if s.ReplaceIfCurrent(key, expected, cutTestMsg(q.Name, dns.RcodeSuccess, 120), time.Time{}, 0) {
+				winners.Add(1)
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	if got := winners.Load(); got != 1 {
+		t.Fatalf("successful concurrent replacements = %d, want exactly 1", got)
+	}
+	if current, ok := s.LookupByKey(key); !ok || current == expected {
+		t.Fatal("winning replacement was not published")
+	}
+}
+
+// TestWriteMsg_CutUntilSeam drives the middleware seam end to end
+// within the cache package: a downstream handler (standing in for the
+// resolver) folds a delegation-cut deadline into the request's
+// ResponseMeta; the cache ResponseWriter must bound the stored entry
+// with it.
+func TestWriteMsg_CutUntilSeam(t *testing.T) {
+	cfg := &config.Config{CacheSize: 1024, Expire: 600}
+	c := New(cfg)
+	defer c.Stop()
+
+	cut := time.Now().Add(90 * time.Second)
+	const cutKey = uint64(0xabcdef)
+
+	resolver := middleware.HandlerFunc(func(ctx context.Context, ch *middleware.Chain) {
+		middleware.ResponseMetaFrom(ctx).BoundCutFor(cut, cutKey)
+		resp := cutTestMsg("seam.example.", dns.RcodeSuccess, 300)
+		resp.SetReply(ch.Request)
+		resp.Answer = cutTestMsg("seam.example.", dns.RcodeSuccess, 300).Answer
+		_ = ch.Writer.WriteMsg(resp)
+		ch.Cancel()
+	})
+
+	req := new(dns.Msg)
+	req.SetQuestion("seam.example.", dns.TypeA)
+	req.RecursionDesired = true
+
+	w := mock.NewWriter("udp", "127.0.0.1:0")
+	ch := middleware.NewChain([]middleware.Handler{c, resolver})
+	ch.Reset(w, req)
+	ch.Next(context.Background())
+
+	key := CacheKey{Question: req.Question[0], CD: false}.Hash()
+	entry, ok := c.store.LookupByKey(key)
+	if !ok {
+		t.Fatal("response was not cached")
+	}
+	if !entry.cutUntil.Equal(cut) {
+		t.Fatalf("entry cutUntil = %v, want the resolver-reported cut %v", entry.cutUntil, cut)
+	}
+	if entry.cutKey != cutKey {
+		t.Fatalf("entry cutKey = %#x, want resolver-reported key %#x", entry.cutKey, cutKey)
+	}
+}
+
+func TestWriteMsg_CNAMEChainUsesShortestCut(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, Expire: 600})
+	defer c.Stop()
+
+	longCut := time.Now().Add(10 * time.Minute)
+	shortCut := time.Now().Add(90 * time.Second)
+	const longKey, shortKey = uint64(0x401), uint64(0x402)
+
+	targetHandler := middleware.HandlerFunc(func(ctx context.Context, ch *middleware.Chain) {
+		middleware.ResponseMetaFrom(ctx).BoundCutFor(shortCut, shortKey)
+		resp := new(dns.Msg)
+		resp.SetReply(ch.Request)
+		resp.Answer = []dns.RR{&dns.A{
+			Hdr: dns.RR_Header{Name: "target.short.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+			A:   []byte{192, 0, 2, 44},
+		}}
+		_ = ch.Writer.WriteMsg(resp)
+		ch.Cancel()
+	})
+	c.SetQueryer(&cutTestQueryer{handlers: []middleware.Handler{c, targetHandler}})
+
+	outerHandler := middleware.HandlerFunc(func(ctx context.Context, ch *middleware.Chain) {
+		middleware.ResponseMetaFrom(ctx).BoundCutFor(longCut, longKey)
+		resp := new(dns.Msg)
+		resp.SetReply(ch.Request)
+		resp.Answer = []dns.RR{&dns.CNAME{
+			Hdr:    dns.RR_Header{Name: "alias.long.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+			Target: "target.short.",
+		}}
+		_ = ch.Writer.WriteMsg(resp)
+		ch.Cancel()
+	})
+
+	req := new(dns.Msg)
+	req.SetQuestion("alias.long.", dns.TypeA)
+	req.RecursionDesired = true
+	w := mock.NewWriter("udp", "127.0.0.1:0")
+	ch := middleware.NewChain([]middleware.Handler{c, outerHandler})
+	ch.Reset(w, req)
+	ch.Next(context.Background())
+
+	if !w.Written() {
+		t.Fatal("CNAME chase wrote no response")
+	}
+	if len(w.Msg().Answer) != 2 {
+		t.Fatalf("CNAME chase response answers = %d, want CNAME + A", len(w.Msg().Answer))
+	}
+	if got := ch.Meta.CutUntil(); !got.Equal(shortCut) || ch.Meta.CutKey() != shortKey {
+		t.Fatalf("request-tree cut = (%v, %#x), want shortest target cut (%v, %#x)", got, ch.Meta.CutKey(), shortCut, shortKey)
+	}
+
+	for _, name := range []string{"alias.long.", "target.short."} {
+		q := dns.Question{Name: name, Qtype: dns.TypeA, Qclass: dns.ClassINET}
+		entry, ok := c.store.LookupByKey(CacheKey{Question: q, CD: false}.Hash())
+		if !ok {
+			t.Fatalf("%s cache entry missing", name)
+		}
+		if !entry.cutUntil.Equal(shortCut) || entry.cutKey != shortKey {
+			t.Fatalf("%s cut = (%v, %#x), want shortest chain cut (%v, %#x)", name, entry.cutUntil, entry.cutKey, shortCut, shortKey)
+		}
+	}
+}
+
+func TestWriteMsg_ForwarderAndLocalAnswersRemainUnbounded(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, Expire: 600})
+	defer c.Stop()
+
+	boundedCut := time.Now().Add(time.Minute)
+	h := middleware.HandlerFunc(func(ctx context.Context, ch *middleware.Chain) {
+		if ch.Request.Question[0].Name == "bounded.example." {
+			middleware.ResponseMetaFrom(ctx).BoundCutFor(boundedCut, 0x501)
+		}
+		resp := cutTestMsg(ch.Request.Question[0].Name, dns.RcodeSuccess, 300)
+		resp.SetReply(ch.Request)
+		resp.Answer = cutTestMsg(ch.Request.Question[0].Name, dns.RcodeSuccess, 300).Answer
+		_ = ch.Writer.WriteMsg(resp)
+		ch.Cancel()
+	})
+	ch := middleware.NewChain([]middleware.Handler{c, h})
+
+	query := func(name string) *CacheEntry {
+		t.Helper()
+		req := new(dns.Msg)
+		req.SetQuestion(name, dns.TypeA)
+		req.RecursionDesired = true
+		w := mock.NewWriter("udp", "127.0.0.1:0")
+		ch.Reset(w, req)
+		ch.Next(context.Background())
+		entry, ok := c.store.LookupByKey(CacheKey{Question: req.Question[0], CD: false}.Hash())
+		if !ok {
+			t.Fatalf("%s was not cached", name)
+		}
+		return entry
+	}
+
+	if entry := query("bounded.example."); entry.cutUntil.IsZero() {
+		t.Fatal("test setup: bounded resolver-style answer did not carry a cut")
+	}
+	for _, name := range []string{"local.example.", "forwarded.example."} {
+		entry := query(name)
+		if !entry.cutUntil.IsZero() || entry.cutKey != 0 {
+			t.Fatalf("%s inherited pooled metadata from a prior request: cut=(%v, %#x)", name, entry.cutUntil, entry.cutKey)
+		}
+	}
+}

--- a/middleware/cache/negative_cache.go
+++ b/middleware/cache/negative_cache.go
@@ -32,7 +32,7 @@ func (nc *NegativeCache) Get(key uint64) (*CacheEntry, bool) {
 
 	entry := v.(*CacheEntry)
 	if entry.IsExpired() {
-		nc.cache.Remove(key)
+		nc.cache.CompareAndDelete(key, entry)
 		return nil, false
 	}
 

--- a/middleware/cache/positive_cache.go
+++ b/middleware/cache/positive_cache.go
@@ -35,7 +35,7 @@ func (pc *PositiveCache) Get(key uint64) (*CacheEntry, bool) {
 
 	entry := v.(*CacheEntry)
 	if entry.IsExpired() {
-		pc.cache.Remove(key)
+		pc.cache.CompareAndDelete(key, entry)
 		return nil, false
 	}
 

--- a/middleware/cache/prefetch_queue.go
+++ b/middleware/cache/prefetch_queue.go
@@ -3,10 +3,12 @@ package cache
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/internal/dnsutil"
+	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/zlog/v2"
 )
 
@@ -23,6 +25,8 @@ type PrefetchQueue struct {
 	items   chan PrefetchRequest
 	workers int
 	wg      sync.WaitGroup
+	stop    sync.Once
+	stopped atomic.Bool
 	ctx     context.Context
 	cancel  context.CancelFunc
 	metrics *CacheMetrics
@@ -30,7 +34,7 @@ type PrefetchQueue struct {
 
 // NewPrefetchQueue creates a new prefetch queue.
 func NewPrefetchQueue(workers, queueSize int, metrics *CacheMetrics) *PrefetchQueue {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.Background()) //nolint:gosec // G118 - cancel is stored on the queue and called by Stop
 
 	pq := &PrefetchQueue{
 		items:   make(chan PrefetchRequest, queueSize),
@@ -51,7 +55,27 @@ func NewPrefetchQueue(workers, queueSize int, metrics *CacheMetrics) *PrefetchQu
 
 // (*PrefetchQueue).Add add queues a prefetch request.
 func (pq *PrefetchQueue) Add(req PrefetchRequest) bool {
+	// Never send after shutdown. The queue deliberately remains open:
+	// closing it would race with a cache-hit goroutine already entering Add
+	// and can panic with "send on closed channel". Cancellation is enough to
+	// wake every worker, and the channel is reclaimed with the queue.
+	if pq.stopped.Load() {
+		return false
+	}
+
+	var done <-chan struct{}
+	if pq.ctx != nil {
+		done = pq.ctx.Done()
+	}
 	select {
+	case <-done:
+		return false
+	default:
+	}
+
+	select {
+	case <-done:
+		return false
 	case pq.items <- req:
 		return true
 	default:
@@ -63,8 +87,12 @@ func (pq *PrefetchQueue) Add(req PrefetchRequest) bool {
 
 // (*PrefetchQueue).Stop stop gracefully shuts down the prefetch queue.
 func (pq *PrefetchQueue) Stop() {
-	pq.cancel()
-	close(pq.items)
+	pq.stop.Do(func() {
+		pq.stopped.Store(true)
+		if pq.cancel != nil {
+			pq.cancel()
+		}
+	})
 	pq.wg.Wait()
 }
 
@@ -118,6 +146,13 @@ func (pq *PrefetchQueue) processPrefetch(req PrefetchRequest) {
 		prefetchReq.SetEdns0(dnsutil.DefaultMsgSize, true)
 	}
 
+	// Give the refresh its own ResponseMeta sink so the resolver in
+	// the sub-pipeline reports the delegation-cut deadline of the
+	// re-resolved answer; the new entry is bounded by it just like
+	// an entry written on the external path.
+	var meta middleware.ResponseMeta
+	ctx = middleware.WithResponseMeta(ctx, &meta)
+
 	// Route through the cache-less prefetch sub-pipeline so the
 	// refresh reaches the upstream resolver/forwarder instead of
 	// its own about-to-expire entry. Local-answer middleware
@@ -137,7 +172,18 @@ func (pq *PrefetchQueue) processPrefetch(req PrefetchRequest) {
 	// mutated by upstream middleware; using req.Request.CD
 	// preserves the dedup invariant that CD=1 and CD=0 entries
 	// stay separate.
-	req.Cache.store.SetFromResponseWithKey(req.Key, resp)
+	//
+	// Pointer-CAS write-back (GHSA-mqfw-f48p-2vc8): this refresh
+	// started while req.Entry was live. If newer state replaced it
+	// meanwhile — a withdrawal NXDOMAIN, a re-delegated answer —
+	// storing the stale refresh would resurrect the old answer past
+	// the parent's decision. Only the exact entry that claimed the
+	// prefetch may be replaced.
+	cutUntil, cutKey := meta.Cut()
+	if !req.Cache.store.ReplaceIfCurrent(req.Key, req.Entry, resp, cutUntil, cutKey) {
+		zlog.Debug("Prefetch dropped, entry superseded", "query", formatQuestion(req.Request.Question[0]))
+		return
+	}
 	pq.metrics.Prefetch()
 
 	if len(resp.Answer) > 0 {

--- a/middleware/cache/prefetch_worker_test.go
+++ b/middleware/cache/prefetch_worker_test.go
@@ -2,12 +2,46 @@ package cache
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/config"
 )
+
+func TestPrefetchQueue_ConcurrentAddAndStop(t *testing.T) {
+	pq := NewPrefetchQueue(0, 256, &CacheMetrics{})
+
+	req := new(dns.Msg)
+	req.SetQuestion("shutdown.example.", dns.TypeA)
+	item := PrefetchRequest{Request: req}
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for range 32 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for range 256 {
+				if !pq.Add(item) {
+					return
+				}
+			}
+		}()
+	}
+
+	close(start)
+	pq.Stop()
+	wg.Wait()
+
+	// Stop is idempotent and a completed stop permanently rejects new work.
+	pq.Stop()
+	if pq.Add(item) {
+		t.Fatal("Add succeeded after PrefetchQueue.Stop")
+	}
+}
 
 // signalingPrefetchQueryer returns a canned response and fires a
 // channel so the test can wait for the worker to run before

--- a/middleware/cache/store.go
+++ b/middleware/cache/store.go
@@ -132,7 +132,15 @@ func (s *Store) Get(req *dns.Msg) (*dns.Msg, bool) {
 // SetFromResponse classifies resp (positive / NXDOMAIN+NODATA /
 // SERVFAIL) and stores it under (resp.Question[0], keyCD). CHAOS
 // signalling responses are skipped, matching ResponseWriter.WriteMsg.
-func (s *Store) SetFromResponse(resp *dns.Msg, keyCD bool) {
+// cutUntil bounds the entry to the delegation cut that produced it; zero
+// means unbounded. This compatibility entry point has no lineage identity.
+func (s *Store) SetFromResponse(resp *dns.Msg, keyCD bool, cutUntil time.Time) {
+	s.SetFromResponseWithCut(resp, keyCD, cutUntil, 0)
+}
+
+// SetFromResponseWithCut is SetFromResponse plus the delegation identity that
+// supplied cutUntil, retained for the optional Phase-3 generation design.
+func (s *Store) SetFromResponseWithCut(resp *dns.Msg, keyCD bool, cutUntil time.Time, cutKey uint64) {
 	if len(resp.Question) == 0 {
 		return
 	}
@@ -141,13 +149,13 @@ func (s *Store) SetFromResponse(resp *dns.Msg, keyCD bool) {
 		(q.Qclass == dns.ClassCHAOS && q.Qtype == dns.TypeNULL) {
 		return
 	}
-	s.SetFromResponseWithKey(CacheKey{Question: q, CD: keyCD}.Hash(), resp)
+	s.SetFromResponseWithKey(CacheKey{Question: q, CD: keyCD}.Hash(), resp, cutUntil, cutKey)
 }
 
 // SetFromResponseWithKey is the pre-keyed form of SetFromResponse,
 // used by ResponseWriter.WriteMsg, which has the key already.
-func (s *Store) SetFromResponseWithKey(key uint64, resp *dns.Msg) {
-	s.setFromResponseWithKey(key, resp, false)
+func (s *Store) SetFromResponseWithKey(key uint64, resp *dns.Msg, cutUntil time.Time, cutKey uint64) {
+	s.setFromResponseWithKey(key, resp, false, cutUntil, cutKey)
 }
 
 // SetFromResponseScoped is SetFromResponseWithKey for entries that
@@ -155,11 +163,11 @@ func (s *Store) SetFromResponseWithKey(key uint64, resp *dns.Msg) {
 // PrefetchEligible is false — the prefetch worker has no client IP
 // to derive ECS from, so refreshing a scoped entry would lose its
 // scope and store the wrong-audience answer.
-func (s *Store) SetFromResponseScoped(key uint64, resp *dns.Msg) {
-	s.setFromResponseWithKey(key, resp, true)
+func (s *Store) SetFromResponseScoped(key uint64, resp *dns.Msg, cutUntil time.Time, cutKey uint64) {
+	s.setFromResponseWithKey(key, resp, true, cutUntil, cutKey)
 }
 
-func (s *Store) setFromResponseWithKey(key uint64, resp *dns.Msg, scoped bool) {
+func (s *Store) setFromResponseWithKey(key uint64, resp *dns.Msg, scoped bool, cutUntil time.Time, cutKey uint64) {
 	mt, _ := dnsutil.ClassifyResponse(resp, time.Now().UTC())
 	filtered := filterCacheableAnswer(resp)
 	msgTTL := dnsutil.CalculateCacheTTL(filtered, mt)
@@ -178,12 +186,16 @@ func (s *Store) setFromResponseWithKey(key uint64, resp *dns.Msg, scoped bool) {
 	}
 
 	newEntry := func(msg *dns.Msg, ttl time.Duration) *CacheEntry {
+		var e *CacheEntry
 		if scoped {
-			e := NewScopedCacheEntry(msg, ttl, s.cfg.RateLimit)
+			e = NewScopedCacheEntry(msg, ttl, s.cfg.RateLimit)
 			e.rateLimKey = key
-			return e
+		} else {
+			e = NewCacheEntryWithKey(msg, ttl, s.cfg.RateLimit, key)
 		}
-		return NewCacheEntryWithKey(msg, ttl, s.cfg.RateLimit, key)
+		e.cutUntil = cutUntil
+		e.cutKey = cutKey
+		return e
 	}
 
 	switch mt {
@@ -194,6 +206,46 @@ func (s *Store) setFromResponseWithKey(key uint64, resp *dns.Msg, scoped bool) {
 		ttl := capTTL(s.negative.ttl.Calculate(msgTTL))
 		s.negative.Set(key, newEntry(filtered, ttl))
 	}
+}
+
+// ReplaceIfCurrent stores resp under key only if expected is still
+// the live entry for that key — the pointer-CAS late-write guard for
+// asynchronous refreshes (GHSA-mqfw-f48p-2vc8). A prefetch captures
+// the entry that claimed it; by the time its refresh returns, newer
+// state (a withdrawal NXDOMAIN, a re-delegated answer) may have
+// replaced that entry, and the stale result must be dropped, not
+// stored. Returns whether the replacement happened.
+//
+// Two deliberate asymmetries:
+//   - A SERVFAIL refresh never displaces a positive entry: it only
+//     CASes into the negative cache, so a transient upstream failure
+//     can't evict a still-valid answer.
+//   - The CAS stays within one sub-cache. A negative entry refreshing
+//     to a positive answer is dropped rather than promoted — the two
+//     caches can't be swapped atomically, and the negative entry's
+//     short TTL re-resolves naturally.
+func (s *Store) ReplaceIfCurrent(key uint64, expected *CacheEntry, resp *dns.Msg, cutUntil time.Time, cutKey uint64) bool {
+	if expected == nil || len(resp.Question) == 0 {
+		return false
+	}
+
+	mt, _ := dnsutil.ClassifyResponse(resp, time.Now().UTC())
+	filtered := filterCacheableAnswer(resp)
+	msgTTL := dnsutil.CalculateCacheTTL(filtered, mt)
+
+	switch mt {
+	case dnsutil.TypeSuccess, dnsutil.TypeReferral, dnsutil.TypeNXDomain, dnsutil.TypeNoRecords:
+		entry := NewCacheEntryWithKey(filtered, s.positive.ttl.Calculate(msgTTL), s.cfg.RateLimit, key)
+		entry.cutUntil = cutUntil
+		entry.cutKey = cutKey
+		return s.positive.cache.CompareAndSwap(key, expected, entry)
+	case dnsutil.TypeServerFailure:
+		entry := NewCacheEntryWithKey(filtered, s.negative.ttl.Calculate(msgTTL), s.cfg.RateLimit, key)
+		entry.cutUntil = cutUntil
+		entry.cutKey = cutKey
+		return s.negative.cache.CompareAndSwap(key, expected, entry)
+	}
+	return false
 }
 
 // SetEntryWithKey replaces a stored entry directly. Used by

--- a/middleware/cache/store_test.go
+++ b/middleware/cache/store_test.go
@@ -79,7 +79,7 @@ func TestStoreGetLookupRoundTrip(t *testing.T) {
 	s := newTestStore(t)
 
 	resp := newTestSuccessResp("example.com.")
-	s.SetFromResponse(resp, false)
+	s.SetFromResponse(resp, false, time.Time{})
 
 	req := new(dns.Msg)
 	req.SetQuestion("example.com.", dns.TypeA)
@@ -129,11 +129,11 @@ func TestStorePurge(t *testing.T) {
 	s := newTestStore(t)
 
 	respCDFalse := newTestSuccessResp("purge.com.")
-	s.SetFromResponse(respCDFalse, false)
+	s.SetFromResponse(respCDFalse, false, time.Time{})
 
 	respCDTrue := newTestSuccessResp("purge.com.")
 	respCDTrue.CheckingDisabled = true
-	s.SetFromResponse(respCDTrue, true)
+	s.SetFromResponse(respCDTrue, true, time.Time{})
 
 	// Confirm both sides populated.
 	reqCDFalse := new(dns.Msg)
@@ -166,7 +166,7 @@ func TestCachePurgePublicAPI(t *testing.T) {
 	defer c.Stop()
 
 	resp := newTestSuccessResp("purge.com.")
-	c.store.SetFromResponse(resp, false)
+	c.store.SetFromResponse(resp, false, time.Time{})
 
 	req := new(dns.Msg)
 	req.SetQuestion("purge.com.", dns.TypeA)

--- a/middleware/cache/types.go
+++ b/middleware/cache/types.go
@@ -36,6 +36,34 @@ type CacheEntry struct {
 	// entries are not eligible for background refresh — they just
 	// expire normally. PrefetchEligible() reflects this.
 	scoped bool
+
+	// cutUntil bounds the entry's effective lifetime to the
+	// delegation cut that produced the answer (GHSA-mqfw-f48p-2vc8,
+	// answer-cache ghost): an answer must never be served past the
+	// parent-granted lease of the delegation it came from, no matter
+	// how long its own TTL is. Zero means unbounded (forwarder and
+	// local answers, or no learned delegation on the path). Enforced
+	// at read time — remaining() takes the min of the TTL expiry and
+	// this deadline — so it also overrides the configured MinTTL
+	// floor when the cut is shorter.
+	cutUntil time.Time
+
+	// cutKey identifies the delegation cache entry that supplied cutUntil.
+	// It is retained for the optional Phase-3 generation design; Phase 1b
+	// enforcement depends only on cutUntil.
+	cutKey uint64
+}
+
+// remaining returns the entry's effective remaining lifetime at now:
+// the stored TTL minus elapsed time, further bounded by cutUntil.
+func (e *CacheEntry) remaining(now time.Time) time.Duration {
+	rem := e.ttl - now.Sub(e.stored)
+	if !e.cutUntil.IsZero() {
+		if cutRem := e.cutUntil.Sub(now); cutRem < rem {
+			rem = cutRem
+		}
+	}
+	return rem
 }
 
 // NewCacheEntry creates a new cache entry from a DNS message.
@@ -90,8 +118,11 @@ func NewCacheEntryWithKey(msg *dns.Msg, ttl time.Duration, rateLimit int, key ui
 	}
 
 	entry := &CacheEntry{
-		msg:        msgCopy,
-		stored:     time.Now().UTC(),
+		msg: msgCopy,
+		// Keep the monotonic clock reading. Converting to UTC strips it and
+		// would let a backward wall-clock adjustment extend both the TTL and
+		// an inherited delegation cut.
+		stored:     time.Now(),
 		ttl:        ttl,
 		origTTL:    uint32(ttl.Seconds()),
 		rateLimit:  rateLimit,
@@ -104,9 +135,8 @@ func NewCacheEntryWithKey(msg *dns.Msg, ttl time.Duration, rateLimit int, key ui
 
 // (*CacheEntry).ToMsg toMsg creates a response message with updated TTLs.
 func (e *CacheEntry) ToMsg(req *dns.Msg) *dns.Msg {
-	now := time.Now().UTC()
-	elapsed := now.Sub(e.stored)
-	remainingTTL := e.ttl - elapsed
+	now := time.Now()
+	remainingTTL := e.remaining(now)
 
 	if remainingTTL <= 0 {
 		return nil
@@ -181,12 +211,12 @@ func (e *CacheEntry) ToMsg(req *dns.Msg) *dns.Msg {
 
 // (*CacheEntry).IsExpired isExpired checks if the cache entry has expired.
 func (e *CacheEntry) IsExpired() bool {
-	return time.Since(e.stored) >= e.ttl
+	return e.remaining(time.Now()) <= 0
 }
 
 // (*CacheEntry).TTL TTL returns the remaining TTL in seconds.
 func (e *CacheEntry) TTL() int {
-	remaining := e.ttl - time.Since(e.stored)
+	remaining := e.remaining(time.Now())
 	if remaining <= 0 {
 		return 0
 	}

--- a/middleware/chain.go
+++ b/middleware/chain.go
@@ -2,9 +2,120 @@ package middleware
 
 import (
 	"context"
+	"sync/atomic"
+	"time"
 
 	"github.com/miekg/dns"
 )
+
+// ResponseMeta carries resolver-produced metadata about a response
+// that the wire format cannot express — today the delegation-cut
+// deadline that bounds how long the answer may be cached
+// (GHSA-mqfw-f48p-2vc8, answer-cache ghost).
+//
+// One ResponseMeta spans a whole client request tree: the first
+// middleware that needs it establishes it in ctx (usually pointing at
+// its Chain's pooled Meta field) and every nested sub-pipeline reuses
+// the ctx one, so deadlines observed anywhere in the tree accumulate
+// into the same place. Folding is min-only (BoundCut), which makes
+// cross-leg sharing safe: the worst case is an answer cached slightly
+// shorter than its own cut allowed, never longer.
+type responseCut struct {
+	deadline time.Time
+	key      uint64
+}
+
+type ResponseMeta struct {
+	// cut is an atomic pointer to an immutable deadline. Resolver work can
+	// fan out into concurrent NS-address sub-queries that share the request
+	// context, so a plain time.Time here races even though every update is
+	// min-only.
+	cut atomic.Pointer[responseCut]
+}
+
+// (*ResponseMeta).BoundCut folds a delegation-cut deadline into the
+// meta, keeping the earliest. Nil-safe and zero-ignoring so resolver
+// call sites can invoke it unconditionally.
+func (m *ResponseMeta) BoundCut(deadline time.Time) {
+	m.BoundCutFor(deadline, 0)
+}
+
+// BoundCutFor folds a delegation-cut deadline and its cache identity into the
+// response metadata. The identity travels with the winning (earliest)
+// deadline as one immutable atomic value, ready for the optional generation
+// checks described by the Ghost/Phoenix durable design.
+func (m *ResponseMeta) BoundCutFor(deadline time.Time, key uint64) {
+	if m == nil || deadline.IsZero() {
+		return
+	}
+
+	next := &responseCut{deadline: deadline, key: key}
+	for {
+		current := m.cut.Load()
+		if current != nil && !deadline.Before(current.deadline) {
+			return
+		}
+		if m.cut.CompareAndSwap(current, next) {
+			return
+		}
+	}
+}
+
+// Cut returns the earliest delegation-cut deadline observed for the request
+// tree and the delegation-cache key that supplied it. A zero deadline means
+// unbounded; in that case the key is also zero.
+func (m *ResponseMeta) Cut() (time.Time, uint64) {
+	if m == nil {
+		return time.Time{}, 0
+	}
+	if cut := m.cut.Load(); cut != nil {
+		return cut.deadline, cut.key
+	}
+	return time.Time{}, 0
+}
+
+// CutUntil returns the earliest delegation-cut deadline observed for the
+// request tree. Zero means unbounded.
+func (m *ResponseMeta) CutUntil() time.Time {
+	deadline, _ := m.Cut()
+	return deadline
+}
+
+// CutKey returns the delegation-cache key associated with CutUntil. It is
+// meaningful only when CutUntil is non-zero.
+func (m *ResponseMeta) CutKey() uint64 {
+	_, key := m.Cut()
+	return key
+}
+
+// Reset clears the accumulated deadline before a pooled Chain is reused.
+// Store(nil) is safe even if the ResponseMeta has previously been used; do
+// not replace the struct by assignment because atomic values must not be
+// copied after first use.
+func (m *ResponseMeta) Reset() {
+	if m != nil {
+		m.cut.Store(nil)
+	}
+}
+
+// responseMetaKey tags ctx with the active *ResponseMeta. Sentinel
+// pointer keeps ctx.Value comparisons alloc-free.
+type responseMetaKeyType struct{}
+
+var responseMetaKey = &responseMetaKeyType{}
+
+// WithResponseMeta returns a derived ctx carrying m as the request
+// tree's response metadata sink.
+func WithResponseMeta(ctx context.Context, m *ResponseMeta) context.Context {
+	return context.WithValue(ctx, responseMetaKey, m)
+}
+
+// ResponseMetaFrom returns the ctx's response metadata sink, or nil
+// when none was established (background/priming work).
+func ResponseMetaFrom(ctx context.Context) *ResponseMeta {
+	m, _ := ctx.Value(responseMetaKey).(*ResponseMeta)
+	return m
+}
 
 // Chain carries per-request state through the middleware pipeline.
 // Instances are reused via a sync.Pool: NewChain allocates the fixed
@@ -12,6 +123,13 @@ import (
 type Chain struct {
 	Writer  ResponseWriter
 	Request *dns.Msg
+
+	// Meta is the pooled backing storage for the request's
+	// ResponseMeta. The first middleware that needs a meta sink and
+	// finds none in ctx establishes &Meta via WithResponseMeta;
+	// nested pipelines then reuse the ctx pointer rather than their
+	// own chain's field.
+	Meta ResponseMeta
 
 	handlers []Handler
 	pos      int // index of the next handler to run
@@ -68,6 +186,7 @@ func (ch *Chain) CancelWithRcode(rcode int, do bool) {
 func (ch *Chain) Reset(w dns.ResponseWriter, r *dns.Msg) {
 	ch.Writer.Reset(w)
 	ch.Request = r
+	ch.Meta.Reset()
 	ch.pos = 0
 	ch.count = len(ch.handlers)
 }

--- a/middleware/chain_test.go
+++ b/middleware/chain_test.go
@@ -2,12 +2,57 @@ package middleware
 
 import (
 	"context"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestResponseMeta_ConcurrentBoundCut(t *testing.T) {
+	var meta ResponseMeta
+	base := time.Now()
+	earliest := base.Add(time.Second)
+	const earliestKey = uint64(0xfeed)
+
+	deadlines := make([]time.Time, 128)
+	for i := range deadlines {
+		deadlines[i] = base.Add(time.Duration(i+2) * time.Second)
+	}
+	deadlines[len(deadlines)/2] = earliest
+
+	var wg sync.WaitGroup
+	for i, deadline := range deadlines {
+		deadline := deadline
+		key := uint64(i + 1)
+		if deadline.Equal(earliest) {
+			key = earliestKey
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			meta.BoundCutFor(deadline, key)
+		}()
+	}
+	wg.Wait()
+
+	if got := meta.CutUntil(); !got.Equal(earliest) {
+		t.Fatalf("CutUntil = %v, want earliest concurrent deadline %v", got, earliest)
+	}
+	if got := meta.CutKey(); got != earliestKey {
+		t.Fatalf("CutKey = %#x, want earliest cut key %#x", got, earliestKey)
+	}
+
+	meta.Reset()
+	if got := meta.CutUntil(); !got.IsZero() {
+		t.Fatalf("CutUntil after Reset = %v, want zero", got)
+	}
+	if got := meta.CutKey(); got != 0 {
+		t.Fatalf("CutKey after Reset = %#x, want zero", got)
+	}
+}
 
 func Test_Chain(t *testing.T) {
 	w := mock.NewWriter("tcp", "127.0.0.1:0")

--- a/middleware/resolver/ghost_answer_prefetch_test.go
+++ b/middleware/resolver/ghost_answer_prefetch_test.go
@@ -1,0 +1,222 @@
+package resolver
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/middleware"
+	cachemw "github.com/semihalev/sdns/middleware/cache"
+)
+
+// chainQueryer runs a request through the given handlers — the
+// minimal stand-in for the sub-pipeline Queryer that sdns.go wiring
+// installs in production.
+type chainQueryer struct{ handlers []middleware.Handler }
+
+func (q *chainQueryer) Query(ctx context.Context, req *dns.Msg) (*dns.Msg, error) {
+	w := mock.NewWriter("tcp", "127.0.0.255:0")
+	ch := middleware.NewChain(q.handlers)
+	ch.Reset(w, req)
+	ch.Next(ctx)
+	if !w.Written() {
+		return nil, middleware.ErrNoResponse
+	}
+	return w.Msg(), nil
+}
+
+// TestGhostDomain_AnswerCacheAndPrefetch_FullPipeline is the full
+// parent-referral → answer-cache → prefetch → withdrawal regression
+// for GHSA-mqfw-f48p-2vc8, covering the two layers above the
+// delegation cache:
+//
+//   - Phase 1b (answer-cache ghost): an answer with a long TTL (600s)
+//     obtained through a short delegation lease (1s) must stop being
+//     served when the lease expires — the entry's cutUntil, fed
+//     through the Chain.Meta seam, overrides both the answer TTL and
+//     the 5s MinTTL floor.
+//   - Phase 2 (late prefetch overwrite): a prefetch refresh that
+//     started before the withdrawal and returns after a newer
+//     NXDOMAIN landed must be dropped by the pointer-CAS write-back,
+//     not resurrect the withdrawn domain.
+//
+// Topology: mock root delegates ghost. (NS TTL 1s, TEST-NET glue
+// remapped to a loopback listener); the former child keeps answering
+// www.ghost. with a 600s TTL. The refresh is made deterministically
+// "late" by blocking the child's second answer on a channel the test
+// releases only after the withdrawal NXDOMAIN is cached.
+func TestGhostDomain_AnswerCacheAndPrefetch_FullPipeline(t *testing.T) {
+	var ignore int64
+
+	softNeg := func(zone string) *dns.Msg {
+		m := &dns.Msg{}
+		m.Authoritative = true
+		if zone == "." {
+			m.Ns = []dns.RR{mustRR(t, ". 30 IN SOA a.root. hostmaster.root. 1 30 30 30 30")}
+		} else {
+			m.Ns = []dns.RR{mustRR(t, zone+" 30 IN SOA ns."+zone+" hostmaster."+zone+" 1 30 30 30 30")}
+		}
+		return m
+	}
+
+	// ghost. — the former child. Keeps answering with a LONG TTL. The
+	// second-and-later A query is the prefetch refresh: signal it and
+	// block until the test releases it (bounded well under the 2s
+	// exchange timeout so the refresh completes rather than erroring).
+	var wwwQueries atomic.Int64
+	var signalStart sync.Once
+	refreshStarted := make(chan struct{})
+	releaseRefresh := make(chan struct{})
+	ghostAddr, stopGhost := startMockAuth(t, &ignore, func(q dns.Question) *dns.Msg {
+		if q.Qtype == dns.TypeA && dns.CanonicalName(q.Name) == "www.ghost." {
+			if wwwQueries.Add(1) >= 2 {
+				signalStart.Do(func() { close(refreshStarted) })
+				select {
+				case <-releaseRefresh:
+				case <-time.After(1900 * time.Millisecond):
+				}
+			}
+			m := &dns.Msg{}
+			m.Authoritative = true
+			m.Answer = []dns.RR{mustRR(t, "www.ghost. 600 IN A 192.0.2.55")}
+			return m
+		}
+		return softNeg("ghost.")
+	})
+	defer stopGhost()
+
+	// root — delegates ghost. with a 1s lease until the withdrawal
+	// flag flips, then answers NXDOMAIN for everything under it.
+	var withdrawn atomic.Bool
+	rootAddr, stopRoot := startMockAuth(t, &ignore, func(q dns.Question) *dns.Msg {
+		if dns.CanonicalName(q.Name) == "." && q.Qtype == dns.TypeNS {
+			m := &dns.Msg{}
+			m.Authoritative = true
+			m.Answer = []dns.RR{mustRR(t, ". 3600 IN NS a.root.")}
+			return m
+		}
+		if q.Qtype == dns.TypeDS {
+			return softNeg(".")
+		}
+		if dns.IsSubDomain("ghost.", dns.CanonicalName(q.Name)) || dns.CanonicalName(q.Name) == "ghost." {
+			if withdrawn.Load() {
+				m := softNeg(".")
+				m.Rcode = dns.RcodeNameError
+				return m
+			}
+			m := &dns.Msg{} // referral
+			m.Ns = []dns.RR{mustRR(t, "ghost. 1 IN NS ns.ghost.")}
+			m.Extra = []dns.RR{mustRR(t, "ns.ghost. 1 IN A 192.0.2.21")}
+			return m
+		}
+		return softNeg(".")
+	})
+	defer stopRoot()
+
+	remap := map[string]string{"192.0.2.21:53": ghostAddr}
+	mapper := func(addr string) string {
+		if to, ok := remap[addr]; ok {
+			return to
+		}
+		return addr
+	}
+
+	base := makeTestConfig()
+	cfg := *base
+	cfg.RootServers = []string{rootAddr}
+	cfg.Root6Servers = nil
+	cfg.DNSSEC = "off"
+	cfg.CacheSize = 1024
+	cfg.Prefetch = 90
+	cfg.RateLimit = 0
+
+	h := New(&cfg)
+	h.resolver.resolveTarget.Store(&mapper)
+
+	cm := cachemw.New(&cfg)
+	defer cm.Stop()
+	refreshPipeline := &chainQueryer{handlers: []middleware.Handler{h}}
+	cm.SetPrefetchQueryer(refreshPipeline)
+	cm.SetQueryer(refreshPipeline)
+
+	ask := func(label string) *dns.Msg {
+		t.Helper()
+		req := new(dns.Msg)
+		req.SetQuestion("www.ghost.", dns.TypeA)
+		w := mock.NewWriter("udp", "127.0.0.1:0")
+		ch := middleware.NewChain([]middleware.Handler{cm, h})
+		ch.Reset(w, req)
+		ch.Next(context.Background())
+		if !w.Written() {
+			t.Fatalf("%s: no response written", label)
+		}
+		return w.Msg()
+	}
+
+	// 1. Prime the cache: 600s answer under the 1s ghost. lease.
+	if resp := ask("prime"); resp.Rcode != dns.RcodeSuccess || len(resp.Answer) == 0 {
+		t.Fatalf("prime: expected a positive answer, got rcode=%s answers=%d",
+			dns.RcodeToString[resp.Rcode], len(resp.Answer))
+	}
+	probe := new(dns.Msg)
+	probe.SetQuestion("www.ghost.", dns.TypeA)
+	cacheStore, ok := cm.Store().(*cachemw.Store)
+	if !ok {
+		t.Fatal("cache StoreProvider did not return *cache.Store")
+	}
+	claimedEntry, ok := cacheStore.Lookup(probe)
+	if !ok {
+		t.Fatal("prime: cached entry not found for prefetch claim tracking")
+	}
+
+	// 2. Cache hit claims the prefetch; wait until the refresh has
+	// actually reached the former child (and is now held there).
+	if resp := ask("hit"); resp.Rcode != dns.RcodeSuccess {
+		t.Fatalf("hit: expected a positive answer, got rcode=%s", dns.RcodeToString[resp.Rcode])
+	}
+	select {
+	case <-refreshStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("prefetch refresh never reached the former child")
+	}
+
+	// 3. The parent withdraws the delegation while the refresh is in
+	// flight, and the 1s lease (delegation AND answer cut) runs out.
+	withdrawn.Store(true)
+	time.Sleep(1300 * time.Millisecond)
+
+	// 4. Phase 1b: the 600s answer must NOT be served past its 1s cut
+	// (without cutUntil this is a cache hit — TTL and the 5s MinTTL
+	// floor both leave the entry valid). The miss re-resolves via the
+	// parent and caches the withdrawal NXDOMAIN.
+	if resp := ask("post-withdrawal"); resp.Rcode != dns.RcodeNameError {
+		t.Fatalf("ghost answer served past its delegation cut: rcode=%s answers=%d",
+			dns.RcodeToString[resp.Rcode], len(resp.Answer))
+	}
+
+	// 5. Phase 2: release the stale refresh. Its positive answer must
+	// be dropped by the pointer-CAS write-back — the entry it claimed
+	// was replaced by the NXDOMAIN.
+	close(releaseRefresh)
+
+	// processPrefetch releases the captured entry's claim in a defer after
+	// ReplaceIfCurrent returns. Waiting for the flag to clear proves the CAS
+	// attempt completed; a fixed sleep could let this test pass before a slow
+	// worker performed a later resurrection.
+	claimDeadline := time.Now().Add(2 * time.Second)
+	for !claimedEntry.ShouldPrefetch(int(cfg.Prefetch)) && time.Now().Before(claimDeadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !claimedEntry.ShouldPrefetch(int(cfg.Prefetch)) {
+		t.Fatal("late prefetch did not finish its CAS attempt")
+	}
+
+	if resp := ask("after-late-prefetch"); resp.Rcode != dns.RcodeNameError {
+		t.Fatalf("late prefetch resurrected the withdrawn domain: rcode=%s answers=%d",
+			dns.RcodeToString[resp.Rcode], len(resp.Answer))
+	}
+}

--- a/middleware/resolver/ghost_domain_test.go
+++ b/middleware/resolver/ghost_domain_test.go
@@ -54,9 +54,9 @@ func mustRR(t *testing.T, s string) dns.RR {
 // GHSA-mqfw-f48p-2vc8 (ghost / phoenix domain) at the delegation-lease layer.
 // It seeds r.delegations with explicit ip:port servers and drives
 // Resolver.Resolve directly, so it exercises the delegation cache + walk-up.
-// It does NOT cover the answer-cache/prefetch pipeline: a full parent-referral
-// -> answer-cache -> prefetch -> withdrawal test is deferred to the
-// delegation-generation/CAS follow-up.
+// The complementary full parent-referral -> answer-cache -> prefetch ->
+// withdrawal pipeline is covered by
+// TestGhostDomain_AnswerCacheAndPrefetch_FullPipeline.
 //
 // Topology (random loopback ports):
 //   - parent: authoritative for ghostzone. The delegation for loop.ghostzone.
@@ -294,5 +294,51 @@ func TestProgressingReferral(t *testing.T) {
 					tc.referral, tc.authZone, qname, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestExtractDelegationInfo_CoherentRRSetAndMinimumTTL(t *testing.T) {
+	resp := new(dns.Msg)
+	resp.Ns = []dns.RR{
+		mustRR(t, "child.example. 300 IN NS ns1.child.example."),
+		mustRR(t, "child.example. 30 IN NS ns2.child.example."),
+		// These records are not members of the anchored owner/class RRset and
+		// must not widen its hosts or shorten/lengthen its lease.
+		mustRR(t, "offpath.example. 1 IN NS ns.offpath.example."),
+		mustRR(t, "child.example. 2 CH NS ns-chaos.child.example."),
+	}
+
+	info := (&Resolver{}).extractDelegationInfo(resp)
+	if info.nsRecord == nil || info.nsRecord.Header().Name != "child.example." {
+		t.Fatalf("anchored NS owner = %v, want child.example.", info.nsRecord)
+	}
+	if info.nsTTL != 30 {
+		t.Fatalf("NS RRset TTL = %d, want minimum coherent TTL 30", info.nsTTL)
+	}
+	if len(info.hosts) != 2 {
+		t.Fatalf("coherent NS hosts = %v, want exactly ns1 and ns2", info.hosts)
+	}
+	for _, host := range []string{"ns1.child.example.", "ns2.child.example."} {
+		if _, ok := info.hosts[host]; !ok {
+			t.Fatalf("coherent NS host %s missing from %v", host, info.hosts)
+		}
+	}
+}
+
+func TestMinRRSetTTL_ZeroWins(t *testing.T) {
+	rrs := []dns.RR{
+		mustRR(t, "child.example. 300 IN DS 12345 13 2 0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"),
+		mustRR(t, "child.example. 0 IN DS 12346 13 2 1123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF"),
+	}
+	if got := minRRSetTTL(rrs); got != 0 {
+		t.Fatalf("minimum DS RRset TTL = %d, want zero", got)
+	}
+}
+
+func TestMinCut_PreservesAncestorIdentityOnEqualDeadline(t *testing.T) {
+	deadline := time.Now().Add(time.Minute)
+	gotDeadline, gotKey := minCut(deadline, 0x601, deadline, 0x602)
+	if !gotDeadline.Equal(deadline) || gotKey != 0x601 {
+		t.Fatalf("equal minCut = (%v, %#x), want ancestor (%v, %#x)", gotDeadline, gotKey, deadline, uint64(0x601))
 	}
 }

--- a/middleware/resolver/handler.go
+++ b/middleware/resolver/handler.go
@@ -87,6 +87,14 @@ func (h *DNSHandler) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	if ctx.Value(contextKeyRequestID) == nil {
 		ctx = context.WithValue(ctx, contextKeyRequestID, req.Id)
 	}
+	// Ensure a ResponseMeta sink exists so resolve() can report the
+	// delegation-cut deadline that bounds caching of this answer.
+	// Normally the cache middleware established one already (and
+	// reads it back on WriteMsg); this covers cache-less pipelines,
+	// where the sink is simply never consumed.
+	if middleware.ResponseMetaFrom(ctx) == nil {
+		ctx = middleware.WithResponseMeta(ctx, &ch.Meta)
+	}
 	msg := h.handle(ctx, req)
 
 	_ = w.WriteMsg(msg)

--- a/middleware/resolver/optout_delegation_test.go
+++ b/middleware/resolver/optout_delegation_test.go
@@ -63,7 +63,7 @@ func (s *cannedDNSSECStore) Get(req *dns.Msg) (*dns.Msg, bool) {
 	return nil, false
 }
 
-func (s *cannedDNSSECStore) SetFromResponse(resp *dns.Msg, keyCD bool) {}
+func (s *cannedDNSSECStore) SetFromResponse(resp *dns.Msg, keyCD bool, cutUntil time.Time) {}
 
 // Test_provenInsecureDelegation_OptOutSpan reproduces issue #506
 // (variant 1, tether.edge.apple): a signed parent zone that uses

--- a/middleware/resolver/parent_deadline_test.go
+++ b/middleware/resolver/parent_deadline_test.go
@@ -1,0 +1,141 @@
+package resolver
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// TestGhostDomain_ParentStateAtLeaseDeadline complements the withdrawal
+// regressions with the other two parent outcomes at the same boundary: an
+// unchanged delegation is renewed through the parent, while a re-delegation
+// switches to the new child and never consults the former child again.
+func TestGhostDomain_ParentStateAtLeaseDeadline(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		redelegate  bool
+		wantAddress string
+	}{
+		{name: "parent unchanged", wantAddress: "192.0.2.10"},
+		{name: "parent redelegated", redelegate: true, wantAddress: "192.0.2.20"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var rootHits, oldHits, newHits int64
+
+			leaf := func(address string) func(dns.Question) *dns.Msg {
+				return func(q dns.Question) *dns.Msg {
+					m := new(dns.Msg)
+					m.Authoritative = true
+					if q.Qtype == dns.TypeA && dns.CanonicalName(q.Name) == "www.ghost." {
+						m.Answer = []dns.RR{mustRR(t, "www.ghost. 300 IN A "+address)}
+						return m
+					}
+					m.Ns = []dns.RR{mustRR(t, "ghost. 30 IN SOA ns.ghost. hostmaster.ghost. 1 30 30 30 30")}
+					return m
+				}
+			}
+
+			oldAddr, stopOld := startMockAuth(t, &oldHits, leaf("192.0.2.10"))
+			defer stopOld()
+			newAddr, stopNew := startMockAuth(t, &newHits, leaf("192.0.2.20"))
+			defer stopNew()
+
+			var switched atomic.Bool
+			rootAddr, stopRoot := startMockAuth(t, &rootHits, func(q dns.Question) *dns.Msg {
+				m := new(dns.Msg)
+				name := dns.CanonicalName(q.Name)
+				if name == "." && q.Qtype == dns.TypeNS {
+					m.Authoritative = true
+					m.Answer = []dns.RR{mustRR(t, ". 3600 IN NS a.root.")}
+					return m
+				}
+				if q.Qtype == dns.TypeDS {
+					m.Authoritative = true
+					m.Ns = []dns.RR{mustRR(t, ". 30 IN SOA a.root. hostmaster.root. 1 30 30 30 30")}
+					return m
+				}
+				if dns.IsSubDomain("ghost.", name) || name == "ghost." {
+					if switched.Load() {
+						m.Ns = []dns.RR{mustRR(t, "ghost. 1 IN NS ns2.ghost.")}
+						m.Extra = []dns.RR{mustRR(t, "ns2.ghost. 1 IN A 192.0.2.22")}
+					} else {
+						m.Ns = []dns.RR{mustRR(t, "ghost. 1 IN NS ns1.ghost.")}
+						m.Extra = []dns.RR{mustRR(t, "ns1.ghost. 1 IN A 192.0.2.21")}
+					}
+					return m
+				}
+				m.Authoritative = true
+				m.Ns = []dns.RR{mustRR(t, ". 30 IN SOA a.root. hostmaster.root. 1 30 30 30 30")}
+				return m
+			})
+			defer stopRoot()
+
+			remap := map[string]string{
+				"192.0.2.21:53": oldAddr,
+				"192.0.2.22:53": newAddr,
+			}
+			mapper := func(addr string) string {
+				if target, ok := remap[addr]; ok {
+					return target
+				}
+				return addr
+			}
+
+			base := makeTestConfig()
+			cfg := *base
+			cfg.RootServers = []string{rootAddr}
+			cfg.Root6Servers = nil
+			cfg.DNSSEC = "off"
+			r := newWiredTestResolver(&cfg)
+			r.resolveTarget.Store(&mapper)
+
+			ask := func() string {
+				t.Helper()
+				req := new(dns.Msg)
+				req.SetQuestion("www.ghost.", dns.TypeA)
+				req.CheckingDisabled = true
+				ctx := context.WithValue(context.Background(), contextKeyRequestID, req.Id)
+				resp, err := r.Resolve(ctx, req, r.rootServers, true, 30, 0, true, nil)
+				if err != nil {
+					t.Fatalf("resolve failed: %v", err)
+				}
+				for _, rr := range resp.Answer {
+					if a, ok := rr.(*dns.A); ok {
+						return a.A.String()
+					}
+				}
+				return ""
+			}
+
+			if got := ask(); got != "192.0.2.10" {
+				t.Fatalf("initial answer = %q, want former child", got)
+			}
+			rootBefore := atomic.LoadInt64(&rootHits)
+			oldBefore := atomic.LoadInt64(&oldHits)
+			if tc.redelegate {
+				switched.Store(true)
+			}
+
+			time.Sleep(1300 * time.Millisecond)
+			if got := ask(); got != tc.wantAddress {
+				t.Fatalf("post-deadline answer = %q, want %q", got, tc.wantAddress)
+			}
+			if atomic.LoadInt64(&rootHits) <= rootBefore {
+				t.Fatal("parent was not contacted after the delegation deadline")
+			}
+			if tc.redelegate {
+				if got := atomic.LoadInt64(&oldHits); got != oldBefore {
+					t.Fatalf("former child contacted after re-delegation: hits %d -> %d", oldBefore, got)
+				}
+				if atomic.LoadInt64(&newHits) == 0 {
+					t.Fatal("new child was not contacted after re-delegation")
+				}
+			} else if atomic.LoadInt64(&oldHits) <= oldBefore {
+				t.Fatal("unchanged child was not renewed through the parent")
+			}
+		})
+	}
+}

--- a/middleware/resolver/phoenix_t2_test.go
+++ b/middleware/resolver/phoenix_t2_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/internal/authority"
 	"github.com/semihalev/sdns/internal/cache"
+	"github.com/semihalev/sdns/middleware"
 )
 
 // TestPhoenixT2_NestedDelegationInheritsAncestorDeadline is the Phase-1a
@@ -117,6 +118,10 @@ func TestPhoenixT2_NestedDelegationInheritsAncestorDeadline(t *testing.T) {
 	req.SetQuestion("www.sub.ghostzone.", dns.TypeA)
 	req.CheckingDisabled = true
 	ctx := context.WithValue(context.Background(), contextKeyRequestID, req.Id)
+	// Phase 1b seam: the resolution must report the delegation-cut
+	// deadline that bounds caching of this answer into the ctx meta.
+	var meta middleware.ResponseMeta
+	ctx = middleware.WithResponseMeta(ctx, &meta)
 
 	resp, err := r.Resolve(ctx, req, r.rootServers, true, 30, 0, true, nil)
 	if err != nil {
@@ -151,6 +156,17 @@ func TestPhoenixT2_NestedDelegationInheritsAncestorDeadline(t *testing.T) {
 	// And it must be far below the 12h it advertised.
 	if subDeleg.ExpiresAt.After(time.Now().Add(time.Hour)) {
 		t.Fatalf("Phoenix T2: nested cut cached for far longer than the ancestor lease: ExpiresAt=%s", subDeleg.ExpiresAt)
+	}
+
+	// Phase 1b: the answer's reported cache bound must be the deepest
+	// cut on the path — exactly the (inherited) sub delegation deadline.
+	if !meta.CutUntil().Equal(subDeleg.ExpiresAt) {
+		t.Fatalf("ResponseMeta.CutUntil = %s, want the answering cut's deadline %s",
+			meta.CutUntil(), subDeleg.ExpiresAt)
+	}
+	ghostKey := cache.Key(dns.Question{Name: "ghostzone.", Qtype: dns.TypeNS, Qclass: dns.ClassINET}, true)
+	if got := meta.CutKey(); got != ghostKey {
+		t.Fatalf("ResponseMeta.CutKey = %#x, want shortest ancestor ghostzone key %#x", got, ghostKey)
 	}
 }
 

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -124,6 +124,7 @@ type resolveState struct {
 	// can never outlive an ancestor cut — the Phoenix downward-delegation
 	// (T2) protection (GHSA-mqfw-f48p-2vc8).
 	cutDeadline time.Time
+	cutKey      uint64
 }
 
 // minNonZero returns the earlier of two deadlines, treating a zero time as
@@ -139,6 +140,34 @@ func minNonZero(a, b time.Time) time.Time {
 	default:
 		return b
 	}
+}
+
+// minCut returns the earliest bounded cut together with the identity that
+// supplied it. Zero deadlines are unbounded. On equal deadlines the first
+// cut wins, preserving the ancestor identity when a descendant inherits the
+// exact same absolute expiry.
+func minCut(a time.Time, aKey uint64, b time.Time, bKey uint64) (time.Time, uint64) {
+	switch {
+	case a.IsZero():
+		return b, bKey
+	case b.IsZero():
+		return a, aKey
+	case b.Before(a):
+		return b, bKey
+	default:
+		return a, aKey
+	}
+}
+
+// noteCut folds a delegation-cut deadline into the request tree's
+// ResponseMeta sink (established by the cache middleware or
+// DNSHandler.ServeDNS). The cache layer reads the accumulated minimum
+// back when storing the answer, so a cached answer can never outlive
+// the delegation cut that produced it (GHSA-mqfw-f48p-2vc8,
+// answer-cache ghost). No-op when ctx carries no sink (priming,
+// background work) or the deadline is zero.
+func noteCut(ctx context.Context, deadline time.Time, key uint64) {
+	middleware.ResponseMetaFrom(ctx).BoundCutFor(deadline, key)
 }
 
 type hostSet map[string]struct{}
@@ -305,7 +334,8 @@ func (r *Resolver) resolve(ctx context.Context, rs *resolveState) (*dns.Msg, err
 		rs.servers, rs.parentDS, rs.level = m.servers, m.parentDS, m.level
 		// Seed the cut deadline from the deepest cached delegation so any
 		// delegation established below it inherits this bound.
-		rs.cutDeadline = minNonZero(rs.cutDeadline, m.deadline)
+		rs.cutDeadline, rs.cutKey = minCut(rs.cutDeadline, rs.cutKey, m.deadline, m.key)
+		noteCut(ctx, rs.cutDeadline, rs.cutKey)
 	}
 
 	// RFC 7816 query minimization. There are some concerns in RFC.
@@ -1555,13 +1585,14 @@ func (r *Resolver) newDialer(ctx context.Context, rs *resolveState, proto string
 
 // delegationMatch is the result of a delegation-cache walk: the servers to
 // use, the DS set proving the delegation, the descent level, and the absolute
-// expiry of the matched cut (zero for the root, which is unbounded). The
-// deadline seeds resolveState.cutDeadline so descendants inherit it.
+// expiry + identity of the matched cut (zero for the root, which is
+// unbounded). The pair seeds resolveState so descendants inherit it.
 type delegationMatch struct {
 	servers  *authority.Servers
 	parentDS []dns.RR
 	level    int
 	deadline time.Time
+	key      uint64
 }
 
 func (r *Resolver) searchCache(q dns.Question, cd bool, origin string) delegationMatch {
@@ -1593,6 +1624,7 @@ func (r *Resolver) searchCache(q dns.Question, cd bool, origin string) delegatio
 			parentDS: ns.DSSet,
 			level:    dns.CompareDomainName(origin, q.Name),
 			deadline: ns.ExpiresAt,
+			key:      key,
 		}
 	}
 
@@ -2033,7 +2065,22 @@ func (r *Resolver) subQuery(ctx context.Context, req *dns.Msg) (*dns.Msg, error)
 		return nil, err
 	}
 	if store != nil && resp != nil {
-		(*store).SetFromResponse(resp, req.CheckingDisabled)
+		// Bound the entry to the delegation cut the sub-resolution
+		// walked (its terminal noteCut calls fed the same ctx sink).
+		// Zero when no sink exists (priming/background) — unbounded,
+		// matching the pre-seam behaviour.
+		var (
+			cutUntil time.Time
+			cutKey   uint64
+		)
+		if meta := middleware.ResponseMetaFrom(ctx); meta != nil {
+			cutUntil, cutKey = meta.Cut()
+		}
+		if cutStore, ok := (*store).(middleware.CutStore); ok {
+			cutStore.SetFromResponseWithCut(resp, req.CheckingDisabled, cutUntil, cutKey)
+		} else {
+			(*store).SetFromResponse(resp, req.CheckingDisabled, cutUntil)
+		}
 	}
 	return resp, nil
 }
@@ -2693,6 +2740,11 @@ func (r *Resolver) filterAuthorityRecords(nsRecords []dns.RR) []dns.RR {
 func (r *Resolver) processDelegation(ctx context.Context, rs *resolveState, resp *dns.Msg, nsInfo delegationInfo, minimized bool) (*dns.Msg, error) {
 	nsrr := nsInfo.nsRecord
 	q := dns.Question{Name: nsrr.Header().Name, Qtype: nsrr.Header().Rrtype, Qclass: nsrr.Header().Class}
+	// Delegation identity is keyed on the client's CD bit, matching
+	// searchCache. It travels with the winning cut deadline into answer-cache
+	// metadata so a future Phase-3 generation check can identify the owner.
+	keyCD := rs.req.CheckingDisabled
+	key := cache.Key(q, keyCD)
 
 	// Ghost-domain guard (GHSA-mqfw-f48p-2vc8): a referral MUST progress
 	// strictly below the zone we queried. A former child that returns its
@@ -2736,7 +2788,10 @@ func (r *Resolver) processDelegation(ctx context.Context, rs *resolveState, resp
 	// the shallowest delegation on its path (Phoenix T2). This absolute
 	// deadline is stored verbatim (SetUntil), never reconstructed from a
 	// duration, so it cannot be re-inflated by scheduling delay.
-	childDeadline := minNonZero(leaseDeadline, rs.cutDeadline)
+	// Put the ancestor first so an exactly inherited deadline retains the
+	// ancestor's identity rather than being relabelled as the descendant cut.
+	childDeadline, childKey := minCut(rs.cutDeadline, rs.cutKey, leaseDeadline, key)
+	noteCut(ctx, childDeadline, childKey)
 
 	// Check for parent detection
 	nlevel := dns.CountLabel(q.Name)
@@ -2771,8 +2826,6 @@ func (r *Resolver) processDelegation(ctx context.Context, rs *resolveState, resp
 	// it under CD=1 instead — and a transient/unvalidated CD=1 delegation
 	// (client or internal NS/DS lookup) could then be served to CD=0 queries,
 	// silently stripping AD from a genuinely signed zone.
-	keyCD := rs.req.CheckingDisabled
-	key := cache.Key(q, keyCD)
 	if cached, err := r.delegations.Get(key); err == nil {
 		// Carry the CURRENT referral's deadline into the cached descent.
 		// The cached entry may hold a longer lease than the referral we just
@@ -2780,6 +2833,7 @@ func (r *Resolver) processDelegation(ctx context.Context, rs *resolveState, resp
 		// TTL); resolveWithCachedNameservers combines this with
 		// cached.ExpiresAt so the shortest applicable cut always wins.
 		rs.cutDeadline = childDeadline
+		rs.cutKey = childKey
 		return r.resolveWithCachedNameservers(ctx, rs, cached, key, q, cd)
 	}
 
@@ -2839,6 +2893,7 @@ func (r *Resolver) processDelegation(ctx context.Context, rs *resolveState, resp
 	rs.level = nlevel
 	rs.isRoot = false
 	rs.cutDeadline = childDeadline
+	rs.cutKey = childKey
 	return r.resolve(ctx, rs)
 }
 
@@ -3017,6 +3072,7 @@ func (r *Resolver) resolveWithCachedNameservers(ctx context.Context, rs *resolve
 	rs.isRoot = false
 	// Inherit the cached cut's deadline (defensive min, not overwrite) so a
 	// delegation established below it cannot outlive it.
-	rs.cutDeadline = minNonZero(rs.cutDeadline, cached.ExpiresAt)
+	rs.cutDeadline, rs.cutKey = minCut(rs.cutDeadline, rs.cutKey, cached.ExpiresAt, key)
+	noteCut(ctx, rs.cutDeadline, rs.cutKey)
 	return r.resolve(ctx, rs)
 }

--- a/middleware/resolver/setstore_test.go
+++ b/middleware/resolver/setstore_test.go
@@ -13,8 +13,8 @@ import (
 // stubStore implements middleware.Store with no-op semantics.
 type stubStore struct{}
 
-func (stubStore) Get(*dns.Msg) (*dns.Msg, bool)  { return nil, false }
-func (stubStore) SetFromResponse(*dns.Msg, bool) {}
+func (stubStore) Get(*dns.Msg) (*dns.Msg, bool)             { return nil, false }
+func (stubStore) SetFromResponse(*dns.Msg, bool, time.Time) {}
 
 // TestDNSHandlerSetStore pins that SetStore installs the store on
 // the underlying Resolver so subQuery can consult it. Auto-wired

--- a/middleware/resolver/subquery_cache_hit_test.go
+++ b/middleware/resolver/subquery_cache_hit_test.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/middleware"
@@ -23,7 +24,7 @@ func (s *stubHitStore) Get(req *dns.Msg) (*dns.Msg, bool) {
 	return s.resp.Copy(), true
 }
 
-func (s *stubHitStore) SetFromResponse(resp *dns.Msg, keyCD bool) {
+func (s *stubHitStore) SetFromResponse(resp *dns.Msg, keyCD bool, cutUntil time.Time) {
 	s.sets++
 }
 

--- a/middleware/wiring.go
+++ b/middleware/wiring.go
@@ -1,6 +1,10 @@
 package middleware
 
-import "github.com/miekg/dns"
+import (
+	"time"
+
+	"github.com/miekg/dns"
+)
 
 // ClientOnly marks a Handler as serving real client traffic only.
 // Middlewares that implement this method returning true are excluded
@@ -24,7 +28,19 @@ type ClientOnly interface {
 // the cache package.
 type Store interface {
 	Get(req *dns.Msg) (*dns.Msg, bool)
-	SetFromResponse(resp *dns.Msg, keyCD bool)
+	// SetFromResponse stores resp keyed on (Question[0], keyCD).
+	// cutUntil bounds the entry's effective lifetime to the
+	// delegation cut that produced it (GHSA-mqfw-f48p-2vc8); zero
+	// means unbounded.
+	SetFromResponse(resp *dns.Msg, keyCD bool, cutUntil time.Time)
+}
+
+// CutStore is the extended production cache contract. Keeping Store's Phase
+// 1b signature stable avoids forcing plugin/test stores to implement lineage
+// identity before Phase 3 needs it; the built-in cache implements both.
+type CutStore interface {
+	Store
+	SetFromResponseWithCut(resp *dns.Msg, keyCD bool, cutUntil time.Time, cutKey uint64)
 }
 
 // StoreProvider is implemented by handlers that own a Store which


### PR DESCRIPTION
## Summary

Phases 1b and 2 of the durable Ghost/Phoenix protection ([design doc](docs/security/ghost-phoenix-durable-design.md), now committed to the repo), completing the remaining layers above the delegation cache fixed in #513/#514.

### Phase 1b — answer↔cut binding (answer-cache ghost)

A cached answer could outlive the delegation cut that produced it: a 600s answer under a withdrawn 1s lease kept being served, and the 5s MinTTL floor made even short answers survive a shorter cut.

- New `middleware.ResponseMeta` seam: pooled on `Chain.Meta`, shared across nested sub-pipelines via ctx (first establisher wins, min-only folding). The accumulator is an atomic pointer to an immutable deadline+key pair — concurrent NS-address sub-queries share the sink, so a plain field would race.
- The resolver folds the delegation-cut deadline (and the owning delegation cache key, the Phase-3 generation seam) into the sink at every point the cut is known: searchCache seed, `processDelegation`, cached descent.
- Every cache write — external chain, ECS-scoped, subQuery direct — stores `CacheEntry.cutUntil` (+`cutKey`); effective lifetime = `min(stored+ttl, cutUntil)` enforced at read time, so it overrides the MinTTL floor. Zero deadline (forwarder, local answers, root) keeps today's behaviour bit-for-bit.
- `middleware.Store` gains the `cutUntil` parameter; the new `CutStore` extension carries the lineage key so plugin stores aren't forced to implement it.

### Phase 2 — pointer-CAS prefetch write-back (late prefetch overwrite)

The prefetch worker stored its refresh unconditionally, so a refresh started before a withdrawal could land after a newer NXDOMAIN and resurrect the ghost.

- `internal/cache.Cache.CompareAndSwap` — segment-locked pointer-identity CAS.
- `Store.ReplaceIfCurrent`: a refresh may only replace the exact entry that claimed it; a SERVFAIL refresh never displaces a positive entry; CAS stays within one sub-cache.
- `PrefetchQueue.Stop` no longer closes the items channel (send-after-close race with concurrent cache-hit claims); cancellation drains the workers.

## Tests

- `TestGhostDomain_AnswerCacheAndPrefetch_FullPipeline` — hermetic parent referral → answer cache → prefetch → withdrawal: the 600s answer dies at its 1s cut, and a deliberately held-back refresh cannot displace the newer NXDOMAIN (pointer-CAS drop verified via the claim release).
- `TestGhostDomain_ParentStateAtLeaseDeadline` — parent unchanged vs re-delegated at the lease boundary.
- Entry/store cut math (`cutuntil_test.go`): MinTTL-floor override, negative/CD/ECS buckets, `ReplaceIfCurrent` semantics, `Chain.Meta` seam, `ResponseMeta` race safety.
- Phoenix T2 test extended: the resolution must report exactly the answering cut's deadline through the seam.
- All 33 packages green under `-race`; `golangci-lint` 0 issues; `gofmt` clean.