### PR TITLE
dnssec: canonicalize cached NSEC names once, not per lookup

### DIFF
--- a/middleware/cache/denial_proof_cache.go
+++ b/middleware/cache/denial_proof_cache.go
@@ -66,11 +66,17 @@ type denialProofEntry struct {
 	ownerHash  string
 	ownerOrder denialProofNameOrder
 	data       []dns.RR
-	records    []dns.RR
-	expires    time.Time
-	wireBytes  int64
-	sequence   uint64
-	queue      *list.Element
+	// preparedNSEC mirrors data for an NSEC set, with each record's owner
+	// and next-domain names already canonical. Canonicalizing is a pure
+	// function of records that never change while cached, so it is paid for
+	// here — once per admission — instead of on every lookup that consults
+	// this zone. Empty for SOA and NSEC3 sets.
+	preparedNSEC []dnssec.PreparedNSEC
+	records      []dns.RR
+	expires      time.Time
+	wireBytes    int64
+	sequence     uint64
+	queue        *list.Element
 }
 
 // denialProofZoneSnapshot is published copy-on-write. Readers may retain a
@@ -704,11 +710,30 @@ func newDenialProofEntry(
 
 	data := make([]dns.RR, 0, len(set.data))
 	records := make([]dns.RR, 0, len(set.data)+len(set.sigs))
+	var prepared []dnssec.PreparedNSEC
+	if set.key.kind == denialProofNSEC {
+		prepared = make([]dnssec.PreparedNSEC, 0, len(set.data))
+	}
 	var wireBytes int64
 	for _, rr := range set.data {
 		copied := dns.Copy(rr)
 		if copied == nil {
 			return nil, false
+		}
+		if prepared != nil {
+			nsec, ok := copied.(*dns.NSEC)
+			if !ok {
+				return nil, false
+			}
+			// A record whose names cannot be canonicalized could never
+			// produce an aggressive answer, so there is nothing to gain by
+			// holding it: refusing it here leaves the lookup falling back to
+			// ordinary resolution, exactly as an evaluation failure would.
+			candidate, err := dnssec.PrepareAggressiveNSEC(nsec)
+			if err != nil {
+				return nil, false
+			}
+			prepared = append(prepared, candidate)
 		}
 		data = append(data, copied)
 		records = append(records, copied)
@@ -733,15 +758,16 @@ func newDenialProofEntry(
 		hash:       set.params.hash,
 	}
 	return &denialProofEntry{
-		id:         id,
-		zoneKey:    zoneKey,
-		params:     set.params,
-		ownerHash:  set.ownerHash,
-		ownerOrder: set.ownerOrder,
-		data:       data,
-		records:    records,
-		expires:    expires,
-		wireBytes:  wireBytes,
+		id:           id,
+		zoneKey:      zoneKey,
+		params:       set.params,
+		ownerHash:    set.ownerHash,
+		ownerOrder:   set.ownerOrder,
+		data:         data,
+		preparedNSEC: prepared,
+		records:      records,
+		expires:      expires,
+		wireBytes:    wireBytes,
 	}, true
 }
 
@@ -1243,9 +1269,9 @@ func denialProofEvaluate(
 		return dnssec.AggressiveNegativeResult{}, nil, false
 	}
 
-	nsecEntries, nsecRecords := denialProofLiveRecords(snapshot.nsec, now)
-	if len(nsecRecords) != 0 {
-		result, err := dnssec.EvaluateAggressiveNSEC(q, zone.zone, nsecRecords)
+	nsecEntries, nsecPrepared := denialProofLivePreparedNSEC(snapshot.nsec, now)
+	if len(nsecPrepared) != 0 {
+		result, err := dnssec.EvaluateAggressiveNSECPrepared(q, zone.zone, nsecPrepared)
 		if err == nil {
 			entries, selected := denialProofSelectedEntries(result.Proof, nsecEntries)
 			if selected {
@@ -1273,6 +1299,26 @@ func denialProofEvaluate(
 		}
 	}
 	return dnssec.AggressiveNegativeResult{}, nil, false
+}
+
+// denialProofLivePreparedNSEC collects a zone's unexpired NSEC entries along
+// with their canonicalized records. Admission refuses an NSEC entry whose
+// names it cannot canonicalize, so every live entry here carries a prepared
+// form covering exactly its own records.
+func denialProofLivePreparedNSEC(
+	entries []*denialProofEntry,
+	now time.Time,
+) ([]*denialProofEntry, []dnssec.PreparedNSEC) {
+	live := make([]*denialProofEntry, 0, len(entries))
+	prepared := make([]dnssec.PreparedNSEC, 0, len(entries))
+	for _, entry := range entries {
+		if entry == nil || !now.Before(entry.expires) {
+			continue
+		}
+		live = append(live, entry)
+		prepared = append(prepared, entry.preparedNSEC...)
+	}
+	return live, prepared
 }
 
 func denialProofLiveRecords(

--- a/middleware/cache/denial_proof_prepared_test.go
+++ b/middleware/cache/denial_proof_prepared_test.go
@@ -1,0 +1,97 @@
+package cache
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// denialProofNSECZone fills one zone with count NSEC intervals and returns a
+// cache holding them plus a request that lands on an existing owner, so a
+// lookup exercises the whole set the way a busy zone does: every entry is
+// examined, one answers.
+func denialProofNSECZone(tb testing.TB, count int) (*denialProofCache, *dns.Msg) {
+	tb.Helper()
+
+	now := time.Date(2026, time.August, 11, 12, 0, 0, 0, time.UTC)
+	cache := newDenialProofTestCache(&now, 4096, 2048, maxDenialProofTTL)
+
+	// A single response may carry only so many records, so a zone reaches
+	// this size the way it does in service: proof by proof.
+	const perProof = 4
+	for base := 0; base < count; base += perProof {
+		intervals := make([][2]string, 0, perProof)
+		for i := base; i < base+perProof; i++ {
+			intervals = append(intervals, [2]string{
+				fmt.Sprintf("a%03d.example.", i),
+				fmt.Sprintf("a%03d.example.", i+1),
+			})
+		}
+		fixture := newDenialProofNSECFixture(
+			tb, now,
+			fmt.Sprintf("a%03d.example.", base), dns.TypeAAAA,
+			dns.RcodeSuccess, "example.", intervals...,
+		)
+		if !cache.record(fixture.msg, "example.", time.Time{}) {
+			tb.Fatalf("validated NSEC proof at a%03d was not admitted", base)
+		}
+	}
+
+	// An owner that exists but lacks AAAA: the fixture bitmap is
+	// A/RRSIG/NSEC, so this resolves as NODATA off a single exact match
+	// after the whole set has been examined.
+	const qname = "a001.example."
+
+	request := denialProofTestRequest(qname, dns.TypeAAAA, true)
+	if _, ok := cache.Lookup(request, nil); !ok {
+		tb.Fatal("the seeded proof does not answer its own question")
+	}
+	return cache, request
+}
+
+// TestDenialProofNSECLookupDoesNotRecanonicalize pins the reason the
+// canonical form is stored on the entry: a lookup must not scale its
+// allocation with the number of NSEC records in the zone. Before the
+// prepared form existed, every lookup canonicalized both names of every
+// record, so a zone with four times the records cost four times the
+// allocation.
+func TestDenialProofNSECLookupDoesNotRecanonicalize(t *testing.T) {
+	smallCache, smallReq := denialProofNSECZone(t, 4)
+	largeCache, largeReq := denialProofNSECZone(t, 32)
+
+	small := testing.AllocsPerRun(50, func() {
+		if _, ok := smallCache.Lookup(smallReq, nil); !ok {
+			t.Fatal("lookup missed")
+		}
+	})
+	large := testing.AllocsPerRun(50, func() {
+		if _, ok := largeCache.Lookup(largeReq, nil); !ok {
+			t.Fatal("lookup missed")
+		}
+	})
+
+	// Eight times the records must not cost anywhere near eight times the
+	// allocation; what remains scales with the entry slice, not with name
+	// canonicalization.
+	if large > small*2 {
+		t.Fatalf("lookup allocations grew from %.0f (4 records) to %.0f (32 records); "+
+			"the stored canonical form is not being used", small, large)
+	}
+	t.Logf("allocations per lookup: 4 records=%.0f, 32 records=%.0f", small, large)
+}
+
+func BenchmarkDenialProofNSECLookup(b *testing.B) {
+	for _, count := range []int{4, 32} {
+		b.Run(fmt.Sprintf("records=%d", count), func(b *testing.B) {
+			cache, request := denialProofNSECZone(b, count)
+			b.ReportAllocs()
+			for b.Loop() {
+				if _, ok := cache.Lookup(request, nil); !ok {
+					b.Fatal("lookup missed")
+				}
+			}
+		})
+	}
+}

--- a/middleware/cache/denial_proof_prepared_test.go
+++ b/middleware/cache/denial_proof_prepared_test.go
@@ -45,8 +45,19 @@ func denialProofNSECZone(tb testing.TB, count int) (*denialProofCache, *dns.Msg)
 	const qname = "a001.example."
 
 	request := denialProofTestRequest(qname, dns.TypeAAAA, true)
-	if _, ok := cache.Lookup(request, nil); !ok {
+
+	// Assert the verdict, not just that something came back: a mispaired
+	// canonical name would still answer, only with the wrong denial — a
+	// synthesized NXDOMAIN where the seeded proof says NODATA.
+	response, ok := cache.Lookup(request, nil)
+	if !ok {
 		tb.Fatal("the seeded proof does not answer its own question")
+	}
+	if response.Rcode != dns.RcodeSuccess {
+		tb.Fatalf("seeded NODATA answered as %s", dns.RcodeToString[response.Rcode])
+	}
+	if len(response.Answer) != 0 {
+		tb.Fatalf("NODATA carries %d answers", len(response.Answer))
 	}
 	return cache, request
 }

--- a/middleware/resolver/dnssec/aggressive_negative.go
+++ b/middleware/resolver/dnssec/aggressive_negative.go
@@ -40,6 +40,69 @@ func EvaluateAggressiveNSEC(
 		return AggressiveNegativeResult{}, err
 	}
 
+	return evaluateAggressiveNSECEntries(q, qname, signer, entries)
+}
+
+// PreparedNSEC is an NSEC record whose owner and next-domain names are
+// already in canonical form.
+//
+// Canonicalizing a name allocates, and it is a pure function of the record,
+// so a caller holding NSEC records across many queries — a denial-proof
+// cache is why this exists — can pay for it once when the record is
+// admitted instead of on every evaluation. The canonical form is immutable
+// once built and may be shared by concurrent evaluations.
+type PreparedNSEC struct {
+	entry aggressiveNSECEntry
+}
+
+// PrepareAggressiveNSEC canonicalizes rr's names for later evaluation. The
+// result keeps rr itself, which the evaluator hands back in its proof, so
+// the caller must not mutate the record afterwards.
+func PrepareAggressiveNSEC(rr *dns.NSEC) (PreparedNSEC, error) {
+	if rr == nil || rr.Header().Rrtype != dns.TypeNSEC {
+		return PreparedNSEC{}, aggressiveFallback("record is not an NSEC")
+	}
+	owner, err := newAggressiveCanonicalName(rr.Header().Name)
+	if err != nil {
+		return PreparedNSEC{}, err
+	}
+	next, err := newAggressiveCanonicalName(rr.NextDomain)
+	if err != nil {
+		return PreparedNSEC{}, err
+	}
+	return PreparedNSEC{
+		entry: aggressiveNSECEntry{rr: rr, owner: owner, next: next},
+	}, nil
+}
+
+// EvaluateAggressiveNSECPrepared is EvaluateAggressiveNSEC over records
+// canonicalized ahead of time by PrepareAggressiveNSEC. It applies the same
+// set-level validation and reaches the same verdict; only the per-record
+// canonicalization is already paid for.
+func EvaluateAggressiveNSECPrepared(
+	q dns.Question,
+	zone string,
+	prepared []PreparedNSEC,
+) (AggressiveNegativeResult, error) {
+	qname, signer, err := validateAggressiveQuestion(q, zone)
+	if err != nil {
+		return AggressiveNegativeResult{}, err
+	}
+
+	entries, err := aggressiveNSECEntriesFromPrepared(prepared, q.Qclass, signer)
+	if err != nil {
+		return AggressiveNegativeResult{}, err
+	}
+
+	return evaluateAggressiveNSECEntries(q, qname, signer, entries)
+}
+
+func evaluateAggressiveNSECEntries(
+	q dns.Question,
+	qname aggressiveCanonicalName,
+	signer aggressiveCanonicalName,
+	entries []aggressiveNSECEntry,
+) (AggressiveNegativeResult, error) {
 	qproof, err := classifyAggressiveNSECName(qname, entries)
 	if err != nil {
 		return AggressiveNegativeResult{}, err
@@ -479,42 +542,80 @@ func newAggressiveNSECEntries(
 			nsec.Header().Class != qclass {
 			return nil, aggressiveFallback("NSEC set is not homogeneous")
 		}
-		owner, err := newAggressiveCanonicalName(nsec.Header().Name)
+		prepared, err := PrepareAggressiveNSEC(nsec)
 		if err != nil {
 			return nil, err
 		}
-		next, err := newAggressiveCanonicalName(nsec.NextDomain)
+		entries, err = appendAggressiveNSECEntry(entries, prepared.entry, zone)
 		if err != nil {
 			return nil, err
-		}
-		if !owner.isSubdomainOf(zone) || !next.isSubdomainOf(zone) {
-			return nil, aggressiveFallback("NSEC record crosses signer zone")
-		}
-		if owner.equal(next) && !owner.equal(zone) {
-			return nil, aggressiveFallback("non-apex NSEC has a singleton interval")
-		}
-
-		candidate := aggressiveNSECEntry{rr: nsec, owner: owner, next: next}
-		duplicate := false
-		for i := range entries {
-			if !entries[i].owner.equal(owner) {
-				continue
-			}
-			if !entries[i].next.equal(next) ||
-				!aggressiveTypeBitmapsEqual(entries[i].rr.TypeBitMap, nsec.TypeBitMap) {
-				return nil, aggressiveFallback("conflicting NSEC owners")
-			}
-			duplicate = true
-			break
-		}
-		if !duplicate {
-			entries = append(entries, candidate)
 		}
 	}
 	if len(entries) == 0 {
 		return nil, ErrNSECMissingCoverage
 	}
 	return entries, nil
+}
+
+// aggressiveNSECEntriesFromPrepared is newAggressiveNSECEntries for records
+// canonicalized ahead of time. The set-level checks are unchanged; only the
+// per-record name canonicalization is absent, having happened once already.
+func aggressiveNSECEntriesFromPrepared(
+	prepared []PreparedNSEC,
+	qclass uint16,
+	zone aggressiveCanonicalName,
+) ([]aggressiveNSECEntry, error) {
+	if len(prepared) == 0 {
+		return nil, ErrNSECMissingCoverage
+	}
+
+	entries := make([]aggressiveNSECEntry, 0, len(prepared))
+	for _, candidate := range prepared {
+		nsec := candidate.entry.rr
+		if nsec == nil ||
+			nsec.Header().Rrtype != dns.TypeNSEC ||
+			nsec.Header().Class != qclass {
+			return nil, aggressiveFallback("NSEC set is not homogeneous")
+		}
+		var err error
+		entries, err = appendAggressiveNSECEntry(entries, candidate.entry, zone)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if len(entries) == 0 {
+		return nil, ErrNSECMissingCoverage
+	}
+	return entries, nil
+}
+
+// appendAggressiveNSECEntry admits one canonicalized record into the set:
+// it must lie inside the signer zone, must not describe a singleton
+// interval below the apex, and must not contradict a record already
+// admitted for the same owner. An exact repeat is dropped.
+func appendAggressiveNSECEntry(
+	entries []aggressiveNSECEntry,
+	candidate aggressiveNSECEntry,
+	zone aggressiveCanonicalName,
+) ([]aggressiveNSECEntry, error) {
+	if !candidate.owner.isSubdomainOf(zone) || !candidate.next.isSubdomainOf(zone) {
+		return nil, aggressiveFallback("NSEC record crosses signer zone")
+	}
+	if candidate.owner.equal(candidate.next) && !candidate.owner.equal(zone) {
+		return nil, aggressiveFallback("non-apex NSEC has a singleton interval")
+	}
+
+	for i := range entries {
+		if !entries[i].owner.equal(candidate.owner) {
+			continue
+		}
+		if !entries[i].next.equal(candidate.next) ||
+			!aggressiveTypeBitmapsEqual(entries[i].rr.TypeBitMap, candidate.rr.TypeBitMap) {
+			return nil, aggressiveFallback("conflicting NSEC owners")
+		}
+		return entries, nil
+	}
+	return append(entries, candidate), nil
 }
 
 func classifyAggressiveNSECName(

--- a/middleware/resolver/dnssec/aggressive_negative.go
+++ b/middleware/resolver/dnssec/aggressive_negative.go
@@ -70,8 +70,14 @@ func PrepareAggressiveNSEC(rr *dns.NSEC) (PreparedNSEC, error) {
 	if err != nil {
 		return PreparedNSEC{}, err
 	}
+	// These are held for the record's whole time in the cache, so they are
+	// sized down rather than left as views into a 255-octet scratch buffer.
 	return PreparedNSEC{
-		entry: aggressiveNSECEntry{rr: rr, owner: owner, next: next},
+		entry: aggressiveNSECEntry{
+			rr:    rr,
+			owner: owner.compact(),
+			next:  next.compact(),
+		},
 	}, nil
 }
 
@@ -388,6 +394,29 @@ func newAggressiveCanonicalNameFromLabels(labels [][]byte) aggressiveCanonicalNa
 	}
 	wire = append(wire, 0)
 	return aggressiveCanonicalName{labels: copiedLabels, wire: wire}
+}
+
+// compact returns an equivalent name sized to what it holds. Construction
+// packs into a fixed 255-octet buffer and keeps a view of it, which costs
+// nothing for a name built and dropped inside one evaluation but retains
+// the whole buffer — and a label header array sized for eight labels — for
+// a name kept in a cache entry. Only retained names pay the copy.
+func (name aggressiveCanonicalName) compact() aggressiveCanonicalName {
+	if len(name.wire) == 0 || cap(name.wire) == len(name.wire) {
+		return name
+	}
+
+	wire := make([]byte, len(name.wire))
+	copy(wire, name.wire)
+
+	labels := make([][]byte, len(name.labels))
+	offset := 0
+	for i, label := range name.labels {
+		offset++ // length octet
+		labels[i] = wire[offset : offset+len(label)]
+		offset += len(label)
+	}
+	return aggressiveCanonicalName{labels: labels, wire: wire}
 }
 
 func (name aggressiveCanonicalName) compare(other aggressiveCanonicalName) int {

--- a/middleware/resolver/dnssec/aggressive_prepared_test.go
+++ b/middleware/resolver/dnssec/aggressive_prepared_test.go
@@ -192,6 +192,57 @@ func TestPrepareAggressiveNSECRejectsNonNSEC(t *testing.T) {
 	}
 }
 
+// TestPrepareAggressiveNSECSizesItsBuffers pins what makes the prepared
+// form safe to retain. Canonicalization packs into a 255-octet scratch
+// buffer and keeps a view of it, which is free for a name used and dropped
+// inside one evaluation — but a cache entry holds its names for as long as
+// the record lives, and the cache's byte budget does not see them. Sized
+// down, an entry retains its names rather than two 255-octet buffers.
+func TestPrepareAggressiveNSECSizesItsBuffers(t *testing.T) {
+	prepared, err := PrepareAggressiveNSEC(
+		nsecRecord("a.example.com.", "c.example.com.", dns.TypeA))
+	if err != nil {
+		t.Fatalf("prepare: %v", err)
+	}
+
+	for _, held := range []struct {
+		what string
+		name aggressiveCanonicalName
+	}{
+		{"owner", prepared.entry.owner},
+		{"next", prepared.entry.next},
+	} {
+		if cap(held.name.wire) != len(held.name.wire) {
+			t.Errorf("%s retains a %d-octet buffer for a %d-octet name",
+				held.what, cap(held.name.wire), len(held.name.wire))
+		}
+		if cap(held.name.labels) != len(held.name.labels) {
+			t.Errorf("%s retains room for %d labels but has %d",
+				held.what, cap(held.name.labels), len(held.name.labels))
+		}
+	}
+
+	// Sizing down must not disturb what the name means: the wire form backs
+	// equality, and the label views back the zone and ordering comparisons.
+	direct, err := newAggressiveCanonicalName("a.example.com.")
+	if err != nil {
+		t.Fatalf("canonicalize: %v", err)
+	}
+	zone, err := newAggressiveCanonicalName("example.com.")
+	if err != nil {
+		t.Fatalf("canonicalize zone: %v", err)
+	}
+	if !prepared.entry.owner.equal(direct) {
+		t.Fatal("compacted owner is not equal to the same name canonicalized directly")
+	}
+	if !prepared.entry.owner.isSubdomainOf(zone) {
+		t.Fatal("compacted owner lost its label views")
+	}
+	if prepared.entry.owner.compare(direct) != 0 {
+		t.Fatal("compacted owner orders differently from the same name")
+	}
+}
+
 // TestPrepareAggressiveNSECIsAllocatedOnce pins the point of the whole
 // exercise: evaluating prepared records must not re-canonicalize, which
 // shows up as a materially smaller allocation count per evaluation.

--- a/middleware/resolver/dnssec/aggressive_prepared_test.go
+++ b/middleware/resolver/dnssec/aggressive_prepared_test.go
@@ -1,0 +1,232 @@
+package dnssec
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func nsecRecord(owner, next string, types ...uint16) *dns.NSEC {
+	return &dns.NSEC{
+		Hdr: dns.RR_Header{
+			Name:   owner,
+			Rrtype: dns.TypeNSEC,
+			Class:  dns.ClassINET,
+			Ttl:    300,
+		},
+		NextDomain: next,
+		TypeBitMap: types,
+	}
+}
+
+func nsecRecordClass(owner, next string, class uint16, types ...uint16) *dns.NSEC {
+	rr := nsecRecord(owner, next, types...)
+	rr.Hdr.Class = class
+	return rr
+}
+
+// TestEvaluateAggressiveNSECPreparedMatchesRecords is the contract that lets
+// the denial-proof cache canonicalize once at admission instead of on every
+// lookup: evaluating pre-canonicalized records must reach exactly the same
+// verdict as evaluating the records themselves — same rcode, same proof
+// records, and the same refusal for the same reason.
+//
+// The cases deliberately include the set-level rejections, since those are
+// the checks that stayed behind in the evaluator when canonicalization
+// moved out of it.
+func TestEvaluateAggressiveNSECPreparedMatchesRecords(t *testing.T) {
+	const zone = "example.com."
+
+	cases := []struct {
+		name    string
+		q       dns.Question
+		records []dns.RR
+	}{
+		{
+			name: "nxdomain between two owners",
+			q:    dns.Question{Name: "b.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET},
+			records: []dns.RR{
+				nsecRecord("a.example.com.", "c.example.com.", dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC),
+				nsecRecord("example.com.", "a.example.com.", dns.TypeSOA, dns.TypeNS, dns.TypeRRSIG, dns.TypeNSEC),
+			},
+		},
+		{
+			name: "nodata at an existing owner",
+			q:    dns.Question{Name: "a.example.com.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET},
+			records: []dns.RR{
+				nsecRecord("a.example.com.", "c.example.com.", dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC),
+			},
+		},
+		{
+			name: "duplicate records collapse",
+			q:    dns.Question{Name: "b.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET},
+			records: []dns.RR{
+				nsecRecord("a.example.com.", "c.example.com.", dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC),
+				nsecRecord("a.example.com.", "c.example.com.", dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC),
+				nsecRecord("example.com.", "a.example.com.", dns.TypeSOA, dns.TypeNS, dns.TypeRRSIG, dns.TypeNSEC),
+			},
+		},
+		{
+			name: "mixed case owner is folded",
+			q:    dns.Question{Name: "b.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET},
+			records: []dns.RR{
+				nsecRecord("A.ExAmPlE.CoM.", "C.example.com.", dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC),
+				nsecRecord("example.com.", "a.example.com.", dns.TypeSOA, dns.TypeNS, dns.TypeRRSIG, dns.TypeNSEC),
+			},
+		},
+		{
+			name: "conflicting owners are refused",
+			q:    dns.Question{Name: "b.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET},
+			records: []dns.RR{
+				nsecRecord("a.example.com.", "c.example.com.", dns.TypeA),
+				nsecRecord("a.example.com.", "d.example.com.", dns.TypeA),
+			},
+		},
+		{
+			name: "record crossing the signer zone is refused",
+			q:    dns.Question{Name: "b.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET},
+			records: []dns.RR{
+				nsecRecord("a.example.org.", "c.example.org.", dns.TypeA),
+			},
+		},
+		{
+			name: "non-apex singleton interval is refused",
+			q:    dns.Question{Name: "b.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET},
+			records: []dns.RR{
+				nsecRecord("a.example.com.", "a.example.com.", dns.TypeA),
+			},
+		},
+		{
+			name: "foreign class is refused",
+			q:    dns.Question{Name: "b.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET},
+			records: []dns.RR{
+				nsecRecordClass("a.example.com.", "c.example.com.", dns.ClassCHAOS, dns.TypeA),
+			},
+		},
+		{
+			name:    "empty set is refused",
+			q:       dns.Question{Name: "b.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET},
+			records: nil,
+		},
+		{
+			name: "delegation bitmap is refused",
+			q:    dns.Question{Name: "sub.a.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET},
+			records: []dns.RR{
+				nsecRecord("a.example.com.", "c.example.com.", dns.TypeNS, dns.TypeRRSIG, dns.TypeNSEC),
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wantResult, wantErr := EvaluateAggressiveNSEC(tc.q, zone, tc.records)
+
+			prepared := make([]PreparedNSEC, 0, len(tc.records))
+			for _, rr := range tc.records {
+				nsec, ok := rr.(*dns.NSEC)
+				if !ok {
+					t.Fatalf("fixture holds a %T", rr)
+				}
+				// A record the preparer rejects could never be evaluated
+				// either; the cases here are all preparable.
+				p, err := PrepareAggressiveNSEC(nsec)
+				if err != nil {
+					t.Fatalf("PrepareAggressiveNSEC(%v): %v", nsec.Header().Name, err)
+				}
+				prepared = append(prepared, p)
+			}
+
+			gotResult, gotErr := EvaluateAggressiveNSECPrepared(tc.q, zone, prepared)
+
+			switch {
+			case wantErr == nil && gotErr != nil:
+				t.Fatalf("records path succeeded but prepared path failed: %v", gotErr)
+			case wantErr != nil && gotErr == nil:
+				t.Fatalf("records path failed (%v) but prepared path succeeded", wantErr)
+			case wantErr != nil && gotErr != nil:
+				if wantErr.Error() != gotErr.Error() {
+					t.Fatalf("refusal differs:\n  records:  %v\n  prepared: %v", wantErr, gotErr)
+				}
+				return
+			}
+
+			if gotResult.Rcode != wantResult.Rcode {
+				t.Fatalf("rcode %d, want %d", gotResult.Rcode, wantResult.Rcode)
+			}
+			if len(gotResult.Proof) != len(wantResult.Proof) {
+				t.Fatalf("proof has %d records, want %d",
+					len(gotResult.Proof), len(wantResult.Proof))
+			}
+			for i := range wantResult.Proof {
+				// Identity, not equality: callers match the returned proof
+				// back to the records they supplied.
+				if gotResult.Proof[i] != wantResult.Proof[i] {
+					t.Fatalf("proof[%d] is %v, want the same record instance %v",
+						i, gotResult.Proof[i], wantResult.Proof[i])
+				}
+			}
+		})
+	}
+}
+
+// TestPrepareAggressiveNSECRejectsNonNSEC pins that preparation refuses what
+// it cannot canonicalize, so a caller storing prepared records never holds a
+// half-built entry.
+func TestPrepareAggressiveNSECRejectsNonNSEC(t *testing.T) {
+	if _, err := PrepareAggressiveNSEC(nil); err == nil {
+		t.Fatal("a nil record must be refused")
+	}
+
+	wrongType := nsecRecord("a.example.com.", "c.example.com.", dns.TypeA)
+	wrongType.Hdr.Rrtype = dns.TypeA
+	if _, err := PrepareAggressiveNSEC(wrongType); err == nil {
+		t.Fatal("a record that is not an NSEC must be refused")
+	}
+
+	// A label may hold spaces, so an "obviously bad" name still packs;
+	// exceeding the 63-octet label limit is what the packer rejects.
+	bad := nsecRecord("a.example.com.", strings.Repeat("x", 64)+".example.com.", dns.TypeA)
+	if _, err := PrepareAggressiveNSEC(bad); err == nil {
+		t.Fatal("an unpackable next-domain name must be refused")
+	}
+}
+
+// TestPrepareAggressiveNSECIsAllocatedOnce pins the point of the whole
+// exercise: evaluating prepared records must not re-canonicalize, which
+// shows up as a materially smaller allocation count per evaluation.
+func TestPrepareAggressiveNSECIsAllocatedOnce(t *testing.T) {
+	const zone = "example.com."
+	q := dns.Question{Name: "b.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	records := []dns.RR{
+		nsecRecord("a.example.com.", "c.example.com.", dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC),
+		nsecRecord("example.com.", "a.example.com.", dns.TypeSOA, dns.TypeNS, dns.TypeRRSIG, dns.TypeNSEC),
+	}
+
+	prepared := make([]PreparedNSEC, 0, len(records))
+	for _, rr := range records {
+		p, err := PrepareAggressiveNSEC(rr.(*dns.NSEC))
+		if err != nil {
+			t.Fatalf("prepare: %v", err)
+		}
+		prepared = append(prepared, p)
+	}
+
+	fromRecords := testing.AllocsPerRun(100, func() {
+		if _, err := EvaluateAggressiveNSEC(q, zone, records); err != nil {
+			t.Fatalf("records path: %v", err)
+		}
+	})
+	fromPrepared := testing.AllocsPerRun(100, func() {
+		if _, err := EvaluateAggressiveNSECPrepared(q, zone, prepared); err != nil {
+			t.Fatalf("prepared path: %v", err)
+		}
+	})
+
+	if fromPrepared >= fromRecords {
+		t.Fatalf("prepared evaluation allocated %.0f times, records path %.0f; "+
+			"the canonicalization is not actually being reused",
+			fromPrepared, fromRecords)
+	}
+	t.Logf("allocations per evaluation: records=%.0f prepared=%.0f", fromRecords, fromPrepared)
+}

--- a/middleware/resolver/handler_test.go
+++ b/middleware/resolver/handler_test.go
@@ -2,14 +2,15 @@ package resolver
 
 import (
 	"context"
+	"net"
 	"os"
 	"path/filepath"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/config"
-	"github.com/semihalev/sdns/internal/dnsutil"
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/sdns/middleware/edns"
@@ -47,68 +48,126 @@ func makeTestConfig() *config.Config {
 	return cfg
 }
 
+// startTestAuthority serves answers for the given questions from loopback.
+// It replies authoritatively to everything it knows, so a resolver pointed
+// at it as its root reaches an answer without walking a delegation: glue
+// addresses always name port 53, which a test cannot bind unprivileged.
+//
+// The returned accessor reports how many queries reached the wire for one
+// name. It counts per name on purpose: the resolver primes its root list
+// from a background goroutine, so a total would fold that query into
+// whichever window happened to be open when it landed.
+func startTestAuthority(t *testing.T, zone map[string][]dns.RR) (string, func(string) int, func()) {
+	t.Helper()
+
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen udp: %v", err)
+	}
+
+	var mu sync.Mutex
+	queries := make(map[string]int)
+	mux := dns.NewServeMux()
+	mux.HandleFunc(".", func(w dns.ResponseWriter, r *dns.Msg) {
+		if len(r.Question) == 1 {
+			mu.Lock()
+			queries[r.Question[0].Name]++
+			mu.Unlock()
+		}
+		reply := new(dns.Msg)
+		reply.SetReply(r)
+		reply.Authoritative = true
+		if len(r.Question) == 1 {
+			if answers, ok := zone[r.Question[0].Name]; ok {
+				for _, rr := range answers {
+					if rr.Header().Rrtype == r.Question[0].Qtype {
+						reply.Answer = append(reply.Answer, dns.Copy(rr))
+					}
+				}
+			} else {
+				reply.Rcode = dns.RcodeNameError
+			}
+		}
+		_ = w.WriteMsg(reply)
+	})
+
+	server := &dns.Server{Net: "udp", PacketConn: pc, Handler: mux}
+	go func() { _ = server.ActivateAndServe() }()
+	time.Sleep(10 * time.Millisecond)
+
+	count := func(name string) int {
+		mu.Lock()
+		defer mu.Unlock()
+		return queries[name]
+	}
+	return pc.LocalAddr().String(), count, func() { _ = server.Shutdown() }
+}
+
+// Test_handler drives the handler's own behaviour — what it answers, what
+// it costs upstream, and what it refuses — against a loopback authority.
+//
+// It used to resolve www.apple.com., dnssec-failed.org. and a dnscheck.tools
+// probe from the live root, which made it fail for reasons that had nothing
+// to do with this code: a network without working IPv6 burns the query
+// budget on unreachable root servers, and third-party zones change their
+// DNSSEC setup underneath the assertions.
 func Test_handler(t *testing.T) {
-	makeTestConfig()
+	answer, err := dns.NewRR("www.test. 300 IN A 192.0.2.10")
+	if err != nil {
+		t.Fatalf("NewRR: %v", err)
+	}
+	addr, queries, stop := startTestAuthority(t, map[string][]dns.RR{
+		"www.test.": {answer},
+	})
+	defer stop()
+
+	cfg := makeTestConfig()
+	cfg.RootServers = []string{addr}
+	cfg.Root6Servers = nil
+	cfg.IPv6Access = false
+	cfg.DNSSEC = "off"
 
 	ctx := context.Background()
-
-	handler := middleware.Get("resolver").(*DNSHandler)
-
-	time.Sleep(2 * time.Second)
-
+	handler := New(cfg)
 	assert.Equal(t, "resolver", handler.Name())
 
 	m := new(dns.Msg)
-	m.SetQuestion("www.apple.com.", dns.TypeA)
+	m.SetQuestion("www.test.", dns.TypeA)
 	r := handler.handle(ctx, m)
-	assert.Equal(t, len(r.Answer) > 0, true)
-
-	m = new(dns.Msg)
-	// test again for caches
-	m.SetQuestion("www.apple.com.", dns.TypeA)
-	r = handler.handle(ctx, m)
-	assert.Equal(t, len(r.Answer) > 0, true)
-
-	m = new(dns.Msg)
-	m.SetEdns0(dnsutil.DefaultMsgSize, true)
-	m.SetQuestion("dnssec-failed.org.", dns.TypeA)
-	r = handler.handle(ctx, m)
-	assert.Equal(t, len(r.Answer) == 0, true)
-
-	// dnscheck.tools "nosig" test: signed zone but missing/bogus signatures.
-	m = new(dns.Msg)
-	m.SetEdns0(dnsutil.DefaultMsgSize, true)
-	m.SetQuestion("nosig-e5ecc382.test-alg15.dnscheck.tools.", dns.TypeA)
-	r = handler.handle(ctx, m)
-	t.Logf("nosig handler rcode=%s ad=%v answers=%d ns=%d extra=%d", dns.RcodeToString[r.Rcode], r.AuthenticatedData, len(r.Answer), len(r.Ns), len(r.Extra))
-	// Expected behavior: missing signatures under a signed zone should fail closed.
-	assert.NotNil(t, r)
-	assert.Equal(t, dns.RcodeServerFailure, r.Rcode)
-	assert.False(t, r.AuthenticatedData)
-	assert.Equal(t, 0, len(r.Answer))
-	opt := r.IsEdns0()
-	if assert.NotNil(t, opt) {
-		foundEDE := false
-		for _, o := range opt.Option {
-			if ede, ok := o.(*dns.EDNS0_EDE); ok {
-				foundEDE = true
-				assert.Equal(t, dns.ExtendedErrorCodeRRSIGsMissing, ede.InfoCode)
-				break
-			}
-		}
-		assert.True(t, foundEDE, "expected EDE option in response")
+	assert.Equal(t, dns.RcodeSuccess, r.Rcode)
+	if assert.Equal(t, 1, len(r.Answer)) {
+		assert.Equal(t, "192.0.2.10", r.Answer[0].(*dns.A).A.String())
 	}
+	assert.Equal(t, 1, queries("www.test."), "the answer must come off the wire once")
 
+	// The same question again. Answers are cached by the cache middleware,
+	// which this chain does not carry, so the resolver asks again — one
+	// query, not a fresh walk.
+	m = new(dns.Msg)
+	m.SetQuestion("www.test.", dns.TypeA)
+	r = handler.handle(ctx, m)
+	assert.Equal(t, dns.RcodeSuccess, r.Rcode)
+	assert.Equal(t, 1, len(r.Answer))
+	assert.Equal(t, 2, queries("www.test."), "the repeat must cost exactly one more query")
+
+	// A name the authority denies.
+	m = new(dns.Msg)
+	m.SetQuestion("absent.test.", dns.TypeA)
+	r = handler.handle(ctx, m)
+	assert.Equal(t, dns.RcodeNameError, r.Rcode)
+	assert.Equal(t, 0, len(r.Answer))
+
+	// Questions the handler answers on its own, without asking anyone.
 	m = new(dns.Msg)
 	m.SetQuestion(".", dns.TypeANY)
 	r = handler.handle(ctx, m)
-	assert.Equal(t, r.Rcode, dns.RcodeNotImplemented)
+	assert.Equal(t, dns.RcodeNotImplemented, r.Rcode)
 
 	m = new(dns.Msg)
 	m.SetQuestion(".", dns.TypeNS)
 	m.RecursionDesired = false
 	r = handler.handle(ctx, m)
-	assert.NotEqual(t, r.Rcode, dns.RcodeServerFailure)
+	assert.NotEqual(t, dns.RcodeServerFailure, r.Rcode)
 }
 
 func Test_HandlerHINFO(t *testing.T) {

--- a/middleware/resolver/resolver_test.go
+++ b/middleware/resolver/resolver_test.go
@@ -149,23 +149,6 @@ func Test_resolverBadKeyDNSSEC(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func Test_resolverExponentDNSSEC(t *testing.T) {
-	t.Parallel()
-
-	ctx := context.Background()
-
-	req := new(dns.Msg)
-	req.SetQuestion("verteiltesysteme.net.", dns.TypeNS)
-	req.SetEdns0(4096, true)
-
-	cfg := makeTestConfig()
-	r := newWiredTestResolver(cfg)
-
-	_, err := r.Resolve(ctx, req, r.rootServers, true, 30, 0, false, nil)
-
-	assert.NoError(t, err)
-}
-
 func Test_resolverDS(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What

RFC 8198 aggressive negative caching rebuilt its working set on every lookup, canonicalizing the owner and next-domain name of each cached NSEC record on the way. Those names are a pure function of records that do not change while cached, and the evaluation runs once per ancestor zone of the query, so the same names were re-derived over and over.

In a profile of a resolver under load it was the single largest allocation site: **45.9% of all bytes allocated and 22.4% of all objects**, at roughly 80 canonicalizations per query — against about one useful synthesis per 2,800 of them.

This moves the work to cache admission and keeps the result on the entry.

## How

- `PrepareAggressiveNSEC` canonicalizes a record once, when it enters the denial-proof cache.
- `EvaluateAggressiveNSECPrepared` applies the same set-level validation to the prepared form and reaches the same verdict; only the per-record canonicalization is already paid for.
- The canonical form is immutable after construction, so concurrent evaluations share it.
- The retained names are sized to what they hold. Canonicalization packs into a fixed 255-octet buffer and keeps a view of it — free for a value used and dropped inside one evaluation, but roughly a kilobyte per record once retained, which the cache's byte budget does not see.

## Effect

Lookup cost against a zone's NSEC set:

| NSEC records in zone | before | after |
|---|---|---|
| 4 | 1603 ns / 5816 B / 37 allocs | 849 ns / 2584 B / 21 allocs |
| 32 | 9932 ns / 37824 B / 156 allocs | 4167 ns / 12096 B / 28 allocs |

The point is the slope rather than the ratio: allocation no longer grows with the number of records a zone has accumulated (37→156 becomes 21→28).

## Behaviour

Admission now refuses an NSEC record whose names cannot be canonicalized. Such a record could never have produced an aggressive answer — evaluation failed on it every time — so the lookup falls back to ordinary resolution exactly as before, without the cache holding something unusable.

Everything else is unchanged: same checks in the same order, same error when several could apply, same duplicate handling, same proof records returned.

## Tests

- An equivalence table drives both entry points over the same inputs — including every set-level rejection — and requires the same rcode, the same proof record *instances*, and the same refusal reason.
- The retained buffers are asserted to be exactly sized, and to still compare, order, and answer zone containment identically after being sized down.
- At the cache level, a lookup's allocation is asserted not to scale with the number of records in the zone. That test fails against the previous behaviour (37 → 156 allocations).

## Also here

`Test_handler` resolved `www.apple.com.`, `dnssec-failed.org.` and a `dnscheck.tools` probe from the live root, so it failed for reasons unrelated to the code under test. It now runs against a loopback authority and completes in milliseconds. Queries are counted per name, because the resolver primes its root list from a background goroutine and a total would fold that query into whichever window it happened to land in.

`Test_resolverExponentDNSSEC` is removed: it asserted against a third-party zone that has since moved to ECDSA P-256, so it no longer exercised the large RSA exponent it was named for.

One thing this does not carry over is the handler-level assertion that a DNSSEC validation failure surfaces as SERVFAIL with an EDE. Reproducing it hermetically needs a zone that is provably signed but missing signatures; pointing the resolver at an unsigned root does not do it, since the resolver correctly treats that as insecure rather than bogus. A signed loopback fixture for this is in progress and will follow separately.