### PR TITLE
resolver: make the authority address pipeline netip-native

### DIFF
--- a/internal/authority/server.go
+++ b/internal/authority/server.go
@@ -3,6 +3,7 @@ package authority
 import (
 	"hash/fnv"
 	"net"
+	"net/netip"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -39,15 +40,44 @@ const (
 // NewServer return a new server. addr is expected to be an
 // "IP:port" pair — the IP is parsed once here so upstream exchanges
 // can skip Go's DialContext address-resolution path.
+//
+// Addr is stored in canonical netip form (lowercase, compressed,
+// 4-in-6 unmapped). Every producer builds addr from an IP literal
+// (glue A/AAAA String, configured roots), so the canonical form is
+// what comparison sites and map keys already see; deriving it here
+// keeps one string per server instead of the parse chain's residue.
 func NewServer(addr string, ipVersion IPVersion) *Server {
+	if ap, err := netip.ParseAddrPort(addr); err == nil {
+		return NewServerFromAddrPort(netip.AddrPortFrom(ap.Addr().Unmap(), ap.Port()))
+	}
 	s := &Server{
 		Addr:      addr,
 		IPVersion: ipVersion,
 	}
 	if ua, err := net.ResolveUDPAddr("udp", addr); err == nil {
+		// Non-literal input (tests, exotic callers): keep the historical
+		// resolution fallback.
 		s.UDPAddr = ua
 	}
 	return s
+}
+
+// NewServerFromAddrPort builds a Server straight from a decoded address —
+// the netip-native producer path (glue records, NS-address lookups) that
+// never materializes an intermediate "IP:port" string. The IP family is
+// derived from the address itself, and the canonical string is created
+// exactly once here for the key/log surfaces that need it.
+func NewServerFromAddrPort(ap netip.AddrPort) *Server {
+	ap = netip.AddrPortFrom(ap.Addr().Unmap(), ap.Port())
+	version := IPv4
+	if !ap.Addr().Is4() {
+		version = IPv6
+	}
+	return &Server{
+		Addr:      ap.String(),
+		IPVersion: version,
+		UDPAddr:   net.UDPAddrFromAddrPort(ap),
+	}
 }
 
 func (v IPVersion) String() string {

--- a/middleware/resolver/resolution_attempt_test.go
+++ b/middleware/resolver/resolution_attempt_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"net/netip"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -277,7 +278,7 @@ func TestCheckGlueRRDeduplicatesEndpointsWithoutDroppingHostCache(t *testing.T) 
 	}
 	for name := range hosts {
 		addrs, ok := r.getIPv4Cache(name)
-		if !ok || len(addrs) != 1 || addrs[0] != "192.0.2.70" {
+		if !ok || len(addrs) != 1 || addrs[0] != netip.MustParseAddr("192.0.2.70") {
 			t.Fatalf("cached glue for %s = %v, %v; want one address", name, addrs, ok)
 		}
 	}

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"net/netip"
 	"slices"
 	"sort"
 	"strconv"
@@ -641,7 +642,7 @@ func (r *Resolver) checkHosts(ctx context.Context, servers *authority.Servers) (
 
 	type lookupResult struct {
 		name   string
-		addrs  []string
+		addrs  []netip.Addr
 		isIPv6 bool
 	}
 	results := make(chan lookupResult, len(hostsToCheck)*2)
@@ -689,20 +690,20 @@ func (r *Resolver) checkHosts(ctx context.Context, servers *authority.Servers) (
 	}()
 
 	// Collect results
-	nsipv4 := make(map[string][]string)
-	nsipv6 := make(map[string][]string)
+	nsipv4 := make(map[string][]netip.Addr)
+	nsipv6 := make(map[string][]netip.Addr)
 	var newServers []*authority.Server
 
 	for result := range results {
 		if result.isIPv6 {
 			nsipv6[result.name] = result.addrs
 			for _, addr := range result.addrs {
-				newServers = append(newServers, authority.NewServer(net.JoinHostPort(addr, "53"), authority.IPv6))
+				newServers = append(newServers, authority.NewServerFromAddrPort(netip.AddrPortFrom(addr, 53)))
 			}
 		} else {
 			nsipv4[result.name] = result.addrs
 			for _, addr := range result.addrs {
-				newServers = append(newServers, authority.NewServer(net.JoinHostPort(addr, "53"), authority.IPv4))
+				newServers = append(newServers, authority.NewServerFromAddrPort(netip.AddrPortFrom(addr, 53)))
 			}
 		}
 	}
@@ -743,13 +744,13 @@ func (r *Resolver) checkHosts(ctx context.Context, servers *authority.Servers) (
 
 func (r *Resolver) checkGlueRR(resp *dns.Msg, hosts hostSet, level int) (*authority.Servers, hostSet, hostSet) {
 	authservers := &authority.Servers{}
-	seenServers := make(map[string]struct{})
+	seenServers := make(map[netip.AddrPort]struct{})
 
 	foundv4 := make(hostSet)
 	foundv6 := make(hostSet)
 
 	if r.cfg.IPv6Access {
-		nsipv6 := make(map[string][]string)
+		nsipv6 := make(map[string][]netip.Addr)
 		for _, a := range resp.Extra {
 			if extra, ok := a.(*dns.AAAA); ok {
 				name := strings.ToLower(extra.Header().Name)
@@ -763,23 +764,18 @@ func (r *Resolver) checkGlueRR(resp *dns.Msg, hosts hostSet, level int) (*author
 				}
 
 				if _, ok := hosts[name]; ok {
-					if isLocalIP(extra.AAAA) {
-						continue
-					}
-
-					if extra.AAAA.IsLoopback() {
+					addr, valid := usableAddr(extra.AAAA)
+					if !valid {
 						continue
 					}
 
 					foundv6[name] = struct{}{}
 
-					ip := extra.AAAA.String()
-					nsipv6[name] = appendUniqueString(nsipv6[name], ip)
-					endpoint := net.JoinHostPort(ip, "53")
-					key := middleware.CanonicalResolutionEndpoint(endpoint)
-					if _, ok := seenServers[key]; !ok {
-						seenServers[key] = struct{}{}
-						authservers.List = append(authservers.List, authority.NewServer(endpoint, authority.IPv6))
+					nsipv6[name] = appendUniqueAddr(nsipv6[name], addr)
+					endpoint := netip.AddrPortFrom(addr, 53)
+					if _, ok := seenServers[endpoint]; !ok {
+						seenServers[endpoint] = struct{}{}
+						authservers.List = append(authservers.List, authority.NewServerFromAddrPort(endpoint))
 					}
 				}
 			}
@@ -787,7 +783,7 @@ func (r *Resolver) checkGlueRR(resp *dns.Msg, hosts hostSet, level int) (*author
 		r.addIPv6Cache(nsipv6)
 	}
 
-	nsipv4 := make(map[string][]string)
+	nsipv4 := make(map[string][]netip.Addr)
 	for _, a := range resp.Extra {
 		if extra, ok := a.(*dns.A); ok {
 			name := strings.ToLower(extra.Header().Name)
@@ -801,23 +797,18 @@ func (r *Resolver) checkGlueRR(resp *dns.Msg, hosts hostSet, level int) (*author
 			}
 
 			if _, ok := hosts[name]; ok {
-				if isLocalIP(extra.A) {
-					continue
-				}
-
-				if extra.A.IsLoopback() {
+				addr, valid := usableAddr(extra.A)
+				if !valid {
 					continue
 				}
 
 				foundv4[name] = struct{}{}
 
-				ip := extra.A.String()
-				nsipv4[name] = appendUniqueString(nsipv4[name], ip)
-				endpoint := net.JoinHostPort(ip, "53")
-				key := middleware.CanonicalResolutionEndpoint(endpoint)
-				if _, ok := seenServers[key]; !ok {
-					seenServers[key] = struct{}{}
-					authservers.List = append(authservers.List, authority.NewServer(endpoint, authority.IPv4))
+				nsipv4[name] = appendUniqueAddr(nsipv4[name], addr)
+				endpoint := netip.AddrPortFrom(addr, 53)
+				if _, ok := seenServers[endpoint]; !ok {
+					seenServers[endpoint] = struct{}{}
+					authservers.List = append(authservers.List, authority.NewServerFromAddrPort(endpoint))
 				}
 			}
 		}
@@ -827,49 +818,40 @@ func (r *Resolver) checkGlueRR(resp *dns.Msg, hosts hostSet, level int) (*author
 	return authservers, foundv4, foundv6
 }
 
-func appendUniqueString(values []string, value string) []string {
-	for _, existing := range values {
-		if existing == value {
-			return values
-		}
-	}
-	return append(values, value)
-}
-
-func (r *Resolver) addIPv4Cache(nsipv4 map[string][]string) {
+func (r *Resolver) addIPv4Cache(nsipv4 map[string][]netip.Addr) {
 	for name, addrs := range nsipv4 {
 		key := cache.Key(dns.Question{Name: name, Qtype: dns.TypeA, Qclass: dns.ClassINET})
 		r.glueV4.Add(key, addrs)
 	}
 }
 
-func (r *Resolver) getIPv4Cache(name string) ([]string, bool) {
+func (r *Resolver) getIPv4Cache(name string) ([]netip.Addr, bool) {
 	key := cache.Key(dns.Question{Name: name, Qtype: dns.TypeA, Qclass: dns.ClassINET})
 	if v, ok := r.glueV4.Get(key); ok {
-		return v.([]string), ok
+		return v.([]netip.Addr), ok
 	}
 
-	return []string{}, false
+	return nil, false
 }
 
 func (r *Resolver) removeIPv4Cache(name string) {
 	r.glueV4.Remove(cache.Key(dns.Question{Name: name, Qtype: dns.TypeA, Qclass: dns.ClassINET}))
 }
 
-func (r *Resolver) addIPv6Cache(nsipv6 map[string][]string) {
+func (r *Resolver) addIPv6Cache(nsipv6 map[string][]netip.Addr) {
 	for name, addrs := range nsipv6 {
 		key := cache.Key(dns.Question{Name: name, Qtype: dns.TypeAAAA, Qclass: dns.ClassINET})
 		r.glueV6.Add(key, addrs)
 	}
 }
 
-func (r *Resolver) getIPv6Cache(name string) ([]string, bool) {
+func (r *Resolver) getIPv6Cache(name string) ([]netip.Addr, bool) {
 	key := cache.Key(dns.Question{Name: name, Qtype: dns.TypeAAAA, Qclass: dns.ClassINET})
 	if v, ok := r.glueV6.Get(key); ok {
-		return v.([]string), ok
+		return v.([]netip.Addr), ok
 	}
 
-	return []string{}, false
+	return nil, false
 }
 
 func (r *Resolver) removeIPv6Cache(name string) {
@@ -2458,7 +2440,7 @@ func (r *Resolver) subQuery(ctx context.Context, req *dns.Msg) (*dns.Msg, error)
 	return resp, nil
 }
 
-func (r *Resolver) lookupNSAddrV4(ctx context.Context, qname string, cd bool) (addrs []string, err error) {
+func (r *Resolver) lookupNSAddrV4(ctx context.Context, qname string, cd bool) (addrs []netip.Addr, err error) {
 	zlog.Debug("Lookup NS ipv4 address", "qname", qname)
 
 	if addrs, ok := r.getIPv4Cache(qname); ok {
@@ -2489,7 +2471,7 @@ func (r *Resolver) lookupNSAddrV4(ctx context.Context, qname string, cd bool) (a
 	return addrs, fmt.Errorf("nameserver ipv4 address lookup failed for %s", qname)
 }
 
-func (r *Resolver) lookupNSAddrV6(ctx context.Context, qname string, cd bool) (addrs []string, err error) {
+func (r *Resolver) lookupNSAddrV6(ctx context.Context, qname string, cd bool) (addrs []netip.Addr, err error) {
 	zlog.Debug("Lookup NS ipv6 address", "qname", qname)
 
 	if addrs, ok := r.getIPv6Cache(qname); ok {
@@ -2566,7 +2548,7 @@ func (r *Resolver) lookupV4Nss(ctx context.Context, q dns.Question, authservers 
 		}
 
 		addrs, err := r.lookupNSAddrV4(ctx, name, cd)
-		nsipv4 := make(map[string][]string)
+		nsipv4 := make(map[string][]netip.Addr)
 
 		if err != nil {
 			if errors.Is(err, middleware.ErrRecursionWorkLimit) ||
@@ -2597,13 +2579,13 @@ func (r *Resolver) lookupV4Nss(ctx context.Context, q dns.Question, authservers 
 		before := len(authservers.List)
 	addrsloop:
 		for _, addr := range addrs {
-			raddr := net.JoinHostPort(addr, "53")
+			endpoint := netip.AddrPortFrom(addr, 53)
 			for _, s := range authservers.List {
-				if s.Addr == raddr {
+				if s.UDPAddr != nil && s.UDPAddr.AddrPort() == endpoint {
 					continue addrsloop
 				}
 			}
-			authservers.List = append(authservers.List, authority.NewServer(raddr, authority.IPv4))
+			authservers.List = append(authservers.List, authority.NewServerFromAddrPort(endpoint))
 		}
 		if len(authservers.List) != before {
 			// Invalidate *before* releasing the write lock: after
@@ -2662,7 +2644,7 @@ func (r *Resolver) lookupV6Nss(ctx context.Context, q dns.Question, authservers 
 		}
 
 		addrs, err := r.lookupNSAddrV6(ctx, name, cd)
-		nsipv6 := make(map[string][]string)
+		nsipv6 := make(map[string][]netip.Addr)
 
 		if err != nil {
 			if errors.Is(err, middleware.ErrRecursionWorkLimit) ||
@@ -2687,13 +2669,13 @@ func (r *Resolver) lookupV6Nss(ctx context.Context, q dns.Question, authservers 
 		before := len(authservers.List)
 	addrsloop:
 		for _, addr := range addrs {
-			raddr := net.JoinHostPort(addr, "53")
+			endpoint := netip.AddrPortFrom(addr, 53)
 			for _, s := range authservers.List {
-				if s.Addr == raddr {
+				if s.UDPAddr != nil && s.UDPAddr.AddrPort() == endpoint {
 					continue addrsloop
 				}
 			}
-			authservers.List = append(authservers.List, authority.NewServer(raddr, authority.IPv6))
+			authservers.List = append(authservers.List, authority.NewServerFromAddrPort(endpoint))
 		}
 		if len(authservers.List) != before {
 			authservers.InvalidateFingerprint()
@@ -2938,7 +2920,7 @@ func (r *Resolver) checkPriming() {
 
 	var tmpservers authority.Servers
 	foundServers := make(map[string]bool)
-	seenEndpoints := make(map[string]struct{})
+	seenEndpoints := make(map[netip.AddrPort]struct{})
 
 	// Process IPv6 addresses if enabled
 	if r.cfg.IPv6Access { //nolint:gosec // G118 - detached enrichment is intentionally bounded below
@@ -2947,11 +2929,12 @@ func (r *Resolver) checkPriming() {
 				serverName := strings.ToLower(v6.Header().Name)
 				if nsServers[serverName] {
 					foundServers[serverName] = true
-					host := net.JoinHostPort(v6.AAAA.String(), "53")
-					key := middleware.CanonicalResolutionEndpoint(host)
-					if _, ok := seenEndpoints[key]; !ok {
-						seenEndpoints[key] = struct{}{}
-						tmpservers.List = append(tmpservers.List, authority.NewServer(host, authority.IPv6))
+					if addr, valid := netip.AddrFromSlice(v6.AAAA); valid {
+						endpoint := netip.AddrPortFrom(addr.Unmap(), 53)
+						if _, ok := seenEndpoints[endpoint]; !ok {
+							seenEndpoints[endpoint] = struct{}{}
+							tmpservers.List = append(tmpservers.List, authority.NewServerFromAddrPort(endpoint))
+						}
 					}
 				}
 			}
@@ -2964,11 +2947,12 @@ func (r *Resolver) checkPriming() {
 			serverName := strings.ToLower(v4.Header().Name)
 			if nsServers[serverName] {
 				foundServers[serverName] = true
-				host := net.JoinHostPort(v4.A.String(), "53")
-				key := middleware.CanonicalResolutionEndpoint(host)
-				if _, ok := seenEndpoints[key]; !ok {
-					seenEndpoints[key] = struct{}{}
-					tmpservers.List = append(tmpservers.List, authority.NewServer(host, authority.IPv4))
+				if addr, valid := netip.AddrFromSlice(v4.A); valid {
+					endpoint := netip.AddrPortFrom(addr.Unmap(), 53)
+					if _, ok := seenEndpoints[endpoint]; !ok {
+						seenEndpoints[endpoint] = struct{}{}
+						tmpservers.List = append(tmpservers.List, authority.NewServerFromAddrPort(endpoint))
+					}
 				}
 			}
 		}

--- a/middleware/resolver/utils.go
+++ b/middleware/resolver/utils.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"math/rand/v2"
 	"net"
+	"net/netip"
 	"slices"
 	"strings"
 	"sync"
@@ -41,39 +42,27 @@ func shuffleStr(vals []string) []string {
 	return ret
 }
 
-func searchAddrs(msg *dns.Msg) (addrs []string, found bool) {
+// searchAddrs collects usable NS addresses from an answer as heap-free
+// netip values. Address strings are deliberately never materialized here:
+// the whole downstream pipeline (glue caches, Server construction, dedup)
+// is netip-native and derives its one canonical string per Server.
+func searchAddrs(msg *dns.Msg) (addrs []netip.Addr, found bool) {
 	found = false
 
 	for _, rr := range msg.Answer {
 		if r, ok := rr.(*dns.A); ok {
-			if isLocalIP(r.A) {
+			addr, valid := usableAddr(r.A)
+			if !valid || !addr.Is4() {
 				continue
 			}
-
-			if r.A.To4() == nil {
-				continue
-			}
-
-			if r.A.IsLoopback() {
-				continue
-			}
-
-			addrs = append(addrs, r.A.String())
+			addrs = append(addrs, addr)
 			found = true
 		} else if r, ok := rr.(*dns.AAAA); ok {
-			if isLocalIP(r.AAAA) {
+			addr, valid := usableAddr(r.AAAA)
+			if !valid {
 				continue
 			}
-
-			if r.AAAA.To16() == nil {
-				continue
-			}
-
-			if r.AAAA.IsLoopback() {
-				continue
-			}
-
-			addrs = append(addrs, r.AAAA.String())
+			addrs = append(addrs, addr)
 			found = true
 		}
 	}
@@ -115,6 +104,31 @@ func isLocalIP(ip net.IP) (ok bool) {
 	}
 
 	return
+}
+
+// usableAddr converts an RR address to its canonical netip value and applies
+// the shared NS-address filters (local interface addresses, loopback). The
+// bool is false when the address is malformed or filtered.
+func usableAddr(ip net.IP) (netip.Addr, bool) {
+	addr, ok := netip.AddrFromSlice(ip)
+	if !ok {
+		return netip.Addr{}, false
+	}
+	addr = addr.Unmap()
+	if addr.IsLoopback() || isLocalIP(ip) {
+		return netip.Addr{}, false
+	}
+	return addr, true
+}
+
+// appendUniqueAddr grows a small per-NS address list without duplicates.
+func appendUniqueAddr(values []netip.Addr, value netip.Addr) []netip.Addr {
+	for _, existing := range values {
+		if existing == value {
+			return values
+		}
+	}
+	return append(values, value)
 }
 
 func isDO(req *dns.Msg) bool {

--- a/middleware/resolver/utils_test.go
+++ b/middleware/resolver/utils_test.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"fmt"
 	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/miekg/dns"
@@ -58,8 +59,8 @@ func Test_searchAddr(t *testing.T) {
 
 	addrs, found := searchAddrs(m)
 	assert.Equal(t, len(addrs), 1)
-	assert.NotEqual(t, addrs[0], "127.0.0.1")
-	assert.Equal(t, addrs[0], "192.0.2.1")
+	assert.NotEqual(t, addrs[0], netip.MustParseAddr("127.0.0.1"))
+	assert.Equal(t, addrs[0], netip.MustParseAddr("192.0.2.1"))
 	assert.Equal(t, found, true)
 }
 


### PR DESCRIPTION
## Summary

The authority address pipeline is now netip-native end to end: glue A/AAAA records decode once into `netip.Addr` values, glue caches store address values instead of strings, endpoint dedup compares `netip.AddrPort` values, and each `Server` derives its single canonical string at construction (retiring the `ResolveUDPAddr` parse residue construction used to retain). The UDP dial fast path keeps its pre-parsed `UDPAddr` — its zero-allocation property is worth two retained objects per instance.

## Measurements

Referral hot path (`checkGlueRR`, 4-glue referral):

| | before | after |
|---|---|---|
| allocs/op | 59 | **39** (−34%) |
| B/op | 1737 | 1320 |
| ns/op | 1672 | **1190** (−29%) |

Retained delegation state (5000 delegations, 4 NS + glue each): 30.0 → 24.0 objects (−20%), 899 → 835 B (−7%).

Honest framing: this is primarily a **churn** win on the per-miss referral path plus a modest residency reduction. The two remaining levers for authority residency are deliberately *not* taken here: endpoint interning (needs field dedup-factor data to justify its stats-coupling), and dropping the retained `UDPAddr` (trades two objects per instance for two allocations per UDP dial on the hot path).

## Notes

- `Server.Addr` is now always the canonical netip form. All producers feed IP literals, so comparison sites and map keys see the same strings they did before; a canonicalization test pins v6 compression/case and 4-in-6 unmapping.
- `NewServerFromAddrPort` derives the IP family from the address itself, removing a mismatch class.
