### PR TITLE
chore(release): bump version to 1.7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ docker run -d --name sdns -p 53:53 -p 53:53/udp ghcr.io/semihalev/sdns:latest
 Pin to a specific version (recommended for production):
 
 ```shell
-$ docker run -d --name sdns -p 53:53 -p 53:53/udp ghcr.io/semihalev/sdns:1.7.3
+$ docker run -d --name sdns -p 53:53 -p 53:53/udp ghcr.io/semihalev/sdns:1.7.4
 ```
 
 #### Docker Compose
@@ -136,7 +136,7 @@ example.com.		0	CH	HINFO	"Host" "IPv6:[2001:500:8f::53]:53 rtt:147ms health:[GOO
 example.com.		0	CH	HINFO	"Host" "IPv6:[2001:500:8d::53]:53 rtt:148ms health:[GOOD]"
 ```
 
-## Configuration (v1.7.0)
+## Configuration (v1.7.4)
 
 | Key                  | Description                                                                                                         |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------- |

--- a/config/config.go
+++ b/config/config.go
@@ -18,7 +18,7 @@ import (
 	"github.com/semihalev/zlog/v2"
 )
 
-const configver = "1.7.0"
+const configver = "1.7.4"
 
 // Config type.
 type Config struct {

--- a/contrib/linux/sdns.conf
+++ b/contrib/linux/sdns.conf
@@ -1,6 +1,6 @@
 
 # Configuration file version (not SDNS version)
-version = "1.7.0"
+version = "1.7.4"
 
 # ============================
 # Basic Server Configuration

--- a/sdns.go
+++ b/sdns.go
@@ -20,7 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const version = "1.7.3"
+const version = "1.7.4"
 
 var (
 	cfgPath    string


### PR DESCRIPTION
Version bump for the 1.7.4 release.

- `sdns.go` version 1.7.3 → 1.7.4
- `config/config.go` configver 1.7.0 → 1.7.4 — the schema gained `rfc8198`, `rfc9520`, and the `[recursion_firewall]` section, so older config files now get the out-of-version notice
- `contrib/linux/sdns.conf` regenerated version line (keeps `TestPackagedConfigMatchesGeneratedDefault` exact)
- README docker tag and Configuration header

Base includes PR #527 (recursion firewall) and the seven dependency updates (quic-go 0.61.0, client_golang 1.24.1, k8s 0.36.3 trio, two action bumps).
