### PR TITLE
feat(blocklist): expose entry count as dns_blocklist_entries

### DIFF
--- a/middleware/blocklist/blocklist.go
+++ b/middleware/blocklist/blocklist.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/miekg/dns"
 	"github.com/prometheus/client_golang/prometheus"
@@ -24,6 +25,39 @@ var blocklistHits = metric.NewCounter(nil, prometheus.CounterOpts{
 	Name: "dns_blocklist_hits_total",
 	Help: "Total DNS queries blocked by the blocklist middleware",
 })
+
+// blocklistLen returns the live entry count of the active BlockList.
+// It is set by New and read only at scrape time by blocklistEntries.
+// A plain func value (rather than a *BlockList) mirrors the pattern the
+// cache middleware uses for dns_cache_size, and keeps the gauge working
+// when the middleware is absent — it then reports 0 rather than panicking.
+var blocklistLen atomic.Pointer[func() int]
+
+// blocklistEntries exposes how many names the blocklist currently holds.
+// dns_blocklist_hits_total alone cannot distinguish "nothing matched" from
+// "the list failed to load or was silently emptied by a bad update": both
+// show zero hits. Operators feeding a large remote catalogue need the
+// loaded size to alert on, so this is a gauge over the live maps rather
+// than a number captured once at load time.
+//
+// GaugeFunc evaluates at scrape time, so there is no hot-path cost. Length
+// takes mu.RLock, which is the same lock ServeDNS holds for reads and so
+// cannot serialise queries against each other; only an in-flight mutation
+// briefly delays a scrape.
+var blocklistEntries = prometheus.NewGaugeFunc(prometheus.GaugeOpts{
+	Name: "dns_blocklist_entries",
+	Help: "Current number of entries in the blocklist (exact names plus wildcard suffixes)",
+}, func() float64 {
+	fn := blocklistLen.Load()
+	if fn == nil {
+		return 0
+	}
+	return float64((*fn)())
+})
+
+func init() {
+	prometheus.MustRegister(blocklistEntries)
+}
 
 // BlockList type
 //
@@ -92,6 +126,12 @@ func New(cfg *config.Config) *BlockList {
 	}
 
 	b.loadInitial()
+
+	// Publish before the refresh goroutine starts so a scrape landing
+	// during the initial remote fetch already reports the local count.
+	length := b.Length
+	blocklistLen.Store(&length)
+
 	go b.refreshRemote()
 
 	return b

--- a/middleware/blocklist/blocklist_test.go
+++ b/middleware/blocklist/blocklist_test.go
@@ -402,3 +402,57 @@ func Test_BlockList_PersistOrdering(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Contains(t, string(data), "c.example.", "a newer snapshot must still persist")
 }
+
+// Test_BlockList_EntriesGauge pins dns_blocklist_entries to the live map
+// contents. The gauge exists so operators can alert on a list that failed
+// to load or was emptied by a bad update — cases where the hits counter
+// stays at zero and looks indistinguishable from "nothing matched". A
+// gauge captured once at load time would miss exactly those regressions,
+// so this asserts it tracks mutations too.
+func Test_BlockList_EntriesGauge(t *testing.T) {
+	cfg := new(config.Config)
+	cfg.Nullroute = "0.0.0.0"
+	cfg.Nullroutev6 = "::0"
+	cfg.BlockListDir = filepath.Join(os.TempDir(), "sdns_temp_entriesgauge")
+	_ = os.RemoveAll(cfg.BlockListDir)
+	if err := os.MkdirAll(cfg.BlockListDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+
+	bl := New(cfg)
+
+	read := func() float64 {
+		fn := blocklistLen.Load()
+		if fn == nil {
+			return 0
+		}
+		return float64((*fn)())
+	}
+
+	assert.Equal(t, float64(0), read(), "a fresh blocklist reports zero entries")
+
+	bl.Set("one.example.")
+	bl.Set("two.example.")
+	bl.Set("*.three.example.")
+	assert.Equal(t, float64(3), read(),
+		"gauge must count exact names plus wildcard suffixes")
+	assert.Equal(t, float64(bl.Length()), read(), "gauge must track Length()")
+
+	bl.Remove("one.example.")
+	assert.Equal(t, float64(2), read(), "gauge must follow removals, not just adds")
+
+	// A second instance takes over the published accessor, mirroring what
+	// happens when the middleware is rebuilt; the gauge must follow the
+	// live one rather than keep reporting the dead instance's count.
+	cfg2 := new(config.Config)
+	cfg2.Nullroute = "0.0.0.0"
+	cfg2.Nullroutev6 = "::0"
+	cfg2.BlockListDir = filepath.Join(os.TempDir(), "sdns_temp_entriesgauge2")
+	_ = os.RemoveAll(cfg2.BlockListDir)
+	if err := os.MkdirAll(cfg2.BlockListDir, 0750); err != nil {
+		t.Fatal(err)
+	}
+	bl2 := New(cfg2)
+	bl2.Set("only.example.")
+	assert.Equal(t, float64(1), read(), "gauge must follow the newest instance")
+}


### PR DESCRIPTION
## Problem

`dns_blocklist_hits_total` is currently the only blocklist metric, and it cannot distinguish two very different states:

- nothing matched the blocklist, and
- the list failed to load, or a bad update emptied it.

Both sit at zero. That makes the second case — the one that actually matters — invisible: the resolver keeps answering happily, just with no filtering at all. There is no way to write an alert for "the blocklist went away".

This shows up as soon as the list comes from a large remote catalogue that is refreshed out of band, which is the deployment the `blocklists` config option and the bulk API (#420 / `450f1dd`) are built for.

## Fix

Add `dns_blocklist_entries`, a `GaugeFunc` over the live maps. It reports exact names plus wildcard suffixes, i.e. exactly `Length()`.

- **No hot-path cost.** `GaugeFunc` evaluates at scrape time, not per query.
- **No query serialisation.** `Length` takes `mu.RLock`, the same lock `ServeDNS` already holds for reads, so a scrape and concurrent queries do not block each other; only an in-flight mutation briefly delays a scrape.
- **Published before the refresh goroutine starts**, so a scrape landing during the initial remote fetch reports the locally loaded count rather than zero.
- Held in an `atomic.Pointer`, so the gauge follows the newest instance and reports `0` when the middleware is absent rather than panicking.

This follows the existing `dns_cache_size` / `dns_cache_hit_rate` pattern in `middleware/cache/prometheus.go`, and mirrors what comparable filtering resolvers already expose (hickory-dns has a blocklist entry count, for instance).

No behaviour change to resolution, no config change, no wire-format change.

## Tests

`Test_BlockList_EntriesGauge` asserts the gauge:

- starts at zero on a fresh list,
- counts exact names **and** wildcard suffixes,
- stays equal to `Length()`,
- follows removals, not just additions (a gauge captured once at load time would pass an add-only test and still miss the regression this metric exists for),
- follows the newest instance when the middleware is rebuilt.

Verified on Go 1.26.5:

- `go test ./middleware/blocklist/ -race` — PASS
- `go test ./api/ -race` — PASS
- `go test ./...` — no failures
- `gofmt -l` and `go vet ./middleware/blocklist/` — clean

## Field check

This is running on a recursive resolver carrying the Indonesian TrustPositif catalogue — 9.45M unique domains from the published list, loading as **8,599,608** entries after the loader drops children already covered by a parent. The gauge reports exactly that number, matching the `Blocked domains loaded total=8599608` log line, and it survived a 39.6M-query load test at ~328k qps with no measurable effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
