### PR TITLE
edns: bound the UDP overflow check before measuring exactly

### DIFF
--- a/middleware/edns/edns.go
+++ b/middleware/edns/edns.go
@@ -314,9 +314,21 @@ const name = "edns"
 // compression doesn't apply, OPT options are open-ended, and names
 // inside rdata (CNAME/NS/PTR/MX/DNAME/SRV target) lift even the
 // "small" types past any reasonable constant. An under-estimate
-// there would let an oversize reply slip out on UDP without TC=1,
-// so we just call Msg.Len() — correctness first, and the cost is
-// bounded by response size.
+// there would let an oversize reply slip out on UDP without TC=1.
+//
+// The message's own uncompressed length is an upper bound that carries no
+// such risk: compression only replaces name suffixes with two-octet
+// pointers, so it can never make a message longer. Measuring it costs
+// nothing — Msg.Len builds a compression map only for a message that asks
+// to be compressed — and almost every response clears the limit by that
+// bound alone. Only the ones that do not are worth measuring exactly.
 func udpOverflow(m *dns.Msg, limit int) bool {
+	// A copy of the header, not of the records: Len only reads, and the
+	// response must not be told it is uncompressed on its way out.
+	uncompressed := *m
+	uncompressed.Compress = false
+	if uncompressed.Len() <= limit {
+		return false
+	}
 	return m.Len() > limit
 }

