### PR TITLE
cache: give a sub-query its own lineage

### DIFF
--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -330,7 +330,27 @@ func (c *Cache) internalExchange(ctx context.Context, req *dns.Msg) (*dns.Msg, e
 	if c.queryer == nil {
 		return nil, errQueryerNotWired
 	}
-	return c.queryer.Query(ctx, req)
+
+	// The sub-query accumulates its own delegation-cut deadline. Its answer
+	// is cached under its own key and must carry its own lineage, not the
+	// lifetime of whatever asked for it — a nearly expired alias would
+	// otherwise store a freshly resolved target with seconds of life.
+	parent := middleware.ResponseMetaFrom(ctx)
+	child := parent.ForkCut()
+	if child != nil {
+		ctx = middleware.WithResponseMeta(ctx, child)
+	}
+
+	res, err := c.queryer.Query(ctx, req)
+
+	// The composed answer contains the sub-query's records, so the deriving
+	// request inherits its bound — after the fact, which is what keeps the
+	// two lineages from contaminating each other.
+	if child != nil {
+		deadline, key := child.Cut()
+		parent.BoundCutFor(deadline, key)
+	}
+	return res, err
 }
 
 // prefetchExchange routes prefetch refresh traffic through the

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -324,11 +324,15 @@ func (c *Cache) SetDNSSECCryptoLimiter(limiter middleware.DNSSECCryptoLimiter) {
 // wired Cache fail with a clear error instead of a nil deref.
 var errQueryerNotWired = errors.New("cache: queryer not wired")
 
-// internalExchange routes CNAME-chase sub-queries through the
-// installed Queryer.
-func (c *Cache) internalExchange(ctx context.Context, req *dns.Msg) (*dns.Msg, error) {
+// internalExchange routes CNAME-chase sub-queries through the installed
+// Queryer, and hands back the sub-query's own lineage for the caller to
+// inherit if it uses the answer.
+func (c *Cache) internalExchange(
+	ctx context.Context,
+	req *dns.Msg,
+) (*dns.Msg, subQueryLineage, error) {
 	if c.queryer == nil {
-		return nil, errQueryerNotWired
+		return nil, subQueryLineage{}, errQueryerNotWired
 	}
 
 	// The sub-query accumulates its own delegation-cut deadline. Its answer
@@ -336,21 +340,32 @@ func (c *Cache) internalExchange(ctx context.Context, req *dns.Msg) (*dns.Msg, e
 	// lifetime of whatever asked for it — a nearly expired alias would
 	// otherwise store a freshly resolved target with seconds of life.
 	parent := middleware.ResponseMetaFrom(ctx)
-	child := parent.ForkCut()
-	if child != nil {
-		ctx = middleware.WithResponseMeta(ctx, child)
-	}
+	ctx, child := middleware.WithForkedCut(ctx)
 
 	res, err := c.queryer.Query(ctx, req)
+	return res, subQueryLineage{parent: parent, child: child}, err
+}
 
-	// The composed answer contains the sub-query's records, so the deriving
-	// request inherits its bound — after the fact, which is what keeps the
-	// two lineages from contaminating each other.
-	if child != nil {
-		deadline, key := child.Cut()
-		parent.BoundCutFor(deadline, key)
+// subQueryLineage is a sub-query's delegation-cut bound, held back until the
+// caller knows whether it used the answer.
+//
+// The deriving request inherits the bound because the composed answer
+// contains the sub-query's records. A sub-query that contributed none — it
+// failed, or returned something the chase did not consume — describes an
+// answer nobody is caching, and folding its bound in anyway would shorten an
+// outer entry that has not changed.
+type subQueryLineage struct {
+	parent, child *middleware.ResponseMeta
+}
+
+// inherit folds the sub-query's bound into the deriving request. Call it
+// where the sub-query's records or provenance reach the outer response.
+func (l subQueryLineage) inherit() {
+	if l.child == nil {
+		return
 	}
-	return res, err
+	deadline, key := l.child.Cut()
+	l.parent.BoundCutFor(deadline, key)
 }
 
 // prefetchExchange routes prefetch refresh traffic through the
@@ -1607,7 +1622,7 @@ func (c *Cache) additionalAnswer(ctx context.Context, msg *dns.Msg) *dns.Msg {
 
 		targets = append(targets, target)
 
-		respCname, err := c.internalExchange(ctx, cnameReq)
+		respCname, lineage, err := c.internalExchange(ctx, cnameReq)
 		if errors.Is(err, middleware.ErrRecursionWorkLimit) {
 			edeCode, edeText := middleware.RecursionWorkErrorEDE(ctx, err)
 			do := false
@@ -1640,6 +1655,9 @@ func (c *Cache) additionalAnswer(ctx context.Context, msg *dns.Msg) *dns.Msg {
 		}
 		if err == nil && (len(respCname.Answer) > 0 || len(respCname.Ns) > 0) {
 			target, child = searchAdditionalAnswer(msg, respCname)
+			// The sub-query's records are now part of the outer answer, so
+			// the outer answer inherits how long they may be served.
+			lineage.inherit()
 		}
 
 		if respCname != nil && respCname.Rcode == dns.RcodeNameError {
@@ -1649,6 +1667,8 @@ func (c *Cache) additionalAnswer(ctx context.Context, msg *dns.Msg) *dns.Msg {
 			// attributing the NXDOMAIN to the outer alias owner.
 			msg.Rcode = dns.RcodeNameError
 			middleware.PropagateValidatedDenialResponse(ctx, respCname, msg)
+			// The outer response is now this denial, proof and all.
+			lineage.inherit()
 			return msg
 		}
 		if respCname != nil {
@@ -1660,6 +1680,8 @@ func (c *Cache) additionalAnswer(ctx context.Context, msg *dns.Msg) *dns.Msg {
 				// its authenticated terminal proof on the outer alias
 				// response and stop; another chase cannot create that type.
 				middleware.PropagateValidatedNegativeProofResponse(ctx, respCname, msg)
+				// The outer response now carries the target's terminal proof.
+				lineage.inherit()
 				return msg
 			}
 		}

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -356,14 +356,20 @@ func (c *Cache) internalExchange(
 // outer entry that has not changed.
 type subQueryLineage struct {
 	parent, child *middleware.ResponseMeta
+	inherited     bool
 }
 
 // inherit folds the sub-query's bound into the deriving request. Call it
 // where the sub-query's records or provenance reach the outer response.
-func (l subQueryLineage) inherit() {
-	if l.child == nil {
+//
+// Idempotent: a terminal denial carrying authority records is consumed by
+// the generic merge and then again by the branch that adopts its rcode, and
+// the second fold would take both metas' locks to learn the same thing.
+func (l *subQueryLineage) inherit() {
+	if l.child == nil || l.inherited {
 		return
 	}
+	l.inherited = true
 	deadline, key := l.child.Cut()
 	l.parent.BoundCutFor(deadline, key)
 }

--- a/middleware/cache/negative_lineage_test.go
+++ b/middleware/cache/negative_lineage_test.go
@@ -383,3 +383,58 @@ func TestChildEntryKeepsItsOwnLifetime(t *testing.T) {
 			"cut down to the alias that happened to ask for it", got)
 	}
 }
+
+// boundThenSilentQueryer is a sub-query that observes a short delegation cut
+// and then produces nothing. Its lineage belongs to an answer that was never
+// assembled, so the deriving request must not inherit it.
+type boundThenSilentQueryer struct {
+	deadline time.Time
+}
+
+func (q *boundThenSilentQueryer) Query(ctx context.Context, _ *dns.Msg) (*dns.Msg, error) {
+	middleware.ResponseMetaFrom(ctx).BoundCutFor(q.deadline, 0)
+	return nil, middleware.ErrNoResponse
+}
+
+// TestUnusedSubQueryLineageIsNotInherited pins when a sub-query's bound
+// counts. It travels to the deriving request because the composed answer
+// carries the sub-query's records — so a sub-query that contributed no
+// records must not shorten anything.
+func TestUnusedSubQueryLineageIsNotInherited(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, Expire: 600})
+	defer c.Stop()
+
+	const alias, target = "alias.unused.", "target.unused."
+
+	c.SetQueryer(&boundThenSilentQueryer{deadline: time.Now().Add(time.Second)})
+
+	aliasHandler := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		resp := new(dns.Msg)
+		resp.SetReply(ch.Request)
+		resp.Answer = []dns.RR{&dns.CNAME{
+			Hdr: dns.RR_Header{
+				Name: alias, Rrtype: dns.TypeCNAME,
+				Class: dns.ClassINET, Ttl: 300,
+			},
+			Target: target,
+		}}
+		_ = ch.Writer.WriteMsg(resp)
+		ch.Cancel()
+	})
+
+	req := new(dns.Msg)
+	req.SetQuestion(alias, dns.TypeA)
+	req.RecursionDesired = true
+	chain := middleware.NewChain([]middleware.Handler{c, aliasHandler})
+	chain.Reset(mock.NewWriter("udp", "127.0.0.1:0"), req)
+	chain.Next(context.Background())
+
+	entry, ok := c.store.LookupByKey(CacheKey{Question: req.Question[0], CD: false}.Hash())
+	if !ok {
+		t.Fatal("the alias was not cached")
+	}
+	if got := time.Until(entryExpiry(entry)); got < 30*time.Second {
+		t.Fatalf("the alias was bound to %v by a sub-query that produced "+
+			"nothing for it", got)
+	}
+}

--- a/middleware/cache/negative_lineage_test.go
+++ b/middleware/cache/negative_lineage_test.go
@@ -299,3 +299,87 @@ func (q *failingWireQueryer) Query(ctx context.Context, req *dns.Msg) (*dns.Msg,
 	}
 	return w.Msg(), nil
 }
+
+// TestChildEntryKeepsItsOwnLifetime is the other half of the lineage rule.
+// A derived answer must not outlive its source — but the source must not be
+// shortened to the deriver's lifetime either. They share one request tree,
+// and today they share one bound, so a nearly expired alias drags a freshly
+// resolved target down to its own seconds.
+//
+// Safe, and expensive: the target's entry expires almost immediately and the
+// next query for it resolves again.
+func TestChildEntryKeepsItsOwnLifetime(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, Expire: 600})
+	defer c.Stop()
+
+	const alias, target = "alias.child.", "target.child."
+
+	// The target is resolved fresh, with a long lifetime of its own.
+	targetHandler := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		resp := new(dns.Msg)
+		resp.SetReply(ch.Request)
+		resp.Answer = []dns.RR{&dns.A{
+			Hdr: dns.RR_Header{
+				Name: target, Rrtype: dns.TypeA,
+				Class: dns.ClassINET, Ttl: 300,
+			},
+			A: []byte{192, 0, 2, 7},
+		}}
+		_ = ch.Writer.WriteMsg(resp)
+		ch.Cancel()
+	})
+
+	// The alias is cached and nearly expired when the client asks for it.
+	aliasHandler := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		resp := new(dns.Msg)
+		resp.SetReply(ch.Request)
+		resp.Answer = []dns.RR{&dns.CNAME{
+			Hdr: dns.RR_Header{
+				Name: alias, Rrtype: dns.TypeCNAME,
+				Class: dns.ClassINET, Ttl: 300,
+			},
+			Target: target,
+		}}
+		_ = ch.Writer.WriteMsg(resp)
+		ch.Cancel()
+	})
+
+	c.SetQueryer(&internalQueryer{handlers: []middleware.Handler{c, targetHandler}})
+
+	primeReq := new(dns.Msg)
+	primeReq.SetQuestion(alias, dns.TypeA)
+	primeReq.RecursionDesired = true
+	primeChain := middleware.NewChain([]middleware.Handler{c, aliasHandler})
+	primeChain.Reset(mock.NewWriter("udp", "127.0.0.1:0"), primeReq)
+	primeChain.Next(context.Background())
+
+	aliasKey := CacheKey{Question: primeReq.Question[0], CD: false}.Hash()
+	aliasEntry, ok := c.store.LookupByKey(aliasKey)
+	if !ok {
+		t.Fatal("the alias was not cached")
+	}
+	// Age the alias to a second of remaining life, and drop the target so the
+	// chase below has to resolve it fresh.
+	aliasEntry.stored = aliasEntry.stored.Add(-aliasEntry.ttl + time.Second)
+	targetKey := CacheKey{Question: dns.Question{
+		Name: target, Qtype: dns.TypeA, Qclass: dns.ClassINET,
+	}, CD: false}.Hash()
+	c.store.positive.Remove(targetKey)
+	c.store.negative.Remove(targetKey)
+
+	req := new(dns.Msg)
+	req.SetQuestion(alias, dns.TypeA)
+	req.RecursionDesired = true
+	chain := middleware.NewChain([]middleware.Handler{c, aliasHandler})
+	chain.Reset(mock.NewWriter("udp", "127.0.0.1:0"), req)
+	chain.Next(context.Background())
+
+	targetEntry, ok := c.store.LookupByKey(targetKey)
+	if !ok {
+		t.Fatal("the chase did not cache the target it resolved")
+	}
+	if got := time.Until(entryExpiry(targetEntry)); got < 30*time.Second {
+		t.Fatalf("a freshly resolved target was stored with %v of life, "+
+			"cut down to the alias that happened to ask for it", got)
+	}
+}

