### PR TITLE
cache: publish a denial-proof zone once per bundle

### DIFF
--- a/middleware/cache/denial_proof_cache.go
+++ b/middleware/cache/denial_proof_cache.go
@@ -343,9 +343,13 @@ func (c *denialProofCache) recordWithKind(
 		return false
 	}
 
+	// The whole bundle lands before anything is published. Every entry used
+	// to publish its own snapshot, and every entry it replaced published one
+	// more, so admitting one proof rebuilt its zone's derived views half a
+	// dozen times to arrive at the state the last of them produced.
 	for _, entry := range entries {
 		if previous := c.byID[entry.id]; previous != nil {
-			c.removeEntryLocked(previous)
+			c.detachEntryLocked(previous)
 		}
 		c.sequence++
 		entry.sequence = c.sequence
@@ -354,8 +358,10 @@ func (c *denialProofCache) recordWithKind(
 		c.totalBytes += entry.wireBytes
 
 		c.zoneEntriesLocked(entry.zoneKey)[entry.id] = entry
-		c.publishZoneLocked(entry.zoneKey)
 	}
+	// One bundle carries one signer zone's records, which is the same
+	// assumption the limit enforcement below already makes.
+	c.publishZoneLocked(entries[0].zoneKey)
 
 	c.enforceNSEC3GroupLimitLocked(entries[0].zoneKey)
 	c.enforceZoneLimitsLocked(entries[0].zoneKey)
@@ -920,8 +926,22 @@ func (c *denialProofCache) publishZoneLocked(key denialProofZoneKey) {
 		delete(c.zoneEntries, key)
 		return
 	}
+	// Counted before anything is filled. A snapshot is rebuilt whenever the
+	// zone changes and the NSEC slices are the largest thing in it, so
+	// growing them by doubling leaves the intermediate arrays behind on
+	// every publish.
+	var nsecCount, preparedCount int
+	for _, entry := range entries {
+		if entry.id.kind == denialProofNSEC {
+			nsecCount++
+			preparedCount += len(entry.preparedNSEC)
+		}
+	}
+
 	snapshot := &denialProofZoneSnapshot{
-		nsec3: make(map[denialProofNSEC3Params][]*denialProofEntry),
+		nsec:         make([]*denialProofEntry, 0, nsecCount),
+		nsecPrepared: make([]dnssec.PreparedNSEC, 0, preparedCount),
+		nsec3:        make(map[denialProofNSEC3Params][]*denialProofEntry),
 	}
 	groupSequence := make(map[denialProofNSEC3Params]uint64)
 	for _, entry := range entries {

--- a/middleware/cache/denial_proof_publish_test.go
+++ b/middleware/cache/denial_proof_publish_test.go
@@ -10,6 +10,52 @@ import (
 	"github.com/semihalev/sdns/middleware/resolver/dnssec"
 )
 
+// TestDenialProofAdmissionPublishesOnce pins the cost of admitting one proof
+// into a zone that already holds many.
+//
+// A snapshot is the zone's whole derived view, so publishing per entry — and
+// again per entry replaced — rebuilt it several times to arrive at the state
+// the last publish produced. The budget is what one rebuild costs; a return
+// to per-entry publishing multiplies it.
+func TestDenialProofAdmissionPublishesOnce(t *testing.T) {
+	const zone = "bl.example."
+	const preload = 200
+	// One rebuild of a 200-entry zone: the entry slice, the prepared slice,
+	// the snapshot, the NSEC3 map and its ordering, plus the admitted proof
+	// itself. Raise it deliberately, with the reason.
+	const budget = 60
+
+	now := time.Unix(1_700_000_000, 0)
+	cache := newDenialProofTestCache(&now, 4096, 512, time.Hour)
+	for i := range preload {
+		owner := fmt.Sprintf("h%03d.%s", i, zone)
+		fixture := newDenialProofNSECFixture(
+			t, now, fmt.Sprintf("q%03d.%s", i, zone), dns.TypeA,
+			dns.RcodeNameError, zone,
+			[2]string{owner, fmt.Sprintf("h%03dz.%s", i, zone)},
+		)
+		if !cache.record(fixture.msg, zone, time.Time{}) {
+			t.Fatalf("preload admission %d rejected", i)
+		}
+	}
+
+	churn := newDenialProofNSECFixture(
+		t, now, "qchurn."+zone, dns.TypeA, dns.RcodeNameError, zone,
+		[2]string{"h000." + zone, "h000z." + zone},
+	)
+
+	allocs := testing.AllocsPerRun(50, func() {
+		if !cache.record(churn.msg, zone, time.Time{}) {
+			t.Fatal("churn admission rejected")
+		}
+	})
+	if allocs > budget {
+		t.Fatalf("admitting one proof into a %d-entry zone cost %.0f "+
+			"allocations, budget is %d", preload, allocs, budget)
+	}
+	t.Logf("admission allocations: %.0f of %d", allocs, budget)
+}
+
 // denialProofOnlySnapshot returns the single zone the test cache holds.
 func denialProofOnlySnapshot(
 	tb testing.TB,


### PR DESCRIPTION
## Problem

A field profile over a 418-second window put `denialProofCache.publishZoneLocked` at **7.61% of everything the process allocated** — the largest single item in our own code, second only to `RRSIG.Verify`.

A zone snapshot is the whole derived view: the sorted NSEC entries, the flattened prepared set, the NSEC3 groups and their ordering. Admission rebuilt it **once per entry in the bundle**, and once more for **each entry the bundle replaced** — `removeEntryLocked` publishes too. Recording one proof therefore produced half a dozen snapshots to arrive at the state the last of them left behind, and every earlier one was garbage before any reader could reach it.

The interval's breakdown: 85.25 MB in flattening the prepared set alone, 23.55 MB in replacement publishes, 55.15 MB in the per-entry intermediates.

## Change

The bundle lands first and the zone is published once. One bundle carries one signer zone's records, which is the assumption the limit enforcement after it already makes.

That also makes a proof visible the way it was validated — all of it or none of it, never a half-applied set — where before a reader could observe a bundle mid-application.

The slices are sized before they are filled, in a counting pass. A snapshot is rebuilt on every change and the NSEC slices are the largest thing in it, so growing them by doubling left an intermediate array behind on each publish.

## Measurements

`BenchmarkDenialProofRecordChurn` — admitting one proof into a zone already holding 200, which is the DNSBL-shaped stream that made this the top item in the field:

| | before | after |
|---|---|---|
| bytes/op | 281,952 B | **27,489 B** (−90%) |
| allocs/op | 136 | **51** (−62%) |
| ns/op | 115,900 | **26,400** (−77%) |

## Tests

`TestDenialProofAdmissionPublishesOnce` gates the admission at 60 allocations against a 200-entry zone — one rebuild's worth. Verified to fail at 65 when per-entry publishing is restored, so a return to it is caught rather than measured later.

The existing suite covers what must not change: the published view still holds every admitted entry, still drops a zone that empties, still keeps the writer's index in step, and still reports the earliest expiry to a lookup.

`go test ./middleware/... -race`, the full suite, `go vet` and `golangci-lint` are clean.

## Not here

The same per-entry publishing exists in the eviction loops (`enforceZoneLimitsLocked`, `enforceGlobalLimitsLocked` both call `removeEntryLocked` in a loop). It is 22% of this item against admission's 67%, and batching it means reasoning about limit enforcement that reads the snapshot it is republishing — worth doing, separately, with its own measurement.