### PR TITLE
chore: bump version to 1.7.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ docker run -d --name sdns -p 53:53 -p 53:53/udp ghcr.io/semihalev/sdns:latest
 Pin to a specific version (recommended for production):
 
 ```shell
-$ docker run -d --name sdns -p 53:53 -p 53:53/udp ghcr.io/semihalev/sdns:1.7.2
+$ docker run -d --name sdns -p 53:53 -p 53:53/udp ghcr.io/semihalev/sdns:1.7.3
 ```
 
 #### Docker Compose

--- a/sdns.go
+++ b/sdns.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const version = "1.7.2"
+const version = "1.7.3"
 
 var (
 	cfgPath    string


### PR DESCRIPTION
Bump SDNS version from 1.7.2 to 1.7.3:

- `sdns.go`: `version` constant
- `README.md`: docker run image tag

Left unchanged per convention: the config file format version (`configver` 1.7.0, unchanged format) and the README benchmark table (stays at the last-measured release).