--- a/middleware/chain.go
+++ b/middleware/chain.go
@@ -137,11 +137,49 @@ type ResponseMeta struct {
 	// set so a pooled Chain cannot expose one request's validation to the next.
 	validatedNegativeProofs atomic.Pointer[validatedNegativeProofResponseSet]
 
+	// ledgers, when set, is the meta that owns every field above except the
+	// cut: a sub-query's meta keeps its own delegation-cut deadline and
+	// shares the rest of the request tree's state. It is written once, at
+	// construction, and read without synchronisation.
+	//
+	// Sharing by delegation rather than by copying the pointers is what makes
+	// it correct: the ledgers are created lazily, so a child that copied a
+	// nil pointer would build its own and the request tree would never see
+	// what it recorded.
+	ledgers *ResponseMeta
+
 	// workPolicy is immutable after a Chain is constructed. It lets the
 	// server's request context create the ledger only when real recursive work
 	// begins while preserving the outer pipeline's first-policy precedence.
 	// Standalone ResponseMeta values leave it zero.
 	workPolicy RecursionWorkPolicy
+}
+
+// ledgerHost returns the meta that owns the request-tree state. A sub-query's
+// meta delegates to the one it was forked from; every other meta owns its own.
+func (m *ResponseMeta) ledgerHost() *ResponseMeta {
+	if m == nil || m.ledgers == nil {
+		return m
+	}
+	return m.ledgers
+}
+
+// ForkCut returns a meta that shares this one's request-tree state — work
+// ledger, retry guard, failure and proof provenance — but accumulates its own
+// delegation-cut deadline.
+//
+// A sub-query's answer is cached under its own key, so it must be bounded by
+// its own lineage and not by whatever asked for it: a nearly expired alias
+// would otherwise store a freshly resolved target with seconds of life. The
+// deriving request still inherits the sub-query's bound, by folding the fork's
+// deadline back in once the sub-query has returned — the composed answer does
+// contain the sub-query's records.
+func (m *ResponseMeta) ForkCut() *ResponseMeta {
+	if m == nil {
+		return nil
+	}
+	host := m.ledgerHost()
+	return &ResponseMeta{ledgers: host, workPolicy: host.workPolicy}
 }
 
 // (*ResponseMeta).BoundCut folds a delegation-cut deadline into the
@@ -218,13 +256,13 @@ func (m *ResponseMeta) MarkCachedFailureResponse(msg *dns.Msg) func() {
 		return func() {}
 	}
 
