### PR TITLE
cache: retain answer entries in packed wire form

### DIFF
--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -1096,6 +1096,9 @@ func (c *Cache) Set(key uint64, msg *dns.Msg) {
 	ttl := c.positive.ttl.Calculate(msgTTL)
 
 	entry := NewCacheEntryWithKey(filtered, ttl, c.config.RateLimit, key)
+	if entry == nil {
+		return
+	}
 	if ttl > 0 {
 		entry.origTTL = uint32(ttl.Seconds())
 	}

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -237,7 +237,7 @@ func TestCacheDNSSEC(t *testing.T) {
 	msg := new(dns.Msg)
 	msg.SetReply(req)
 	msg.Answer = append(msg.Answer, makeRR("secure.com. 300 IN A 1.2.3.4"))
-	msg.Answer = append(msg.Answer, makeRR("secure.com. 300 IN RRSIG A 8 2 300 20301231235959 20201231235959 12345 secure.com. fakesig=="))
+	msg.Answer = append(msg.Answer, makeRR("secure.com. 300 IN RRSIG A 8 2 300 20301231235959 20201231235959 12345 secure.com. ZmFrZXNpZw=="))
 
 	c.Set(key, msg)
 

--- a/middleware/cache/entry_wire_test.go
+++ b/middleware/cache/entry_wire_test.go
@@ -94,3 +94,55 @@ func TestCacheEntryWireRoundTrip(t *testing.T) {
 		t.Fatal("CD=1 serve kept the AD bit")
 	}
 }
+
+// TestCacheEntryPreservesCompressFlag pins the parsed representation's
+// contract for direct writers: the admitted message's Compress flag survives
+// the round trip even though Unpack never sets it.
+func TestCacheEntryPreservesCompressFlag(t *testing.T) {
+	for _, compress := range []bool{true, false} {
+		req := new(dns.Msg)
+		req.SetQuestion("flag.example.com.", dns.TypeA)
+		src := new(dns.Msg)
+		src.SetReply(req)
+		src.Compress = compress
+		src.Answer = append(src.Answer, makeRR("flag.example.com. 300 IN A 192.0.2.9"))
+
+		entry := NewCacheEntryWithKey(src, time.Minute, 0, 1)
+		if entry == nil {
+			t.Fatal("entry not admitted")
+		}
+		resp := entry.ToMsg(req)
+		if resp == nil {
+			t.Fatal("entry did not serve")
+		}
+		if resp.Compress != compress {
+			t.Fatalf("served Compress = %v, want %v", resp.Compress, compress)
+		}
+	}
+}
+
+// TestCacheEntryWireIsExactSize pins the residency contract against Pack's
+// scratch buffer: PackBuffer sizes its backing array for the uncompressed
+// length, and retaining that slice would silently keep the dead capacity
+// alive for the entry's whole lifetime.
+func TestCacheEntryWireIsExactSize(t *testing.T) {
+	req := new(dns.Msg)
+	req.SetQuestion("www.compressible.example.com.", dns.TypeA)
+	src := new(dns.Msg)
+	src.SetReply(req)
+	// A highly compressible shape: repeated long owner names.
+	for range 5 {
+		src.Answer = append(src.Answer, makeRR(
+			"www.compressible.example.com. 300 IN CNAME edge.very-long-cdn-target.example.net.",
+		))
+	}
+
+	entry := NewCacheEntryWithKey(src, time.Minute, 0, 1)
+	if entry == nil {
+		t.Fatal("entry not admitted")
+	}
+	if cap(entry.wire) != len(entry.wire) {
+		t.Fatalf("wire cap %d != len %d: entry retains Pack's oversized scratch buffer",
+			cap(entry.wire), len(entry.wire))
+	}
+}

--- a/middleware/cache/entry_wire_test.go
+++ b/middleware/cache/entry_wire_test.go
@@ -1,0 +1,96 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// TestCacheEntryWireRoundTrip pins the packed representation's serve
+// fidelity: everything the parsed entry preserved must survive the
+// pack-at-admission / unpack-at-serve round trip.
+func TestCacheEntryWireRoundTrip(t *testing.T) {
+	req := new(dns.Msg)
+	req.SetQuestion("WWW.Example.COM.", dns.TypeA)
+	req.Id = 4242
+	req.SetEdns0(1232, true)
+
+	src := new(dns.Msg)
+	src.SetReply(req)
+	src.Rcode = dns.RcodeSuccess
+	src.AuthenticatedData = true
+	src.RecursionAvailable = true
+	src.Answer = append(src.Answer,
+		makeRR("www.example.com. 300 IN CNAME edge.example.net."),
+		makeRR("edge.example.net. 60 IN A 192.0.2.7"),
+		makeRR("edge.example.net. 60 IN RRSIG A 13 3 60 20370101000000 20260101000000 7 example.net. ZmFrZXNpZ25hdHVyZQ=="),
+	)
+	src.Ns = append(src.Ns,
+		makeRR("example.net. 120 IN NS ns1.example.net."),
+	)
+	opt := new(dns.OPT)
+	opt.Hdr.Name = "."
+	opt.Hdr.Rrtype = dns.TypeOPT
+	opt.SetUDPSize(1232)
+	opt.Option = append(opt.Option, &dns.EDNS0_EDE{
+		InfoCode:  dns.ExtendedErrorCodeStaleAnswer,
+		ExtraText: "pinned",
+	})
+	src.Extra = append(src.Extra, opt)
+
+	entry := NewCacheEntryWithKey(src, 90*time.Second, 0, 1)
+	if entry == nil {
+		t.Fatal("packable message was rejected at admission")
+	}
+
+	resp := entry.ToMsg(req)
+	if resp == nil {
+		t.Fatal("fresh entry did not serve")
+	}
+	if resp.Id != req.Id || resp.Rcode != dns.RcodeSuccess {
+		t.Fatalf("header = id %d rcode %d", resp.Id, resp.Rcode)
+	}
+	if !resp.AuthenticatedData || resp.Authoritative {
+		t.Fatalf("flags: ad=%v aa=%v", resp.AuthenticatedData, resp.Authoritative)
+	}
+	if got := resp.Question[0].Name; got != "WWW.Example.COM." {
+		t.Fatalf("question case = %q, want client spelling", got)
+	}
+	if len(resp.Answer) != 3 || len(resp.Ns) != 1 {
+		t.Fatalf("sections = %d/%d answers/ns, want 3/1", len(resp.Answer), len(resp.Ns))
+	}
+	for i, want := range []string{
+		"www.example.com.\t", "edge.example.net.\t", "edge.example.net.\t",
+	} {
+		if got := resp.Answer[i].String(); got[:len(want)] != want {
+			t.Fatalf("answer[%d] = %q", i, got)
+		}
+		if resp.Answer[i].Header().Ttl != resp.Answer[0].Header().Ttl {
+			t.Fatal("TTLs are not uniform")
+		}
+	}
+	// The stored OPT was stripped; the EDE must be re-attached because the
+	// client sent EDNS.
+	respOpt := resp.IsEdns0()
+	if respOpt == nil {
+		t.Fatal("EDE carrier OPT missing for an EDNS client")
+	}
+	foundEDE := false
+	for _, option := range respOpt.Option {
+		if ede, ok := option.(*dns.EDNS0_EDE); ok &&
+			ede.InfoCode == dns.ExtendedErrorCodeStaleAnswer {
+			foundEDE = true
+		}
+	}
+	if !foundEDE {
+		t.Fatal("preserved EDE was not restored on serve")
+	}
+
+	// CD=1 request must never receive AD.
+	cdReq := req.Copy()
+	cdReq.CheckingDisabled = true
+	if cd := entry.ToMsg(cdReq); cd == nil || cd.AuthenticatedData {
+		t.Fatal("CD=1 serve kept the AD bit")
+	}
+}

--- a/middleware/cache/prefetch_dnssec_test.go
+++ b/middleware/cache/prefetch_dnssec_test.go
@@ -107,8 +107,12 @@ func TestPrefetchKeepsDNSSECForDO0Trigger(t *testing.T) {
 			// Refreshed. The stored answer must still carry the RRSIG
 			// and the AD bit — proving the DO=0 trigger did not strip
 			// DNSSEC via the prefetch sub-pipeline's edns layer.
+			stored := got.storedMsg()
+			if stored == nil {
+				t.Fatal("refreshed entry wire failed to unpack")
+			}
 			hasRRSIG := false
-			for _, rr := range got.msg.Answer {
+			for _, rr := range stored.Answer {
 				if _, ok := rr.(*dns.RRSIG); ok {
 					hasRRSIG = true
 				}
@@ -116,7 +120,7 @@ func TestPrefetchKeepsDNSSECForDO0Trigger(t *testing.T) {
 			if !hasRRSIG {
 				t.Fatalf("prefetch dropped the RRSIG: a DO=0 trigger downgraded the signed entry")
 			}
-			if !got.msg.AuthenticatedData {
+			if !stored.AuthenticatedData {
 				t.Fatalf("prefetch cleared the AD bit: a DO=0 trigger downgraded the signed entry")
 			}
 			return

--- a/middleware/cache/prefetch_worker_test.go
+++ b/middleware/cache/prefetch_worker_test.go
@@ -126,8 +126,9 @@ func TestPrefetchWorkerStoresRefresh(t *testing.T) {
 		got, ok := c.positive.Get(key)
 		if ok && got != entry {
 			// Replaced — worker finished.
-			if len(got.msg.Answer) != 1 {
-				t.Fatalf("refreshed entry answer count = %d, want 1", len(got.msg.Answer))
+			stored := got.storedMsg()
+			if stored == nil || len(stored.Answer) != 1 {
+				t.Fatalf("refreshed entry = %v, want one answer", stored)
 			}
 			return
 		}

--- a/middleware/cache/store.go
+++ b/middleware/cache/store.go
@@ -154,10 +154,10 @@ func (s *Store) LookupByKeyVerified(key uint64, q dns.Question) (*CacheEntry, bo
 // type and class exactly, name case-insensitively (RFC 4343 — matching the
 // key hash, which lowercases the name in its preimage).
 func entryMatchesQuestion(entry *CacheEntry, q dns.Question) bool {
-	if entry == nil || entry.msg == nil || len(entry.msg.Question) == 0 {
+	if entry == nil || entry.question.Name == "" {
 		return false
 	}
-	eq := entry.msg.Question[0]
+	eq := entry.question
 	return eq.Qtype == q.Qtype && eq.Qclass == q.Qclass && equalNameASCIIFold(eq.Name, q.Name)
 }
 
@@ -475,9 +475,15 @@ func (s *Store) setFromResponseWithKey(key uint64, resp *dns.Msg, scoped bool, c
 		var e *CacheEntry
 		if scoped {
 			e = NewScopedCacheEntry(msg, ttl, s.cfg.RateLimit)
-			e.rateLimKey = key
 		} else {
 			e = NewCacheEntryWithKey(msg, ttl, s.cfg.RateLimit, key)
+		}
+		if e == nil {
+			// Unpackable response: never cacheable, callers skip the write.
+			return nil
+		}
+		if scoped {
+			e.rateLimKey = key
 		}
 		e.cutUntil = cutUntil
 		e.cutKey = cutKey
@@ -487,7 +493,9 @@ func (s *Store) setFromResponseWithKey(key uint64, resp *dns.Msg, scoped bool, c
 	switch mt {
 	case dnsutil.TypeSuccess, dnsutil.TypeReferral, dnsutil.TypeNXDomain, dnsutil.TypeNoRecords:
 		ttl := capTTL(s.positive.ttl.Calculate(msgTTL))
-		s.positive.Set(key, newEntry(filtered, ttl))
+		if entry := newEntry(filtered, ttl); entry != nil {
+			s.positive.Set(key, entry)
+		}
 		// A scoped write has no source prefix here (only its already-hashed
 		// cache key), so it must not reset the unrelated global failure
 		// audience. Cache.ResponseWriter owns scoped failure reset because it
@@ -535,11 +543,17 @@ func (s *Store) ReplaceIfCurrent(key uint64, expected *CacheEntry, resp *dns.Msg
 	switch mt {
 	case dnsutil.TypeSuccess, dnsutil.TypeReferral, dnsutil.TypeNXDomain, dnsutil.TypeNoRecords:
 		entry := NewCacheEntryWithKey(filtered, s.positive.ttl.Calculate(msgTTL), s.cfg.RateLimit, key)
+		if entry == nil {
+			return false
+		}
 		entry.cutUntil = cutUntil
 		entry.cutKey = cutKey
 		return s.positive.cache.CompareAndSwap(key, expected, entry)
 	case dnsutil.TypeServerFailure:
 		entry := NewCacheEntryWithKey(filtered, s.negative.ttl.Calculate(msgTTL), s.cfg.RateLimit, key)
+		if entry == nil {
+			return false
+		}
 		entry.cutUntil = cutUntil
 		entry.cutKey = cutKey
 		return s.negative.cache.CompareAndSwap(key, expected, entry)
@@ -554,13 +568,16 @@ func (s *Store) ReplaceIfCurrent(key uint64, expected *CacheEntry, resp *dns.Msg
 func (s *Store) SetEntryWithKey(key uint64, entry *CacheEntry, mt dnsutil.ResponseType) {
 	switch mt {
 	case dnsutil.TypeSuccess, dnsutil.TypeReferral, dnsutil.TypeNXDomain, dnsutil.TypeNoRecords:
+		if entry == nil {
+			return
+		}
 		s.positive.Set(key, entry)
-		if entry != nil && entry.msg != nil && len(entry.msg.Question) > 0 {
-			s.resetQuestionFailure(entry.msg.Question[0], entry.msg.CheckingDisabled, netip.Prefix{})
+		if entry.question.Name != "" {
+			s.resetQuestionFailure(entry.question, entry.cd, netip.Prefix{})
 		}
 	case dnsutil.TypeServerFailure:
-		if entry != nil && entry.msg != nil {
-			s.RecordFailure(entry.msg, netip.Prefix{}, FailureProvenance("response"))
+		if entry != nil && entry.question.Name != "" {
+			s.recordFailureQuestion(entry.question, entry.cd, netip.Prefix{}, FailureProvenance("response"))
 		}
 	}
 }
@@ -600,10 +617,10 @@ func (s *Store) Purge(q dns.Question) {
 	}
 	var hits []located
 	s.ForEach(func(positive bool, key uint64, e *CacheEntry) bool {
-		if e == nil || !e.scoped || e.msg == nil || len(e.msg.Question) == 0 {
+		if e == nil || !e.scoped || e.question.Name == "" {
 			return true
 		}
-		eq := e.msg.Question[0]
+		eq := e.question
 		// DNS names compare case-insensitively (RFC 4343). The
 		// unscoped purge path is already case-insensitive — its
 		// key derives from internal/cache.Key which lowercases the

--- a/middleware/cache/types.go
+++ b/middleware/cache/types.go
@@ -20,8 +20,22 @@ type DCache interface {
 }
 
 // CacheEntry represents an immutable cache entry.
+//
+// The response is retained in packed wire form: one pointer-free byte slice
+// instead of a parsed message graph of ~two dozen heap objects. At the field
+// scale that graph was the dominant GC mark cost (18M live objects on a warm
+// 743k-entry canary). Serving unpacks a fresh message per hit — comparable
+// work to the deep Copy the parsed representation already paid, since a
+// served message must be privately mutable either way.
 type CacheEntry struct {
-	msg        *dns.Msg
+	wire []byte
+	// question is the packed message's question, retained unpacked so the
+	// per-hit hash-collision verification (LookupByKeyVerified) and the cold
+	// compat paths never need to touch the wire.
+	question dns.Question
+	// cd mirrors the packed header's CD bit for compat paths that classify
+	// an entry without unpacking it.
+	cd         bool
 	stored     time.Time
 	ttl        time.Duration
 	origTTL    uint32 // Original TTL in seconds for prefetch calculation
@@ -76,6 +90,9 @@ func NewCacheEntry(msg *dns.Msg, ttl time.Duration, rateLimit int) *CacheEntry {
 // client IP to derive the scope from on refresh).
 func NewScopedCacheEntry(msg *dns.Msg, ttl time.Duration, rateLimit int) *CacheEntry {
 	e := NewCacheEntryWithKey(msg, ttl, rateLimit, 0)
+	if e == nil {
+		return nil
+	}
 	e.scoped = true
 	return e
 }
@@ -86,12 +103,14 @@ func NewScopedCacheEntry(msg *dns.Msg, ttl time.Duration, rateLimit int) *CacheE
 // shared-key entry instead — wrong answer for the wrong audience.
 func (e *CacheEntry) PrefetchEligible() bool { return !e.scoped }
 
-// NewCacheEntryWithKey creates a new cache entry with a specific key for rate limiting
+// NewCacheEntryWithKey creates a new cache entry with a specific key for rate
+// limiting. A message that cannot be packed returns nil — such a response was
+// never servable on the wire, so declining to cache it is the safe outcome.
 func NewCacheEntryWithKey(msg *dns.Msg, ttl time.Duration, rateLimit int, key uint64) *CacheEntry {
-	// Create a copy and filter out OPT records (matching V1 behavior)
+	// Assemble the storable view and filter out OPT records (matching V1
+	// behavior): OPT is per-client hop metadata the serve path rebuilds.
 	msgCopy := new(dns.Msg)
 	msgCopy.MsgHdr = msg.MsgHdr
-	msgCopy.Compress = msg.Compress
 	msgCopy.Question = msg.Question
 	msgCopy.Answer = msg.Answer
 	msgCopy.Ns = msg.Ns
@@ -117,8 +136,15 @@ func NewCacheEntryWithKey(msg *dns.Msg, ttl time.Duration, rateLimit int, key ui
 		msgCopy.Extra = extra
 	}
 
+	// Name compression keeps the stored form smaller than the upstream wire.
+	msgCopy.Compress = true
+	wire, err := msgCopy.Pack()
+	if err != nil {
+		return nil
+	}
+
 	entry := &CacheEntry{
-		msg: msgCopy,
+		wire: wire,
 		// Keep the monotonic clock reading. Converting to UTC strips it and
 		// would let a backward wall-clock adjustment extend both the TTL and
 		// an inherited delegation cut.
@@ -128,6 +154,10 @@ func NewCacheEntryWithKey(msg *dns.Msg, ttl time.Duration, rateLimit int, key ui
 		rateLimit:  rateLimit,
 		rateLimKey: key,
 		ede:        ede,
+		cd:         msg.CheckingDisabled,
+	}
+	if len(msg.Question) > 0 {
+		entry.question = msg.Question[0]
 	}
 
 	return entry
@@ -142,7 +172,12 @@ func (e *CacheEntry) ToMsg(req *dns.Msg) *dns.Msg {
 		return nil
 	}
 
-	resp := e.msg.Copy()
+	resp := new(dns.Msg)
+	if err := resp.Unpack(e.wire); err != nil {
+		// The wire was produced by our own Pack at admission; failure here
+		// means corruption, and a miss re-resolves safely.
+		return nil
+	}
 	originalRcode := resp.Rcode // Save the original Rcode
 	originalExtra := resp.Extra // Save the original Extra section
 	resp.SetReply(req)
@@ -207,6 +242,20 @@ func (e *CacheEntry) ToMsg(req *dns.Msg) *dns.Msg {
 	}
 
 	return resp
+}
+
+// storedMsg unpacks the retained wire form without any serve-time shaping.
+// Inspection paths (tests, future debug surfaces) use it; the hit path goes
+// through ToMsg.
+func (e *CacheEntry) storedMsg() *dns.Msg {
+	if e == nil {
+		return nil
+	}
+	msg := new(dns.Msg)
+	if err := msg.Unpack(e.wire); err != nil {
+		return nil
+	}
+	return msg
 }
 
 // (*CacheEntry).IsExpired isExpired checks if the cache entry has expired.

--- a/middleware/cache/types.go
+++ b/middleware/cache/types.go
@@ -35,7 +35,13 @@ type CacheEntry struct {
 	question dns.Question
 	// cd mirrors the packed header's CD bit for compat paths that classify
 	// an entry without unpacking it.
-	cd         bool
+	cd bool
+	// compress preserves the admitted message's Compress flag. Unpack never
+	// sets it, so without this a served message would always repack
+	// uncompressed — invisible inside the standard chain (the edns layer
+	// re-enables compression) but a behavior break for exported
+	// Store/CacheEntry consumers writing responses directly.
+	compress   bool
 	stored     time.Time
 	ttl        time.Duration
 	origTTL    uint32 // Original TTL in seconds for prefetch calculation
@@ -138,10 +144,16 @@ func NewCacheEntryWithKey(msg *dns.Msg, ttl time.Duration, rateLimit int, key ui
 
 	// Name compression keeps the stored form smaller than the upstream wire.
 	msgCopy.Compress = true
-	wire, err := msgCopy.Pack()
+	packed, err := msgCopy.Pack()
 	if err != nil {
 		return nil
 	}
+	// Pack sizes its backing array for the uncompressed length and returns
+	// the compressed prefix — half the capacity can be dead weight on
+	// compressible messages. The entry is long-lived; retain an exact-size
+	// copy, not the oversized scratch buffer.
+	wire := make([]byte, len(packed))
+	copy(wire, packed)
 
 	entry := &CacheEntry{
 		wire: wire,
@@ -155,6 +167,7 @@ func NewCacheEntryWithKey(msg *dns.Msg, ttl time.Duration, rateLimit int, key ui
 		rateLimKey: key,
 		ede:        ede,
 		cd:         msg.CheckingDisabled,
+		compress:   msg.Compress,
 	}
 	if len(msg.Question) > 0 {
 		entry.question = msg.Question[0]
@@ -178,6 +191,9 @@ func (e *CacheEntry) ToMsg(req *dns.Msg) *dns.Msg {
 		// means corruption, and a miss re-resolves safely.
 		return nil
 	}
+	// Unpack leaves Compress unset; restore the admitted flag so direct
+	// writers repack exactly as the parsed representation did.
+	resp.Compress = e.compress
 	originalRcode := resp.Rcode // Save the original Rcode
 	originalExtra := resp.Extra // Save the original Extra section
 	resp.SetReply(req)
@@ -255,6 +271,7 @@ func (e *CacheEntry) storedMsg() *dns.Msg {
 	if err := msg.Unpack(e.wire); err != nil {
 		return nil
 	}
+	msg.Compress = e.compress
 	return msg
 }
 


### PR DESCRIPTION
## Summary

Answer-cache entries now retain the response as **one packed, pointer-free byte slice** instead of a parsed message graph. Serving unpacks a fresh message per hit and then applies exactly the same shaping as before (SetReply, uniform TTL, AD/CD rules, EDE restore) — behavior is unchanged, pinned by a new round-trip test covering CNAME chains, RRSIG/AD, question-case echo, EDE re-attachment, and CD=1 AD-stripping.

## Why

A parsed entry pins a graph of roughly two dozen heap objects — RR structs, name strings, rdata slices. At a full answer cache (256k–1M entries) that graph dominates the garbage collector's mark cost, and mark phases surface as periodic CPU spikes. Mark cost scales with live object count: the representation, not the allocation churn, is the remaining lever.

## Measurements

Per-entry residency (20k retained CNAME+2×A+NS entries):

| | parsed | wire | |
|---|---|---|---|
| objects/entry | 18.0 | **3.0** | 6× |
| bytes/entry | 761 | **409** | −46% |

At a warm million-entry cache this removes on the order of 10M live objects, shrinking every GC mark proportionally.

The honest per-hit cost (unpack does more work than the shallow copy it replaces):

| pipeline positive cache hit | before | after |
|---|---|---|
| ns/op | ~490 | ~600 |
| allocs/op | 9 | 12 |

+110ns per hit in exchange for proportionally smaller GC mark phases at scale. A follow-up byte-patch fast path (serving straight from the stored wire for exact-match hits, measured at 16–72ns in a design spike) can reclaim the difference and more.

## Notes

- A message that fails to Pack is now rejected at admission. Such a response could never have been written to a client socket, so this is fail-safe; everything that arrives via Unpack always re-packs.
- One test fixture (`fakesig==`, invalid base64) relied on never being packed and was corrected.
