### PR TITLE
cache: stop rebuilding the denial-proof lookup path per query

### DIFF
--- a/middleware/cache/denial_proof_cache.go
+++ b/middleware/cache/denial_proof_cache.go
@@ -1176,13 +1176,21 @@ func (c *denialProofCache) lookupWithMeta(
 		return nil, 0, "", false
 	}
 
+	// A name deep enough to overflow either buffer simply grows it; the sizes
+	// cover ordinary names so that a lookup allocates nothing to find its
+	// candidate zones.
+	var (
+		ancestorStorage  [12]string
+		candidateStorage [12]denialProofCandidate
+	)
+
 	c.mu.RLock()
 	if c.stopped {
 		c.mu.RUnlock()
 		return nil, 0, "", false
 	}
-	candidates := make([]denialProofCandidate, 0, len(dns.Split(qname))+1)
-	for _, zone := range denialProofAncestors(qname) {
+	candidates := candidateStorage[:0]
+	for _, zone := range denialProofAncestors(qname, ancestorStorage[:0]) {
 		key := denialProofZoneKey{zone: zone, qclass: q.Qclass}
 		if snapshot := c.zoneIndex[key]; snapshot != nil {
 			candidates = append(candidates, denialProofCandidate{
@@ -1263,17 +1271,24 @@ func (c *denialProofCache) nsec3SelectionConflictedLocked(
 	return false
 }
 
-func denialProofAncestors(name string) []string {
-	if name == "." {
-		return []string{"."}
+// denialProofAncestors appends name and each of its ancestors, ending at the
+// root, to buf and returns it. Every lookup walks this list, so the caller
+// supplies the storage: the names themselves are substrings of name and cost
+// nothing, and a caller whose buffer is large enough allocates nothing at all.
+func denialProofAncestors(name string, buf []string) []string {
+	buf = buf[:0]
+	for offset := 0; ; {
+		buf = append(buf, name[offset:])
+		next, end := dns.NextLabel(name, offset)
+		if end {
+			break
+		}
+		offset = next
 	}
-	offsets := dns.Split(name)
-	result := make([]string, 0, len(offsets)+1)
-	for _, offset := range offsets {
-		result = append(result, name[offset:])
+	if name != "." {
+		buf = append(buf, ".")
 	}
-	result = append(result, ".")
-	return result
+	return buf
 }
 
 func denialProofEvaluate(
@@ -1497,7 +1512,7 @@ func (c *denialProofCache) purge(q dns.Question) {
 	// backstop cannot identify its originating tuple, so clear it globally;
 	// keyed tombstones below are removed only for the requested ancestors.
 	c.nsec3ConflictOverflowUntil = time.Time{}
-	for _, zone := range denialProofAncestors(q.Name) {
+	for _, zone := range denialProofAncestors(q.Name, nil) {
 		key := denialProofZoneKey{zone: zone, qclass: q.Qclass}
 		for conflict := range c.nsec3Conflicts {
 			if conflict.zone == key {

--- a/middleware/cache/denial_proof_cache.go
+++ b/middleware/cache/denial_proof_cache.go
@@ -1093,25 +1093,29 @@ func (c *denialProofCache) removeEntryLocked(entry *denialProofEntry) {
 	}
 }
 
-// pruneExpiredZoneLocked drops the zone's expired entries. Nothing else
-// removes them: a proof leaves the cache when a newer one replaces it or
-// when capacity evicts it, so an expired entry no one re-queries stays in
-// its zone's published view, where every lookup has to filter it out again.
+// pruneZoneLocked drops what a lookup found unusable. Nothing else removes
+// it: a proof leaves the cache when a newer one replaces it or when capacity
+// evicts it, so an expired entry no one re-queries stays in its zone's
+// published view, where every lookup has to filter it out again.
 //
 // published is the snapshot the lookup evaluated. A different one means
 // another writer has already rebuilt the zone, and rescanning it here would
 // only cost the write lock a second time.
-func (c *denialProofCache) pruneExpiredZoneLocked(
+func (c *denialProofCache) pruneZoneLocked(
 	key denialProofZoneKey,
 	published *denialProofZoneSnapshot,
 	now time.Time,
+	mode denialProofPrune,
 ) {
 	if c.zoneIndex[key] != published {
 		return
 	}
 	pruned := false
 	for _, entry := range c.zoneEntries[key] {
-		if !now.Before(entry.expires) && c.detachEntryLocked(entry) {
+		if mode != denialProofPruneZone && now.Before(entry.expires) {
+			continue
+		}
+		if c.detachEntryLocked(entry) {
 			pruned = true
 		}
 	}
@@ -1239,16 +1243,16 @@ func (c *denialProofCache) lookupWithMeta(
 
 	now := c.now()
 	for _, candidate := range candidates {
-		result, entries, stale, ok := denialProofEvaluate(
+		result, entries, prune, ok := denialProofEvaluate(
 			q,
 			candidate.zone,
 			candidate.snapshot,
 			now,
 			work,
 		)
-		if stale {
+		if prune != denialProofPruneNone {
 			c.mu.Lock()
-			c.pruneExpiredZoneLocked(candidate.zone, candidate.snapshot, now)
+			c.pruneZoneLocked(candidate.zone, candidate.snapshot, now, prune)
 			c.mu.Unlock()
 		}
 		if !ok {
@@ -1332,24 +1336,36 @@ func denialProofAncestors(name string, buf []string) []string {
 	return buf
 }
 
-// denialProofEvaluate additionally reports whether it passed over an expired
-// entry, so the caller can retire it. Filtering one out is cheap, but nothing
-// else removes it, so an entry left behind is filtered again by every lookup
-// the zone serves from then on.
+// denialProofPrune is what a lookup leaves behind for the zone it evaluated.
+type denialProofPrune uint8
+
+const (
+	denialProofPruneNone denialProofPrune = iota
+	// denialProofPruneExpired retires the zone's expired entries. Filtering
+	// one out of an evaluation is cheap, but nothing else removes it, so an
+	// entry left behind is filtered again by every lookup the zone serves
+	// from then on.
+	denialProofPruneExpired
+	// denialProofPruneZone retires the zone outright. Evaluation stops at a
+	// zone without a live SOA, so it can neither answer nor ever notice its
+	// remaining proofs expiring: retiring only the expired entries would
+	// leave the rest pinned for as long as the cache has room for them.
+	denialProofPruneZone
+)
+
+// denialProofEvaluate additionally reports what the lookup should retire.
 func denialProofEvaluate(
 	q dns.Question,
 	zone denialProofZoneKey,
 	snapshot *denialProofZoneSnapshot,
 	now time.Time,
 	work dnssec.NSEC3Work,
-) (_ dnssec.AggressiveNegativeResult, _ []*denialProofEntry, stale, ok bool) {
-	if snapshot == nil || snapshot.soa == nil {
-		return dnssec.AggressiveNegativeResult{}, nil, false, false
+) (_ dnssec.AggressiveNegativeResult, _ []*denialProofEntry, prune denialProofPrune, ok bool) {
+	if snapshot == nil {
+		return dnssec.AggressiveNegativeResult{}, nil, denialProofPruneNone, false
 	}
-	if !now.Before(snapshot.soa.expires) {
-		// Without a live SOA the zone cannot answer at all, and every entry
-		// under it is at least as old as the SOA's own admission.
-		return dnssec.AggressiveNegativeResult{}, nil, true, false
+	if snapshot.soa == nil || !now.Before(snapshot.soa.expires) {
+		return dnssec.AggressiveNegativeResult{}, nil, denialProofPruneZone, false
 	}
 
 	nsecEntries, nsecPrepared := denialProofLivePreparedNSEC(
@@ -1357,13 +1373,15 @@ func denialProofEvaluate(
 		snapshot.nsecPrepared,
 		now,
 	)
-	stale = len(nsecEntries) != len(snapshot.nsec)
+	if len(nsecEntries) != len(snapshot.nsec) {
+		prune = denialProofPruneExpired
+	}
 	if len(nsecPrepared) != 0 {
 		result, err := dnssec.EvaluateAggressiveNSECPrepared(q, zone.zone, nsecPrepared)
 		if err == nil {
 			entries, selected := denialProofSelectedEntries(result.Proof, nsecEntries)
 			if selected {
-				return result, entries, stale, true
+				return result, entries, prune, true
 			}
 		}
 	}
@@ -1372,7 +1390,7 @@ func denialProofEvaluate(
 		group := snapshot.nsec3[params]
 		entries, records := denialProofLiveRecords(group, now)
 		if len(entries) != len(group) {
-			stale = true
+			prune = denialProofPruneExpired
 		}
 		if len(records) == 0 {
 			continue
@@ -1380,16 +1398,16 @@ func denialProofEvaluate(
 		result, err := dnssec.EvaluateAggressiveNSEC3(q, zone.zone, records, work)
 		if err != nil {
 			if dnssec.IsWorkError(err) {
-				return dnssec.AggressiveNegativeResult{}, nil, stale, false
+				return dnssec.AggressiveNegativeResult{}, nil, prune, false
 			}
 			continue
 		}
 		selectedEntries, selected := denialProofSelectedEntries(result.Proof, entries)
 		if selected {
-			return result, selectedEntries, stale, true
+			return result, selectedEntries, prune, true
 		}
 	}
-	return dnssec.AggressiveNegativeResult{}, nil, stale, false
+	return dnssec.AggressiveNegativeResult{}, nil, prune, false
 }
 
 // denialProofLivePreparedNSEC collects a zone's unexpired NSEC entries along

--- a/middleware/cache/denial_proof_cache.go
+++ b/middleware/cache/denial_proof_cache.go
@@ -1067,9 +1067,12 @@ func denialProofCanonicalWireLabels(name string) ([][]byte, bool) {
 	}
 }
 
-func (c *denialProofCache) removeEntryLocked(entry *denialProofEntry) {
+// detachEntryLocked unlinks one entry from the cache's own bookkeeping
+// without republishing its zone, so that a caller removing several entries
+// from one zone can publish once at the end.
+func (c *denialProofCache) detachEntryLocked(entry *denialProofEntry) bool {
 	if entry == nil || c.byID[entry.id] != entry {
-		return
+		return false
 	}
 	delete(c.byID, entry.id)
 	if entry.queue != nil {
@@ -1081,7 +1084,40 @@ func (c *denialProofCache) removeEntryLocked(entry *denialProofEntry) {
 	}
 
 	delete(c.zoneEntries[entry.zoneKey], entry.id)
-	c.publishZoneLocked(entry.zoneKey)
+	return true
+}
+
+func (c *denialProofCache) removeEntryLocked(entry *denialProofEntry) {
+	if c.detachEntryLocked(entry) {
+		c.publishZoneLocked(entry.zoneKey)
+	}
+}
+
+// pruneExpiredZoneLocked drops the zone's expired entries. Nothing else
+// removes them: a proof leaves the cache when a newer one replaces it or
+// when capacity evicts it, so an expired entry no one re-queries stays in
+// its zone's published view, where every lookup has to filter it out again.
+//
+// published is the snapshot the lookup evaluated. A different one means
+// another writer has already rebuilt the zone, and rescanning it here would
+// only cost the write lock a second time.
+func (c *denialProofCache) pruneExpiredZoneLocked(
+	key denialProofZoneKey,
+	published *denialProofZoneSnapshot,
+	now time.Time,
+) {
+	if c.zoneIndex[key] != published {
+		return
+	}
+	pruned := false
+	for _, entry := range c.zoneEntries[key] {
+		if !now.Before(entry.expires) && c.detachEntryLocked(entry) {
+			pruned = true
+		}
+	}
+	if pruned {
+		c.publishZoneLocked(key)
+	}
 }
 
 func (c *denialProofCache) enforceNSEC3GroupLimitLocked(
@@ -1203,13 +1239,18 @@ func (c *denialProofCache) lookupWithMeta(
 
 	now := c.now()
 	for _, candidate := range candidates {
-		result, entries, ok := denialProofEvaluate(
+		result, entries, stale, ok := denialProofEvaluate(
 			q,
 			candidate.zone,
 			candidate.snapshot,
 			now,
 			work,
 		)
+		if stale {
+			c.mu.Lock()
+			c.pruneExpiredZoneLocked(candidate.zone, candidate.snapshot, now)
+			c.mu.Unlock()
+		}
 		if !ok {
 			continue
 		}
@@ -1291,16 +1332,24 @@ func denialProofAncestors(name string, buf []string) []string {
 	return buf
 }
 
+// denialProofEvaluate additionally reports whether it passed over an expired
+// entry, so the caller can retire it. Filtering one out is cheap, but nothing
+// else removes it, so an entry left behind is filtered again by every lookup
+// the zone serves from then on.
 func denialProofEvaluate(
 	q dns.Question,
 	zone denialProofZoneKey,
 	snapshot *denialProofZoneSnapshot,
 	now time.Time,
 	work dnssec.NSEC3Work,
-) (dnssec.AggressiveNegativeResult, []*denialProofEntry, bool) {
-	if snapshot == nil || snapshot.soa == nil ||
-		!now.Before(snapshot.soa.expires) {
-		return dnssec.AggressiveNegativeResult{}, nil, false
+) (_ dnssec.AggressiveNegativeResult, _ []*denialProofEntry, stale, ok bool) {
+	if snapshot == nil || snapshot.soa == nil {
+		return dnssec.AggressiveNegativeResult{}, nil, false, false
+	}
+	if !now.Before(snapshot.soa.expires) {
+		// Without a live SOA the zone cannot answer at all, and every entry
+		// under it is at least as old as the SOA's own admission.
+		return dnssec.AggressiveNegativeResult{}, nil, true, false
 	}
 
 	nsecEntries, nsecPrepared := denialProofLivePreparedNSEC(
@@ -1308,12 +1357,13 @@ func denialProofEvaluate(
 		snapshot.nsecPrepared,
 		now,
 	)
+	stale = len(nsecEntries) != len(snapshot.nsec)
 	if len(nsecPrepared) != 0 {
 		result, err := dnssec.EvaluateAggressiveNSECPrepared(q, zone.zone, nsecPrepared)
 		if err == nil {
 			entries, selected := denialProofSelectedEntries(result.Proof, nsecEntries)
 			if selected {
-				return result, entries, true
+				return result, entries, stale, true
 			}
 		}
 	}
@@ -1321,22 +1371,25 @@ func denialProofEvaluate(
 	for _, params := range snapshot.nsec3Order {
 		group := snapshot.nsec3[params]
 		entries, records := denialProofLiveRecords(group, now)
+		if len(entries) != len(group) {
+			stale = true
+		}
 		if len(records) == 0 {
 			continue
 		}
 		result, err := dnssec.EvaluateAggressiveNSEC3(q, zone.zone, records, work)
 		if err != nil {
 			if dnssec.IsWorkError(err) {
-				return dnssec.AggressiveNegativeResult{}, nil, false
+				return dnssec.AggressiveNegativeResult{}, nil, stale, false
 			}
 			continue
 		}
 		selectedEntries, selected := denialProofSelectedEntries(result.Proof, entries)
 		if selected {
-			return result, selectedEntries, true
+			return result, selectedEntries, stale, true
 		}
 	}
-	return dnssec.AggressiveNegativeResult{}, nil, false
+	return dnssec.AggressiveNegativeResult{}, nil, stale, false
 }
 
 // denialProofLivePreparedNSEC collects a zone's unexpired NSEC entries along

--- a/middleware/cache/denial_proof_publish_test.go
+++ b/middleware/cache/denial_proof_publish_test.go
@@ -203,3 +203,48 @@ func TestDenialProofPreparedNSECDropsExpired(t *testing.T) {
 		t.Fatal("filtering an expired entry disturbed the published set")
 	}
 }
+
+// TestDenialProofAncestorsMatchesSplit pins the ancestor walk to the
+// dns.Split-based list it replaced, including the shapes where they could
+// differ: the root, a single label, and escaped separators.
+func TestDenialProofAncestorsMatchesSplit(t *testing.T) {
+	reference := func(name string) []string {
+		if name == "." {
+			return []string{"."}
+		}
+		var result []string
+		for _, offset := range dns.Split(name) {
+			result = append(result, name[offset:])
+		}
+		return append(result, ".")
+	}
+
+	for _, name := range []string{
+		".",
+		"com.",
+		"example.com.",
+		"a.b.example.com.",
+		`a\.b.example.com.`,
+	} {
+		want := reference(name)
+		got := denialProofAncestors(name, nil)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("ancestors of %q = %v, want %v", name, got, want)
+		}
+	}
+}
+
+// TestDenialProofAncestorsUsesCallerStorage pins that the walk allocates
+// nothing when the caller's buffer is large enough. Every lookup makes this
+// call, which is why the list is not built freshly each time.
+func TestDenialProofAncestorsUsesCallerStorage(t *testing.T) {
+	var storage [12]string
+	allocs := testing.AllocsPerRun(200, func() {
+		if got := denialProofAncestors("a.b.example.com.", storage[:0]); len(got) != 5 {
+			t.Fatalf("ancestors = %d entries, want 5", len(got))
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("ancestor walk allocated %.1f times per call, want 0", allocs)
+	}
+}

--- a/middleware/cache/denial_proof_publish_test.go
+++ b/middleware/cache/denial_proof_publish_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -246,5 +247,123 @@ func TestDenialProofAncestorsUsesCallerStorage(t *testing.T) {
 	})
 	if allocs != 0 {
 		t.Fatalf("ancestor walk allocated %.1f times per call, want 0", allocs)
+	}
+}
+
+// TestDenialProofLookupRetiresExpiredEntry pins that a lookup which passes
+// over an expired entry retires it. Nothing else would: the entry is never
+// re-queried, so it would sit in the zone's published view and be filtered
+// out again by every later lookup, permanently defeating the fast path.
+func TestDenialProofLookupRetiresExpiredEntry(t *testing.T) {
+	now := time.Date(2026, time.August, 12, 12, 0, 0, 0, time.UTC)
+	cache := newDenialProofTestCache(&now, 64, 32, maxDenialProofTTL)
+
+	admit := func(label string) {
+		t.Helper()
+		owner, next := label+".example.", label+"z.example."
+		fixture := newDenialProofNSECFixture(
+			t, now, owner, dns.TypeA, dns.RcodeNameError, "example.",
+			[2]string{owner, next},
+		)
+		if !cache.record(fixture.msg, "example.", time.Time{}) {
+			t.Fatalf("admission of %s was rejected", owner)
+		}
+	}
+
+	admit("a")
+	now = now.Add(100 * time.Second) // the later entry outlives the first
+	admit("b")
+
+	if got := cache.len(); got != 3 {
+		t.Fatalf("cached entries = %d, want 3 (SOA and two NSEC)", got)
+	}
+
+	// Past the first entry's expiry, short of the second's and the SOA's.
+	now = now.Add(250 * time.Second)
+	cache.Lookup(denialProofTestRequest("q.example.", dns.TypeA, true), nil)
+
+	if got := cache.len(); got != 2 {
+		t.Fatalf("cached entries after the lookup = %d, want 2 — the expired "+
+			"entry was filtered but never retired", got)
+	}
+
+	snapshot := denialProofOnlySnapshot(t, cache)
+	if len(snapshot.nsec) != 1 || len(snapshot.nsecPrepared) != 1 {
+		t.Fatalf("republished zone holds %d entries / %d prepared, want 1 / 1",
+			len(snapshot.nsec), len(snapshot.nsecPrepared))
+	}
+	if owner := snapshot.nsec[0].data[0].Header().Name; owner != "b.example." {
+		t.Fatalf("surviving entry = %q, want the later one", owner)
+	}
+
+	// With the stale entry gone the zone is back on the fast path.
+	live, prepared := denialProofLivePreparedNSEC(
+		snapshot.nsec,
+		snapshot.nsecPrepared,
+		now,
+	)
+	if &live[0] != &snapshot.nsec[0] || &prepared[0] != &snapshot.nsecPrepared[0] {
+		t.Fatal("the pruned zone still rebuilds its prepared set per lookup")
+	}
+}
+
+// TestDenialProofLookupRetiresExpiredZone covers the whole-zone case: once the
+// SOA has expired the zone cannot answer anything, so it should not keep
+// occupying the cache.
+func TestDenialProofLookupRetiresExpiredZone(t *testing.T) {
+	now := time.Date(2026, time.August, 12, 12, 0, 0, 0, time.UTC)
+	cache := newDenialProofTestCache(&now, 64, 32, maxDenialProofTTL)
+
+	fixture := newDenialProofNSECFixture(
+		t, now, "a.example.", dns.TypeA, dns.RcodeNameError, "example.",
+		[2]string{"a.example.", "az.example."},
+	)
+	if !cache.record(fixture.msg, "example.", time.Time{}) {
+		t.Fatal("admission was rejected")
+	}
+
+	now = now.Add(400 * time.Second) // past every record's TTL
+	cache.Lookup(denialProofTestRequest("q.example.", dns.TypeA, true), nil)
+
+	if got := cache.len(); got != 0 {
+		t.Fatalf("cached entries = %d, want 0 — an expired zone was retained", got)
+	}
+	if len(cache.zoneIndex) != 0 || len(cache.zoneEntries) != 0 {
+		t.Fatalf("zones left behind: %d published, %d writer-side",
+			len(cache.zoneIndex), len(cache.zoneEntries))
+	}
+}
+
+// BenchmarkDenialProofStaleZoneLookup measures repeated lookups against a zone
+// that holds one expired entry among many live ones — the shape a resolver
+// settles into, since a proof no one re-queries is never replaced.
+func BenchmarkDenialProofStaleZoneLookup(b *testing.B) {
+	now := time.Unix(1_700_000_000, 0)
+	cache := newDenialProofTestCache(&now, 4096, 512, time.Hour)
+
+	const zone = "bl.example."
+	admit := func(index int) {
+		owner := fmt.Sprintf("h%03d.%s", index, zone)
+		fixture := newDenialProofNSECFixture(
+			b, now, owner, dns.TypeA, dns.RcodeNameError, zone,
+			[2]string{owner, fmt.Sprintf("h%03dz.%s", index, zone)},
+		)
+		if !cache.record(fixture.msg, zone, time.Time{}) {
+			b.Fatalf("admission %d rejected", index)
+		}
+	}
+
+	admit(0)
+	now = now.Add(100 * time.Second) // everything below outlives entry 0
+	for i := 1; i < 200; i++ {
+		admit(i)
+	}
+	now = now.Add(250 * time.Second) // entry 0 has expired, the rest have not
+
+	req := denialProofTestRequest("q000."+zone, dns.TypeA, true)
+
+	b.ReportAllocs()
+	for b.Loop() {
+		cache.Lookup(req, nil)
 	}
 }

--- a/middleware/cache/denial_proof_publish_test.go
+++ b/middleware/cache/denial_proof_publish_test.go
@@ -367,3 +367,64 @@ func BenchmarkDenialProofStaleZoneLookup(b *testing.B) {
 		cache.Lookup(req, nil)
 	}
 }
+
+// TestDenialProofLookupRetiresZoneWhenSOAExpiresFirst covers the case where
+// the SOA is shorter-lived than the proofs beneath it, which a server can
+// cause at any time by lowering its negative TTL. Retiring only the expired
+// entries would leave the zone published without a SOA — unable to answer,
+// and invisible to every later lookup, which stops evaluating at the missing
+// SOA and so never notices the remaining proofs expiring either.
+func TestDenialProofLookupRetiresZoneWhenSOAExpiresFirst(t *testing.T) {
+	now := time.Date(2026, time.August, 12, 12, 0, 0, 0, time.UTC)
+	cache := newDenialProofTestCache(&now, 64, 32, maxDenialProofTTL)
+
+	long := newDenialProofNSECFixture(
+		t, now, "a.example.", dns.TypeA, dns.RcodeNameError, "example.",
+		[2]string{"a.example.", "az.example."},
+	)
+	if !cache.record(long.msg, "example.", time.Time{}) {
+		t.Fatal("first admission was rejected")
+	}
+
+	// A second proof carrying a much shorter SOA. Only the SOA entry is
+	// replaced; the NSEC admitted above keeps its own longer lifetime.
+	now = now.Add(50 * time.Second)
+	short := newDenialProofNSECFixture(
+		t, now, "b.example.", dns.TypeA, dns.RcodeNameError, "example.",
+		[2]string{"b.example.", "bz.example."},
+	)
+	short.soa.Hdr.Ttl = 30
+	short.soa.Minttl = 30
+	short.soaSig.Hdr.Ttl = 30
+	short.soaSig.OrigTtl = 30
+	if !cache.record(short.msg, "example.", time.Time{}) {
+		t.Fatal("second admission was rejected")
+	}
+
+	snapshot := denialProofOnlySnapshot(t, cache)
+	if got := cache.len(); got != 3 {
+		t.Fatalf("cached entries = %d, want 3 (SOA and two NSEC)", got)
+	}
+	outlives := 0
+	for _, entry := range snapshot.nsec {
+		if snapshot.soa.expires.Before(entry.expires) {
+			outlives++
+		}
+	}
+	if outlives == 0 {
+		t.Fatalf("fixture is wrong: no proof outlives the SOA, which expires at %v",
+			snapshot.soa.expires)
+	}
+
+	// Past the SOA, short of every proof.
+	now = now.Add(100 * time.Second)
+	cache.Lookup(denialProofTestRequest("q.example.", dns.TypeA, true), nil)
+
+	if got := cache.len(); got != 0 {
+		t.Fatalf("cached entries = %d, want 0 — the zone outlived its SOA", got)
+	}
+	if len(cache.zoneIndex) != 0 || len(cache.zoneEntries) != 0 {
+		t.Fatalf("zones left behind: %d published, %d writer-side",
+			len(cache.zoneIndex), len(cache.zoneEntries))
+	}
+}

--- a/middleware/resolver/dnssec/aggressive_canonical_test.go
+++ b/middleware/resolver/dnssec/aggressive_canonical_test.go
@@ -1,0 +1,67 @@
+package dnssec
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// TestAggressiveCanonicalNameRejectsOverlongName pins the wire-format ceiling
+// to the packing buffer. PackDomainName does not enforce the 255-octet limit
+// itself, so a buffer sized purely from the presentation form would start
+// admitting names no resolver may canonicalize.
+func TestAggressiveCanonicalNameRejectsOverlongName(t *testing.T) {
+	overlong := strings.Repeat(strings.Repeat("a", 63)+".", 5) + "com."
+	if _, err := newAggressiveCanonicalName(overlong); err == nil {
+		t.Fatalf("canonicalized a %d-octet name, want rejection", len(overlong))
+	}
+
+	// The longest name that still fits: 255 wire octets.
+	fits := strings.Repeat(strings.Repeat("a", 49)+".", 5) + "com."
+	packed := make([]byte, 512)
+	wire, err := dns.PackDomainName(fits, packed, 0, nil, false)
+	if err != nil || wire != 255 {
+		t.Fatalf("fixture is %d wire octets (err %v), want exactly 255", wire, err)
+	}
+	if _, err := newAggressiveCanonicalName(fits); err != nil {
+		t.Fatalf("rejected a 255-octet name: %v", err)
+	}
+}
+
+// TestAggressiveCanonicalNameSizedBuffer covers the shapes where the buffer
+// bound is tightest: escaped separators, which make the wire form shorter than
+// the text, and the root. A buffer one octet short would fail to pack them.
+func TestAggressiveCanonicalNameSizedBuffer(t *testing.T) {
+	for _, name := range []string{
+		".",
+		"a.",
+		"example.com",
+		"example.com.",
+		`a\.b.example.com.`,
+		`\..`,
+		strings.Repeat(`\.`, 30) + ".example.com.",
+	} {
+		canonical, err := newAggressiveCanonicalName(name)
+		if err != nil {
+			t.Fatalf("newAggressiveCanonicalName(%q): %v", name, err)
+		}
+		reference := make([]byte, 512)
+		end, err := dns.PackDomainName(dns.Fqdn(name), reference, 0, nil, false)
+		if err != nil {
+			t.Fatalf("reference pack of %q: %v", name, err)
+		}
+		if got, want := string(canonical.wire), string(reference[:end]); got != want {
+			t.Fatalf("wire form of %q = %q, want %q", name, got, want)
+		}
+	}
+}
+
+func BenchmarkAggressiveCanonicalName(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := newAggressiveCanonicalName("www.example.com."); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/middleware/resolver/dnssec/aggressive_negative.go
+++ b/middleware/resolver/dnssec/aggressive_negative.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base32"
 	"encoding/hex"
 	"fmt"
+	"strings"
 
 	"github.com/miekg/dns"
 )
@@ -340,14 +341,22 @@ func newAggressiveCanonicalName(name string) (aggressiveCanonicalName, error) {
 		return aggressiveCanonicalName{}, aggressiveFallback("empty domain name")
 	}
 
-	packed := make([]byte, 255)
-	end, err := dns.PackDomainName(dns.Fqdn(name), packed, 0, nil, false)
+	// A name's wire form never exceeds its presentation length by more than
+	// the root label, and escape sequences only make it shorter, so the text
+	// bounds the buffer. The 255-octet ceiling is not merely a cap here:
+	// PackDomainName does not enforce the wire-format limit itself, so the
+	// buffer is what rejects an over-long name.
+	fqdn := dns.Fqdn(name)
+	packed := make([]byte, min(len(fqdn)+1, 255))
+	end, err := dns.PackDomainName(fqdn, packed, 0, nil, false)
 	if err != nil || end == 0 || end > len(packed) {
 		return aggressiveCanonicalName{}, aggressiveFallback("invalid domain name")
 	}
 	packed = packed[:end]
 
-	labels := make([][]byte, 0, 8)
+	// Every label but the root is preceded by a separator in the text, so the
+	// separator count bounds the label count. Escaped dots only overcount.
+	labels := make([][]byte, 0, strings.Count(fqdn, "."))
 	for offset := 0; ; {
 		if offset >= len(packed) {
 			return aggressiveCanonicalName{}, aggressiveFallback("unterminated domain name")
@@ -397,10 +406,10 @@ func newAggressiveCanonicalNameFromLabels(labels [][]byte) aggressiveCanonicalNa
 }
 
 // compact returns an equivalent name sized to what it holds. Construction
-// packs into a fixed 255-octet buffer and keeps a view of it, which costs
-// nothing for a name built and dropped inside one evaluation but retains
-// the whole buffer — and a label header array sized for eight labels — for
-// a name kept in a cache entry. Only retained names pay the copy.
+// packs into a buffer bounded by the presentation form and keeps a view of
+// it, which costs nothing for a name built and dropped inside one evaluation
+// but retains the slack for a name kept in a cache entry. Only retained names
+// pay the copy.
 func (name aggressiveCanonicalName) compact() aggressiveCanonicalName {
 	if len(name.wire) == 0 || cap(name.wire) == len(name.wire) {
 		return name


### PR DESCRIPTION
## Problem

Follow-up to #540. With the snapshot clone gone, an allocation profile from a busy recursive resolver showed the denial-proof lookup path itself — `denialProofCache.lookupWithMeta` — at **5.06% of everything the process allocated**, spread over three sites that all redo work the cache already has:

| site | share | what it redoes |
|---|---|---|
| `denialProofLivePreparedNSEC` | 2.26% | filters the zone's live entries and rebuilds its prepared NSEC set |
| `newAggressiveCanonicalName` | 2.35% | canonicalizes the question and signer zone, for every candidate zone |
| `denialProofAncestors` + candidate slice | ~1.2% | builds the ancestor list and the candidate slice |

## Changes

**1. Size the canonicalization buffers to the name.** `newAggressiveCanonicalName` packed into a fixed 255-octet buffer and sized the label headers for eight labels, so every call allocated the maximum regardless of the name. The presentation form bounds the wire form — escape sequences only shorten it — and the separators bound the label count.

The 255-octet ceiling stays as an explicit clamp, and this is load-bearing: `PackDomainName` does not enforce the wire-format limit itself. A 324-octet name packs cleanly into a large enough buffer, so today the fixed buffer is the only thing rejecting it. `TestAggressiveCanonicalNameRejectsOverlongName` pins that, and fails if the clamp is dropped.

This one helps every caller, not just the cache: the NSEC3 ring hasher, `nsec3IdentityKey`, and `prepareNSEC3Set` on the validation path all canonicalize names.

**2. Walk the ancestors without allocating.** Finding a lookup's candidate zones split the question name into a fresh `[]string`, and sized the candidate slice by splitting it a second time. The ancestor names are substrings of the question and cost nothing to derive; only the slices were allocated. The walk now appends into caller-supplied storage, which the lookup keeps on its own stack. A deeper name than the buffers still works — it just grows them.

**3. Retire expired proofs when a lookup finds them.** An expired proof left the cache only when a newer one replaced it or capacity evicted it. A proof no one re-queries meets neither condition, so it stayed in its zone's published view and every later lookup filtered it out again — permanently defeating the fast path #540 added, for a zone that would otherwise allocate nothing. Evaluation now reports that it passed over an expired entry and the lookup retires the zone's expired entries. An expired SOA retires the whole zone, which can answer nothing while it holds one. Concurrent lookups noticing the same stale zone cost one pointer comparison after the first has republished it.

## Measurements

Canonicalizing `www.example.com.`:

| | before | after |
|---|---|---|
| bytes/op | 448 B | 104 B (−77%) |
| ns/op | 101 | 70 (−31%) |

Repeated lookups against a 200-entry zone holding one expired proof (`BenchmarkDenialProofStaleZoneLookup`) — the shape a resolver settles into:

| | before | after |
|---|---|---|
| bytes/op | 46,448 B | 21,932 B (−53%) |
| allocs/op | 11 | 5 |
| ns/op | 46,600 | 44,000 |

NSEC lookup with nothing expired (`BenchmarkDenialProofNSECLookup`, 32 records):

| | before | after |
|---|---|---|
| bytes/op | 8,384 B | 7,400 B (−12%) |
| allocs/op | 26 | 22 |

## Tests

Each new test was verified to fail against a mutant of the code it covers:

- `TestAggressiveCanonicalNameRejectsOverlongName` — the 255-octet ceiling survives the sizing (fails when the clamp is removed).
- `TestAggressiveCanonicalNameSizedBuffer` — escaped separators and the root still pack identically to a reference buffer.
- `TestDenialProofAncestorsMatchesSplit` — the walk matches the `dns.Split` list it replaced, root and escapes included.
- `TestDenialProofAncestorsUsesCallerStorage` — the walk allocates nothing with caller storage.
- `TestDenialProofLookupRetiresExpiredEntry` — a lookup retires the expired entry and the zone returns to the fast path.
- `TestDenialProofLookupRetiresExpiredZone` — an expired SOA retires the zone from both indexes.

`go test ./middleware/cache/ -race`, the resolver suite, and the full suite pass; `golangci-lint` is clean.

## Out of scope

`prepareNSEC3Set` (1.04%) also showed up, but it belongs to the DNSSEC validation path for freshly received responses, not to this cache. It benefits from change 1 only.