-	markers := m.cachedFailures.Load()
+	markers := m.ledgerHost().cachedFailures.Load()
 	if markers == nil {
 		candidate := &cachedFailureResponseSet{messages: make(map[*dns.Msg]uint32)}
-		if m.cachedFailures.CompareAndSwap(nil, candidate) {
+		if m.ledgerHost().cachedFailures.CompareAndSwap(nil, candidate) {
 			markers = candidate
 		} else {
-			markers = m.cachedFailures.Load()
+			markers = m.ledgerHost().cachedFailures.Load()
 		}
 	}
 
@@ -253,7 +291,7 @@ func (m *ResponseMeta) IsCachedFailureResponse(msg *dns.Msg) bool {
 	if m == nil || msg == nil {
 		return false
 	}
-	markers := m.cachedFailures.Load()
+	markers := m.ledgerHost().cachedFailures.Load()
 	if markers == nil {
 		return false
 	}
@@ -286,15 +324,15 @@ func (m *ResponseMeta) markValidatedNegativeProofResponse(
 	negative.Zone = dns.CanonicalName(negative.Zone)
 	negative.Proof = proof
 
-	negatives := m.validatedNegativeProofs.Load()
+	negatives := m.ledgerHost().validatedNegativeProofs.Load()
 	if negatives == nil {
 		candidate := &validatedNegativeProofResponseSet{
 			messages: make(map[*dns.Msg]validatedNegativeProofRecord),
 		}
-		if m.validatedNegativeProofs.CompareAndSwap(nil, candidate) {
+		if m.ledgerHost().validatedNegativeProofs.CompareAndSwap(nil, candidate) {
 			negatives = candidate
 		} else {
-			negatives = m.validatedNegativeProofs.Load()
+			negatives = m.ledgerHost().validatedNegativeProofs.Load()
 		}
 	}
 
@@ -332,7 +370,7 @@ func (m *ResponseMeta) validatedNegativeProofForResponse(
 	if m == nil || msg == nil {
 		return ValidatedNegativeProof{}, false
 	}
-	negatives := m.validatedNegativeProofs.Load()
+	negatives := m.ledgerHost().validatedNegativeProofs.Load()
 	if negatives == nil {
 		return ValidatedNegativeProof{}, false
 	}
@@ -380,15 +418,15 @@ func (m *ResponseMeta) EnsureResolutionAttemptGuard() *ResolutionAttemptGuard {
 	if m == nil {
 		return nil
 	}
-	if guard := m.attempts.Load(); guard != nil {
+	if guard := m.ledgerHost().attempts.Load(); guard != nil {
 		return guard
 	}
 
 	guard := NewResolutionAttemptGuard()
-	if m.attempts.CompareAndSwap(nil, guard) {
+	if m.ledgerHost().attempts.CompareAndSwap(nil, guard) {
 		return guard
 	}
-	return m.attempts.Load()
+	return m.ledgerHost().attempts.Load()
 }
 
 // ResolutionAttemptGuard returns the request tree's retry guard, if present.
@@ -396,7 +434,7 @@ func (m *ResponseMeta) ResolutionAttemptGuard() *ResolutionAttemptGuard {
 	if m == nil {
 		return nil
 	}
-	return m.attempts.Load()
+	return m.ledgerHost().attempts.Load()
 }
 
 // ensureRecursionWork returns the request tree's ledger, installing one with
@@ -413,15 +451,15 @@ func (m *ResponseMeta) ensureRecursionWork(policy RecursionWorkPolicy) *Recursio
 	if !policy.Enabled() {
 		return nil
 	}
-	if ledger := m.work.Load(); ledger != nil {
+	if ledger := m.ledgerHost().work.Load(); ledger != nil {
 		return ledger
 	}
 
 	ledger := NewRecursionWorkLedger(policy)
-	if m.work.CompareAndSwap(nil, ledger) {
+	if m.ledgerHost().work.CompareAndSwap(nil, ledger) {
 		return ledger
 	}
-	return m.work.Load()
+	return m.ledgerHost().work.Load()
 }
 
 // RecursionWork returns the request tree's ledger, if accounting is active.
@@ -429,7 +467,7 @@ func (m *ResponseMeta) RecursionWork() *RecursionWorkLedger {
 	if m == nil {
 		return nil
 	}
-	return m.work.Load()
+	return m.ledgerHost().work.Load()
 }
 
 // responseMetaKey tags ctx with the active *ResponseMeta. Sentinel

--- a/middleware/chain.go
+++ b/middleware/chain.go
@@ -139,14 +139,18 @@ type ResponseMeta struct {
 
 	// ledgers, when set, is the meta that owns every field above except the
 	// cut: a sub-query's meta keeps its own delegation-cut deadline and
-	// shares the rest of the request tree's state. It is written once, at
-	// construction, and read without synchronisation.
+	// shares the rest of the request tree's state.
 	//
 	// Sharing by delegation rather than by copying the pointers is what makes
 	// it correct: the ledgers are created lazily, so a child that copied a
 	// nil pointer would build its own and the request tree would never see
 	// what it recorded.
-	ledgers *ResponseMeta
+	//
+	// Atomic because metas are pooled: Reset detaches the link while a
+	// sub-query of the request before it may still be reading the tree
+	// through it, which is the same lifetime rule the ledger pointers above
+	// already follow.
+	ledgers atomic.Pointer[ResponseMeta]
 
 	// workPolicy is immutable after a Chain is constructed. It lets the
 	// server's request context create the ledger only when real recursive work
@@ -158,10 +162,13 @@ type ResponseMeta struct {
 // ledgerHost returns the meta that owns the request-tree state. A sub-query's
 // meta delegates to the one it was forked from; every other meta owns its own.
 func (m *ResponseMeta) ledgerHost() *ResponseMeta {
-	if m == nil || m.ledgers == nil {
-		return m
+	if m == nil {
+		return nil
 	}
-	return m.ledgers
+	if host := m.ledgers.Load(); host != nil {
+		return host
+	}
+	return m
 }
 
 // ForkCut returns a meta that shares this one's request-tree state — work
@@ -179,7 +186,9 @@ func (m *ResponseMeta) ForkCut() *ResponseMeta {
 		return nil
 	}
 	host := m.ledgerHost()
-	return &ResponseMeta{ledgers: host, workPolicy: host.workPolicy}
+	child := &ResponseMeta{workPolicy: host.workPolicy}
+	child.ledgers.Store(host)
+	return child
 }
 
 // (*ResponseMeta).BoundCut folds a delegation-cut deadline into the
@@ -244,7 +253,7 @@ func (m *ResponseMeta) Reset() {
 		// Detached first: a fork left attached would keep reading the state
 		// of the request it was forked from, which is exactly what a reset
 		// exists to prevent.
-		m.ledgers = nil
+		m.ledgers.Store(nil)
 		m.work.Store(nil)
 		m.attempts.Store(nil)
 		m.cachedFailures.Store(nil)
@@ -515,7 +524,7 @@ func WithForkedCut(ctx context.Context) (context.Context, *ResponseMeta) {
 	}
 	host := parent.ledgerHost()
 	forked := &forkedCutContext{Context: ctx}
-	forked.meta.ledgers = host
+	forked.meta.ledgers.Store(host)
 	forked.meta.workPolicy = host.workPolicy
 	return forked, &forked.meta
 }

--- a/middleware/chain.go
+++ b/middleware/chain.go
@@ -103,6 +103,33 @@ type validatedNegativeProofRecord struct {
 	fingerprint [sha256.Size]byte
 }
 
+// requestLedgers is one request tree's shared state, held apart from the
+// metas that reach it.
+//
+// A ResponseMeta is pooled and reused by the next request, so its address is
+// not an identity: a sub-query that outlives its request would otherwise read
+// whatever the next one put in the same struct. This is allocated per request
+// generation and captured by the root and every fork under it, so a reset
+// root drops only its own reference and the forks that came before keep the
+// state they belong to.
+type requestLedgers struct {
+	// work is the request-tree recursion ledger. Reset detaches the pointer
+	// without mutating the ledger so resolver goroutines that briefly outlive
+	// a pooled Chain keep charging their original request.
+	work atomic.Pointer[RecursionWorkLedger]
+
+	// attempts is the RFC 9520 request-tree retry guard.
+	attempts atomic.Pointer[ResolutionAttemptGuard]
+
+	// cachedFailures is a pointer-identity set of failure cache responses
+	// currently crossing outer response-writer wrappers.
+	cachedFailures atomic.Pointer[cachedFailureResponseSet]
+
+	// validatedNegativeProofs is immutable, exact-response NXDOMAIN or NODATA
+	// provenance produced by this resolver.
+	validatedNegativeProofs atomic.Pointer[validatedNegativeProofResponseSet]
+}
+
 type ResponseMeta struct {
 	// cut is the earliest deadline observed for the request tree, guarded by
 	// its own mutex. Resolver work can fan out into concurrent NS-address
@@ -116,41 +143,11 @@ type ResponseMeta struct {
 	cutMu sync.Mutex
 	cut   responseCut
 
-	// work points at a heap-owned request-tree ledger. Reset detaches the
-	// pointer without mutating the ledger so resolver goroutines that briefly
-	// outlive a pooled Chain keep charging their original request.
-	work atomic.Pointer[RecursionWorkLedger]
-
-	// attempts points at a heap-owned RFC 9520 request-tree retry guard.
-	// Reset only detaches it; pinned resolver goroutines keep their original
-	// guard even after the pooled Chain is reused.
-	attempts atomic.Pointer[ResolutionAttemptGuard]
-
-	// cachedFailures points at a heap-owned, pointer-identity set of failure
-	// cache responses currently crossing outer response-writer wrappers.
-	// Reset detaches the set rather than mutating it, matching the lifetime
-	// rules for work and attempts above.
-	cachedFailures atomic.Pointer[cachedFailureResponseSet]
-
-	// validatedNegativeProofs points at immutable, exact-response NXDOMAIN or
-	// NODATA provenance produced by this resolver. Reset detaches the complete
-	// set so a pooled Chain cannot expose one request's validation to the next.
-	validatedNegativeProofs atomic.Pointer[validatedNegativeProofResponseSet]
-
-	// ledgers, when set, is the meta that owns every field above except the
-	// cut: a sub-query's meta keeps its own delegation-cut deadline and
-	// shares the rest of the request tree's state.
-	//
-	// Sharing by delegation rather than by copying the pointers is what makes
-	// it correct: the ledgers are created lazily, so a child that copied a
-	// nil pointer would build its own and the request tree would never see
-	// what it recorded.
-	//
-	// Atomic because metas are pooled: Reset detaches the link while a
-	// sub-query of the request before it may still be reading the tree
-	// through it, which is the same lifetime rule the ledger pointers above
-	// already follow.
-	ledgers atomic.Pointer[ResponseMeta]
+	// ledgers is this request tree's shared state. A root creates it on first
+	// use and drops it on Reset; a fork captures the same one at construction
+	// and keeps it for as long as it lives, which is what stops a fork from
+	// following a pooled root into the next request.
+	ledgers atomic.Pointer[requestLedgers]
 
 	// workPolicy is immutable after a Chain is constructed. It lets the
 	// server's request context create the ledger only when real recursive work
@@ -159,16 +156,33 @@ type ResponseMeta struct {
 	workPolicy RecursionWorkPolicy
 }
 
-// ledgerHost returns the meta that owns the request-tree state. A sub-query's
-// meta delegates to the one it was forked from; every other meta owns its own.
-func (m *ResponseMeta) ledgerHost() *ResponseMeta {
+// ledgerHost returns this meta's request-tree state, or nil when the request
+// has established none. Readers take this one.
+//
+// Every operation snapshots the host once and works on that value: a root
+// being reset concurrently must not leave a single operation reading one
+// generation and writing another.
+func (m *ResponseMeta) ledgerHost() *requestLedgers {
+	if m == nil {
+		return nil
+	}
+	return m.ledgers.Load()
+}
+
+// ensureLedgerHost is ledgerHost for the operations that establish state,
+// creating the request tree's ledgers on first use.
+func (m *ResponseMeta) ensureLedgerHost() *requestLedgers {
 	if m == nil {
 		return nil
 	}
 	if host := m.ledgers.Load(); host != nil {
 		return host
 	}
-	return m
+	host := new(requestLedgers)
+	if m.ledgers.CompareAndSwap(nil, host) {
+		return host
+	}
+	return m.ledgers.Load()
 }
 
 // ForkCut returns a meta that shares this one's request-tree state — work
@@ -185,9 +199,11 @@ func (m *ResponseMeta) ForkCut() *ResponseMeta {
 	if m == nil {
 		return nil
 	}
-	host := m.ledgerHost()
-	child := &ResponseMeta{workPolicy: host.workPolicy}
-	child.ledgers.Store(host)
+	// Established here rather than read: a fork is the moment the tree needs
+	// a stable host, and a child that captured a nil one would build its own
+	// and record where the tree cannot see it.
+	child := &ResponseMeta{workPolicy: m.workPolicy}
+	child.ledgers.Store(m.ensureLedgerHost())
 	return child
 }
 
@@ -250,14 +266,12 @@ func (m *ResponseMeta) Reset() {
 		m.cutMu.Lock()
 		m.cut = responseCut{}
 		m.cutMu.Unlock()
-		// Detached first: a fork left attached would keep reading the state
-		// of the request it was forked from, which is exactly what a reset
-		// exists to prevent.
+		// Dropping the reference is the whole of it: the next request gets a
+		// new one on first use, and anything still holding this one — a
+		// resolver goroutine outliving the pooled Chain, a sub-query's fork —
+		// keeps the request it belongs to rather than following this struct
+		// into the next.
 		m.ledgers.Store(nil)
-		m.work.Store(nil)
-		m.attempts.Store(nil)
-		m.cachedFailures.Store(nil)
-		m.validatedNegativeProofs.Store(nil)
 	}
 }
 
@@ -269,13 +283,14 @@ func (m *ResponseMeta) MarkCachedFailureResponse(msg *dns.Msg) func() {
 		return func() {}
 	}
 
-	markers := m.ledgerHost().cachedFailures.Load()
+	host := m.ensureLedgerHost()
+	markers := host.cachedFailures.Load()
 	if markers == nil {
 		candidate := &cachedFailureResponseSet{messages: make(map[*dns.Msg]uint32)}
-		if m.ledgerHost().cachedFailures.CompareAndSwap(nil, candidate) {
+		if host.cachedFailures.CompareAndSwap(nil, candidate) {
 			markers = candidate
 		} else {
-			markers = m.ledgerHost().cachedFailures.Load()
+			markers = host.cachedFailures.Load()
 		}
 	}
 
@@ -304,7 +319,11 @@ func (m *ResponseMeta) IsCachedFailureResponse(msg *dns.Msg) bool {
 	if m == nil || msg == nil {
 		return false
 	}
-	markers := m.ledgerHost().cachedFailures.Load()
+	host := m.ledgerHost()
+	if host == nil {
+		return false
+	}
+	markers := host.cachedFailures.Load()
 	if markers == nil {
 		return false
 	}
@@ -337,15 +356,16 @@ func (m *ResponseMeta) markValidatedNegativeProofResponse(
 	negative.Zone = dns.CanonicalName(negative.Zone)
 	negative.Proof = proof
 
-	negatives := m.ledgerHost().validatedNegativeProofs.Load()
+	host := m.ensureLedgerHost()
+	negatives := host.validatedNegativeProofs.Load()
 	if negatives == nil {
 		candidate := &validatedNegativeProofResponseSet{
 			messages: make(map[*dns.Msg]validatedNegativeProofRecord),
 		}
-		if m.ledgerHost().validatedNegativeProofs.CompareAndSwap(nil, candidate) {
+		if host.validatedNegativeProofs.CompareAndSwap(nil, candidate) {
 			negatives = candidate
 		} else {
-			negatives = m.ledgerHost().validatedNegativeProofs.Load()
+			negatives = host.validatedNegativeProofs.Load()
 		}
 	}
 
@@ -383,7 +403,11 @@ func (m *ResponseMeta) validatedNegativeProofForResponse(
 	if m == nil || msg == nil {
 		return ValidatedNegativeProof{}, false
 	}
-	negatives := m.ledgerHost().validatedNegativeProofs.Load()
+	host := m.ledgerHost()
+	if host == nil {
+		return ValidatedNegativeProof{}, false
+	}
+	negatives := host.validatedNegativeProofs.Load()
 	if negatives == nil {
 		return ValidatedNegativeProof{}, false
 	}
@@ -431,23 +455,25 @@ func (m *ResponseMeta) EnsureResolutionAttemptGuard() *ResolutionAttemptGuard {
 	if m == nil {
 		return nil
 	}
-	if guard := m.ledgerHost().attempts.Load(); guard != nil {
+	host := m.ensureLedgerHost()
+	if guard := host.attempts.Load(); guard != nil {
 		return guard
 	}
 
 	guard := NewResolutionAttemptGuard()
-	if m.ledgerHost().attempts.CompareAndSwap(nil, guard) {
+	if host.attempts.CompareAndSwap(nil, guard) {
 		return guard
 	}
-	return m.ledgerHost().attempts.Load()
+	return host.attempts.Load()
 }
 
 // ResolutionAttemptGuard returns the request tree's retry guard, if present.
 func (m *ResponseMeta) ResolutionAttemptGuard() *ResolutionAttemptGuard {
-	if m == nil {
+	host := m.ledgerHost()
+	if host == nil {
 		return nil
 	}
-	return m.ledgerHost().attempts.Load()
+	return host.attempts.Load()
 }
 
 // ensureRecursionWork returns the request tree's ledger, installing one with
@@ -464,23 +490,25 @@ func (m *ResponseMeta) ensureRecursionWork(policy RecursionWorkPolicy) *Recursio
 	if !policy.Enabled() {
 		return nil
 	}
-	if ledger := m.ledgerHost().work.Load(); ledger != nil {
+	host := m.ensureLedgerHost()
+	if ledger := host.work.Load(); ledger != nil {
 		return ledger
 	}
 
 	ledger := NewRecursionWorkLedger(policy)
-	if m.ledgerHost().work.CompareAndSwap(nil, ledger) {
+	if host.work.CompareAndSwap(nil, ledger) {
 		return ledger
 	}
-	return m.ledgerHost().work.Load()
+	return host.work.Load()
 }
 
 // RecursionWork returns the request tree's ledger, if accounting is active.
 func (m *ResponseMeta) RecursionWork() *RecursionWorkLedger {
-	if m == nil {
+	host := m.ledgerHost()
+	if host == nil {
 		return nil
 	}
-	return m.ledgerHost().work.Load()
+	return host.work.Load()
 }
 
 // responseMetaKey tags ctx with the active *ResponseMeta. Sentinel
@@ -522,10 +550,9 @@ func WithForkedCut(ctx context.Context) (context.Context, *ResponseMeta) {
 	if parent == nil {
 		return ctx, nil
 	}
-	host := parent.ledgerHost()
 	forked := &forkedCutContext{Context: ctx}
-	forked.meta.ledgers.Store(host)
-	forked.meta.workPolicy = host.workPolicy
+	forked.meta.ledgers.Store(parent.ensureLedgerHost())
+	forked.meta.workPolicy = parent.workPolicy
 	return forked, &forked.meta
 }
 

--- a/middleware/chain.go
+++ b/middleware/chain.go
@@ -118,12 +118,17 @@ type requestLedgers struct {
 	// a pooled Chain keep charging their original request.
 	work atomic.Pointer[RecursionWorkLedger]
 
-	// attempts is the RFC 9520 request-tree retry guard. It points at guard
-	// below once established: every recursive request establishes one, so
-	// giving it storage here costs the request nothing beyond the ledgers it
-	// was already allocating, where a separate guard is a second object.
-	attempts atomic.Pointer[ResolutionAttemptGuard]
-	guard    ResolutionAttemptGuard
+	// guard is the RFC 9520 request-tree retry guard, ready to use as soon as
+	// this value exists. It has storage here rather than being a second
+	// object per request.
+	//
+	// There is no flag for whether it was established: every path that can
+	// create these ledgers establishes the guard first — the queryer, the
+	// cache, the resolver, the forwarder and failover all do — so inside a
+	// request tree the distinction cannot arise. Outside one there is no
+	// meta at all, and the callers that are meant to skip accounting still
+	// find nothing.
+	guard ResolutionAttemptGuard
 
 	// cachedFailures is a pointer-identity set of failure cache responses
 	// currently crossing outer response-writer wrappers.
@@ -465,14 +470,7 @@ func (m *ResponseMeta) EnsureResolutionAttemptGuard() *ResolutionAttemptGuard {
 		return nil
 	}
 	host := m.ensureLedgerHost()
-	if guard := host.attempts.Load(); guard != nil {
-		return guard
-	}
-
-	if host.attempts.CompareAndSwap(nil, &host.guard) {
-		return &host.guard
-	}
-	return host.attempts.Load()
+	return &host.guard
 }
 
 // ResolutionAttemptGuard returns the request tree's retry guard, if present.
@@ -481,7 +479,7 @@ func (m *ResponseMeta) ResolutionAttemptGuard() *ResolutionAttemptGuard {
 	if host == nil {
 		return nil
 	}
-	return host.attempts.Load()
+	return &host.guard
 }
 
 // ensureRecursionWork returns the request tree's ledger, installing one with

--- a/middleware/chain.go
+++ b/middleware/chain.go
@@ -118,8 +118,12 @@ type requestLedgers struct {
 	// a pooled Chain keep charging their original request.
 	work atomic.Pointer[RecursionWorkLedger]
 
-	// attempts is the RFC 9520 request-tree retry guard.
+	// attempts is the RFC 9520 request-tree retry guard. It points at guard
+	// below once established: every recursive request establishes one, so
+	// giving it storage here costs the request nothing beyond the ledgers it
+	// was already allocating, where a separate guard is a second object.
 	attempts atomic.Pointer[ResolutionAttemptGuard]
+	guard    ResolutionAttemptGuard
 
 	// cachedFailures is a pointer-identity set of failure cache responses
 	// currently crossing outer response-writer wrappers.
@@ -171,18 +175,23 @@ func (m *ResponseMeta) ledgerHost() *requestLedgers {
 
 // ensureLedgerHost is ledgerHost for the operations that establish state,
 // creating the request tree's ledgers on first use.
+//
+// It retries rather than reading back after a lost race: a Reset landing
+// between the losing exchange and the read would return nil to a caller that
+// is about to establish state in it.
 func (m *ResponseMeta) ensureLedgerHost() *requestLedgers {
 	if m == nil {
 		return nil
 	}
-	if host := m.ledgers.Load(); host != nil {
-		return host
+	for {
+		if host := m.ledgers.Load(); host != nil {
+			return host
+		}
+		host := new(requestLedgers)
+		if m.ledgers.CompareAndSwap(nil, host) {
+			return host
+		}
 	}
-	host := new(requestLedgers)
-	if m.ledgers.CompareAndSwap(nil, host) {
-		return host
-	}
-	return m.ledgers.Load()
 }
 
 // ForkCut returns a meta that shares this one's request-tree state — work
@@ -460,9 +469,8 @@ func (m *ResponseMeta) EnsureResolutionAttemptGuard() *ResolutionAttemptGuard {
 		return guard
 	}
 
-	guard := NewResolutionAttemptGuard()
-	if host.attempts.CompareAndSwap(nil, guard) {
-		return guard
+	if host.attempts.CompareAndSwap(nil, &host.guard) {
+		return &host.guard
 	}
 	return host.attempts.Load()
 }

--- a/middleware/chain.go
+++ b/middleware/chain.go
@@ -536,11 +536,21 @@ func WithResponseMeta(ctx context.Context, m *ResponseMeta) context.Context {
 type forkedCutContext struct {
 	context.Context
 	meta ResponseMeta
+	// guard is the request tree's retry guard, carried here because the
+	// first thing a sub-query does is pin it: a scope that did not offer it
+	// would be followed immediately by another context wrapper holding the
+	// same value.
+	guard *ResolutionAttemptGuard
 }
 
 func (c *forkedCutContext) Value(key any) any {
-	if key == responseMetaKey {
+	switch key {
+	case responseMetaKey:
 		return &c.meta
+	case resolutionAttemptContextKey:
+		if c.guard != nil {
+			return c.guard
+		}
 	}
 	return c.Context.Value(key)
 }
@@ -556,8 +566,18 @@ func WithForkedCut(ctx context.Context) (context.Context, *ResponseMeta) {
 	if parent == nil {
 		return ctx, nil
 	}
-	forked := &forkedCutContext{Context: ctx}
-	forked.meta.ledgers.Store(parent.ensureLedgerHost())
+	host := parent.ensureLedgerHost()
+
+	// The tree's own guard, unless one is already pinned — a detached or
+	// custom context can carry a guard this meta does not own, and shadowing
+	// it would silently move that sub-query's accounting somewhere else.
+	guard := &host.guard
+	if pinned, _ := ctx.Value(resolutionAttemptContextKey).(*ResolutionAttemptGuard); pinned != nil {
+		guard = pinned
+	}
+
+	forked := &forkedCutContext{Context: ctx, guard: guard}
+	forked.meta.ledgers.Store(host)
 	forked.meta.workPolicy = parent.workPolicy
 	return forked, &forked.meta
 }

--- a/middleware/chain.go
+++ b/middleware/chain.go
@@ -241,6 +241,10 @@ func (m *ResponseMeta) Reset() {
 		m.cutMu.Lock()
 		m.cut = responseCut{}
 		m.cutMu.Unlock()
+		// Detached first: a fork left attached would keep reading the state
+		// of the request it was forked from, which is exactly what a reset
+		// exists to prevent.
+		m.ledgers = nil
 		m.work.Store(nil)
 		m.attempts.Store(nil)
 		m.cachedFailures.Store(nil)
@@ -480,6 +484,40 @@ var responseMetaKey = &responseMetaKeyType{}
 // tree's response metadata sink.
 func WithResponseMeta(ctx context.Context, m *ResponseMeta) context.Context {
 	return context.WithValue(ctx, responseMetaKey, m)
+}
+
+// forkedCutContext carries a sub-query's meta inside the context value itself.
+// Forking a meta and then wrapping the context in a value node is two
+// allocations on a path that runs once per chase hop; holding the meta here
+// makes it one.
+type forkedCutContext struct {
+	context.Context
+	meta ResponseMeta
+}
+
+func (c *forkedCutContext) Value(key any) any {
+	if key == responseMetaKey {
+		return &c.meta
+	}
+	return c.Context.Value(key)
+}
+
+// WithForkedCut returns ctx carrying a meta that keeps its own
+// delegation-cut deadline while sharing the request tree's state, and that
+// meta. See ForkCut for what the separation is for.
+//
+// The returned meta is nil, and ctx unchanged, when ctx carries no meta to
+// fork from — a caller with nothing to separate needs no scope.
+func WithForkedCut(ctx context.Context) (context.Context, *ResponseMeta) {
+	parent := ResponseMetaFrom(ctx)
+	if parent == nil {
+		return ctx, nil
+	}
+	host := parent.ledgerHost()
+	forked := &forkedCutContext{Context: ctx}
+	forked.meta.ledgers = host
+	forked.meta.workPolicy = host.workPolicy
+	return forked, &forked.meta
 }
 
 func withResponseMeta(ctx context.Context, m *ResponseMeta) (context.Context, bool) {

--- a/middleware/chain_fork_test.go
+++ b/middleware/chain_fork_test.go
@@ -1,6 +1,7 @@
 package middleware
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -65,5 +66,60 @@ func TestForkCutSeparatesLineageAndSharesLedgers(t *testing.T) {
 	if _, ok := parent.validatedNegativeProofForResponse(proof); !ok {
 		t.Fatal("provenance recorded by the sub-query is invisible to the " +
 			"request tree")
+	}
+}
+
+// BenchmarkForkedCutScope measures what a chase hop pays to separate its
+// lineage. It runs once per sub-query, so the scope must not cost more than
+// the separation is worth.
+func BenchmarkForkedCutScope(b *testing.B) {
+	var meta ResponseMeta
+	base := WithResponseMeta(context.Background(), &meta)
+
+	b.Run("embedded", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			ctx, child := WithForkedCut(base)
+			if child == nil || ResponseMetaFrom(ctx) != child {
+				b.Fatal("the scope did not carry its own meta")
+			}
+		}
+	})
+
+	b.Run("separate value node", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			child := meta.ForkCut()
+			ctx := WithResponseMeta(base, child)
+			if child == nil || ResponseMetaFrom(ctx) != child {
+				b.Fatal("the scope did not carry its own meta")
+			}
+		}
+	})
+}
+
+// TestForkResetDetachesTheRequestTree pins the reset contract for a fork.
+// ResponseMeta values are pooled and reused, so a reset one that still read
+// the state of the request it was forked from would hand the next request
+// the previous one's retry guard.
+func TestForkResetDetachesTheRequestTree(t *testing.T) {
+	parent := new(ResponseMeta)
+	guard := parent.EnsureResolutionAttemptGuard()
+	if guard == nil {
+		t.Fatal("the request tree could not establish a retry guard")
+	}
+
+	child := parent.ForkCut()
+	if child.ResolutionAttemptGuard() != guard {
+		t.Fatal("the fork does not share the request tree's retry guard")
+	}
+
+	child.Reset()
+	if got := child.ResolutionAttemptGuard(); got != nil {
+		t.Fatal("a reset fork still reads the state of the request it was " +
+			"forked from")
+	}
+	if parent.ResolutionAttemptGuard() != guard {
+		t.Fatal("resetting a fork disturbed the request tree it left")
 	}
 }

--- a/middleware/chain_fork_test.go
+++ b/middleware/chain_fork_test.go
@@ -9,6 +9,40 @@ import (
 	"github.com/miekg/dns"
 )
 
+// TestForkDoesNotCrossRequestGenerations pins the isolation a pooled root
+// requires. A root meta is reset and reused by the next request, and a fork
+// of the request before it can still be alive — it must keep reading the
+// state of the request it belongs to, never the one that took the root over.
+func TestForkDoesNotCrossRequestGenerations(t *testing.T) {
+	root := new(ResponseMeta)
+
+	first := root.EnsureResolutionAttemptGuard()
+	if first == nil {
+		t.Fatal("the first request could not establish a retry guard")
+	}
+	child := root.ForkCut()
+	if child.ResolutionAttemptGuard() != first {
+		t.Fatal("the fork does not share its own request's retry guard")
+	}
+
+	// The root is returned to the pool and taken over by the next request.
+	root.Reset()
+	second := root.EnsureResolutionAttemptGuard()
+	if second == nil {
+		t.Fatal("the second request could not establish a retry guard")
+	}
+	if second == first {
+		t.Fatal("the reset root handed the second request the first's guard")
+	}
+
+	if got := child.ResolutionAttemptGuard(); got == second {
+		t.Fatal("a fork of the first request now reads the second request's " +
+			"retry guard: the pooled root's address is not an identity")
+	} else if got != first {
+		t.Fatalf("a fork of the first request lost its own guard: %v", got)
+	}
+}
+
 // TestForkResetRacesWithLedgerReaders pins the synchronisation on the fork
 // link. Metas are pooled, so one request can reset a root while a sub-query
 // of the request before it is still reading the tree through its fork.

--- a/middleware/chain_fork_test.go
+++ b/middleware/chain_fork_test.go
@@ -1,0 +1,69 @@
+package middleware
+
+import (
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// TestForkCutSeparatesLineageAndSharesLedgers pins what a sub-query's meta
+// keeps to itself and what it shares.
+//
+// The cut is its own: a sub-query's answer is cached under its own key, so a
+// nearly expired request that happens to ask for it must not shorten it.
+// Everything else belongs to the request tree — the work ledger, the retry
+// guard, and the provenance a nested lookup records — and the tree must see
+// what the sub-query records even though those are created lazily.
+func TestForkCutSeparatesLineageAndSharesLedgers(t *testing.T) {
+	parent := new(ResponseMeta)
+	child := parent.ForkCut()
+	if child == nil {
+		t.Fatal("ForkCut returned nothing")
+	}
+
+	// The child's own bound stays with the child until it is merged back.
+	childDeadline := time.Now().Add(time.Second)
+	child.BoundCutFor(childDeadline, 7)
+	if got, _ := parent.Cut(); !got.IsZero() {
+		t.Fatalf("the sub-query's deadline reached the request tree on its "+
+			"own: parent bound to %v", got)
+	}
+	if got, key := child.Cut(); !got.Equal(childDeadline) || key != 7 {
+		t.Fatalf("child cut = (%v, %d), want (%v, 7)", got, key, childDeadline)
+	}
+
+	// A bound the tree already carries does not shorten the sub-query.
+	parentDeadline := time.Now().Add(time.Millisecond)
+	parent.BoundCutFor(parentDeadline, 3)
+	if got, _ := child.Cut(); !got.Equal(childDeadline) {
+		t.Fatalf("the request tree's deadline shortened the sub-query: "+
+			"child bound to %v, want its own %v", got, childDeadline)
+	}
+
+	// Ledgers created through the child are the tree's, not copies. They are
+	// created lazily, so a fork that copied their pointers would share
+	// nothing here — this is the case that catches it.
+	guard := child.EnsureResolutionAttemptGuard()
+	if guard == nil {
+		t.Fatal("the sub-query could not establish a retry guard")
+	}
+	if parent.ResolutionAttemptGuard() != guard {
+		t.Fatal("a retry guard established by the sub-query is invisible to " +
+			"the request tree")
+	}
+
+	proof := new(dns.Msg)
+	proof.SetQuestion("denied.example.", dns.TypeA)
+	proof.Rcode = dns.RcodeNameError
+	if !child.markValidatedNegativeProofResponse(proof, proof, ValidatedNegativeProof{
+		Subject: "denied.example.", Zone: "example.",
+		Kind: ValidatedNegativeProofNSEC, Proof: proof,
+	}) {
+		t.Fatal("the sub-query could not record provenance")
+	}
+	if _, ok := parent.validatedNegativeProofForResponse(proof); !ok {
+		t.Fatal("provenance recorded by the sub-query is invisible to the " +
+			"request tree")
+	}
+}

--- a/middleware/chain_fork_test.go
+++ b/middleware/chain_fork_test.go
@@ -2,11 +2,37 @@ package middleware
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/miekg/dns"
 )
+
+// TestForkResetRacesWithLedgerReaders pins the synchronisation on the fork
+// link. Metas are pooled, so one request can reset a root while a sub-query
+// of the request before it is still reading the tree through its fork.
+func TestForkResetRacesWithLedgerReaders(t *testing.T) {
+	parent := new(ResponseMeta)
+	parent.EnsureResolutionAttemptGuard()
+	child := parent.ForkCut()
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for range 2000 {
+			child.Reset()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for range 2000 {
+			_ = child.ResolutionAttemptGuard()
+		}
+	}()
+	wg.Wait()
+}
 
 // TestForkCutSeparatesLineageAndSharesLedgers pins what a sub-query's meta
 // keeps to itself and what it shares.
@@ -66,6 +92,26 @@ func TestForkCutSeparatesLineageAndSharesLedgers(t *testing.T) {
 	if _, ok := parent.validatedNegativeProofForResponse(proof); !ok {
 		t.Fatal("provenance recorded by the sub-query is invisible to the " +
 			"request tree")
+	}
+}
+
+// TestForkedCutScopeCostsOneAllocation is the gate the benchmark below only
+// reports. A sub-query scope runs once per chase hop and once per DNAME leg,
+// so carrying the meta inside the context value rather than forking one and
+// wrapping the context around it is a property worth failing on, not a
+// number to read afterwards.
+func TestForkedCutScopeCostsOneAllocation(t *testing.T) {
+	var meta ResponseMeta
+	base := WithResponseMeta(context.Background(), &meta)
+
+	allocs := testing.AllocsPerRun(200, func() {
+		ctx, child := WithForkedCut(base)
+		if child == nil || ResponseMetaFrom(ctx) != child {
+			t.Fatal("the scope did not carry its own meta")
+		}
+	})
+	if allocs != 1 {
+		t.Fatalf("a sub-query scope cost %.0f allocations, want 1", allocs)
 	}
 }
 

--- a/middleware/chain_fork_test.go
+++ b/middleware/chain_fork_test.go
@@ -167,19 +167,46 @@ func TestForkCutSeparatesLineageAndSharesLedgers(t *testing.T) {
 // so carrying the meta inside the context value rather than forking one and
 // wrapping the context around it is a property worth failing on, not a
 // number to read afterwards.
+//
+// Both the warm and the cold shape are measured. AllocsPerRun establishes
+// the request's ledgers during its warm-up, so a warm-only gate would never
+// see what the first scope of a request costs — which is the one a CNAME or
+// DNAME leg actually pays.
 func TestForkedCutScopeCostsOneAllocation(t *testing.T) {
-	var meta ResponseMeta
-	base := WithResponseMeta(context.Background(), &meta)
+	t.Run("warm", func(t *testing.T) {
+		var meta ResponseMeta
+		base := WithResponseMeta(context.Background(), &meta)
 
-	allocs := testing.AllocsPerRun(200, func() {
-		ctx, child := WithForkedCut(base)
-		if child == nil || ResponseMetaFrom(ctx) != child {
-			t.Fatal("the scope did not carry its own meta")
+		allocs := testing.AllocsPerRun(200, func() {
+			ctx, child := WithForkedCut(base)
+			if child == nil || ResponseMetaFrom(ctx) != child {
+				t.Fatal("the scope did not carry its own meta")
+			}
+		})
+		if allocs != 1 {
+			t.Fatalf("a sub-query scope cost %.0f allocations, want 1", allocs)
 		}
 	})
-	if allocs != 1 {
-		t.Fatalf("a sub-query scope cost %.0f allocations, want 1", allocs)
-	}
+
+	t.Run("cold", func(t *testing.T) {
+		// The scope, and the request's ledgers it establishes.
+		const budget = 2
+
+		var meta ResponseMeta
+		base := WithResponseMeta(context.Background(), &meta)
+
+		allocs := testing.AllocsPerRun(200, func() {
+			meta.Reset()
+			ctx, child := WithForkedCut(base)
+			if child == nil || ResponseMetaFrom(ctx) != child {
+				t.Fatal("the scope did not carry its own meta")
+			}
+		})
+		if allocs > budget {
+			t.Fatalf("the first sub-query scope of a request cost %.0f "+
+				"allocations, budget is %d", allocs, budget)
+		}
+	})
 }
 
 // BenchmarkForkedCutScope measures what a chase hop pays to separate its

--- a/middleware/chain_fork_test.go
+++ b/middleware/chain_fork_test.go
@@ -173,18 +173,33 @@ func TestForkCutSeparatesLineageAndSharesLedgers(t *testing.T) {
 // see what the first scope of a request costs — which is the one a CNAME or
 // DNAME leg actually pays.
 func TestForkedCutScopeCostsOneAllocation(t *testing.T) {
+	// What a sub-query actually does: take a scope, then pin the request
+	// tree's retry guard. Measuring the scope alone would miss a wrapper the
+	// pin adds when the scope does not carry the guard itself.
+	enterSubQuery := func(t *testing.T, base context.Context) {
+		t.Helper()
+		ctx, child := WithForkedCut(base)
+		if child == nil || ResponseMetaFrom(ctx) != child {
+			t.Fatal("the scope did not carry its own meta")
+		}
+		pinned, guard := EnsureResolutionAttemptGuard(ctx)
+		if guard == nil {
+			t.Fatal("the sub-query has no retry guard")
+		}
+		if pinned != ctx {
+			t.Fatal("pinning the retry guard wrapped the scope again; the " +
+				"scope must carry it")
+		}
+	}
+
 	t.Run("warm", func(t *testing.T) {
 		var meta ResponseMeta
+		meta.EnsureResolutionAttemptGuard()
 		base := WithResponseMeta(context.Background(), &meta)
 
-		allocs := testing.AllocsPerRun(200, func() {
-			ctx, child := WithForkedCut(base)
-			if child == nil || ResponseMetaFrom(ctx) != child {
-				t.Fatal("the scope did not carry its own meta")
-			}
-		})
+		allocs := testing.AllocsPerRun(200, func() { enterSubQuery(t, base) })
 		if allocs != 1 {
-			t.Fatalf("a sub-query scope cost %.0f allocations, want 1", allocs)
+			t.Fatalf("a sub-query cost %.0f allocations, want 1", allocs)
 		}
 	})
 
@@ -197,16 +212,35 @@ func TestForkedCutScopeCostsOneAllocation(t *testing.T) {
 
 		allocs := testing.AllocsPerRun(200, func() {
 			meta.Reset()
-			ctx, child := WithForkedCut(base)
-			if child == nil || ResponseMetaFrom(ctx) != child {
-				t.Fatal("the scope did not carry its own meta")
-			}
+			enterSubQuery(t, base)
 		})
 		if allocs > budget {
-			t.Fatalf("the first sub-query scope of a request cost %.0f "+
+			t.Fatalf("the first sub-query of a request cost %.0f "+
 				"allocations, budget is %d", allocs, budget)
 		}
 	})
+}
+
+// TestForkedCutScopeKeepsAPinnedGuard pins what the scope may not do with a
+// guard it does not own. A detached or custom context can carry one, and
+// shadowing it would move that sub-query's retry accounting to a guard
+// nobody else is reading.
+func TestForkedCutScopeKeepsAPinnedGuard(t *testing.T) {
+	var meta ResponseMeta
+	own := meta.EnsureResolutionAttemptGuard()
+
+	foreign := NewResolutionAttemptGuard()
+	base := WithResolutionAttemptGuard(
+		WithResponseMeta(context.Background(), &meta), foreign)
+
+	ctx, _ := WithForkedCut(base)
+	got := ResolutionAttemptGuardFrom(ctx)
+	if got == own {
+		t.Fatal("the scope replaced a pinned guard with the meta's own")
+	}
+	if got != foreign {
+		t.Fatalf("the scope lost the pinned guard: %v", got)
+	}
 }
 
 // BenchmarkForkedCutScope measures what a chase hop pays to separate its

--- a/middleware/chain_fork_test.go
+++ b/middleware/chain_fork_test.go
@@ -43,6 +43,39 @@ func TestForkDoesNotCrossRequestGenerations(t *testing.T) {
 	}
 }
 
+// TestEstablishingUnderResetAlwaysYieldsAHost pins what an operation that is
+// about to record something gets while the root is being reset underneath it.
+//
+// Establishing state is a load, a create and an exchange; a reset landing
+// between a lost exchange and a read back would hand the caller nothing to
+// record into. Every caller here dereferences what it is given.
+func TestEstablishingUnderResetAlwaysYieldsAHost(t *testing.T) {
+	root := new(ResponseMeta)
+
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range 4000 {
+				if guard := root.EnsureResolutionAttemptGuard(); guard == nil {
+					t.Error("establishing a retry guard yielded nothing to " +
+						"record into")
+					return
+				}
+			}
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for range 4000 {
+			root.Reset()
+		}
+	}()
+	wg.Wait()
+}
+
 // TestForkResetRacesWithLedgerReaders pins the synchronisation on the fork
 // link. Metas are pooled, so one request can reset a root while a sub-query
 // of the request before it is still reading the tree through its fork.

--- a/middleware/queryer_alloc_test.go
+++ b/middleware/queryer_alloc_test.go
@@ -1,0 +1,48 @@
+//go:build !race
+
+package middleware
+
+import (
+	"context"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+)
+
+// TestPipelineQueryerQueryAllocationBudget gates what one sub-query costs.
+//
+// This is the shape production runs — a request through the whole pipeline,
+// establishing the request-tree state a recursive query needs — so it is
+// where an accidental extra object shows up, and where counting one scope in
+// isolation would miss it.
+//
+// The number is a budget, not a law: raise it deliberately, with the reason,
+// never to make a run pass.
+//
+// Excluded under the race detector, which adds allocations of its own (11
+// against 9 here) and would make the budget measure the tooling.
+func TestPipelineQueryerQueryAllocationBudget(t *testing.T) {
+	const budget = 9
+
+	rec := &recordingHandler{name: "rec", rcode: dns.RcodeSuccess}
+	Reset()
+	t.Cleanup(Reset)
+	DefaultRegistry.Register(rec.Name(), func(_ *config.Config) Handler { return rec })
+	Setup(&config.Config{})
+
+	q := NewPipelineQueryer(GlobalPipeline())
+	req := new(dns.Msg)
+	req.SetQuestion("example.com.", dns.TypeA)
+	ctx := context.Background()
+
+	allocs := testing.AllocsPerRun(200, func() {
+		if _, err := q.Query(ctx, req); err != nil {
+			t.Fatalf("query: %v", err)
+		}
+	})
+	if allocs > budget {
+		t.Fatalf("a sub-query cost %.0f allocations, budget is %d", allocs, budget)
+	}
+	t.Logf("sub-query allocations: %.0f of %d", allocs, budget)
+}

--- a/middleware/resolver/dname_lineage_test.go
+++ b/middleware/resolver/dname_lineage_test.go
@@ -1,0 +1,95 @@
+package resolver
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/middleware"
+)
+
+// dnameLineageQueryer answers the DNAME target leg. It records the bound the
+// leg was resolved under, and publishes one of its own.
+type dnameLineageQueryer struct {
+	observed time.Time
+	publish  time.Time
+}
+
+func (q *dnameLineageQueryer) Query(ctx context.Context, req *dns.Msg) (*dns.Msg, error) {
+	meta := middleware.ResponseMetaFrom(ctx)
+	q.observed = meta.CutUntil()
+	meta.BoundCutFor(q.publish, 42)
+
+	resp := new(dns.Msg)
+	resp.SetReply(req)
+	resp.CheckingDisabled = true
+	resp.Answer = []dns.RR{&dns.A{
+		Hdr: dns.RR_Header{
+			Name:   req.Question[0].Name,
+			Rrtype: dns.TypeA,
+			Class:  dns.ClassINET,
+			Ttl:    300,
+		},
+		A: []byte{192, 0, 2, 33},
+	}}
+	return resp, nil
+}
+
+// TestDNAMETargetResolvesUnderItsOwnLineage pins both directions of the rule
+// for the DNAME leg, which is cached under the target's own name.
+//
+// The target must not be resolved under the outer DNAME's bound — a nearly
+// expired alias would otherwise store a freshly resolved target with the
+// alias's seconds. And the outer response must inherit the target's bound,
+// because after the splice the target's records are what the client is
+// served.
+func TestDNAMETargetResolvesUnderItsOwnLineage(t *testing.T) {
+	req := new(dns.Msg)
+	req.SetQuestion("host.alias.test.", dns.TypeA)
+	req.CheckingDisabled = true
+
+	outer := new(dns.Msg)
+	outer.SetReply(req)
+	outer.CheckingDisabled = true
+	outer.Answer = []dns.RR{&dns.DNAME{
+		Hdr: dns.RR_Header{
+			Name:   "alias.test.",
+			Rrtype: dns.TypeDNAME,
+			Class:  dns.ClassINET,
+			Ttl:    120,
+		},
+		Target: "target.test.",
+	}}
+
+	// The outer response is bound long, the target short, so the direction of
+	// the merge is visible: only the target's bound can win.
+	outerDeadline := time.Now().Add(10 * time.Minute)
+	targetDeadline := time.Now().Add(30 * time.Second)
+
+	queryer := &dnameLineageQueryer{publish: targetDeadline}
+	var queryerInterface middleware.Queryer = queryer
+	r := new(Resolver)
+	r.queryer.Store(&queryerInterface)
+
+	var meta middleware.ResponseMeta
+	meta.BoundCutFor(outerDeadline, 7)
+	ctx := middleware.WithResponseMeta(context.Background(), &meta)
+
+	if _, err := r.answer(ctx, req, outer, nil, "alias.test."); err != nil {
+		t.Fatalf("merge DNAME target: %v", err)
+	}
+
+	if !queryer.observed.IsZero() {
+		t.Fatalf("the target leg was resolved under the outer response's "+
+			"bound of %v; it is cached under its own name and must carry "+
+			"its own lineage", queryer.observed)
+	}
+
+	got, key := meta.Cut()
+	if !got.Equal(targetDeadline) || key != 42 {
+		t.Fatalf("outer bound = (%v, %d) after the splice, want the target's "+
+			"(%v, 42): the records the client is served came from it",
+			got, key, targetDeadline)
+	}
+}

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -901,20 +901,23 @@ func (r *Resolver) setTags(req, resp *dns.Msg) *dns.Msg {
 // the redirect would let an overlong or cyclic chain degrade into a
 // NOERROR response containing only the outer DNAME and leave the
 // client with an unresolved reference.
-func (r *Resolver) checkDname(ctx context.Context, resp *dns.Msg) (*dns.Msg, error) {
+func (r *Resolver) checkDname(
+	ctx context.Context,
+	resp *dns.Msg,
+) (*dns.Msg, *middleware.ResponseMeta, error) {
 	if len(resp.Question) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	q := resp.Question[0]
 
 	if q.Qtype == dns.TypeCNAME {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	target := dnsutil.DnameTarget(resp)
 	if target == "" {
-		return nil, nil
+		return nil, nil, nil
 	}
 
 	// Cap the DNAME alias chain. Each follow-up goes through
@@ -925,7 +928,7 @@ func (r *Resolver) checkDname(ctx context.Context, resp *dns.Msg) (*dns.Msg, err
 	depth, _ := ctx.Value(contextKeyDnameDepth).(int)
 	if depth >= maxDnameDepth {
 		zlog.Warn("DNAME alias chain too long", "qname", q.Name, "target", target, "depth", depth)
-		return nil, errMaxDepth
+		return nil, nil, errMaxDepth
 	}
 	ctx = context.WithValue(ctx, contextKeyDnameDepth, depth+1)
 
@@ -940,11 +943,18 @@ func (r *Resolver) checkDname(ctx context.Context, resp *dns.Msg) (*dns.Msg, err
 	// setTags() so it's the authoritative source here.
 	req.CheckingDisabled = resp.CheckingDisabled
 
+	// The DNAME target is resolved and cached under its own name, so it
+	// carries its own lineage rather than the outer DNAME's. The outer
+	// answer inherits it only where the target is spliced in, which is
+	// after validation and is the only place the target's records become
+	// part of what the client is served.
+	ctx, targetCut := middleware.WithForkedCut(ctx)
+
 	msg, err := r.internalExchange(ctx, req)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return msg, nil
+	return msg, targetCut, nil
 }
 
 func (r *Resolver) answer(ctx context.Context, req, resp *dns.Msg, parentDS []dns.RR, zone string, extra ...bool) (*dns.Msg, error) {
@@ -956,7 +966,7 @@ func (r *Resolver) answer(ctx context.Context, req, resp *dns.Msg, parentDS []dn
 	// answer. By validating the outer response alone and merging the
 	// target data afterward, dnssec.VerifyRRSIG sees only the signer zone's
 	// records and the combined AD still reflects both sides.
-	targetMsg, err := r.checkDname(ctx, resp)
+	targetMsg, targetCut, err := r.checkDname(ctx, resp)
 	if err != nil {
 		// Depth cap or internal-exchange failure on the DNAME leg.
 		// Surfacing the error prevents a cyclic/overlong DNAME chain
@@ -1077,6 +1087,12 @@ func (r *Resolver) answer(ctx context.Context, req, resp *dns.Msg, parentDS []dn
 		// and set msg.AuthenticatedData accordingly; AND it into the
 		// outer AD so the combined response is authentic only if
 		// both sides are.
+		if targetCut != nil {
+			// The target's records are part of the client's answer now, so
+			// the outer response inherits how long they may be served.
+			deadline, key := targetCut.Cut()
+			middleware.ResponseMetaFrom(ctx).BoundCutFor(deadline, key)
+		}
 		resp.Answer = append(resp.Answer, targetMsg.Answer...)
 		resp.Rcode = targetMsg.Rcode
 		terminalDenial := targetMsg.Rcode == dns.RcodeNameError


### PR DESCRIPTION
## Problem

#544 established that a derived answer must not outlive the entry it was built from. The other half of that rule was missing: the source must not be shortened to the deriver's lifetime either.

A sub-query and the request that issued it share one `ResponseMeta`, so the bound flows both ways. A nearly expired alias stored the target its chase had just resolved with a second of life:

```
alias remaining:      1s   (cached, nearly expired)
target resolved with: 300s
target stored with:   999ms
```

Safe — it errs short — and expensive: that target expires almost immediately and the next query for it resolves again, which is a recursion and an allocation the cache existed to avoid.

## Change

A sub-query accumulates its own delegation-cut deadline. The deriving request inherits it once the sub-query returns, because the composed answer does contain the sub-query's records — so the bound travels one way only, and both directions of the rule hold.

Everything else about the request tree stays shared: the work ledger, the RFC 9520 retry guard, failure markers, and validated-denial provenance.

**The child delegates rather than copies.** The first attempt copied those pointers at fork time, which shares nothing when the parent has not populated them yet — they are all created lazily by CAS from nil. The child then built its own set and the tree never saw what it recorded. That is not hypothetical: it lost terminal CNAME provenance outright (`TestNXDomainCutIntegrationCNAMETransfersTerminalProvenance` admitted 0 cuts where it wants 1). The child now holds a pointer to the meta it was forked from and every ledger access goes through it.

## Tests

- `TestChildEntryKeepsItsOwnLifetime` — a freshly resolved target keeps its own lifetime when the alias that asked for it is nearly expired. Against `main` it fails, storing a 300-second answer with 999ms.
- `TestForkCutSeparatesLineageAndSharesLedgers` — the cut is the sub-query's alone in both directions, while a retry guard and provenance it establishes are visible to the request tree. The lazily-created ledgers are exactly what the pointer-copying version got wrong, so this is the case that catches it.
- `TestCNAMEChainInheritsCachedTargetLifetime` (from #544) still holds across all three sub-query shapes — the derived answer still never outlives its source.

`BoundCutFor` is unchanged and still allocation-free: 4.2 ns losing, 7.4 ns winning, 74.7 ns contended, 0 B/op throughout. The fork itself allocates one meta per sub-query, on the chase path, which has just issued a full query.

`go test ./middleware/... -race`, the full suite, `go vet` and `golangci-lint` are clean.

## Next

This unblocks the CNAME work it was found in the way of: a composed entry materialized under CAS so the first hit builds it and the second never enters the Queryer at all.