### PR TITLE
fix(dnssec): reject exact-owner NSEC3 matches as denial-of-existence coverage

### DIFF
--- a/middleware/resolver/dnssec/nsec3.go
+++ b/middleware/resolver/dnssec/nsec3.go
@@ -26,6 +26,14 @@ func nsec3Safe(n *dns.NSEC3) bool {
 	return n.Iterations <= maxNSEC3Iterations
 }
 
+// nsec3Covers reports strict NSEC3 interval coverage. An exact owner match
+// proves that the name exists and therefore must never be accepted as a
+// denial-of-existence cover, even if the DNS library's Cover method includes
+// the owner boundary for an ordinary interval.
+func nsec3Covers(n *dns.NSEC3, name string) bool {
+	return !n.Match(name) && n.Cover(name)
+}
+
 func typesSet(set []uint16, types ...uint16) bool {
 	tm := make(map[uint16]struct{}, len(types))
 	for _, t := range types {
@@ -84,7 +92,7 @@ func findCoverer(name string, nsec []dns.RR) ([]uint16, bool, error) {
 		if !nsec3Safe(n) {
 			continue
 		}
-		if n.Cover(name) {
+		if nsec3Covers(n, name) {
 			return n.TypeBitMap, (n.Flags & 1) == 1, nil
 		}
 	}

--- a/middleware/resolver/dnssec/nsec3_test.go
+++ b/middleware/resolver/dnssec/nsec3_test.go
@@ -31,6 +31,58 @@ func makeNSEC3(name, next string, optOut bool, types []uint16) *dns.NSEC3 {
 	}
 }
 
+// adjacentNSEC3Hash returns the immediately adjacent base32hex value. It is
+// useful for constructing a narrow, ordinary NSEC3 interval around a name.
+func adjacentNSEC3Hash(t *testing.T, hash string, delta int) string {
+	t.Helper()
+	const alphabet = "0123456789ABCDEFGHIJKLMNOPQRSTUV"
+
+	b := []byte(hash)
+	fill := byte('0')
+	if delta < 0 {
+		fill = 'V'
+	}
+	for i := len(b) - 1; i >= 0; i-- {
+		idx := strings.IndexByte(alphabet, b[i])
+		if idx < 0 {
+			t.Fatalf("invalid NSEC3 hash %q", hash)
+		}
+		next := idx + delta
+		if next < 0 || next >= len(alphabet) {
+			continue
+		}
+		b[i] = alphabet[next]
+		for j := i + 1; j < len(b); j++ {
+			b[j] = fill
+		}
+		return string(b)
+	}
+
+	t.Fatalf("cannot find adjacent value for NSEC3 hash %q", hash)
+	return ""
+}
+
+func makeNSEC3Coverer(t *testing.T, name, zone string) *dns.NSEC3 {
+	t.Helper()
+	hash := dns.HashName(name, dns.SHA1, 0, "")
+	n := &dns.NSEC3{
+		Hdr: dns.RR_Header{
+			Name:   adjacentNSEC3Hash(t, hash, -1) + "." + dns.Fqdn(zone),
+			Class:  dns.ClassINET,
+			Rrtype: dns.TypeNSEC3,
+			Ttl:    10,
+		},
+		Hash:       dns.SHA1,
+		Iterations: 0,
+		HashLength: 32,
+		NextDomain: adjacentNSEC3Hash(t, hash, 1),
+	}
+	if !n.Cover(name) || n.Match(name) {
+		t.Fatalf("test NSEC3 does not strictly cover %q", name)
+	}
+	return n
+}
+
 func zoneToRecords(t *testing.T, z string) []dns.RR {
 	records := []dns.RR{}
 	tokens := dns.NewZoneParser(strings.NewReader(z), "", "")
@@ -82,6 +134,30 @@ b4um86eghhds6nea196smvmlo4ors995.example. 3600 IN NSEC3 1 0 12 aabbccdd gjeqe526
 	err = VerifyNameError(msg.SetQuestion("a.c.x.w.example.", dns.TypeA), records)
 	if err != nil {
 		t.Fatalf("VerifyNameError failed with RFC5155 Appendix B.1 example: %s", err)
+	}
+}
+
+func TestVerifyNameErrorRejectsExactOwnerAsCoverage(t *testing.T) {
+	const qname = "a.example.com."
+	exact := makeNSEC3(qname, "", false, nil)
+	hash := dns.HashName(qname, exact.Hash, exact.Iterations, exact.Salt)
+	exact.NextDomain = adjacentNSEC3Hash(t, hash, 1)
+	if !exact.Match(qname) || !exact.Cover(qname) {
+		t.Fatal("test requires the DNS library to report both Match and Cover for the exact owner")
+	}
+
+	// The wildcard denial is otherwise valid. The proof is still invalid
+	// because the record offered for next-closer coverage exactly matches the
+	// queried name and therefore proves its existence.
+	wildcardCover := makeNSEC3Coverer(t, "*."+qname, "com.")
+	if wildcardCover.Cover(qname) {
+		t.Fatal("wildcard coverer unexpectedly also covers the queried name")
+	}
+	records := []dns.RR{exact, wildcardCover}
+
+	msg := new(dns.Msg).SetQuestion(qname, dns.TypeA)
+	if err := VerifyNameError(msg, records); err != ErrNSECMissingCoverage {
+		t.Fatalf("exact NSEC3 owner must not prove NXDOMAIN coverage, got %v", err)
 	}
 }
 

--- a/middleware/resolver/dnssec/wildcard.go
+++ b/middleware/resolver/dnssec/wildcard.go
@@ -81,7 +81,7 @@ func nextCloserDenied(nextCloser string, nsecSet, nsec3Set []dns.RR) bool {
 		if !nsec3Safe(n) {
 			continue
 		}
-		if n.Cover(nextCloser) {
+		if nsec3Covers(n, nextCloser) {
 			return true
 		}
 	}

--- a/middleware/resolver/dnssec/wildcard_test.go
+++ b/middleware/resolver/dnssec/wildcard_test.go
@@ -139,6 +139,27 @@ func TestVerifyWildcardAnswer_NSEC3(t *testing.T) {
 	}
 }
 
+func TestVerifyWildcardAnswer_NSEC3ExactOwnerRejected(t *testing.T) {
+	const nextCloser = "secure.example.com."
+	msg := new(dns.Msg)
+	msg.Answer = []dns.RR{
+		aRR(nextCloser),
+		wildcardSig(nextCloser, 2),
+	}
+
+	exact := makeNSEC3(nextCloser, "", false, nil)
+	hash := dns.HashName(nextCloser, exact.Hash, exact.Iterations, exact.Salt)
+	exact.NextDomain = adjacentNSEC3Hash(t, hash, 1)
+	if !exact.Match(nextCloser) || !exact.Cover(nextCloser) {
+		t.Fatal("test requires the DNS library to report both Match and Cover for the exact owner")
+	}
+	msg.Ns = []dns.RR{exact}
+
+	if err := VerifyWildcardAnswer(msg); err != ErrWildcardNoDenial {
+		t.Fatalf("exact NSEC3 owner must not deny the wildcard next closer, got %v", err)
+	}
+}
+
 // bumpHash returns the base32hex-encoded label h shifted by delta in its
 // last character, producing a neighbour hash for building covering NSEC3
 // intervals in tests.


### PR DESCRIPTION
## Problem

miekg/dns `NSEC3.Cover()` (v1.1.72) accepts `nameHash == ownerHash` inside an ordinary interval — the lower-bound check uses strict less-than, so equality falls through to the upper-bound check:

```go
if nameHash < ownerHash { // equality falls through
    return false
}
return nameHash < nextHash // exact match: ownerHash == nameHash < nextHash → true
```

An NSEC3 record that exactly matches a name is proof the name **exists**, yet `findCoverer` and `nextCloserDenied` accepted it as proof of nonexistence. Impact:

- An attacker can replay a zone's own signed NSEC3 to forge an authenticated (AD=1) NXDOMAIN for a name that exists.
- The wildcard next-closer denial check in `VerifyWildcardAnswer` can be defeated the same way, re-enabling the wildcard RRSIG replay it exists to prevent.

The empty-interval and end-of-zone branches of `Cover()` already exclude equality; only ordinary intervals are affected.

## Fix

Add `nsec3Covers`, a strict RFC 5155 coverage predicate (`!Match && Cover`) that rejects exact owner matches before accepting coverage, and use it at both NSEC3 coverage call sites — the only two `Cover()` call sites in the repo. The plain-NSEC path (`nsecCovers`) already uses strict inequalities and is unaffected.

## Tests

Both regression tests construct an NSEC3 whose owner hash equals the target name's hash with an ordinary interval, and assert the proof is rejected:

- `TestVerifyNameErrorRejectsExactOwnerAsCoverage` — forged NXDOMAIN via exact-owner "coverage" of the next closer name
- `TestVerifyWildcardAnswer_NSEC3ExactOwnerRejected` — wildcard replay where the exact-owner NSEC3 "denies" the next closer name

Verified both fail on main (the bogus proofs validated with a nil error) and pass with the fix. Each test also guards the library-behavior assumption (`Match && Cover` both true for the exact owner), so it fails loudly if a future miekg/dns release changes `Cover()` semantics.

Full `./middleware/resolver/...` suite passes with `-race`; `gofmt` clean; `golangci-lint` 0 issues.