### PR TITLE
cache: publish only what denial-proof readers use

### DIFF
--- a/middleware/cache/denial_proof_cache.go
+++ b/middleware/cache/denial_proof_cache.go
@@ -83,12 +83,15 @@ type denialProofEntry struct {
 // pointer after dropping the cache lock; writers therefore never mutate its
 // maps or slices.
 type denialProofZoneSnapshot struct {
-	entries    map[denialProofID]*denialProofEntry
-	soa        *denialProofEntry
-	nsec       []*denialProofEntry
-	nsec3      map[denialProofNSEC3Params][]*denialProofEntry
-	nsec3Order []denialProofNSEC3Params
-	wireBytes  int64
+	soa  *denialProofEntry
+	nsec []*denialProofEntry
+	// nsecPrepared is nsec's canonicalized records, flattened in the same
+	// order. Readers treat it as immutable, as they do the rest of the
+	// snapshot.
+	nsecPrepared []dnssec.PreparedNSEC
+	nsec3        map[denialProofNSEC3Params][]*denialProofEntry
+	nsec3Order   []denialProofNSEC3Params
+	wireBytes    int64
 }
 
 type denialProofCacheConfig struct {
@@ -110,8 +113,13 @@ type denialProofCache struct {
 	mu sync.RWMutex
 
 	zoneIndex map[denialProofZoneKey]*denialProofZoneSnapshot
-	byID      map[denialProofID]*denialProofEntry
-	fifo      list.List
+	// zoneEntries is the writer's own index of what each zone holds. It is
+	// never published, so it can be mutated in place: a snapshot used to
+	// carry this map too, which meant admitting or evicting one entry
+	// copied the entire zone.
+	zoneEntries map[denialProofZoneKey]map[denialProofID]*denialProofEntry
+	byID        map[denialProofID]*denialProofEntry
+	fifo        list.List
 
 	maxEntries        int
 	maxEntriesPerZone int
@@ -185,6 +193,7 @@ func newDenialProofCacheWithConfig(cfg denialProofCacheConfig) *denialProofCache
 
 	return &denialProofCache{
 		zoneIndex:         make(map[denialProofZoneKey]*denialProofZoneSnapshot),
+		zoneEntries:       make(map[denialProofZoneKey]map[denialProofID]*denialProofEntry),
 		byID:              make(map[denialProofID]*denialProofEntry),
 		maxEntries:        cfg.MaxEntries,
 		maxEntriesPerZone: cfg.MaxEntriesPerZone,
@@ -344,10 +353,8 @@ func (c *denialProofCache) recordWithKind(
 		c.byID[entry.id] = entry
 		c.totalBytes += entry.wireBytes
 
-		snapshot := c.zoneIndex[entry.zoneKey]
-		zoneEntries := cloneDenialProofEntries(snapshot)
-		zoneEntries[entry.id] = entry
-		c.publishZoneLocked(entry.zoneKey, zoneEntries)
+		c.zoneEntriesLocked(entry.zoneKey)[entry.id] = entry
+		c.publishZoneLocked(entry.zoneKey)
 	}
 
 	c.enforceNSEC3GroupLimitLocked(entries[0].zoneKey)
@@ -887,30 +894,34 @@ func denialProofTypeBitmapsEqual(a, b []uint16) bool {
 	return true
 }
 
-func cloneDenialProofEntries(
-	snapshot *denialProofZoneSnapshot,
+// zoneEntriesLocked returns the writer's index for a zone, creating it on
+// first use. It is not published, so callers add to and delete from it
+// directly; publishZoneLocked then derives a fresh read-only snapshot from
+// whatever it holds.
+func (c *denialProofCache) zoneEntriesLocked(
+	key denialProofZoneKey,
 ) map[denialProofID]*denialProofEntry {
-	if snapshot == nil {
-		return make(map[denialProofID]*denialProofEntry)
-	}
-	entries := make(map[denialProofID]*denialProofEntry, len(snapshot.entries)+1)
-	for id, entry := range snapshot.entries {
-		entries[id] = entry
+	entries := c.zoneEntries[key]
+	if entries == nil {
+		entries = make(map[denialProofID]*denialProofEntry)
+		c.zoneEntries[key] = entries
 	}
 	return entries
 }
 
-func (c *denialProofCache) publishZoneLocked(
-	key denialProofZoneKey,
-	entries map[denialProofID]*denialProofEntry,
-) {
+// publishZoneLocked rebuilds the read-only view readers see. Readers keep a
+// pointer to it without holding the lock, so it is replaced rather than
+// edited — but only the derived views need copying, not the writer's index
+// of the zone.
+func (c *denialProofCache) publishZoneLocked(key denialProofZoneKey) {
+	entries := c.zoneEntries[key]
 	if len(entries) == 0 {
 		delete(c.zoneIndex, key)
+		delete(c.zoneEntries, key)
 		return
 	}
 	snapshot := &denialProofZoneSnapshot{
-		entries: entries,
-		nsec3:   make(map[denialProofNSEC3Params][]*denialProofEntry),
+		nsec3: make(map[denialProofNSEC3Params][]*denialProofEntry),
 	}
 	groupSequence := make(map[denialProofNSEC3Params]uint64)
 	for _, entry := range entries {
@@ -937,6 +948,16 @@ func (c *denialProofCache) publishZoneLocked(
 		}
 		return snapshot.nsec[i].sequence < snapshot.nsec[j].sequence
 	})
+	// The flat prepared form is what the reader actually evaluates, and it
+	// only changes when the zone's NSEC set does. Building it here means a
+	// lookup that finds nothing expired evaluates the published slice as it
+	// stands, instead of concatenating it again on every query.
+	for _, entry := range snapshot.nsec {
+		snapshot.nsecPrepared = append(
+			snapshot.nsecPrepared,
+			entry.preparedNSEC...,
+		)
+	}
 	snapshot.nsec3Order = make(
 		[]denialProofNSEC3Params,
 		0,
@@ -1059,10 +1080,8 @@ func (c *denialProofCache) removeEntryLocked(entry *denialProofEntry) {
 		c.totalBytes = 0
 	}
 
-	snapshot := c.zoneIndex[entry.zoneKey]
-	zoneEntries := cloneDenialProofEntries(snapshot)
-	delete(zoneEntries, entry.id)
-	c.publishZoneLocked(entry.zoneKey, zoneEntries)
+	delete(c.zoneEntries[entry.zoneKey], entry.id)
+	c.publishZoneLocked(entry.zoneKey)
 }
 
 func (c *denialProofCache) enforceNSEC3GroupLimitLocked(
@@ -1086,7 +1105,7 @@ func (c *denialProofCache) enforceZoneLimitsLocked(key denialProofZoneKey) {
 	for {
 		snapshot := c.zoneIndex[key]
 		if snapshot == nil ||
-			(len(snapshot.entries) <= c.maxEntriesPerZone &&
+			(len(c.zoneEntries[key]) <= c.maxEntriesPerZone &&
 				snapshot.wireBytes <= c.maxBytesPerZone) {
 			return
 		}
@@ -1269,7 +1288,11 @@ func denialProofEvaluate(
 		return dnssec.AggressiveNegativeResult{}, nil, false
 	}
 
-	nsecEntries, nsecPrepared := denialProofLivePreparedNSEC(snapshot.nsec, now)
+	nsecEntries, nsecPrepared := denialProofLivePreparedNSEC(
+		snapshot.nsec,
+		snapshot.nsecPrepared,
+		now,
+	)
 	if len(nsecPrepared) != 0 {
 		result, err := dnssec.EvaluateAggressiveNSECPrepared(q, zone.zone, nsecPrepared)
 		if err == nil {
@@ -1305,12 +1328,28 @@ func denialProofEvaluate(
 // with their canonicalized records. Admission refuses an NSEC entry whose
 // names it cannot canonicalize, so every live entry here carries a prepared
 // form covering exactly its own records.
+//
+// The common case is that nothing in the zone has expired since it was
+// published, and then both results are the published slices themselves. Only
+// an actual expiry pays for a filtered copy.
 func denialProofLivePreparedNSEC(
 	entries []*denialProofEntry,
+	published []dnssec.PreparedNSEC,
 	now time.Time,
 ) ([]*denialProofEntry, []dnssec.PreparedNSEC) {
+	expired := false
+	for _, entry := range entries {
+		if entry == nil || !now.Before(entry.expires) {
+			expired = true
+			break
+		}
+	}
+	if !expired {
+		return entries, published
+	}
+
 	live := make([]*denialProofEntry, 0, len(entries))
-	prepared := make([]dnssec.PreparedNSEC, 0, len(entries))
+	prepared := make([]dnssec.PreparedNSEC, 0, len(published))
 	for _, entry := range entries {
 		if entry == nil || !now.Before(entry.expires) {
 			continue
@@ -1469,8 +1508,9 @@ func (c *denialProofCache) purge(q dns.Question) {
 		if snapshot == nil {
 			continue
 		}
-		entries := make([]*denialProofEntry, 0, len(snapshot.entries)-1)
-		for _, entry := range snapshot.entries {
+		zoneEntries := c.zoneEntries[key]
+		entries := make([]*denialProofEntry, 0, len(zoneEntries))
+		for _, entry := range zoneEntries {
 			if entry.id.kind != denialProofSOA {
 				entries = append(entries, entry)
 			}
@@ -1518,6 +1558,7 @@ func (c *denialProofCache) stop() {
 	c.mu.Lock()
 	c.stopped = true
 	c.zoneIndex = make(map[denialProofZoneKey]*denialProofZoneSnapshot)
+	c.zoneEntries = make(map[denialProofZoneKey]map[denialProofID]*denialProofEntry)
 	c.byID = make(map[denialProofID]*denialProofEntry)
 	c.nsec3Conflicts = make(map[denialProofNSEC3ConflictKey]time.Time)
 	c.nsec3ConflictOverflowUntil = time.Time{}

--- a/middleware/cache/denial_proof_cache_test.go
+++ b/middleware/cache/denial_proof_cache_test.go
@@ -1027,12 +1027,12 @@ func TestDenialProofCacheConcurrentCopyOnWrite(t *testing.T) {
 		t.Fatalf("entry byte sum = %d, counter = %d", bytes, cache.totalBytes)
 	}
 	for key, snapshot := range cache.zoneIndex {
-		if len(snapshot.entries) > cache.maxEntriesPerZone ||
+		if len(cache.zoneEntries[key]) > cache.maxEntriesPerZone ||
 			snapshot.wireBytes > cache.maxBytesPerZone {
 			t.Fatalf(
 				"zone %v invariants: entries=%d/%d bytes=%d/%d",
 				key,
-				len(snapshot.entries),
+				len(cache.zoneEntries[key]),
 				cache.maxEntriesPerZone,
 				snapshot.wireBytes,
 				cache.maxBytesPerZone,

--- a/middleware/cache/denial_proof_publish_test.go
+++ b/middleware/cache/denial_proof_publish_test.go
@@ -1,0 +1,205 @@
+package cache
+
+import (
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/middleware/resolver/dnssec"
+)
+
+// denialProofOnlySnapshot returns the single zone the test cache holds.
+func denialProofOnlySnapshot(
+	tb testing.TB,
+	cache *denialProofCache,
+) *denialProofZoneSnapshot {
+	tb.Helper()
+	if len(cache.zoneIndex) != 1 {
+		tb.Fatalf("published zones = %d, want 1", len(cache.zoneIndex))
+	}
+	for _, snapshot := range cache.zoneIndex {
+		return snapshot
+	}
+	return nil
+}
+
+// TestDenialProofAdmissionKeepsZoneIndex pins that admitting into a zone
+// reuses the writer's entry map rather than rewriting it. Republishing used
+// to clone the map on every admission and every eviction, so a zone holding
+// thousands of names paid for all of them to record one.
+func TestDenialProofAdmissionKeepsZoneIndex(t *testing.T) {
+	now := time.Date(2026, time.August, 12, 12, 0, 0, 0, time.UTC)
+	cache := newDenialProofTestCache(&now, 64, 32, maxDenialProofTTL)
+
+	admit := func(label string) {
+		t.Helper()
+		owner, next := label+".example.", label+"z.example."
+		fixture := newDenialProofNSECFixture(
+			t, now, owner, dns.TypeA, dns.RcodeNameError, "example.",
+			[2]string{owner, next},
+		)
+		if !cache.record(fixture.msg, "example.", time.Time{}) {
+			t.Fatalf("admission of %s was rejected", owner)
+		}
+	}
+
+	admit("a")
+	if len(cache.zoneEntries) != 1 {
+		t.Fatalf("writer zones = %d, want 1", len(cache.zoneEntries))
+	}
+	var key denialProofZoneKey
+	for zone := range cache.zoneEntries {
+		key = zone
+	}
+	before := reflect.ValueOf(cache.zoneEntries[key]).Pointer()
+
+	admit("b")
+	if after := reflect.ValueOf(cache.zoneEntries[key]).Pointer(); after != before {
+		t.Fatal("admission replaced the zone's entry map instead of adding to it")
+	}
+
+	cache.purge(dns.Question{
+		Name: "b.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET,
+	})
+	if after := reflect.ValueOf(cache.zoneEntries[key]).Pointer(); after != before {
+		t.Fatal("eviction replaced the zone's entry map instead of deleting from it")
+	}
+}
+
+// TestDenialProofZoneIndexesStayInStep pins that the writer's index does not
+// outlive the published view. The two are updated together, and a zone that
+// empties has to disappear from both — otherwise the map the writer keeps
+// grows for every zone ever seen.
+func TestDenialProofZoneIndexesStayInStep(t *testing.T) {
+	now := time.Date(2026, time.August, 12, 12, 0, 0, 0, time.UTC)
+	// Two entries — one SOA and one NSEC — so admitting a second zone
+	// evicts the first one whole.
+	cache := newDenialProofTestCache(&now, 2, 2, maxDenialProofTTL)
+
+	admit := func(zone string) {
+		t.Helper()
+		owner := "gone." + zone
+		fixture := newDenialProofNSECFixture(
+			t, now, owner, dns.TypeA, dns.RcodeNameError, zone,
+			[2]string{owner, "gonez." + zone},
+		)
+		if !cache.record(fixture.msg, zone, time.Time{}) {
+			t.Fatalf("admission into %s was rejected", zone)
+		}
+	}
+
+	admit("first.example.")
+	if len(cache.zoneEntries) != 1 || len(cache.zoneIndex) != 1 {
+		t.Fatalf("after admission: %d writer zones, %d published zones, want 1 / 1",
+			len(cache.zoneEntries), len(cache.zoneIndex))
+	}
+
+	// Displaces the first zone entirely.
+	admit("second.example.")
+
+	if len(cache.zoneEntries) != len(cache.zoneIndex) {
+		t.Fatalf("after eviction: %d writer zones, %d published zones — the "+
+			"writer index is retaining zones nobody can see",
+			len(cache.zoneEntries), len(cache.zoneIndex))
+	}
+	if len(cache.zoneEntries) != 1 {
+		t.Fatalf("writer zones = %d, want only the surviving one",
+			len(cache.zoneEntries))
+	}
+}
+
+// TestDenialProofPreparedNSECPublished pins the two halves of the prepared
+// NSEC set: publication flattens it in the same order as the entries it came
+// from, and a lookup that finds nothing expired evaluates that published
+// slice as it stands instead of rebuilding it.
+func TestDenialProofPreparedNSECPublished(t *testing.T) {
+	now := time.Date(2026, time.August, 12, 12, 0, 0, 0, time.UTC)
+	cache := newDenialProofTestCache(&now, 64, 32, maxDenialProofTTL)
+
+	for _, label := range []string{"a", "b"} {
+		owner, next := label+".example.", label+"z.example."
+		fixture := newDenialProofNSECFixture(
+			t, now, owner, dns.TypeA, dns.RcodeNameError, "example.",
+			[2]string{owner, next},
+		)
+		if !cache.record(fixture.msg, "example.", time.Time{}) {
+			t.Fatalf("admission of %s was rejected", owner)
+		}
+	}
+
+	snapshot := denialProofOnlySnapshot(t, cache)
+	if len(snapshot.nsec) != 2 {
+		t.Fatalf("published NSEC entries = %d, want 2", len(snapshot.nsec))
+	}
+
+	var want []dnssec.PreparedNSEC
+	for _, entry := range snapshot.nsec {
+		want = append(want, entry.preparedNSEC...)
+	}
+	if !reflect.DeepEqual(snapshot.nsecPrepared, want) {
+		t.Fatal("the published prepared set does not match its entries in order")
+	}
+
+	live, prepared := denialProofLivePreparedNSEC(
+		snapshot.nsec,
+		snapshot.nsecPrepared,
+		now,
+	)
+	if len(live) == 0 || &live[0] != &snapshot.nsec[0] {
+		t.Fatal("nothing had expired, yet the live entries were copied")
+	}
+	if len(prepared) == 0 || &prepared[0] != &snapshot.nsecPrepared[0] {
+		t.Fatal("nothing had expired, yet the prepared set was rebuilt")
+	}
+}
+
+// TestDenialProofPreparedNSECDropsExpired covers the other side: once an
+// entry has expired the lookup has to filter, and it must do so without
+// disturbing the published slice that other readers still hold.
+func TestDenialProofPreparedNSECDropsExpired(t *testing.T) {
+	now := time.Date(2026, time.August, 12, 12, 0, 0, 0, time.UTC)
+	cache := newDenialProofTestCache(&now, 64, 32, maxDenialProofTTL)
+
+	early := newDenialProofNSECFixture(
+		t, now, "a.example.", dns.TypeA, dns.RcodeNameError, "example.",
+		[2]string{"a.example.", "az.example."},
+	)
+	if !cache.record(early.msg, "example.", time.Time{}) {
+		t.Fatal("first admission was rejected")
+	}
+
+	// Admitted 100 seconds later, so it outlives the first by that much.
+	now = now.Add(100 * time.Second)
+	late := newDenialProofNSECFixture(
+		t, now, "b.example.", dns.TypeA, dns.RcodeNameError, "example.",
+		[2]string{"b.example.", "bz.example."},
+	)
+	if !cache.record(late.msg, "example.", time.Time{}) {
+		t.Fatal("second admission was rejected")
+	}
+
+	snapshot := denialProofOnlySnapshot(t, cache)
+	publishedLen := len(snapshot.nsecPrepared)
+	if len(snapshot.nsec) != 2 || publishedLen != 2 {
+		t.Fatalf("published %d entries / %d prepared, want 2 / 2",
+			len(snapshot.nsec), publishedLen)
+	}
+
+	// Past the first entry's expiry, short of the second's.
+	live, prepared := denialProofLivePreparedNSEC(
+		snapshot.nsec,
+		snapshot.nsecPrepared,
+		now.Add(250*time.Second),
+	)
+	if len(live) != 1 || len(prepared) != 1 {
+		t.Fatalf("live = %d entries / %d prepared, want 1 / 1",
+			len(live), len(prepared))
+	}
+	if owner := live[0].data[0].Header().Name; owner != "b.example." {
+		t.Fatalf("surviving entry = %q, want the later one", owner)
+	}
+	if len(snapshot.nsecPrepared) != publishedLen {
+		t.Fatal("filtering an expired entry disturbed the published set")
+	}
+}


### PR DESCRIPTION
## Problem

Allocation profiles from a busy recursive resolver put two functions in the denial-proof cache near the top of the list — together roughly a quarter of everything the process allocated:

| function | share of allocated bytes |
|---|---|
| `cloneDenialProofEntries` | 15.8% |
| `denialProofLivePreparedNSEC` | 9.0% |

Both do work that the design does not require.

**The zone's entry map was published.** `denialProofZoneSnapshot` is copy-on-write: readers keep a pointer to it after dropping the cache lock, so writers replace it rather than edit it. It carried `entries`, the map of every proof in the zone — but no reader ever touched that field. Lookups use the derived `soa`, `nsec` and `nsec3` views; `entries` was read only by writers, all of them already under the cache lock. Publishing it meant every admission and every eviction cloned the entire map to change one key, so recording a single name in a zone cost the size of that zone. Its share grew from 10.4% to 15.8% over five hours as the cache filled and eviction picked up.

**The prepared NSEC set was rebuilt per lookup.** `denialProofLivePreparedNSEC` concatenated each live entry's canonicalized records into a fresh slice on every query, although the result only changes when the zone's NSEC set does.

## Change

- The entry map becomes `denialProofCache.zoneEntries`, a writer-only index mutated in place. `publishZoneLocked` derives the read-only views from it and drops both indexes together when a zone empties.
- `nsecPrepared` joins the snapshot, flattened at publication in the same order as `nsec`. A lookup that finds nothing expired returns the published slices as they stand; an actual expiry still pays for a filtered copy.

Nothing about what readers observe changes — the same views, still immutable, still replaced rather than edited.

## Measurements

One admission into a zone already holding 200 NSEC entries (`BenchmarkDenialProofRecordChurn`):

| | before | after |
|---|---|---|
| bytes/op | 97,408 B | 23,328 B (−76%) |
| allocs/op | 120 | 104 |
| ns/op | 133,900 | 97,400 (−27%) |

NSEC lookup over a 32-record zone (`BenchmarkDenialProofNSECLookup`):

| | before | after |
|---|---|---|
| bytes/op | 12,096 B | 8,384 B (−31%) |
| allocs/op | 28 | 26 |
| ns/op | 4,754 | 4,290 (−10%) |

## Tests

Four tests in `denial_proof_publish_test.go`, each verified to fail against a mutant of the code it covers:

- `TestDenialProofAdmissionKeepsZoneIndex` — admission and eviction reuse the zone's map instead of replacing it (fails when the clone is restored).
- `TestDenialProofZoneIndexesStayInStep` — an evicted zone leaves both indexes (fails when the writer-side delete is dropped).
- `TestDenialProofPreparedNSECPublished` — publication flattens the prepared set in entry order, and an unexpired lookup returns the published slices themselves (fails when the fast path is disabled).
- `TestDenialProofPreparedNSECDropsExpired` — an expired entry is filtered out without disturbing the published slice.

`go test ./middleware/cache/ -race` and the full suite pass; `golangci-lint` is clean.