### PR TITLE
cache: report which gate turns a hit away from byte serving

### DIFF
--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -15,6 +15,7 @@ import (
 	"github.com/semihalev/sdns/internal/contextutil"
 	"github.com/semihalev/sdns/internal/dnsutil"
 	"github.com/semihalev/sdns/internal/ecs"
+	"github.com/semihalev/sdns/internal/metric"
 	"github.com/semihalev/sdns/internal/waitgroup"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/sdns/middleware/resolver/dnssec"
@@ -1013,29 +1014,51 @@ func (c *Cache) handleCacheHit(ctx context.Context, ch *middleware.Chain, entry 
 	// Byte fast path: serve the stored wire directly. The entry-local gate
 	// runs first, then the writer chain's preflight — both allocation-free
 	// and together complete, so a request bound for the Msg path never
-	// builds a body nor makes the chain compose anything.
-	if !w.Internal() && entry.wireEligibleFor(req) {
-		if ww, ok := w.(middleware.WireWriter); ok {
-			if capability, ready := ww.WireReady(); ready &&
-				entry.wireFitsChain(capability) {
-				if body, info, built := entry.serveWire(req, capability.Reserve); built {
-					switch err := ww.WriteWire(body, info); {
-					case err == nil:
-						wireFastServed.Inc()
-						ch.Cancel()
-						return true
-					case errors.Is(err, middleware.ErrWireFallback):
-						wireFastFallback.Inc()
-						// fall through to the Msg path below
-					default:
-						// Transport-level failure after commit — mirror the
-						// Msg path's ignored WriteMsg error.
-						ch.Cancel()
-						return true
-					}
-				}
-			}
+	// builds a body nor makes the chain compose anything. A hit that never
+	// reaches WriteWire records which gate turned it away.
+	var served bool
+	if skipped := func() *metric.Counter {
+		if w.Internal() {
+			return wireSkipInternal
 		}
+		if !entry.wireEligibleFor(req) {
+			return wireSkipEntry
+		}
+		ww, ok := w.(middleware.WireWriter)
+		if !ok {
+			return wireSkipWriter
+		}
+		capability, ready := ww.WireReady()
+		if !ready {
+			return wireSkipWriter
+		}
+		if mismatch := entry.wireChainMismatch(capability); mismatch != nil {
+			return mismatch
+		}
+		body, info, built := entry.serveWire(req, capability.Reserve)
+		if !built {
+			return wireSkipBuild
+		}
+		switch err := ww.WriteWire(body, info); {
+		case err == nil:
+			wireFastServed.Inc()
+			ch.Cancel()
+			served = true
+		case errors.Is(err, middleware.ErrWireFallback):
+			wireFastFallback.Inc()
+			// fall through to the Msg path below
+		default:
+			// Transport-level failure after commit — mirror the
+			// Msg path's ignored WriteMsg error.
+			ch.Cancel()
+			served = true
+		}
+		return nil
+	}(); skipped != nil {
+		skipped.Inc()
+	}
+	if served {
+		return true
 	}
 
 	// Build response from cache

--- a/middleware/cache/entry_wire.go
+++ b/middleware/cache/entry_wire.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/metric"
 	"github.com/semihalev/sdns/internal/wire"
 	"github.com/semihalev/sdns/middleware"
 )
@@ -89,13 +90,21 @@ func (e *CacheEntry) wireEligibleFor(req *dns.Msg) bool {
 // are allocation-free and complete, so no body is ever built for a request
 // that will fall back.
 func (e *CacheEntry) wireFitsChain(capability middleware.WireCapability) bool {
+	return e.wireChainMismatch(capability) == nil
+}
+
+// wireChainMismatch is wireFitsChain naming what turned the request away, for
+// the counter that reports which gate a hit failed.
+func (e *CacheEntry) wireChainMismatch(
+	capability middleware.WireCapability,
+) *metric.Counter {
 	if !capability.DO && e.wireServe&wireHasDNSSEC != 0 {
-		return false
+		return wireSkipDNSSEC
 	}
 	if capability.MaxSize > 0 && len(e.wire)+capability.Reserve > capability.MaxSize {
-		return false
+		return wireSkipSize
 	}
-	return true
+	return nil
 }
 
 // serveWire produces a transport-ready body (sans OPT) for req: the stored

--- a/middleware/cache/prometheus.go
+++ b/middleware/cache/prometheus.go
@@ -48,6 +48,17 @@ var (
 	wireFastServed   = wireFastPath.Register("served")
 	wireFastFallback = wireFastPath.Register("fallback")
 
+	// A hit that never attempts the byte path is counted by what stopped it.
+	// Serving bytes is what keeps a hit from decoding and re-encoding a
+	// message it already holds, so which gate turns hits away decides where
+	// widening it would pay.
+	wireSkipInternal = wireFastPath.Register("skip_internal")
+	wireSkipEntry    = wireFastPath.Register("skip_entry")
+	wireSkipWriter   = wireFastPath.Register("skip_writer")
+	wireSkipDNSSEC   = wireFastPath.Register("skip_dnssec")
+	wireSkipSize     = wireFastPath.Register("skip_size")
+	wireSkipBuild    = wireFastPath.Register("skip_build")
+
 	nxDomainCutHits = metric.NewCounter(nil, prometheus.CounterOpts{
 		Name: "nxdomain_cut_hits_total",
 		Help: "Total number of descendant NXDOMAIN responses served from locally validated RFC 8020 cuts",

--- a/middleware/cache/wire_skip_reason_test.go
+++ b/middleware/cache/wire_skip_reason_test.go
@@ -1,0 +1,82 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/metric"
+	"github.com/semihalev/sdns/middleware"
+)
+
+// TestWireChainMismatchNamesTheGate pins the attribution the skip counter
+// reports. The counter exists to say which gate turns hits away from byte
+// serving, so a gate credited to the wrong reason would point the next
+// change at the wrong place.
+func TestWireChainMismatchNamesTheGate(t *testing.T) {
+	plain := NewCacheEntryWithKey(
+		wireFastEntry(t, "gate.example.com.", dns.TypeA, false), time.Minute, 0, 1)
+	signed := NewCacheEntryWithKey(
+		wireFastEntry(t, "gate.example.com.", dns.TypeA, true), time.Minute, 0, 1)
+	if plain == nil || signed == nil {
+		t.Fatal("entries were not admitted")
+	}
+
+	cases := []struct {
+		name       string
+		entry      *CacheEntry
+		capability middleware.WireCapability
+		want       string
+	}{
+		{
+			name:       "signed entry to a client without DO",
+			entry:      signed,
+			capability: middleware.WireCapability{DO: false},
+			want:       "skip_dnssec",
+		},
+		{
+			name:       "reply beyond the transport ceiling",
+			entry:      plain,
+			capability: middleware.WireCapability{DO: true, Reserve: 11, MaxSize: len(plain.wire) + 10},
+			want:       "skip_size",
+		},
+		{
+			name:       "signed entry to a client with DO",
+			entry:      signed,
+			capability: middleware.WireCapability{DO: true},
+			want:       "",
+		},
+		{
+			name:       "plain entry to a client without DO",
+			entry:      plain,
+			capability: middleware.WireCapability{DO: false},
+			want:       "",
+		},
+	}
+
+	named := map[*metric.Counter]string{
+		wireSkipDNSSEC: "skip_dnssec",
+		wireSkipSize:   "skip_size",
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mismatch := tc.entry.wireChainMismatch(tc.capability)
+			got := ""
+			if mismatch != nil {
+				got = named[mismatch]
+				if got == "" {
+					t.Fatalf("mismatch reported an unnamed counter")
+				}
+			}
+			if got != tc.want {
+				t.Fatalf("mismatch = %q, want %q", got, tc.want)
+			}
+			// The boolean gate and the named one must never disagree: the
+			// counter is derived from the same decision that routes the hit.
+			if fits := tc.entry.wireFitsChain(tc.capability); fits != (mismatch == nil) {
+				t.Fatalf("wireFitsChain = %v but mismatch = %v", fits, mismatch)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

Byte serving is what keeps a cache hit from decoding a message it already holds as bytes and packing it again. An allocation profile from a busy recursive resolver shows what the hits that *don't* take it cost:

```
Msg.Unpack              1912.70MB  11.69%
  └─ 78%  CacheEntry.ToMsg   1490.18MB  9.11%
       └─ 92%  Cache.handleCacheHit
```

Plus the re-packing on the way out (`compressionMap.insert`, 4.80%) and, for signed entries, base64-encoding every RRSIG signature into a Go string during the unpack (3.43%) — a good part of which is then discarded, because a client without DO has those very records stripped again a few frames later.

The existing counter says how many hits took the byte path (1.8M) and how many fell back from it (0). It does not say anything about the hits that never attempted it, and that is the number that decides where widening the path would pay. The candidate gates are quite different problems: an internal sub-query needs records, not bytes; a signed entry meeting a client without DO could be served from a pre-stripped body; a chase-unsafe entry cannot be served as bytes at all.

## Change

Each gate now names itself, as a new `outcome` value on `dns_cache_wire_fastpath_total`:

| outcome | meaning |
|---|---|
| `skip_internal` | a resolver-private sub-query, which needs records |
| `skip_entry` | the entry was never byte-eligible (EDE, RRSIG question, chase-unsafe, …) |
| `skip_writer` | the writer chain cannot take bytes |
| `skip_dnssec` | a signed entry meeting a client without DO |
| `skip_size` | the reply exceeds the transport ceiling |
| `skip_build` | the body could not be built (expired between check and use) |

`served` and `fallback` keep their meanings. The gate itself is unchanged: `wireFitsChain` now derives its boolean from the same decision that names the reason, so the two can never disagree.

## Tests

`TestWireChainMismatchNamesTheGate` pins the attribution — a signed entry against a DO=0 client reports `skip_dnssec`, an oversize reply reports `skip_size`, and the two cases that should pass report nothing — and asserts on every case that `wireFitsChain` agrees with the named reason. A gate credited to the wrong reason would point the next change at the wrong place, which is the one failure this instrumentation must not have.

`go test ./middleware/cache/ -race` and `golangci-lint` are clean. The full suite passes; `server.TestCertManagerConcurrency` flakes under whole-suite load for a pre-existing reason unrelated to this change (`server_test.go` writes certificates to a fixed `os.TempDir()` path shared between tests) and passes on its own.

## Next

This is instrumentation, not the fix — it exists to size the fix. Once deployed it says whether the ~9% spent re-materializing cached messages is reachable by widening the byte path, and through which gate.