### PR TITLE
cache: precompute denial-proof canonical order at admission

### DIFF
--- a/middleware/cache/denial_proof_cache.go
+++ b/middleware/cache/denial_proof_cache.go
@@ -60,16 +60,17 @@ type denialProofID struct {
 // touched only while the cache write lock is held and is never observed by
 // readers.
 type denialProofEntry struct {
-	id        denialProofID
-	zoneKey   denialProofZoneKey
-	params    denialProofNSEC3Params
-	ownerHash string
-	data      []dns.RR
-	records   []dns.RR
-	expires   time.Time
-	wireBytes int64
-	sequence  uint64
-	queue     *list.Element
+	id         denialProofID
+	zoneKey    denialProofZoneKey
+	params     denialProofNSEC3Params
+	ownerHash  string
+	ownerOrder denialProofNameOrder
+	data       []dns.RR
+	records    []dns.RR
+	expires    time.Time
+	wireBytes  int64
+	sequence   uint64
+	queue      *list.Element
 }
 
 // denialProofZoneSnapshot is published copy-on-write. Readers may retain a
@@ -206,14 +207,15 @@ type denialProofRRSetKey struct {
 }
 
 type denialProofRRSet struct {
-	key       denialProofRRSetKey
-	params    denialProofNSEC3Params
-	ownerHash string
-	next      string
-	flags     uint8
-	types     []uint16
-	data      []dns.RR
-	sigs      []dns.RR
+	key        denialProofRRSetKey
+	ownerOrder denialProofNameOrder
+	params     denialProofNSEC3Params
+	ownerHash  string
+	next       string
+	flags      uint8
+	types      []uint16
+	data       []dns.RR
+	sigs       []dns.RR
 }
 
 // record accepts only a terminal response whose denial semantics and
@@ -471,7 +473,10 @@ func (c *denialProofCache) extract(
 			}
 			set := sets[soaKey]
 			if set == nil {
-				set = &denialProofRRSet{key: soaKey}
+				set = &denialProofRRSet{
+					key:        soaKey,
+					ownerOrder: denialProofNameOrderFor(zone),
+				}
 				sets[soaKey] = set
 			}
 			// RFC 1035 defines one SOA at an apex. Multiple SOA RDATA
@@ -500,9 +505,10 @@ func (c *denialProofCache) extract(
 			set := sets[key]
 			if set == nil {
 				set = &denialProofRRSet{
-					key:   key,
-					next:  next,
-					types: append([]uint16(nil), record.TypeBitMap...),
+					key:        key,
+					ownerOrder: denialProofNameOrderFor(owner),
+					next:       next,
+					types:      append([]uint16(nil), record.TypeBitMap...),
 				}
 				sets[key] = set
 			} else if set.next != next ||
@@ -535,12 +541,13 @@ func (c *denialProofCache) extract(
 			set := sets[key]
 			if set == nil {
 				set = &denialProofRRSet{
-					key:       key,
-					params:    params,
-					ownerHash: ownerHash,
-					next:      nextHash,
-					flags:     record.Flags,
-					types:     append([]uint16(nil), record.TypeBitMap...),
+					key:        key,
+					ownerOrder: denialProofNameOrderFor(owner),
+					params:     params,
+					ownerHash:  ownerHash,
+					next:       nextHash,
+					flags:      record.Flags,
+					types:      append([]uint16(nil), record.TypeBitMap...),
 				}
 				sets[key] = set
 			} else if set.params != params ||
@@ -617,10 +624,7 @@ func (c *denialProofCache) extract(
 		if proofSets[i].key.kind != proofSets[j].key.kind {
 			return proofSets[i].key.kind < proofSets[j].key.kind
 		}
-		return denialProofCanonicalNameCompare(
-			proofSets[i].key.owner,
-			proofSets[j].key.owner,
-		) < 0
+		return proofSets[i].ownerOrder.compare(proofSets[j].ownerOrder) < 0
 	})
 
 	retained := make([]dns.RR, 0, maxDenialProofBundleRRs)
@@ -729,14 +733,15 @@ func newDenialProofEntry(
 		hash:       set.params.hash,
 	}
 	return &denialProofEntry{
-		id:        id,
-		zoneKey:   zoneKey,
-		params:    set.params,
-		ownerHash: set.ownerHash,
-		data:      data,
-		records:   records,
-		expires:   expires,
-		wireBytes: wireBytes,
+		id:         id,
+		zoneKey:    zoneKey,
+		params:     set.params,
+		ownerHash:  set.ownerHash,
+		ownerOrder: set.ownerOrder,
+		data:       data,
+		records:    records,
+		expires:    expires,
+		wireBytes:  wireBytes,
 	}, true
 }
 
@@ -900,10 +905,7 @@ func (c *denialProofCache) publishZoneLocked(
 		}
 	}
 	sort.Slice(snapshot.nsec, func(i, j int) bool {
-		compared := denialProofCanonicalNameCompare(
-			snapshot.nsec[i].id.owner,
-			snapshot.nsec[j].id.owner,
-		)
+		compared := snapshot.nsec[i].ownerOrder.compare(snapshot.nsec[j].ownerOrder)
 		if compared != 0 {
 			return compared < 0
 		}
@@ -939,24 +941,47 @@ func (c *denialProofCache) publishZoneLocked(
 	c.zoneIndex[key] = snapshot
 }
 
-func denialProofCanonicalNameCompare(a, b string) int {
-	aLabels, aOK := denialProofCanonicalWireLabels(a)
-	bLabels, bOK := denialProofCanonicalWireLabels(b)
-	if !aOK || !bOK {
-		return strings.Compare(dns.CanonicalName(a), dns.CanonicalName(b))
+// denialProofNameOrder is a name's canonical comparison form, derived exactly
+// once per admitted RRset. Snapshot republication sorts on every admission and
+// eviction; deriving wire labels inside the comparator instead made that sort
+// the process's dominant allocation site (84% of all allocated bytes on a
+// DNSBL-heavy resolver).
+type denialProofNameOrder struct {
+	// labels are the lowercased wire labels; nil when the name cannot be
+	// packed, in which case fallback carries the comparison identity.
+	labels   [][]byte
+	fallback string
+}
+
+// denialProofNameOrderFor expects name in dns.CanonicalName form, which every
+// admission-path owner already is.
+func denialProofNameOrderFor(name string) denialProofNameOrder {
+	labels, ok := denialProofCanonicalWireLabels(name)
+	if !ok {
+		return denialProofNameOrder{fallback: name}
 	}
-	i, j := len(aLabels)-1, len(bLabels)-1
+	return denialProofNameOrder{labels: labels, fallback: name}
+}
+
+// compare is the RFC 4034 §6.1 canonical name ordering. The unpackable-name
+// fallback compares the canonical presentation forms, preserving the previous
+// comparator's behaviour.
+func (a denialProofNameOrder) compare(b denialProofNameOrder) int {
+	if a.labels == nil || b.labels == nil {
+		return strings.Compare(a.fallback, b.fallback)
+	}
+	i, j := len(a.labels)-1, len(b.labels)-1
 	for i >= 0 && j >= 0 {
-		if compared := bytes.Compare(aLabels[i], bLabels[j]); compared != 0 {
+		if compared := bytes.Compare(a.labels[i], b.labels[j]); compared != 0 {
 			return compared
 		}
 		i--
 		j--
 	}
 	switch {
-	case len(aLabels) < len(bLabels):
+	case len(a.labels) < len(b.labels):
 		return -1
-	case len(aLabels) > len(bLabels):
+	case len(a.labels) > len(b.labels):
 		return 1
 	default:
 		return 0

--- a/middleware/cache/denial_proof_cache_test.go
+++ b/middleware/cache/denial_proof_cache_test.go
@@ -270,7 +270,7 @@ func TestDenialProofCanonicalNameOrder(t *testing.T) {
 		"com.",
 	}
 	sort.Slice(names, func(i, j int) bool {
-		return denialProofCanonicalNameCompare(names[i], names[j]) < 0
+		return denialProofNameOrderFor(names[i]).compare(denialProofNameOrderFor(names[j])) < 0
 	})
 	want := []string{
 		".",

--- a/middleware/cache/denial_proof_order_test.go
+++ b/middleware/cache/denial_proof_order_test.go
@@ -1,0 +1,79 @@
+package cache
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// TestDenialProofNameOrderFallbackMatchesStringCompare pins the unpackable-
+// name fallback the precomputed order inherited from the old per-comparison
+// converter: when either side has no wire labels, ordering degrades to a
+// plain comparison of the canonical presentation forms.
+func TestDenialProofNameOrderFallbackMatchesStringCompare(t *testing.T) {
+	overlongLabel := strings.Repeat("a", 64) + ".example.com."
+	cases := []struct{ a, b string }{
+		{overlongLabel, "b.example.com."},
+		{"b.example.com.", overlongLabel},
+		{overlongLabel, overlongLabel},
+	}
+	for _, tc := range cases {
+		got := denialProofNameOrderFor(tc.a).compare(denialProofNameOrderFor(tc.b))
+		want := strings.Compare(tc.a, tc.b)
+		if (got < 0) != (want < 0) || (got == 0) != (want == 0) {
+			t.Fatalf("compare(%q,%q) = %d, want sign of %d", tc.a, tc.b, got, want)
+		}
+	}
+}
+
+// BenchmarkDenialProofRecordChurn models the DNSBL-shaped admission stream
+// that made snapshot republication the process's dominant allocation site: a
+// zone shard already holding many NSEC entries receives a replacement
+// admission, forcing a full snapshot re-sort. Before the precomputed
+// ownerOrder, every comparison re-derived both names' wire labels.
+func BenchmarkDenialProofRecordChurn(b *testing.B) {
+	now := time.Unix(1_700_000_000, 0)
+	cache := newDenialProofTestCache(&now, 4096, 512, time.Hour)
+
+	const zone = "bl.example."
+	const preload = 200
+	for i := range preload {
+		owner := fmt.Sprintf("h%03d.%s", i, zone)
+		next := fmt.Sprintf("h%03dz.%s", i, zone)
+		fixture := newDenialProofNSECFixture(
+			b,
+			now,
+			fmt.Sprintf("q%03d.%s", i, zone),
+			dns.TypeA,
+			dns.RcodeNameError,
+			zone,
+			[2]string{owner, next},
+		)
+		if !cache.record(fixture.msg, zone, time.Time{}) {
+			b.Fatalf("preload admission %d rejected", i)
+		}
+	}
+	if got := cache.len(); got != preload+1 { // + shared SOA entry
+		b.Fatalf("preloaded entries = %d, want %d", got, preload+1)
+	}
+
+	churn := newDenialProofNSECFixture(
+		b,
+		now,
+		"qchurn."+zone,
+		dns.TypeA,
+		dns.RcodeNameError,
+		zone,
+		[2]string{"h000." + zone, "h000z." + zone},
+	)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if !cache.record(churn.msg, zone, time.Time{}) {
+			b.Fatal("churn admission rejected")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Production profiling on a DNSBL-heavy public resolver (v1.7.4, ~19h uptime) showed `denialProofCanonicalWireLabels` responsible for **84.4% of all bytes ever allocated** by the process (682 GB of 808 GB; 3.27 B of 4.87 B objects, ≈46,500 calls/s) — the dominant driver of GC cycle frequency and the observed periodic CPU spikes.

Mechanism: the RFC 8198 proof cache re-sorts a zone's NSEC snapshot on every admission and eviction (`publishZoneLocked`), and the comparator re-derived both owners' canonical wire labels **per comparison** — a 255-byte pack plus label slices, O(K log K) times per mutation on a shard holding up to 256 entries, under a constant DNSBL-shaped admission stream.

## Change

Derive each owner's canonical comparison form (`denialProofNameOrder`) once per admitted RRset in `extract`, carry it on the immutable entry, and sort on the precomputed form. The unpackable-name fallback (plain canonical string compare) is preserved and pinned by a new test. No behavioral change — ordering semantics are identical; existing snapshot-ordering tests pass unchanged.

## Benchmark

`BenchmarkDenialProofRecordChurn` (new; 200-entry NSEC shard receiving replacement admissions — the production shape):

| | before | after | |
|---|---|---|---|
| time | 1,334 µs/op | 120 µs/op | 11× |
| allocated | 5.65 MB/op | 96 KB/op | 59× |
| allocations | 24,918/op | 111/op | 224× |

Projected field impact: this path drops from ~10 MB/s of the canary's 12.3 MB/s allocation rate to ~0.2 MB/s, stretching GC cycles (and the CPU spikes they cause) roughly 5×.