--- a/middleware/edns/overflow_test.go
+++ b/middleware/edns/overflow_test.go
@@ -1,0 +1,106 @@
+package edns
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// overflowTestMessage builds a compressible response of roughly size bytes:
+// every record shares an owner suffix, so the compressed form is materially
+// shorter than the uncompressed one.
+func overflowTestMessage(tb testing.TB, records int) *dns.Msg {
+	tb.Helper()
+	m := new(dns.Msg)
+	m.SetQuestion("very.long.owner.name.for.compression.example.com.", dns.TypeA)
+	m.Compress = true
+	for i := range records {
+		rr, err := dns.NewRR(fmt.Sprintf(
+			"host%03d.very.long.owner.name.for.compression.example.com. 300 IN A 192.0.2.%d",
+			i, i%256,
+		))
+		if err != nil {
+			tb.Fatalf("NewRR: %v", err)
+		}
+		m.Answer = append(m.Answer, rr)
+	}
+	return m
+}
+
+// TestUDPOverflowMatchesExactLength is the contract the cheap bound has to
+// keep: the answer must be the one Msg.Len would have given at every limit
+// around the message's true size. A bound that ever under-estimates would
+// let an oversize reply out on UDP without TC=1.
+func TestUDPOverflowMatchesExactLength(t *testing.T) {
+	for _, records := range []int{0, 1, 5, 40, 200} {
+		m := overflowTestMessage(t, records)
+		exact := m.Len()
+
+		// An uncompressed message is never shorter, so the interesting
+		// limits are the ones between the two lengths, where the cheap
+		// bound is inconclusive and the exact length decides.
+		uncompressed := *m
+		uncompressed.Compress = false
+		bound := uncompressed.Len()
+		if bound < exact {
+			t.Fatalf("records=%d: uncompressed length %d is below the compressed %d",
+				records, bound, exact)
+		}
+
+		for _, limit := range []int{
+			0, exact - 1, exact, exact + 1, bound - 1, bound, bound + 1, 4096,
+		} {
+			if limit < 0 {
+				continue
+			}
+			if got, want := udpOverflow(m, limit), exact > limit; got != want {
+				t.Fatalf("records=%d limit=%d: udpOverflow = %v, want %v (exact %d, bound %d)",
+					records, limit, got, want, exact, bound)
+			}
+		}
+
+		if !m.Compress {
+			t.Fatalf("records=%d: the response was left uncompressed", records)
+		}
+	}
+}
+
+// TestUDPOverflowFitsWithoutAllocating pins the fast path. A response that
+// clears the limit by its uncompressed length must not build a compression
+// map, which is what every UDP reply used to pay for.
+func TestUDPOverflowFitsWithoutAllocating(t *testing.T) {
+	m := overflowTestMessage(t, 5)
+	allocs := testing.AllocsPerRun(200, func() {
+		if udpOverflow(m, 4096) {
+			t.Fatal("a small response was reported as overflowing")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("the fitting path allocated %.1f times per call, want 0", allocs)
+	}
+}
+
+func BenchmarkUDPOverflow(b *testing.B) {
+	m := overflowTestMessage(b, 20)
+	b.ReportAllocs()
+	for b.Loop() {
+		if udpOverflow(m, 4096) {
+			b.Fatal("unexpected overflow")
+		}
+	}
+}
+
+func BenchmarkUDPOverflowBySize(b *testing.B) {
+	for _, records := range []int{1, 3, 10, 50} {
+		m := overflowTestMessage(b, records)
+		b.Run(fmt.Sprintf("records=%d", records), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if udpOverflow(m, 4096) {
+					b.Fatal("unexpected overflow")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem

Every UDP response ends with one question — does it need TC=1? — answered by `Msg.Len()`:

```go
func udpOverflow(m *dns.Msg, limit int) bool {
	return m.Len() > limit
}
```

`Msg.Len` builds a compression map for any message that asks to be compressed, and every client response does. An allocation profile from a busy recursive resolver put that single call at **3.64% of everything the process allocated** — and it was *all* of the process's `Msg.Len` allocation:

```
Msg.Len   596.18MB (3.64%)
  └─ 100%  middleware/edns.udpOverflow
       └─ 90.9%  msgLenWithCompressionMap → compressionLenSearch
```

## Change

The comment already there is right that no count-based estimate is safe: an under-estimate lets an oversize reply out on UDP without TC=1, and no RR type has a wire-size bound that is both tight and useful.

The message's own **uncompressed** length has no such risk. Compression only replaces name suffixes with two-octet pointers, so it can never make a message longer — the uncompressed length is always an upper bound on the wire size. And it costs nothing to obtain: `Msg.Len` builds a compression map only for a message that asks to be compressed, so a header copy with `Compress` cleared measures allocation-free.

```go
uncompressed := *m
uncompressed.Compress = false
if uncompressed.Len() <= limit {
	return false
}
return m.Len() > limit
```

Almost every response clears the limit by that bound alone. Only the ones that do not — where the bound is inconclusive and compression might still bring the message under the limit — pay for the exact measurement, and they were going to be measured anyway.

The copy is of the header, not the records: `Len` only reads, and the response must not be told it is uncompressed on its way out.

## Measurements

`BenchmarkUDPOverflow`, a compressible 20-record response against a 4096-byte limit:

| | before | after |
|---|---|---|
| bytes/op | 1,640 B | **0 B** |
| allocs/op | 7 | **0** |
| ns/op | 1,186 | **88** (13×) |

Allocation-free at every size, scaling only with record count — 12 ns (1 record), 20 ns (3), 52 ns (10), 202 ns (50). What remains is inherent: knowing a message's size means looking at every record in it.

## Tests

- `TestUDPOverflowMatchesExactLength` — for messages of 0, 1, 5, 40 and 200 records, the answer matches what `Msg.Len` alone would have given at every limit around both the compressed and uncompressed sizes, including the band between them where the cheap bound is inconclusive. It also asserts the uncompressed length is never below the compressed one, and that the response is not left uncompressed.
- `TestUDPOverflowFitsWithoutAllocating` — a response that clears the limit by its bound builds no compression map.

`go test ./middleware/edns/ -race`, the full suite, and `golangci-lint` are clean.

## Note

Writing our own length computation was considered and rejected: it would duplicate miekg/dns's per-type rdata layout tables, could drift silently on a library upgrade, and a drift in the under-estimating direction is exactly the failure this function exists to prevent — for a few nanoseconds per response. The allocation was the cost worth removing, and it is gone.