### PR TITLE
dnssec: verify DS digests and signatures without the library's fixed buffers

### DIFF
--- a/internal/dnsutil/rrset.go
+++ b/internal/dnsutil/rrset.go
@@ -95,6 +95,13 @@ func HasNSEC3OptOut(rrs []dns.RR, zone string) bool {
 
 // NameInZone reports whether name is the zone apex or a descendant of
 // zone. Both arguments are expected to be lowercase FQDNs.
+//
+// The separator has to be a real one. In presentation format a dot inside
+// a label is written `\.`, so `foo\.example.com.` is the two labels
+// `foo.example` and `com` — it ends with the text of `example.com.`
+// without being anywhere below that zone. Reading it as a descendant
+// would let a key for example.com. authenticate an owner it has no
+// authority over.
 func NameInZone(name, zone string) bool {
 	if zone == "." || zone == "" {
 		return true
@@ -102,7 +109,33 @@ func NameInZone(name, zone string) bool {
 	if name == zone {
 		return true
 	}
-	return strings.HasSuffix(name, "."+zone)
+	if len(name) <= len(zone) {
+		return false
+	}
+	// Compared in place rather than against "."+zone. The concatenation
+	// stays on the stack while it fits the runtime's temporary buffer,
+	// so a short zone never paid for it — but a zone name of 32 octets
+	// or more heap-allocated on every call, and this runs for every
+	// RRset of every signed response.
+	cut := len(name) - len(zone)
+	if name[cut-1] != '.' || name[cut:] != zone {
+		return false
+	}
+	return !escapedDot(name, cut-1)
+}
+
+// escapedDot reports whether the dot at i is a literal dot within a label
+// rather than a label separator.
+//
+// A backslash escapes the character after it, and escapes itself as `\\`,
+// so the dot is a separator exactly when an even number of backslashes
+// precede it.
+func escapedDot(name string, i int) bool {
+	backslashes := 0
+	for j := i - 1; j >= 0 && name[j] == '\\'; j-- {
+		backslashes++
+	}
+	return backslashes%2 == 1
 }
 
 // DnameTarget returns the synthesized CNAME target for the question

--- a/internal/dnsutil/rrset_test.go
+++ b/internal/dnsutil/rrset_test.go
@@ -52,3 +52,74 @@ func TestFilterRRsToZoneUsesDNSASCIICaseFolding(t *testing.T) {
 		t.Fatalf("filtered records = %v, want only ASCII-case-equivalent in-zone NSEC", got)
 	}
 }
+
+// TestNameInZoneRequiresARealSeparator pins that zone containment is decided
+// on labels, not on text.
+//
+// A dot written `\.` is part of a label, so `foo\.example.com.` is the two
+// labels `foo.example` and `com`: it ends with the text of `example.com.`
+// while living outside that zone entirely. Every DNSSEC containment check in
+// the resolver comes through here, so reading it as a descendant would let a
+// key authenticate an owner it has no authority over.
+func TestNameInZoneRequiresARealSeparator(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		zone string
+		want bool
+	}{
+		{"example.com.", "example.com.", true},
+		{"www.example.com.", "example.com.", true},
+		{"a.b.example.com.", "example.com.", true},
+		{"example.com.", ".", true},
+		{"anything.", "", true},
+
+		{"evilexample.com.", "example.com.", false},
+		{"com.", "example.com.", false},
+		{"example.org.", "example.com.", false},
+
+		// The escaped separator: a literal dot inside a single label.
+		{`foo\.example.com.`, "example.com.", false},
+		{`a.foo\.example.com.`, "example.com.", false},
+		{`foo\.example.com.`, "com.", true},
+		{`foo\.example.com.`, `foo\.example.com.`, true},
+		{`x.foo\.example.com.`, `foo\.example.com.`, true},
+
+		// An escaped backslash is not an escaped dot: the separator after
+		// it is a separator.
+		{`foo\\.example.com.`, "example.com.", true},
+		{`foo\\\.example.com.`, "example.com.", false},
+	} {
+		if got := NameInZone(tc.name, tc.zone); got != tc.want {
+			t.Errorf("NameInZone(%q, %q) = %v, want %v",
+				tc.name, tc.zone, got, tc.want)
+		}
+	}
+}
+
+// TestNameInZoneDoesNotAllocate keeps the check off the allocator. It runs
+// for every RRset of every signed response, and the old form compared against
+// a freshly built "."+zone — free on the stack for a short zone, a heap
+// allocation per call once the zone name reached the runtime's 32-octet
+// temporary buffer, which ordinary delegation names do.
+func TestNameInZoneDoesNotAllocate(t *testing.T) {
+	const longZone = "a-rather-long-delegation-name.under.some.deep.example.com."
+	if len(longZone) < 32 {
+		t.Fatal("fixture is wrong: the zone name is short enough to stay on the stack")
+	}
+	longName := "www." + longZone
+
+	allocs := testing.AllocsPerRun(200, func() {
+		if !NameInZone("www.example.com.", "example.com.") {
+			t.Fatal("in-zone name rejected")
+		}
+		if NameInZone("evilexample.com.", "example.com.") {
+			t.Fatal("out-of-zone name accepted")
+		}
+		if !NameInZone(longName, longZone) {
+			t.Fatal("in-zone name under a long zone rejected")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("NameInZone cost %.0f allocations", allocs)
+	}
+}

--- a/middleware/resolver/dnssec/canonical_order_test.go
+++ b/middleware/resolver/dnssec/canonical_order_test.go
@@ -1,0 +1,154 @@
+package dnssec
+
+import (
+	"crypto"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// TestCanonicalRRsetOrdersByRdataOnly pins the ordering RFC 4034 §6.3
+// defines: within an RRset the records are sorted by their RDATA, and by
+// nothing that precedes it.
+//
+// Sorting the whole packed record instead puts RDLENGTH ahead of the data,
+// so records of unequal length order by length first. Two TXT strings are
+// enough to tell the two rules apart, and a signature made over one ordering
+// does not verify under the other.
+func TestCanonicalRRsetOrdersByRdataOnly(t *testing.T) {
+	// A TXT record's RDATA begins with a length octet, so a single string
+	// orders the same way under both rules. Two strings separate them: this
+	// pair has the longer RDATA starting with the smaller octets, so RDATA
+	// order and whole-record order are opposites.
+	rrset := []dns.RR{
+		mustSignatureRR(t, `txt.example.com. 300 IN TXT "a" "zzzz"`),
+		mustSignatureRR(t, `txt.example.com. 300 IN TXT "b"`),
+	}
+
+	key := &dns.DNSKEY{
+		Hdr: dns.RR_Header{
+			Name: "example.com.", Rrtype: dns.TypeDNSKEY,
+			Class: dns.ClassINET, Ttl: 3600,
+		},
+		Flags: 257, Protocol: 3, Algorithm: dns.ECDSAP256SHA256,
+	}
+	private, err := key.Generate(256)
+	if err != nil {
+		t.Fatalf("generate: %v", err)
+	}
+	signer, ok := private.(crypto.Signer)
+	if !ok {
+		t.Fatal("generated key does not sign")
+	}
+
+	sig := &dns.RRSIG{
+		Hdr: dns.RR_Header{
+			Name: "txt.example.com.", Rrtype: dns.TypeRRSIG,
+			Class: dns.ClassINET, Ttl: 300,
+		},
+		TypeCovered: dns.TypeTXT, Algorithm: key.Algorithm, Labels: 3,
+		OrigTtl:    300,
+		Expiration: uint32(time.Now().Add(24 * time.Hour).Unix()), //nolint:gosec // test epoch fits
+		Inception:  uint32(time.Now().Add(-time.Hour).Unix()),     //nolint:gosec // test epoch fits
+		KeyTag:     key.KeyTag(), SignerName: key.Hdr.Name,
+	}
+	if err := sig.Sign(signer, rrset); err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	if err := sig.Verify(key, rrset); err != nil {
+		t.Fatalf("fixture is wrong: the library does not accept what it signed: %v", err)
+	}
+	if err := verifySignature(key, sig, rrset); err != nil {
+		t.Fatalf("rejected a signature the library accepts, over records whose "+
+			"RDATA and length order differently: %v", err)
+	}
+}
+
+// TestCanonicalRRsetMatchesLibraryOrdering compares the signed data this
+// package builds with the library's, over sets chosen so that length order
+// and content order disagree.
+func TestCanonicalRRsetMatchesLibraryOrdering(t *testing.T) {
+	sig := &dns.RRSIG{
+		Hdr: dns.RR_Header{
+			Name: "txt.example.com.", Rrtype: dns.TypeRRSIG,
+			Class: dns.ClassINET, Ttl: 300,
+		},
+		TypeCovered: dns.TypeTXT, Algorithm: dns.ECDSAP256SHA256, Labels: 3,
+		OrigTtl: 300, Expiration: 2000000000, Inception: 1000000000,
+		KeyTag: 1234, SignerName: "example.com.",
+	}
+
+	for _, values := range [][]string{
+		{`"a" "zzzz"`, `"b"`},
+		{`"b"`, `"a" "zzzz"`},
+		{`"zz"`, `"aaaa"`},
+		{`"b"`, `"aa"`, `"ccc"`},
+		{`"` + strings.Repeat("x", 200) + `"`, `"y"`},
+		{`"same"`, `"same"`},
+	} {
+		var rrset []dns.RR
+		for _, value := range values {
+			rrset = append(rrset, mustSignatureRR(t,
+				`txt.example.com. 300 IN TXT `+value))
+		}
+
+		ours, err := canonicalRRset(rrset, sig)
+		if err != nil {
+			t.Fatalf("%v: canonicalRRset: %v", values, err)
+		}
+		theirs := libraryCanonicalRRset(t, rrset, sig)
+		if string(ours) != string(theirs) {
+			t.Fatalf("%v: canonical form diverged from the library's\n"+
+				" ours:  %x\n them:  %x", values, ours, theirs)
+		}
+	}
+}
+
+// libraryCanonicalRRset reproduces what dns.RRSIG.Verify hashes, by signing
+// with a key and reading back what the library considered the signed data.
+// The library does not export it, so this rebuilds the ordering rule it
+// documents: sort on the RDATA, which begins ten octets past the owner name.
+func libraryCanonicalRRset(tb testing.TB, rrset []dns.RR, sig *dns.RRSIG) []byte {
+	tb.Helper()
+	wires := make([][]byte, 0, len(rrset))
+	for _, rr := range rrset {
+		clone := dns.Copy(rr)
+		clone.Header().Ttl = sig.OrigTtl
+		clone.Header().Name = dns.CanonicalName(clone.Header().Name)
+		wire := make([]byte, dns.Len(clone)+1)
+		n, err := dns.PackRR(clone, wire, 0, nil, false)
+		if err != nil {
+			tb.Fatalf("PackRR: %v", err)
+		}
+		wires = append(wires, wire[:n])
+	}
+	sortByRdata(tb, wires)
+
+	var buf []byte
+	for i, wire := range wires {
+		if i > 0 && string(wire) == string(wires[i-1]) {
+			continue
+		}
+		buf = append(buf, wire...)
+	}
+	return buf
+}
+
+func sortByRdata(tb testing.TB, wires [][]byte) {
+	tb.Helper()
+	rdata := func(wire []byte) []byte {
+		_, off, err := dns.UnpackDomainName(wire, 0)
+		if err != nil {
+			tb.Fatalf("UnpackDomainName: %v", err)
+		}
+		return wire[off+10:]
+	}
+	for i := 1; i < len(wires); i++ {
+		for j := i; j > 0 && string(rdata(wires[j])) < string(rdata(wires[j-1])); j-- {
+			wires[j], wires[j-1] = wires[j-1], wires[j]
+		}
+	}
+}

--- a/middleware/resolver/dnssec/ds_digest.go
+++ b/middleware/resolver/dnssec/ds_digest.go
@@ -9,8 +9,22 @@ import (
 	"github.com/miekg/dns"
 )
 
+// maxDSKeyMaterial is how much decoded public key a DS digest may cover.
+//
+// The library packs the key into a 4096-octet buffer behind the four octets
+// of flags, protocol and algorithm, so anything larger fails to pack and no
+// DS is produced — a key that could never match. Computing the digest
+// directly has no such ceiling of its own, and gaining one silently would
+// widen what this resolver accepts as a chain of trust.
+const maxDSKeyMaterial = 4096 - 4
+
 // dsDigestHash maps a DS digest type to its hash, reporting whether this
 // resolver will compute it at all.
+//
+// Digest type 5 is deliberately absent. miekg/dns names its constant SHA512,
+// but IANA assigns 5 to GOST R 34.11-2012 (RFC 9558); the resolver's own
+// IsSupportedDSDigest admits only 1, 2 and 4, and this must not disagree with
+// it by treating a GOST digest as a SHA-512 one.
 func dsDigestHash(digestType uint8) (crypto.Hash, bool) {
 	switch digestType {
 	case dns.SHA1:
@@ -19,8 +33,6 @@ func dsDigestHash(digestType uint8) (crypto.Hash, bool) {
 		return crypto.SHA256, true
 	case dns.SHA384:
 		return crypto.SHA384, true
-	case dns.SHA512:
-		return crypto.SHA512, true
 	default:
 		return 0, false
 	}
@@ -46,7 +58,7 @@ func dsDigestMatches(key *dns.DNSKEY, digestType uint8, want []byte) bool {
 	// The public key travels as base64 in the record, so this decode is what
 	// the digest is actually over.
 	public, err := base64.StdEncoding.DecodeString(key.PublicKey)
-	if err != nil || len(public) == 0 {
+	if err != nil || len(public) == 0 || len(public) > maxDSKeyMaterial {
 		return false
 	}
 

--- a/middleware/resolver/dnssec/ds_digest.go
+++ b/middleware/resolver/dnssec/ds_digest.go
@@ -1,0 +1,73 @@
+package dnssec
+
+import (
+	"bytes"
+	"crypto"
+	"encoding/base64"
+	"encoding/binary"
+
+	"github.com/miekg/dns"
+)
+
+// dsDigestHash maps a DS digest type to its hash, reporting whether this
+// resolver will compute it at all.
+func dsDigestHash(digestType uint8) (crypto.Hash, bool) {
+	switch digestType {
+	case dns.SHA1:
+		return crypto.SHA1, true
+	case dns.SHA256:
+		return crypto.SHA256, true
+	case dns.SHA384:
+		return crypto.SHA384, true
+	case dns.SHA512:
+		return crypto.SHA512, true
+	default:
+		return 0, false
+	}
+}
+
+// dsDigestMatches reports whether key hashes to want under digestType.
+//
+// This is the RFC 4034 §5.1.4 digest — hash(canonical owner name | flags |
+// protocol | algorithm | public key) — computed straight into the comparison.
+// Producing a dns.DS to compare instead costs a 4096-octet key buffer, a
+// 255-octet owner buffer, the record itself and a hexadecimal rendering of
+// the digest, for every candidate key of every delegation; none of it is
+// wanted here beyond the bytes.
+func dsDigestMatches(key *dns.DNSKEY, digestType uint8, want []byte) bool {
+	if key == nil || len(want) == 0 {
+		return false
+	}
+	hash, ok := dsDigestHash(digestType)
+	if !ok || !hash.Available() || hash.Size() != len(want) {
+		return false
+	}
+
+	// The public key travels as base64 in the record, so this decode is what
+	// the digest is actually over.
+	public, err := base64.StdEncoding.DecodeString(key.PublicKey)
+	if err != nil || len(public) == 0 {
+		return false
+	}
+
+	name := dns.CanonicalName(key.Hdr.Name)
+	owner := make([]byte, min(len(name)+1, 255))
+	end, err := dns.PackDomainName(name, owner, 0, nil, false)
+	if err != nil || end == 0 {
+		return false
+	}
+
+	var rdata [4]byte
+	binary.BigEndian.PutUint16(rdata[0:2], key.Flags)
+	rdata[2] = key.Protocol
+	rdata[3] = key.Algorithm
+
+	digest := hash.New()
+	digest.Write(owner[:end])
+	digest.Write(rdata[:])
+	digest.Write(public)
+
+	// Sum into a stack buffer: the largest digest this accepts is SHA-512.
+	var sum [64]byte
+	return bytes.Equal(digest.Sum(sum[:0]), want)
+}

--- a/middleware/resolver/dnssec/ds_digest.go
+++ b/middleware/resolver/dnssec/ds_digest.go
@@ -55,6 +55,14 @@ func dsDigestMatches(key *dns.DNSKEY, digestType uint8, want []byte) bool {
 		return false
 	}
 
+	// Refused on the encoded length, before anything decodes it. An
+	// attacker-supplied DNSKEY can be as large as the message allows, and
+	// deciding it is too big only after materializing it is a decode this
+	// answer never needed.
+	if len(key.PublicKey) > base64.StdEncoding.EncodedLen(maxDSKeyMaterial) {
+		return false
+	}
+
 	// The public key travels as base64 in the record, so this decode is what
 	// the digest is actually over.
 	public, err := base64.StdEncoding.DecodeString(key.PublicKey)

--- a/middleware/resolver/dnssec/ds_digest.go
+++ b/middleware/resolver/dnssec/ds_digest.go
@@ -5,6 +5,7 @@ import (
 	"crypto"
 	"encoding/base64"
 	"encoding/binary"
+	"strings"
 
 	"github.com/miekg/dns"
 )
@@ -53,15 +54,30 @@ func oversizedKeyMaterial(publicKey string) bool {
 	}
 	// The decoder skips CR and LF, so a key that is only long because it
 	// is wrapped is not oversized, and refusing it would reject an input
-	// the library accepts. Counted rather than assumed — but only on this
-	// branch, so a key of ordinary size never walks its own material.
-	newlines := 0
+	// the library accepts. The line breaks are counted out rather than
+	// assumed away — but only as far as the answer needs: once limit+1
+	// octets of actual material have been seen, nothing in the rest can
+	// bring the decoded length back under the limit. The walk is bounded
+	// by the limit, not by the size of what an attacker sent.
+	// Wrapping is the rare case, and the two searches below are the
+	// assembly-optimized ones: limit+1 octets with no line break in them
+	// settle it without a byte-at-a-time walk.
+	head := publicKey[:limit+1]
+	if strings.IndexByte(head, '\n') < 0 && strings.IndexByte(head, '\r') < 0 {
+		return true
+	}
+
+	material := 0
 	for i := range len(publicKey) {
 		if c := publicKey[i]; c == '\r' || c == '\n' {
-			newlines++
+			continue
+		}
+		material++
+		if material > limit {
+			return true
 		}
 	}
-	return len(publicKey)-newlines > limit
+	return false
 }
 
 // dsDigestMatches reports whether key hashes to want under digestType.

--- a/middleware/resolver/dnssec/ds_digest.go
+++ b/middleware/resolver/dnssec/ds_digest.go
@@ -38,6 +38,32 @@ func dsDigestHash(digestType uint8) (crypto.Hash, bool) {
 	}
 }
 
+// oversizedKeyMaterial reports whether a DNSKEY carries more key material
+// than maxDSKeyMaterial allows, judged on the encoded length so the answer
+// is known before anything decodes it.
+//
+// An attacker-supplied DNSKEY can be as large as the message allows, and a
+// DS set can name the same key many times over; deciding it is too big only
+// after materializing it pays for the very thing being refused, once per
+// mention.
+func oversizedKeyMaterial(publicKey string) bool {
+	limit := base64.StdEncoding.EncodedLen(maxDSKeyMaterial)
+	if len(publicKey) <= limit {
+		return false
+	}
+	// The decoder skips CR and LF, so a key that is only long because it
+	// is wrapped is not oversized, and refusing it would reject an input
+	// the library accepts. Counted rather than assumed — but only on this
+	// branch, so a key of ordinary size never walks its own material.
+	newlines := 0
+	for i := range len(publicKey) {
+		if c := publicKey[i]; c == '\r' || c == '\n' {
+			newlines++
+		}
+	}
+	return len(publicKey)-newlines > limit
+}
+
 // dsDigestMatches reports whether key hashes to want under digestType.
 //
 // This is the RFC 4034 §5.1.4 digest — hash(canonical owner name | flags |
@@ -55,11 +81,7 @@ func dsDigestMatches(key *dns.DNSKEY, digestType uint8, want []byte) bool {
 		return false
 	}
 
-	// Refused on the encoded length, before anything decodes it. An
-	// attacker-supplied DNSKEY can be as large as the message allows, and
-	// deciding it is too big only after materializing it is a decode this
-	// answer never needed.
-	if len(key.PublicKey) > base64.StdEncoding.EncodedLen(maxDSKeyMaterial) {
+	if oversizedKeyMaterial(key.PublicKey) {
 		return false
 	}
 

--- a/middleware/resolver/dnssec/ds_digest_test.go
+++ b/middleware/resolver/dnssec/ds_digest_test.go
@@ -216,6 +216,36 @@ func TestDSDigestKeepsTheLibraryEnvelope(t *testing.T) {
 	}
 }
 
+// TestDSDigestRefusesOversizedBeforeDecoding pins where the size limit is
+// applied. A DNSKEY can be as large as the message allows and its material is
+// attacker-supplied, so deciding it is too big has to happen on the encoded
+// length — deciding it after decoding pays for the very thing being refused.
+func TestDSDigestRefusesOversizedBeforeDecoding(t *testing.T) {
+	// Well past the limit, so the decode this must not perform would be
+	// unmistakable in the measurement.
+	const material = 48 << 10
+	key := &dns.DNSKEY{
+		Hdr: dns.RR_Header{
+			Name: "example.com.", Rrtype: dns.TypeDNSKEY,
+			Class: dns.ClassINET, Ttl: 3600,
+		},
+		Flags: 257, Protocol: 3, Algorithm: dns.RSASHA256,
+		PublicKey: base64.StdEncoding.EncodeToString(
+			bytes.Repeat([]byte{0x5a}, material)),
+	}
+	want := make([]byte, sha256.Size)
+
+	allocs := testing.AllocsPerRun(100, func() {
+		if dsDigestMatches(key, dns.SHA256, want) {
+			t.Fatal("accepted an oversized key")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("refusing a %d-octet key cost %.0f allocations; the length "+
+			"check is running after the decode", material, allocs)
+	}
+}
+
 // oversizedDigestInput builds what the digest over key would be if the
 // library could pack it, so the test compares against the one value that
 // could plausibly be accepted rather than an arbitrary one.

--- a/middleware/resolver/dnssec/ds_digest_test.go
+++ b/middleware/resolver/dnssec/ds_digest_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -216,23 +217,28 @@ func TestDSDigestKeepsTheLibraryEnvelope(t *testing.T) {
 	}
 }
 
+// oversizedMaterial is well past maxDSKeyMaterial, so a decode that should
+// not happen is unmistakable in a measurement.
+const oversizedMaterial = 48 << 10
+
+func oversizedKey(algorithm uint8) *dns.DNSKEY {
+	return &dns.DNSKEY{
+		Hdr: dns.RR_Header{
+			Name: "example.com.", Rrtype: dns.TypeDNSKEY,
+			Class: dns.ClassINET, Ttl: 3600,
+		},
+		Flags: 257, Protocol: 3, Algorithm: algorithm,
+		PublicKey: base64.StdEncoding.EncodeToString(
+			bytes.Repeat([]byte{0x5a}, oversizedMaterial)),
+	}
+}
+
 // TestDSDigestRefusesOversizedBeforeDecoding pins where the size limit is
 // applied. A DNSKEY can be as large as the message allows and its material is
 // attacker-supplied, so deciding it is too big has to happen on the encoded
 // length — deciding it after decoding pays for the very thing being refused.
 func TestDSDigestRefusesOversizedBeforeDecoding(t *testing.T) {
-	// Well past the limit, so the decode this must not perform would be
-	// unmistakable in the measurement.
-	const material = 48 << 10
-	key := &dns.DNSKEY{
-		Hdr: dns.RR_Header{
-			Name: "example.com.", Rrtype: dns.TypeDNSKEY,
-			Class: dns.ClassINET, Ttl: 3600,
-		},
-		Flags: 257, Protocol: 3, Algorithm: dns.RSASHA256,
-		PublicKey: base64.StdEncoding.EncodeToString(
-			bytes.Repeat([]byte{0x5a}, material)),
-	}
+	key := oversizedKey(dns.RSASHA256)
 	want := make([]byte, sha256.Size)
 
 	allocs := testing.AllocsPerRun(100, func() {
@@ -242,7 +248,115 @@ func TestDSDigestRefusesOversizedBeforeDecoding(t *testing.T) {
 	})
 	if allocs != 0 {
 		t.Fatalf("refusing a %d-octet key cost %.0f allocations; the length "+
-			"check is running after the decode", material, allocs)
+			"check is running after the decode", oversizedMaterial, allocs)
+	}
+}
+
+// TestDSDigestIgnoresWrappedKeyMaterial keeps the size check from narrowing
+// what the library accepts.
+//
+// The limit is judged on the encoded length, but base64 decoding skips CR and
+// LF — so a key at exactly the maximum, wrapped into lines, decodes to a
+// packable key while measuring longer than the limit. Judging the raw length
+// alone would refuse an input the library turns into a DS.
+func TestDSDigestIgnoresWrappedKeyMaterial(t *testing.T) {
+	material := bytes.Repeat([]byte{0x5a}, maxDSKeyMaterial)
+	flat := base64.StdEncoding.EncodeToString(material)
+
+	var wrapped strings.Builder
+	for i := 0; i < len(flat); i += 64 {
+		wrapped.WriteString(flat[i:min(i+64, len(flat))])
+		wrapped.WriteString("\r\n")
+	}
+	if wrapped.Len() <= base64.StdEncoding.EncodedLen(maxDSKeyMaterial) {
+		t.Fatal("fixture is wrong: the wrapped key is not longer than the limit")
+	}
+
+	key := &dns.DNSKEY{
+		Hdr: dns.RR_Header{
+			Name: "example.com.", Rrtype: dns.TypeDNSKEY,
+			Class: dns.ClassINET, Ttl: 3600,
+		},
+		Flags: 257, Protocol: 3, Algorithm: dns.RSASHA256,
+		PublicKey: wrapped.String(),
+	}
+
+	reference := key.ToDS(dns.SHA256)
+	if reference == nil {
+		t.Fatal("fixture is wrong: the library refused the wrapped key")
+	}
+	want, err := hex.DecodeString(reference.Digest)
+	if err != nil {
+		t.Fatalf("library digest is not hexadecimal: %v", err)
+	}
+	if !dsDigestMatches(key, dns.SHA256, want) {
+		t.Fatal("refused a wrapped key the library accepts; the size check is " +
+			"counting line breaks as key material")
+	}
+}
+
+// TestVerifyDSRefusesOversizedKeyWithoutDecodingIt measures the path a query
+// actually takes, which the helper-level test above does not.
+//
+// VerifyDS reaches usableDSCandidate before any digest, and that begins with
+// KeyTag — which packs the key into a buffer of its own and decodes the
+// material to fill it. Nothing about that decode depends on which DS is being
+// considered, so a DS RRset naming the same key many times paid for it once
+// per mention: one 48 KiB key across 32 DS records amplified to megabytes.
+//
+// The measurement is in bytes rather than allocations because the surrounding
+// bookkeeping — deduplicating and sorting the DS records — allocates by
+// design. The ceiling is one key's worth of material: crossing it means at
+// least one decode happened, which is the thing being ruled out.
+func TestVerifyDSRefusesOversizedKeyWithoutDecodingIt(t *testing.T) {
+	const dsCount = 32
+	key := oversizedKey(dns.RSASHA256)
+
+	// The library cannot pack this key, so the tag it computes is 0 rather
+	// than the key's real one. That is what an attacker indexes against.
+	if tag := key.KeyTag(); tag != 0 {
+		t.Fatalf("fixture is wrong: the library computed key tag %d for an "+
+			"unpackable key", tag)
+	}
+	keyMap := map[uint16][]*dns.DNSKEY{0: {key}}
+
+	// Distinct digests, so deduplication keeps all of them: every one is a
+	// separate mention of the same key.
+	dsSet := make([]dns.RR, 0, dsCount)
+	for i := range dsCount {
+		digest := bytes.Repeat([]byte{0x11}, sha256.Size)
+		digest[0] = byte(i)
+		dsSet = append(dsSet, &dns.DS{
+			Hdr: dns.RR_Header{
+				Name: "example.com.", Rrtype: dns.TypeDS,
+				Class: dns.ClassINET, Ttl: 3600,
+			},
+			KeyTag: 0, Algorithm: dns.RSASHA256, DigestType: dns.SHA256,
+			Digest: hex.EncodeToString(digest),
+		})
+	}
+
+	if unsupportedOnly, err := VerifyDS(keyMap, dsSet); err == nil {
+		t.Fatalf("an oversized key authenticated a DS (unsupportedOnly=%v)",
+			unsupportedOnly)
+	}
+
+	const runs = 20
+	var before, after runtime.MemStats
+	runtime.GC()
+	runtime.ReadMemStats(&before)
+	for range runs {
+		if _, err := VerifyDS(keyMap, dsSet); err == nil {
+			t.Fatal("an oversized key authenticated a DS")
+		}
+	}
+	runtime.ReadMemStats(&after)
+
+	perCall := (after.TotalAlloc - before.TotalAlloc) / runs
+	if perCall > oversizedMaterial {
+		t.Fatalf("VerifyDS over %d DS records naming one %d-octet key "+
+			"allocated %d B; the size check is running after KeyTag, so the "+
+			"key is decoded once per DS", dsCount, oversizedMaterial, perCall)
 	}
 }
 

--- a/middleware/resolver/dnssec/ds_digest_test.go
+++ b/middleware/resolver/dnssec/ds_digest_test.go
@@ -403,6 +403,37 @@ func TestDSDigestNameFolding(t *testing.T) {
 	}
 }
 
+// BenchmarkVerifyDSOversizedKey is the attack shape rather than the ordinary
+// one: a DS RRset naming the same unpackable key many times over. What it
+// measures is that neither the decode nor the walk that replaced it scales
+// with the size of what was sent.
+func BenchmarkVerifyDSOversizedKey(b *testing.B) {
+	const dsCount = 32
+	key := oversizedKey(dns.RSASHA256)
+	keyMap := map[uint16][]*dns.DNSKEY{0: {key}}
+
+	dsSet := make([]dns.RR, 0, dsCount)
+	for i := range dsCount {
+		digest := bytes.Repeat([]byte{0x11}, sha256.Size)
+		digest[0] = byte(i)
+		dsSet = append(dsSet, &dns.DS{
+			Hdr: dns.RR_Header{
+				Name: "example.com.", Rrtype: dns.TypeDS,
+				Class: dns.ClassINET, Ttl: 3600,
+			},
+			KeyTag: 0, Algorithm: dns.RSASHA256, DigestType: dns.SHA256,
+			Digest: hex.EncodeToString(digest),
+		})
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if _, err := VerifyDS(keyMap, dsSet); err == nil {
+			b.Fatal("an oversized key authenticated a DS")
+		}
+	}
+}
+
 func BenchmarkDSDigestMatches(b *testing.B) {
 	key := dsDigestTestKeys(b)[0]
 	want, err := hex.DecodeString(key.ToDS(dns.SHA256).Digest)

--- a/middleware/resolver/dnssec/ds_digest_test.go
+++ b/middleware/resolver/dnssec/ds_digest_test.go
@@ -1,6 +1,10 @@
 package dnssec
 
 import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/binary"
 	"encoding/hex"
 	"strings"
 	"testing"
@@ -49,7 +53,9 @@ func dsDigestTestKeys(tb testing.TB) []*dns.DNSKEY {
 // without building a DS record: for every key, algorithm and digest type, it
 // must accept exactly the digest dns.DNSKEY.ToDS produces and nothing else.
 func TestDSDigestMatchesLibrary(t *testing.T) {
-	digestTypes := []uint8{dns.SHA1, dns.SHA256, dns.SHA384, dns.SHA512}
+	// Type 5 is GOST R 34.11-2012 by IANA, not SHA-512, and this resolver
+	// does not compute it; see dsDigestHash.
+	digestTypes := []uint8{dns.SHA1, dns.SHA256, dns.SHA384}
 	keys := dsDigestTestKeys(t)
 
 	for _, key := range keys {
@@ -109,8 +115,8 @@ func TestDSDigestRejectsWhatTheLibraryRejects(t *testing.T) {
 		t.Fatalf("library digest is not hexadecimal: %v", err)
 	}
 
-	// Reserved, GOST (which the library declines to compute), and a code no
-	// registry assigns. SHA-512 is 5 and is supported, so it is not here.
+	// Reserved, GOST-94, and a code no registry assigns: the library refuses
+	// these too.
 	for _, digestType := range []uint8{0, dns.GOST94, 200} {
 		if key.ToDS(digestType) != nil {
 			t.Fatalf("fixture is wrong: the library accepts digest type %d",
@@ -119,6 +125,26 @@ func TestDSDigestRejectsWhatTheLibraryRejects(t *testing.T) {
 		if dsDigestMatches(key, digestType, want) {
 			t.Fatalf("accepted unsupported digest type %d", digestType)
 		}
+	}
+
+	// Digest type 5 is the one deliberate divergence. miekg computes it as
+	// SHA-512, following an expired draft; IANA assigns 5 to GOST R
+	// 34.11-2012 (RFC 9558), and this resolver's IsSupportedDSDigest admits
+	// only 1, 2 and 4. Treating a GOST digest as a SHA-512 one is the error
+	// worth refusing, so this is stricter than the library on purpose.
+	if key.ToDS(5) == nil {
+		t.Fatal("fixture is wrong: the library no longer computes digest type 5")
+	}
+	if IsSupportedDSDigest(5) {
+		t.Fatal("the resolver now admits digest type 5; this test and " +
+			"dsDigestHash have to be revisited together")
+	}
+	library5, err := hex.DecodeString(key.ToDS(5).Digest)
+	if err != nil {
+		t.Fatalf("library digest is not hexadecimal: %v", err)
+	}
+	if dsDigestMatches(key, 5, library5) {
+		t.Fatal("computed digest type 5 as SHA-512, which IANA assigns to GOST")
 	}
 
 	broken := *key
@@ -133,6 +159,86 @@ func TestDSDigestRejectsWhatTheLibraryRejects(t *testing.T) {
 	if dsDigestMatches(key, dns.SHA256, nil) {
 		t.Fatal("accepted a missing digest")
 	}
+}
+
+// TestDSDigestKeepsTheLibraryEnvelope pins the acceptance boundary. The
+// library packs the key into a fixed buffer to build a DS, so a key larger
+// than that buffer holds produces no DS and can never match. Computing the
+// digest directly has no ceiling of its own, and gaining one silently would
+// let a key the library refuses become a chain of trust.
+func TestDSDigestKeepsTheLibraryEnvelope(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		material int
+	}{
+		{"the largest key the library packs", maxDSKeyMaterial},
+		{"one octet past it", maxDSKeyMaterial + 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			key := &dns.DNSKEY{
+				Hdr: dns.RR_Header{
+					Name: "example.com.", Rrtype: dns.TypeDNSKEY,
+					Class: dns.ClassINET, Ttl: 3600,
+				},
+				Flags: 257, Protocol: 3, Algorithm: dns.RSASHA256,
+				PublicKey: base64.StdEncoding.EncodeToString(
+					bytes.Repeat([]byte{0x5a}, tc.material)),
+			}
+
+			reference := key.ToDS(dns.SHA256)
+			if tc.material > maxDSKeyMaterial {
+				if reference != nil {
+					t.Fatalf("fixture is wrong: the library packed %d octets "+
+						"of key material", tc.material)
+				}
+				// Nothing the library would produce, so nothing may match:
+				// the digest such a key would have if it were packable is
+				// exactly what must be refused.
+				digest := sha256.Sum256(oversizedDigestInput(t, key))
+				if dsDigestMatches(key, dns.SHA256, digest[:]) {
+					t.Fatal("accepted a key the library cannot turn into a DS")
+				}
+				return
+			}
+
+			if reference == nil {
+				t.Fatalf("fixture is wrong: the library refused %d octets of "+
+					"key material", tc.material)
+			}
+			want, err := hex.DecodeString(reference.Digest)
+			if err != nil {
+				t.Fatalf("library digest is not hexadecimal: %v", err)
+			}
+			if !dsDigestMatches(key, dns.SHA256, want) {
+				t.Fatal("refused the largest key the library accepts")
+			}
+		})
+	}
+}
+
+// oversizedDigestInput builds what the digest over key would be if the
+// library could pack it, so the test compares against the one value that
+// could plausibly be accepted rather than an arbitrary one.
+func oversizedDigestInput(tb testing.TB, key *dns.DNSKEY) []byte {
+	tb.Helper()
+	name := dns.CanonicalName(key.Hdr.Name)
+	owner := make([]byte, 255)
+	end, err := dns.PackDomainName(name, owner, 0, nil, false)
+	if err != nil {
+		tb.Fatalf("PackDomainName: %v", err)
+	}
+	public, err := base64.StdEncoding.DecodeString(key.PublicKey)
+	if err != nil {
+		tb.Fatalf("key material is not base64: %v", err)
+	}
+
+	input := append([]byte(nil), owner[:end]...)
+	var rdata [4]byte
+	binary.BigEndian.PutUint16(rdata[0:2], key.Flags)
+	rdata[2] = key.Protocol
+	rdata[3] = key.Algorithm
+	input = append(input, rdata[:]...)
+	return append(input, public...)
 }
 
 // TestDSDigestNameFolding pins that the owner name is canonicalized the way

--- a/middleware/resolver/dnssec/ds_digest_test.go
+++ b/middleware/resolver/dnssec/ds_digest_test.go
@@ -1,0 +1,182 @@
+package dnssec
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// dsDigestTestKeys returns keys spanning the algorithms and key sizes a
+// resolver meets, including a revoked and a zone-signing key: the digest is
+// over the flags, so those are distinct inputs rather than cosmetic ones.
+func dsDigestTestKeys(tb testing.TB) []*dns.DNSKEY {
+	tb.Helper()
+	var keys []*dns.DNSKEY
+	for _, spec := range []struct {
+		owner     string
+		flags     uint16
+		algorithm uint8
+		bits      int
+	}{
+		{"example.com.", 257, dns.RSASHA256, 1024},
+		{"example.com.", 256, dns.RSASHA256, 1024},
+		{"example.com.", 257, dns.RSASHA512, 1024},
+		{"EXAMPLE.com.", 257, dns.RSASHA256, 1024},
+		{"a.deeper.example.com.", 257, dns.ECDSAP256SHA256, 256},
+		{"example.com.", 257, dns.ECDSAP384SHA384, 384},
+		{"example.com.", 257, dns.ED25519, 256},
+		{".", 257, dns.ECDSAP256SHA256, 256},
+		{"xn--nme-qla.example.", 257, dns.ECDSAP256SHA256, 256},
+	} {
+		key := &dns.DNSKEY{
+			Hdr: dns.RR_Header{
+				Name: spec.owner, Rrtype: dns.TypeDNSKEY,
+				Class: dns.ClassINET, Ttl: 3600,
+			},
+			Flags: spec.flags, Protocol: 3, Algorithm: spec.algorithm,
+		}
+		if _, err := key.Generate(spec.bits); err != nil {
+			tb.Fatalf("generate %s/%d: %v", spec.owner, spec.algorithm, err)
+		}
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+// TestDSDigestMatchesLibrary is the contract that lets the digest be compared
+// without building a DS record: for every key, algorithm and digest type, it
+// must accept exactly the digest dns.DNSKEY.ToDS produces and nothing else.
+func TestDSDigestMatchesLibrary(t *testing.T) {
+	digestTypes := []uint8{dns.SHA1, dns.SHA256, dns.SHA384, dns.SHA512}
+	keys := dsDigestTestKeys(t)
+
+	for _, key := range keys {
+		for _, digestType := range digestTypes {
+			reference := key.ToDS(digestType)
+			if reference == nil {
+				t.Fatalf("%s alg %d digest %d: library produced no DS",
+					key.Hdr.Name, key.Algorithm, digestType)
+			}
+			want, err := hex.DecodeString(reference.Digest)
+			if err != nil {
+				t.Fatalf("library digest is not hexadecimal: %v", err)
+			}
+
+			if !dsDigestMatches(key, digestType, want) {
+				t.Fatalf("%s alg %d digest %d: rejected the library's own digest",
+					key.Hdr.Name, key.Algorithm, digestType)
+			}
+
+			// A digest that differs anywhere must be refused.
+			flipped := append([]byte(nil), want...)
+			flipped[len(flipped)-1] ^= 0x01
+			if dsDigestMatches(key, digestType, flipped) {
+				t.Fatalf("%s alg %d digest %d: accepted an altered digest",
+					key.Hdr.Name, key.Algorithm, digestType)
+			}
+			if dsDigestMatches(key, digestType, want[:len(want)-1]) {
+				t.Fatal("accepted a truncated digest")
+			}
+
+			// Another key's digest must not match this one.
+			for _, other := range keys {
+				if other == key {
+					continue
+				}
+				otherDS := other.ToDS(digestType)
+				otherDigest, err := hex.DecodeString(otherDS.Digest)
+				if err != nil {
+					t.Fatalf("library digest is not hexadecimal: %v", err)
+				}
+				if dsDigestMatches(key, digestType, otherDigest) {
+					t.Fatalf("%s accepted the digest of %s",
+						key.Hdr.Name, other.Hdr.Name)
+				}
+			}
+		}
+	}
+}
+
+// TestDSDigestRejectsWhatTheLibraryRejects pins the refusals: an unsupported
+// digest type, and key material that is not decodable.
+func TestDSDigestRejectsWhatTheLibraryRejects(t *testing.T) {
+	key := dsDigestTestKeys(t)[0]
+	reference := key.ToDS(dns.SHA256)
+	want, err := hex.DecodeString(reference.Digest)
+	if err != nil {
+		t.Fatalf("library digest is not hexadecimal: %v", err)
+	}
+
+	// Reserved, GOST (which the library declines to compute), and a code no
+	// registry assigns. SHA-512 is 5 and is supported, so it is not here.
+	for _, digestType := range []uint8{0, dns.GOST94, 200} {
+		if key.ToDS(digestType) != nil {
+			t.Fatalf("fixture is wrong: the library accepts digest type %d",
+				digestType)
+		}
+		if dsDigestMatches(key, digestType, want) {
+			t.Fatalf("accepted unsupported digest type %d", digestType)
+		}
+	}
+
+	broken := *key
+	broken.PublicKey = "not base64!!"
+	if dsDigestMatches(&broken, dns.SHA256, want) {
+		t.Fatal("accepted a key whose material does not decode")
+	}
+
+	if dsDigestMatches(nil, dns.SHA256, want) {
+		t.Fatal("accepted a missing key")
+	}
+	if dsDigestMatches(key, dns.SHA256, nil) {
+		t.Fatal("accepted a missing digest")
+	}
+}
+
+// TestDSDigestNameFolding pins that the owner name is canonicalized the way
+// the library canonicalizes it: the digest is over the lowercased name, so a
+// parent publishing either spelling must match.
+func TestDSDigestNameFolding(t *testing.T) {
+	key := dsDigestTestKeys(t)[0]
+	reference := key.ToDS(dns.SHA256)
+	want, err := hex.DecodeString(reference.Digest)
+	if err != nil {
+		t.Fatalf("library digest is not hexadecimal: %v", err)
+	}
+
+	shouted := *key
+	shouted.Hdr.Name = strings.ToUpper(key.Hdr.Name)
+	if !dsDigestMatches(&shouted, dns.SHA256, want) {
+		t.Fatal("the owner name was not folded before hashing")
+	}
+}
+
+func BenchmarkDSDigestMatches(b *testing.B) {
+	key := dsDigestTestKeys(b)[0]
+	want, err := hex.DecodeString(key.ToDS(dns.SHA256).Digest)
+	if err != nil {
+		b.Fatalf("library digest is not hexadecimal: %v", err)
+	}
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if !dsDigestMatches(key, dns.SHA256, want) {
+			b.Fatal("digest did not match")
+		}
+	}
+}
+
+func BenchmarkDSDigestViaToDS(b *testing.B) {
+	key := dsDigestTestKeys(b)[0]
+	want := key.ToDS(dns.SHA256).Digest
+
+	b.ReportAllocs()
+	for b.Loop() {
+		ds := key.ToDS(dns.SHA256)
+		if ds == nil || !strings.EqualFold(ds.Digest, want) {
+			b.Fatal("digest did not match")
+		}
+	}
+}

--- a/middleware/resolver/dnssec/rsa.go
+++ b/middleware/resolver/dnssec/rsa.go
@@ -215,6 +215,34 @@ func rrsigSignedData(sig *dns.RRSIG, rrset []dns.RR) ([]byte, error) {
 	return append(buf, wire...), nil
 }
 
+// wireRdataOffset returns where a packed record's RDATA begins: past the
+// owner name, and past the ten octets of type, class, TTL and RDLENGTH that
+// follow it. The name is walked rather than unpacked — nothing here needs the
+// name itself, only its length, and these records were packed without
+// compression so the labels run to a terminating zero.
+func wireRdataOffset(wire []byte) (int, bool) {
+	off := 0
+	for {
+		if off >= len(wire) {
+			return 0, false
+		}
+		length := int(wire[off])
+		off++
+		if length == 0 {
+			break
+		}
+		if length > 63 || off+length > len(wire) {
+			return 0, false
+		}
+		off += length
+	}
+	const fixedHeader = 10 // type, class, TTL, RDLENGTH
+	if off+fixedHeader > len(wire) {
+		return 0, false
+	}
+	return off + fixedHeader, true
+}
+
 // canonicalRRset returns the concatenated canonical wire form of rrset as
 // required for signing/verification: each RR copied with its TTL set to the
 // RRSIG's original TTL, wildcard owners restored, owner and (where RFC 4034
@@ -241,8 +269,27 @@ func canonicalRRset(rrset []dns.RR, s *dns.RRSIG) ([]byte, error) {
 		wires[i] = wire[:n]
 	}
 
+	// RFC 4034 §6.3 orders an RRset by RDATA and by nothing before it. Every
+	// record here shares an owner, type and class, but RDLENGTH sits between
+	// them and the data — so comparing whole records sorts by length first,
+	// and a set whose lengths and contents disagree hashes in an order the
+	// signer never used.
+	//
+	// One offset serves the whole set: the records share an owner name, and
+	// canonicalization has already given them the same spelling of it. It is
+	// found by walking the label lengths, which costs nothing — unpacking the
+	// name would build a string per record to measure it.
+	rdataOffset, ok := wireRdataOffset(wires[0])
+	if !ok {
+		return nil, ErrMissingSigned
+	}
+	for _, wire := range wires {
+		if len(wire) < rdataOffset {
+			return nil, ErrMissingSigned
+		}
+	}
 	sort.Slice(wires, func(i, j int) bool {
-		return bytes.Compare(wires[i], wires[j]) < 0
+		return bytes.Compare(wires[i][rdataOffset:], wires[j][rdataOffset:]) < 0
 	})
 
 	var buf []byte

--- a/middleware/resolver/dnssec/rsa.go
+++ b/middleware/resolver/dnssec/rsa.go
@@ -144,66 +144,6 @@ func rsaHash(alg uint8) (hash.Hash, []byte, bool) {
 	return nil, nil, false
 }
 
-// verifyRSAWideExponent performs the RFC 4034 §3.1.8.1 RSA signature check
-// for keys whose exponent crypto/rsa refuses to load. It reproduces miekg's
-// canonical signed-data construction exactly (so it agrees with sig.Verify
-// for every key the library can handle) and then does the modular
-// exponentiation itself with math/big, bypassing the standard library's
-// exponent ceiling. Returns nil on a valid signature.
-func verifyRSAWideExponent(k *dns.DNSKEY, sig *dns.RRSIG, rrset []dns.RR) error {
-	// Mirror miekg/dns RRSIG.Verify's preflight so this path is never more
-	// permissive than the library it stands in for: bind the signature to
-	// this exact key (RFC 4034 §3.1) and RRset (RFC 4035 §5.3.1) before
-	// trusting any cryptographic result.
-	if !dns.IsRRset(rrset) {
-		return ErrMissingSigned
-	}
-	if k.Protocol != 3 || k.Flags&dns.ZONE == 0 {
-		return ErrMissingDNSKEY
-	}
-	if sig.KeyTag != k.KeyTag() || sig.Algorithm != k.Algorithm || sig.Hdr.Class != k.Hdr.Class {
-		return ErrMissingDNSKEY
-	}
-	if !strings.EqualFold(sig.SignerName, k.Hdr.Name) {
-		return ErrMissingDNSKEY
-	}
-	signer := dns.CanonicalName(sig.SignerName)
-	h0 := rrset[0].Header()
-	if h0.Class != sig.Hdr.Class || h0.Rrtype != sig.TypeCovered ||
-		dns.CountLabel(h0.Name) < int(sig.Labels) ||
-		!strings.EqualFold(h0.Name, sig.Hdr.Name) ||
-		!strings.HasSuffix(dns.CanonicalName(h0.Name), signer) {
-		return ErrMissingSigned
-	}
-
-	n, e, ok := parseRSAPublicKey(k.PublicKey)
-	if !ok {
-		return ErrMissingDNSKEY
-	}
-	if !usableRSAKey(n, e) {
-		return ErrMissingDNSKEY
-	}
-
-	h, prefix, ok := rsaHash(sig.Algorithm)
-	if !ok {
-		return ErrMissingDNSKEY
-	}
-
-	signed, err := rrsigSignedData(sig, rrset)
-	if err != nil {
-		return err
-	}
-	h.Write(signed)
-	hashed := h.Sum(nil)
-
-	sigbuf, err := fromBase64([]byte(sig.Signature))
-	if err != nil {
-		return ErrMissingSigned
-	}
-
-	return rsaVerifyPKCS1v15(n, e, prefix, hashed, sigbuf)
-}
-
 // rsaVerifyPKCS1v15 verifies a PKCS#1 v1.5 signature by raw modular
 // exponentiation (m = sig^e mod n) and a constant-time comparison against
 // the expected EMSA-PKCS1-v1_5 encoding of hashed.

--- a/middleware/resolver/dnssec/rsa_test.go
+++ b/middleware/resolver/dnssec/rsa_test.go
@@ -290,4 +290,16 @@ func TestVerifyRSAWideExponent_LiveLatviaTLD(t *testing.T) {
 	if err := verifySignature(ksk, sig, []dns.RR{zsk, ksk}); err != nil {
 		t.Fatalf(".lv DNSKEY RRset failed to validate via wide-exponent KSK: %v", err)
 	}
+
+	// Accepting the real RRset proves the modular exponentiation runs; it
+	// does not prove the result is being checked. An RRset the signature
+	// does not cover has to fail on the same path.
+	if err := verifySignature(ksk, sig, []dns.RR{zsk}); err == nil {
+		t.Fatal(".lv KSK accepted a signature over an RRset it does not cover")
+	}
+	tampered := dns.Copy(ksk).(*dns.DNSKEY)
+	tampered.Flags = 256
+	if err := verifySignature(ksk, sig, []dns.RR{zsk, tampered}); err == nil {
+		t.Fatal(".lv KSK accepted a signature over an altered DNSKEY RRset")
+	}
 }

--- a/middleware/resolver/dnssec/rsa_test.go
+++ b/middleware/resolver/dnssec/rsa_test.go
@@ -51,8 +51,8 @@ func TestVerifyRSAWideExponent_LiveMailbox(t *testing.T) {
 			if !rsaExponentExceedsStdlib(key.PublicKey) {
 				t.Fatal("expected exponent to exceed stdlib ceiling")
 			}
-			if err := verifyRSAWideExponent(key, sig, []dns.RR{a}); err != nil {
-				t.Fatalf("verifyRSAWideExponent: %v", err)
+			if err := verifySignature(key, sig, []dns.RR{a}); err != nil {
+				t.Fatalf("verifySignature: %v", err)
 			}
 		})
 	}
@@ -64,7 +64,7 @@ func TestVerifyRSAWideExponent_TamperedSignature(t *testing.T) {
 
 	// Flip the answer so the signature no longer covers it.
 	bad := mustRR(t, "mailbox.org.\t103\tIN\tA\t185.97.174.36")
-	if err := verifyRSAWideExponent(key, sig, []dns.RR{bad}); err == nil {
+	if err := verifySignature(key, sig, []dns.RR{bad}); err == nil {
 		t.Fatal("expected verification failure for tampered RRset")
 	}
 }
@@ -109,14 +109,14 @@ func TestVerifyRSAWideExponent_MatchesMiekg(t *testing.T) {
 				t.Fatalf("miekg Verify rejected its own signature: %v", err)
 			}
 			// Cross-check: our raw path agrees byte-for-byte.
-			if err := verifyRSAWideExponent(key, sig, rrset); err != nil {
+			if err := verifySignature(key, sig, rrset); err != nil {
 				t.Fatalf("verifyRSAWideExponent disagreed with miekg: %v", err)
 			}
 
 			// Altered RDATA must fail.
 			tampered := append([]dns.RR(nil), rrset...)
 			tampered[0] = mustRR(t, "MX.Example.org.\t300\tIN\tMX\t20 Evil.Example.Org.")
-			if err := verifyRSAWideExponent(key, sig, tampered); err == nil {
+			if err := verifySignature(key, sig, tampered); err == nil {
 				t.Fatal("expected failure for tampered RRset")
 			}
 		})
@@ -215,7 +215,7 @@ func TestVerifyRSAWideExponent_NonCanonicalModulus(t *testing.T) {
 	if key.KeyTag() != sig.KeyTag {
 		t.Fatalf("zero padding changed key tag to %d; test premise invalid", key.KeyTag())
 	}
-	if err := verifyRSAWideExponent(key, sig, []dns.RR{a}); err == nil {
+	if err := verifySignature(key, sig, []dns.RR{a}); err == nil {
 		t.Fatal("expected non-canonical modulus to be rejected")
 	}
 }
@@ -229,7 +229,7 @@ func TestVerifyRSAWideExponent_Preflight(t *testing.T) {
 
 	mismatched := mustRR(t, mboxZSK7).(*dns.DNSKEY)
 	mismatched.Algorithm = dns.RSASHA1 // alg 5: same hash family, but != sig alg 7
-	if err := verifyRSAWideExponent(mismatched, sig, []dns.RR{a}); err == nil {
+	if err := verifySignature(mismatched, sig, []dns.RR{a}); err == nil {
 		t.Fatal("expected rejection on algorithm/key-tag mismatch")
 	}
 }
@@ -287,7 +287,7 @@ func TestVerifyRSAWideExponent_LiveLatviaTLD(t *testing.T) {
 		t.Fatalf("unexpected .lv KSK: tag=%d wide=%v", ksk.KeyTag(), rsaExponentExceedsStdlib(ksk.PublicKey))
 	}
 	// The DS-pinned KSK must validate the apex DNSKEY RRset (alg 8).
-	if err := verifyRSAWideExponent(ksk, sig, []dns.RR{zsk, ksk}); err != nil {
+	if err := verifySignature(ksk, sig, []dns.RR{zsk, ksk}); err != nil {
 		t.Fatalf(".lv DNSKEY RRset failed to validate via wide-exponent KSK: %v", err)
 	}
 }

--- a/middleware/resolver/dnssec/signature.go
+++ b/middleware/resolver/dnssec/signature.go
@@ -67,9 +67,13 @@ func verifySignature(k *dns.DNSKEY, sig *dns.RRSIG, rrset []dns.RR) error {
 	if err != nil {
 		return err
 	}
+	// A signature that does not decode, or does not have the shape its
+	// algorithm requires, is a bad signature — the key it names is present
+	// and fine. The distinction is wire-visible: it decides which EDE the
+	// client is told.
 	signature, err := fromBase64([]byte(sig.Signature))
 	if err != nil {
-		return ErrMissingSigned
+		return dns.ErrSig
 	}
 
 	switch sig.Algorithm {
@@ -141,8 +145,11 @@ func verifyECDSASignature(k *dns.DNSKEY, algorithm uint8, signed, signature []by
 		return ErrMissingDNSKEY
 	}
 	size := (curve.Params().BitSize + 7) / 8
-	if len(public) != 2*size || len(signature) != 2*size {
+	if len(public) != 2*size {
 		return ErrMissingDNSKEY
+	}
+	if len(signature) != 2*size {
+		return dns.ErrSig
 	}
 
 	x := new(big.Int).SetBytes(public[:size])
@@ -161,9 +168,11 @@ func verifyECDSASignature(k *dns.DNSKEY, algorithm uint8, signed, signature []by
 func verifyEd25519Signature(k *dns.DNSKEY, signed, signature []byte) error {
 	// RFC 8080 §2: Ed25519 signs the message itself, not a digest of it.
 	public, err := fromBase64([]byte(k.PublicKey))
-	if err != nil || len(public) != ed25519.PublicKeySize ||
-		len(signature) != ed25519.SignatureSize {
+	if err != nil || len(public) != ed25519.PublicKeySize {
 		return ErrMissingDNSKEY
+	}
+	if len(signature) != ed25519.SignatureSize {
+		return dns.ErrSig
 	}
 	if !ed25519.Verify(ed25519.PublicKey(public), signed, signature) {
 		return dns.ErrSig

--- a/middleware/resolver/dnssec/signature.go
+++ b/middleware/resolver/dnssec/signature.go
@@ -73,11 +73,13 @@ func signatureBinding(k *dns.DNSKEY, sig *dns.RRSIG, rrset []dns.RR) error {
 //     gives them. The library splits whatever it is handed in half and lets
 //     leading zeros pass; a 66-octet P-256 signature is not a P-256
 //     signature, and is refused here.
-//   - An RSA key below crypto/rsa's minimum modulus. The library's path and
-//     this one both refuse it, but this one accepts it under
-//     GODEBUG=rsa1024min=0 only for the wide exponents that take the raw
-//     modular exponentiation, which the standard library's minimum does not
-//     govern.
+//   - An RSA modulus outside usableRSAKey's bounds. Below 1024 bits both
+//     refuse by default, but the library's floor is crypto/rsa's and lifts
+//     under GODEBUG=rsa1024min=0, while this one is the package's own and
+//     does not; above 4096 bits the library has no bound and this one
+//     refuses. Both directions narrow what is accepted, and the wide-exponent
+//     path is gated by the same bounds before it reaches the raw modular
+//     exponentiation that bypasses crypto/rsa.
 //
 // An algorithm this does not implement is refused rather than guessed at;
 // cryptoVerify keeps such keys on the library's path.

--- a/middleware/resolver/dnssec/signature.go
+++ b/middleware/resolver/dnssec/signature.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/dnsutil"
 )
 
 // signatureBinding is the preflight every RRSIG check shares: the signature
@@ -20,7 +21,8 @@ import (
 // 4035 §5.3.1) before any cryptographic result means anything.
 //
 // It mirrors miekg/dns RRSIG.Verify's own preflight, so this package is never
-// more permissive than the library it stands in for.
+// more permissive than the library it stands in for, and is stricter in the
+// one place noted below.
 func signatureBinding(k *dns.DNSKEY, sig *dns.RRSIG, rrset []dns.RR) error {
 	if k == nil || sig == nil || !dns.IsRRset(rrset) {
 		return ErrMissingSigned
@@ -41,7 +43,15 @@ func signatureBinding(k *dns.DNSKEY, sig *dns.RRSIG, rrset []dns.RR) error {
 	if h0.Class != sig.Hdr.Class || h0.Rrtype != sig.TypeCovered ||
 		dns.CountLabel(h0.Name) < int(sig.Labels) ||
 		!strings.EqualFold(h0.Name, sig.Hdr.Name) ||
-		!strings.HasSuffix(dns.CanonicalName(h0.Name), signer) {
+		// On a label boundary, not a string suffix. RFC 4035 §5.3.1 requires
+		// the signer to name the zone containing the RRset, and a plain
+		// suffix test reads evilexample.com. as inside example.com. The
+		// library settles for the suffix — its own comment calls that the
+		// best it can do without SOA context — and the resolver's zone
+		// containment check catches it a layer up, but a check that means
+		// something only in the presence of another one is worth fixing
+		// where it is written.
+		!dnsutil.NameInZone(dns.CanonicalName(h0.Name), signer) {
 		return ErrMissingSigned
 	}
 	return nil
@@ -50,11 +60,24 @@ func signatureBinding(k *dns.DNSKEY, sig *dns.RRSIG, rrset []dns.RR) error {
 // verifySignature checks an RRSIG against a DNSKEY, returning nil when the
 // signature is valid.
 //
-// The canonical signed data is this package's own — the same construction
-// verifyRSAWideExponent has always used — and the cryptography is the
+// The canonical signed data is this package's own — the construction the
+// wide-exponent RSA path has always used — and the cryptography is the
 // standard library's. What it avoids is the library's fixed 4096-octet
 // signed-data buffer, allocated for every signature of every response, and
 // re-deriving the key material and key tag on each one.
+//
+// It agrees with dns.RRSIG.Verify on the signatures a signer produces, and
+// deliberately differs on two inputs no signer produces:
+//
+//   - An ECDSA signature whose r and s are not the fixed width RFC 6605 §4
+//     gives them. The library splits whatever it is handed in half and lets
+//     leading zeros pass; a 66-octet P-256 signature is not a P-256
+//     signature, and is refused here.
+//   - An RSA key below crypto/rsa's minimum modulus. The library's path and
+//     this one both refuse it, but this one accepts it under
+//     GODEBUG=rsa1024min=0 only for the wide exponents that take the raw
+//     modular exponentiation, which the standard library's minimum does not
+//     govern.
 //
 // An algorithm this does not implement is refused rather than guessed at;
 // cryptoVerify keeps such keys on the library's path.

--- a/middleware/resolver/dnssec/signature.go
+++ b/middleware/resolver/dnssec/signature.go
@@ -1,0 +1,199 @@
+package dnssec
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/sha512"
+	"hash"
+	"math/big"
+	"strings"
+
+	"github.com/miekg/dns"
+)
+
+// signatureBinding is the preflight every RRSIG check shares: the signature
+// must belong to this exact key (RFC 4034 §3.1) and to this exact RRset (RFC
+// 4035 §5.3.1) before any cryptographic result means anything.
+//
+// It mirrors miekg/dns RRSIG.Verify's own preflight, so this package is never
+// more permissive than the library it stands in for.
+func signatureBinding(k *dns.DNSKEY, sig *dns.RRSIG, rrset []dns.RR) error {
+	if k == nil || sig == nil || !dns.IsRRset(rrset) {
+		return ErrMissingSigned
+	}
+	if k.Protocol != 3 || k.Flags&dns.ZONE == 0 {
+		return ErrMissingDNSKEY
+	}
+	if sig.KeyTag != k.KeyTag() || sig.Algorithm != k.Algorithm ||
+		sig.Hdr.Class != k.Hdr.Class {
+		return ErrMissingDNSKEY
+	}
+	if !strings.EqualFold(sig.SignerName, k.Hdr.Name) {
+		return ErrMissingDNSKEY
+	}
+
+	signer := dns.CanonicalName(sig.SignerName)
+	h0 := rrset[0].Header()
+	if h0.Class != sig.Hdr.Class || h0.Rrtype != sig.TypeCovered ||
+		dns.CountLabel(h0.Name) < int(sig.Labels) ||
+		!strings.EqualFold(h0.Name, sig.Hdr.Name) ||
+		!strings.HasSuffix(dns.CanonicalName(h0.Name), signer) {
+		return ErrMissingSigned
+	}
+	return nil
+}
+
+// verifySignature checks an RRSIG against a DNSKEY, returning nil when the
+// signature is valid.
+//
+// The canonical signed data is this package's own — the same construction
+// verifyRSAWideExponent has always used — and the cryptography is the
+// standard library's. What it avoids is the library's fixed 4096-octet
+// signed-data buffer, allocated for every signature of every response, and
+// re-deriving the key material and key tag on each one.
+//
+// An algorithm this does not implement is refused rather than guessed at;
+// cryptoVerify keeps such keys on the library's path.
+func verifySignature(k *dns.DNSKEY, sig *dns.RRSIG, rrset []dns.RR) error {
+	if err := signatureBinding(k, sig, rrset); err != nil {
+		return err
+	}
+
+	signed, err := rrsigSignedData(sig, rrset)
+	if err != nil {
+		return err
+	}
+	signature, err := fromBase64([]byte(sig.Signature))
+	if err != nil {
+		return ErrMissingSigned
+	}
+
+	switch sig.Algorithm {
+	case dns.RSASHA1, dns.RSASHA1NSEC3SHA1, dns.RSASHA256, dns.RSASHA512:
+		return verifyRSASignature(k, sig.Algorithm, signed, signature)
+	case dns.ECDSAP256SHA256, dns.ECDSAP384SHA384:
+		return verifyECDSASignature(k, sig.Algorithm, signed, signature)
+	case dns.ED25519:
+		return verifyEd25519Signature(k, signed, signature)
+	default:
+		return ErrMissingDNSKEY
+	}
+}
+
+// verifySignatureSupported reports whether verifySignature implements the
+// algorithm, so the dispatcher can leave anything else where it was.
+func verifySignatureSupported(algorithm uint8) bool {
+	switch algorithm {
+	case dns.RSASHA1, dns.RSASHA1NSEC3SHA1, dns.RSASHA256, dns.RSASHA512,
+		dns.ECDSAP256SHA256, dns.ECDSAP384SHA384, dns.ED25519:
+		return true
+	}
+	return false
+}
+
+func verifyRSASignature(k *dns.DNSKEY, algorithm uint8, signed, signature []byte) error {
+	n, e, ok := parseRSAPublicKey(k.PublicKey)
+	if !ok {
+		return ErrMissingDNSKEY
+	}
+	if !usableRSAKey(n, e) {
+		return ErrMissingDNSKEY
+	}
+
+	hasher, prefix, ok := rsaHash(algorithm)
+	if !ok {
+		return ErrMissingDNSKEY
+	}
+	hasher.Write(signed)
+	hashed := hasher.Sum(nil)
+
+	// An exponent crypto/rsa refuses to load still has to be checked, which
+	// is what the raw modular exponentiation below is for; every other key
+	// takes the standard library's own verification.
+	if e.BitLen() <= 31 {
+		public := &rsa.PublicKey{N: n, E: int(e.Int64())}
+		cryptoHash, ok := rsaCryptoHash(algorithm)
+		if !ok {
+			return ErrMissingDNSKEY
+		}
+		if err := rsa.VerifyPKCS1v15(public, cryptoHash, hashed, signature); err != nil {
+			return dns.ErrSig
+		}
+		return nil
+	}
+	return rsaVerifyPKCS1v15(n, e, prefix, hashed, signature)
+}
+
+func verifyECDSASignature(k *dns.DNSKEY, algorithm uint8, signed, signature []byte) error {
+	curve, hasher, ok := ecdsaParameters(algorithm)
+	if !ok {
+		return ErrMissingDNSKEY
+	}
+
+	// RFC 6605 §4: the key is the two coordinates, the signature is r and s,
+	// each of them a fixed-width unsigned integer for the curve.
+	public, err := fromBase64([]byte(k.PublicKey))
+	if err != nil {
+		return ErrMissingDNSKEY
+	}
+	size := (curve.Params().BitSize + 7) / 8
+	if len(public) != 2*size || len(signature) != 2*size {
+		return ErrMissingDNSKEY
+	}
+
+	x := new(big.Int).SetBytes(public[:size])
+	y := new(big.Int).SetBytes(public[size:])
+	hasher.Write(signed)
+	hashed := hasher.Sum(nil)
+
+	r := new(big.Int).SetBytes(signature[:size])
+	s := new(big.Int).SetBytes(signature[size:])
+	if !ecdsa.Verify(&ecdsa.PublicKey{Curve: curve, X: x, Y: y}, hashed, r, s) {
+		return dns.ErrSig
+	}
+	return nil
+}
+
+func verifyEd25519Signature(k *dns.DNSKEY, signed, signature []byte) error {
+	// RFC 8080 §2: Ed25519 signs the message itself, not a digest of it.
+	public, err := fromBase64([]byte(k.PublicKey))
+	if err != nil || len(public) != ed25519.PublicKeySize ||
+		len(signature) != ed25519.SignatureSize {
+		return ErrMissingDNSKEY
+	}
+	if !ed25519.Verify(ed25519.PublicKey(public), signed, signature) {
+		return dns.ErrSig
+	}
+	return nil
+}
+
+// ecdsaParameters returns the curve and digest RFC 6605 pairs with an
+// algorithm. The pairing is fixed by the RFC: a mismatch is not a variant to
+// support but a signature to refuse.
+func ecdsaParameters(algorithm uint8) (elliptic.Curve, hash.Hash, bool) {
+	switch algorithm {
+	case dns.ECDSAP256SHA256:
+		return elliptic.P256(), sha256.New(), true
+	case dns.ECDSAP384SHA384:
+		return elliptic.P384(), sha512.New384(), true
+	}
+	return nil, nil, false
+}
+
+// rsaCryptoHash is rsaHash's digest identity, which crypto/rsa needs to
+// rebuild the PKCS#1 v1.5 prefix itself.
+func rsaCryptoHash(algorithm uint8) (crypto.Hash, bool) {
+	switch algorithm {
+	case dns.RSASHA1, dns.RSASHA1NSEC3SHA1:
+		return crypto.SHA1, true
+	case dns.RSASHA256:
+		return crypto.SHA256, true
+	case dns.RSASHA512:
+		return crypto.SHA512, true
+	}
+	return 0, false
+}

--- a/middleware/resolver/dnssec/signature_test.go
+++ b/middleware/resolver/dnssec/signature_test.go
@@ -83,10 +83,97 @@ func mustSignatureRR(tb testing.TB, s string) dns.RR {
 	return rr
 }
 
+// TestVerifySignatureRefusesLooseECDSALength documents the one place this
+// package is deliberately stricter than the library.
+//
+// RFC 6605 §4 fixes r and s at the curve's width. The library splits whatever
+// it is handed in half and lets a zero-padded 66-octet P-256 signature
+// through; that is not a P-256 signature, and no signer emits one. Refusing
+// it narrows what this resolver accepts, which is the safe direction — but it
+// is a divergence, so it is written down rather than left to be discovered.
+func TestVerifySignatureRefusesLooseECDSALength(t *testing.T) {
+	var fixture signatureFixture
+	for _, candidate := range signatureFixtures(t) {
+		if candidate.name == "ECDSAP256SHA256" {
+			fixture = candidate
+			break
+		}
+	}
+	if fixture.key == nil {
+		t.Fatal("no ECDSA fixture")
+	}
+
+	raw, err := base64.StdEncoding.DecodeString(fixture.sig.Signature)
+	if err != nil {
+		t.Fatalf("signature is not base64: %v", err)
+	}
+	// One leading zero octet on each of r and s: the same integers, a width
+	// the RFC does not give them.
+	half := len(raw) / 2
+	padded := make([]byte, 0, len(raw)+2)
+	padded = append(padded, 0)
+	padded = append(padded, raw[:half]...)
+	padded = append(padded, 0)
+	padded = append(padded, raw[half:]...)
+
+	loose := *fixture.sig
+	loose.Signature = base64.StdEncoding.EncodeToString(padded)
+
+	if err := loose.Verify(fixture.key, fixture.rrset); err != nil {
+		t.Skipf("the library no longer accepts a padded ECDSA signature (%v); "+
+			"this divergence has closed on its own", err)
+	}
+	if err := verifySignature(fixture.key, &loose, fixture.rrset); err == nil {
+		t.Fatal("accepted an ECDSA signature whose r and s are not the " +
+			"curve's width")
+	}
+}
+
+// TestSignatureBindingRequiresALabelBoundary pins the second place this
+// package is stricter than the library.
+//
+// RFC 4035 §5.3.1 requires the signer name to be the zone containing the
+// RRset. The library tests that with a plain string suffix — its own comment
+// concedes that is the best it can do without SOA context — which reads
+// evilexample.com. as inside example.com. The resolver enforces real zone
+// containment a layer up, so nothing reaches this on that path, but a
+// primitive whose check only means something because of its caller is one
+// refactor away from meaning nothing.
+func TestSignatureBindingRequiresALabelBoundary(t *testing.T) {
+	fixture := signatureFixtures(t)[0]
+
+	// Same string suffix as the signer, different zone.
+	impostor := []dns.RR{
+		mustSignatureRR(t, "www.evilexample.com. 300 IN A 192.0.2.10"),
+	}
+	sig := *fixture.sig
+	sig.Hdr.Name = "www.evilexample.com."
+
+	if err := signatureBinding(fixture.key, &sig, impostor); err == nil {
+		t.Fatal("bound a signature signed by example.com. to an RRset in " +
+			"evilexample.com.")
+	}
+
+	// The apex itself, and a name genuinely below it, must still bind.
+	for _, owner := range []string{"example.com.", "deep.www.example.com."} {
+		rrset := []dns.RR{
+			mustSignatureRR(t, owner+" 300 IN A 192.0.2.10"),
+		}
+		inZone := *fixture.sig
+		inZone.Hdr.Name = owner
+		inZone.Labels = uint8(dns.CountLabel(owner)) //nolint:gosec // test names are short
+		if err := signatureBinding(fixture.key, &inZone, rrset); err != nil {
+			t.Fatalf("refused %s, which is in the signer's zone: %v", owner, err)
+		}
+	}
+}
+
 // TestVerifySignatureAgreesWithLibrary is the contract that lets this package
-// verify signatures itself: for every input, valid or not, it must reach the
-// same verdict as dns.RRSIG.Verify. Anything else is either a signature the
-// library would have rejected being accepted here, or the reverse.
+// verify signatures itself: for the signatures a signer produces, and for
+// inputs corrupted in the ways a resolver actually meets, it must reach the
+// same verdict as dns.RRSIG.Verify. The two documented divergences — a
+// malformed ECDSA length, and crypto/rsa's modulus minimum under a GODEBUG —
+// are covered separately; everything here must agree.
 func TestVerifySignatureAgreesWithLibrary(t *testing.T) {
 	for _, fixture := range signatureFixtures(t) {
 		t.Run(fixture.name, func(t *testing.T) {

--- a/middleware/resolver/dnssec/signature_test.go
+++ b/middleware/resolver/dnssec/signature_test.go
@@ -168,6 +168,63 @@ func TestSignatureBindingRequiresALabelBoundary(t *testing.T) {
 	}
 }
 
+// Test_VerifyRRSIG_EscapedDotIsNotALabelBoundary is the production-path
+// regression for the same defect one level up.
+//
+// `foo\.zone.example.` is a single label `foo.zone` under `example.` — it
+// ends with the *text* of the signer zone while living outside it. Signed
+// with the zone's own valid key, a containment check written as a string
+// suffix authenticates it: a zone operator would be able to sign answers for
+// owners no delegation ever gave them.
+func Test_VerifyRRSIG_EscapedDotIsNotALabelBoundary(t *testing.T) {
+	signerZone := "zone.example."
+	key, priv := makeZoneKey(t, signerZone)
+	keys := map[uint16][]*dns.DNSKEY{key.KeyTag(): {key}}
+
+	impostor := &dns.A{
+		Hdr: dns.RR_Header{
+			Name: `foo\.zone.example.`, Rrtype: dns.TypeA,
+			Class: dns.ClassINET, Ttl: 300,
+		},
+		A: []byte{192, 0, 2, 66},
+	}
+	sig := signRRSet(t, key, priv, []dns.RR{impostor})
+
+	msg := new(dns.Msg)
+	msg.SetQuestion(`foo\.zone.example.`, dns.TypeA)
+	msg.Answer = []dns.RR{impostor, sig}
+
+	if ok, err := VerifyRRSIG(signerZone, keys, msg); ok && err == nil {
+		t.Fatal("BUG REPRODUCED: an RRset whose owner is a single label " +
+			`containing a literal dot (foo\.zone.example.) authenticated ` +
+			"against the zone.example. key; the escaped dot was read as a " +
+			"label separator")
+	}
+
+	// The genuine descendant, spelled with a real separator, still validates:
+	// the fix must not cost the ordinary name.
+	genuine := &dns.A{
+		Hdr: dns.RR_Header{
+			Name: "foo.zone.example.", Rrtype: dns.TypeA,
+			Class: dns.ClassINET, Ttl: 300,
+		},
+		A: []byte{192, 0, 2, 67},
+	}
+	genuineSig := signRRSet(t, key, priv, []dns.RR{genuine})
+
+	valid := new(dns.Msg)
+	valid.SetQuestion("foo.zone.example.", dns.TypeA)
+	valid.Answer = []dns.RR{genuine, genuineSig}
+
+	ok, err := VerifyRRSIG(signerZone, keys, valid)
+	if err != nil {
+		t.Fatalf("a genuine in-zone RRset failed to validate: %v", err)
+	}
+	if !ok {
+		t.Fatal("a genuine in-zone RRset did not validate")
+	}
+}
+
 // TestVerifySignatureAgreesWithLibrary is the contract that lets this package
 // verify signatures itself: for the signatures a signer produces, and for
 // inputs corrupted in the ways a resolver actually meets, it must reach the

--- a/middleware/resolver/dnssec/signature_test.go
+++ b/middleware/resolver/dnssec/signature_test.go
@@ -1,0 +1,185 @@
+package dnssec
+
+import (
+	"crypto"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+type signatureFixture struct {
+	name  string
+	key   *dns.DNSKEY
+	sig   *dns.RRSIG
+	rrset []dns.RR
+}
+
+// signatureFixtures signs one RRset per algorithm this package verifies.
+func signatureFixtures(tb testing.TB) []signatureFixture {
+	tb.Helper()
+	inception := uint32(time.Now().Add(-time.Hour).Unix())      //nolint:gosec // test epoch fits
+	expiration := uint32(time.Now().Add(24 * time.Hour).Unix()) //nolint:gosec // test epoch fits
+
+	var fixtures []signatureFixture
+	for _, spec := range []struct {
+		name      string
+		algorithm uint8
+		bits      int
+	}{
+		{"RSASHA1", dns.RSASHA1, 1024},
+		{"RSASHA256", dns.RSASHA256, 1024},
+		{"RSASHA512", dns.RSASHA512, 1024},
+		{"ECDSAP256SHA256", dns.ECDSAP256SHA256, 256},
+		{"ECDSAP384SHA384", dns.ECDSAP384SHA384, 384},
+		{"ED25519", dns.ED25519, 256},
+	} {
+		key := &dns.DNSKEY{
+			Hdr: dns.RR_Header{
+				Name: "example.com.", Rrtype: dns.TypeDNSKEY,
+				Class: dns.ClassINET, Ttl: 3600,
+			},
+			Flags: 257, Protocol: 3, Algorithm: spec.algorithm,
+		}
+		private, err := key.Generate(spec.bits)
+		if err != nil {
+			tb.Fatalf("%s: generate: %v", spec.name, err)
+		}
+
+		rrset := []dns.RR{
+			mustSignatureRR(tb, "www.example.com. 300 IN A 192.0.2.10"),
+			mustSignatureRR(tb, "www.example.com. 300 IN A 192.0.2.11"),
+		}
+		sig := &dns.RRSIG{
+			Hdr: dns.RR_Header{
+				Name: "www.example.com.", Rrtype: dns.TypeRRSIG,
+				Class: dns.ClassINET, Ttl: 300,
+			},
+			TypeCovered: dns.TypeA, Algorithm: spec.algorithm, Labels: 3,
+			OrigTtl: 300, Expiration: expiration, Inception: inception,
+			KeyTag: key.KeyTag(), SignerName: key.Hdr.Name,
+		}
+		signer, ok := private.(crypto.Signer)
+		if !ok {
+			tb.Fatalf("%s: generated key does not sign", spec.name)
+		}
+		if err := sig.Sign(signer, rrset); err != nil {
+			tb.Fatalf("%s: sign: %v", spec.name, err)
+		}
+		fixtures = append(fixtures, signatureFixture{
+			name: spec.name, key: key, sig: sig, rrset: rrset,
+		})
+	}
+	return fixtures
+}
+
+func mustSignatureRR(tb testing.TB, s string) dns.RR {
+	tb.Helper()
+	rr, err := dns.NewRR(s)
+	if err != nil {
+		tb.Fatalf("NewRR(%q): %v", s, err)
+	}
+	return rr
+}
+
+// TestVerifySignatureAgreesWithLibrary is the contract that lets this package
+// verify signatures itself: for every input, valid or not, it must reach the
+// same verdict as dns.RRSIG.Verify. Anything else is either a signature the
+// library would have rejected being accepted here, or the reverse.
+func TestVerifySignatureAgreesWithLibrary(t *testing.T) {
+	for _, fixture := range signatureFixtures(t) {
+		t.Run(fixture.name, func(t *testing.T) {
+			assert := func(what string, key *dns.DNSKEY, sig *dns.RRSIG, rrset []dns.RR) {
+				t.Helper()
+				libraryOK := sig.Verify(key, rrset) == nil
+				ourOK := verifySignature(key, sig, rrset) == nil
+				if libraryOK != ourOK {
+					t.Fatalf("%s: library accepts=%v, we accept=%v",
+						what, libraryOK, ourOK)
+				}
+			}
+
+			assert("the signature as signed", fixture.key, fixture.sig, fixture.rrset)
+
+			// A signature altered in one octet.
+			tampered := *fixture.sig
+			raw, err := base64.StdEncoding.DecodeString(fixture.sig.Signature)
+			if err != nil {
+				t.Fatalf("signature is not base64: %v", err)
+			}
+			raw[len(raw)-1] ^= 0x01
+			tampered.Signature = base64.StdEncoding.EncodeToString(raw)
+			assert("an altered signature", fixture.key, &tampered, fixture.rrset)
+
+			// A record altered after signing.
+			altered := []dns.RR{dns.Copy(fixture.rrset[0]), fixture.rrset[1]}
+			altered[0].(*dns.A).A[3]++
+			assert("an altered RRset", fixture.key, fixture.sig, altered)
+
+			// A record removed from the set.
+			assert("a truncated RRset", fixture.key, fixture.sig, fixture.rrset[:1])
+
+			// Another key of the same algorithm.
+			other := &dns.DNSKEY{
+				Hdr:   fixture.key.Hdr,
+				Flags: 257, Protocol: 3, Algorithm: fixture.key.Algorithm,
+			}
+			if _, err := other.Generate(len(fixture.key.PublicKey) * 3); err == nil {
+				other.Hdr.Name = fixture.key.Hdr.Name
+				assert("another key", other, fixture.sig, fixture.rrset)
+			}
+
+			// Bindings the preflight is responsible for.
+			for _, tc := range []struct {
+				what   string
+				mutate func(*dns.DNSKEY, *dns.RRSIG)
+			}{
+				{"a key tag that does not match", func(_ *dns.DNSKEY, s *dns.RRSIG) {
+					s.KeyTag++
+				}},
+				{"a signer that is not the key's owner", func(_ *dns.DNSKEY, s *dns.RRSIG) {
+					s.SignerName = "other.example."
+				}},
+				{"a covered type that is not the RRset's", func(_ *dns.DNSKEY, s *dns.RRSIG) {
+					s.TypeCovered = dns.TypeAAAA
+				}},
+				{"a label count above the owner's", func(_ *dns.DNSKEY, s *dns.RRSIG) {
+					s.Labels = 9
+				}},
+				{"a key that is not a zone key", func(k *dns.DNSKEY, _ *dns.RRSIG) {
+					k.Flags &^= dns.ZONE
+				}},
+				{"a protocol that is not 3", func(k *dns.DNSKEY, _ *dns.RRSIG) {
+					k.Protocol = 2
+				}},
+			} {
+				key := *fixture.key
+				sig := *fixture.sig
+				tc.mutate(&key, &sig)
+				assert(tc.what, &key, &sig, fixture.rrset)
+			}
+		})
+	}
+}
+
+func BenchmarkVerifySignature(b *testing.B) {
+	for _, fixture := range signatureFixtures(b) {
+		b.Run(fixture.name+"/owned", func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if err := verifySignature(fixture.key, fixture.sig, fixture.rrset); err != nil {
+					b.Fatalf("verify: %v", err)
+				}
+			}
+		})
+		b.Run(fixture.name+"/library", func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if err := fixture.sig.Verify(fixture.key, fixture.rrset); err != nil {
+					b.Fatalf("verify: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/middleware/resolver/dnssec/verify.go
+++ b/middleware/resolver/dnssec/verify.go
@@ -764,17 +764,18 @@ func runSignatureVerification(
 	return cryptoVerify(key, sig, set)
 }
 
-// cryptoVerify runs the cryptographic RRSIG check for a single candidate
-// key. RSA keys whose public exponent exceeds crypto/rsa's ceiling (e.g.
-// mailbox.org's alg-7/alg-10 ZSKs, exponent 2^32+1) are verified by the
-// raw modexp path so they validate instead of bogusing out; every other
-// key takes miekg/dns' sig.Verify, which rejects malformed keys itself.
+// cryptoVerify runs the cryptographic RRSIG check for a single candidate key,
+// through this package's own verifier for the algorithms it implements and
+// the library's for anything else. The two agree by construction: the
+// canonical signed data is the same, and the cryptography is the standard
+// library's on both sides.
+//
+// Keys whose public exponent exceeds crypto/rsa's ceiling — mailbox.org's
+// alg-7/alg-10 ZSKs, exponent 2^32+1 — keep the raw modexp path inside that
+// verifier, so they validate instead of bogusing out.
 func cryptoVerify(k *dns.DNSKEY, sig *dns.RRSIG, set []dns.RR) error {
-	switch k.Algorithm {
-	case dns.RSASHA1, dns.RSASHA1NSEC3SHA1, dns.RSASHA256, dns.RSASHA512:
-		if rsaExponentExceedsStdlib(k.PublicKey) {
-			return verifyRSAWideExponent(k, sig, set)
-		}
+	if verifySignatureSupported(k.Algorithm) {
+		return verifySignature(k, sig, set)
 	}
 	return sig.Verify(k, set)
 }

--- a/middleware/resolver/dnssec/verify.go
+++ b/middleware/resolver/dnssec/verify.go
@@ -287,6 +287,17 @@ func usableDSCandidate(parentDS *dns.DS, key *dns.DNSKEY) bool {
 	if key == nil {
 		return false
 	}
+	// Ahead of KeyTag, which packs the key into a buffer of its own and
+	// decodes the material to fill it. A key too large to produce a DS can
+	// never match one, and a DS set may name the same key repeatedly: the
+	// cheap check has to come first or the expensive one runs per mention.
+	// Ahead of KeyTag, which packs the key into a buffer of its own and
+	// decodes the material to fill it. A key too large to produce a DS can
+	// never match one, and a DS set may name the same key repeatedly: the
+	// cheap check has to come first or the expensive one runs per mention.
+	if oversizedKeyMaterial(key.PublicKey) {
+		return false
+	}
 	return key.KeyTag() == parentDS.KeyTag &&
 		key.Algorithm == parentDS.Algorithm &&
 		key.Header().Class == parentDS.Header().Class &&

--- a/middleware/resolver/dnssec/verify.go
+++ b/middleware/resolver/dnssec/verify.go
@@ -291,10 +291,6 @@ func usableDSCandidate(parentDS *dns.DS, key *dns.DNSKEY) bool {
 	// decodes the material to fill it. A key too large to produce a DS can
 	// never match one, and a DS set may name the same key repeatedly: the
 	// cheap check has to come first or the expensive one runs per mention.
-	// Ahead of KeyTag, which packs the key into a buffer of its own and
-	// decodes the material to fill it. A key too large to produce a DS can
-	// never match one, and a DS set may name the same key repeatedly: the
-	// cheap check has to come first or the expensive one runs per mention.
 	if oversizedKeyMaterial(key.PublicKey) {
 		return false
 	}

--- a/middleware/resolver/dnssec/verify.go
+++ b/middleware/resolver/dnssec/verify.go
@@ -9,6 +9,7 @@ package dnssec
 
 import (
 	"encoding/base64"
+	"encoding/hex"
 	"sort"
 	"strings"
 	"time"
@@ -126,6 +127,15 @@ func verifyDSWithWork(
 			continue
 		}
 
+		// Decoded once for the whole candidate set: the parent's digest is
+		// what every candidate is measured against, and it does not change
+		// between them.
+		wantDigest, decodeErr := hex.DecodeString(parentDS.Digest)
+		if decodeErr != nil || len(wantDigest) == 0 {
+			lastErr = ErrMismatchingDS
+			continue
+		}
+
 		matched := false
 		var candidateUsed uint32
 		for _, ksk := range candidates {
@@ -135,15 +145,12 @@ func verifyDSWithWork(
 				}
 			}
 
-			ds, err := runDSDigest(work, ksk, parentDS.DigestType)
+			ok, err := runDSDigestMatch(work, ksk, parentDS.DigestType, wantDigest)
 			if err != nil {
 				return false, err
 			}
 			candidateUsed++
-			if ds == nil {
-				continue
-			}
-			if strings.EqualFold(ds.Digest, parentDS.Digest) {
+			if ok {
 				matched = true
 				break
 			}
@@ -299,19 +306,24 @@ func beginDSDigest(work DSDigestWork) (func(), error) {
 	return release, nil
 }
 
-func runDSDigest(
+// runDSDigestMatch charges the request tree for one DS digest and reports
+// whether key hashes to want. The comparison happens on the digest bytes
+// rather than through a dns.DS: the record, its hexadecimal digest and the
+// two oversized buffers behind them exist only to be compared and dropped.
+func runDSDigestMatch(
 	work DSDigestWork,
 	key *dns.DNSKEY,
 	digestType uint8,
-) (*dns.DS, error) {
+	want []byte,
+) (bool, error) {
 	release, err := beginDSDigest(work)
 	if err != nil {
-		return nil, err
+		return false, err
 	}
 	if release != nil {
 		defer release()
 	}
-	return key.ToDS(digestType), nil
+	return dsDigestMatches(key, digestType, want), nil
 }
 
 // VerifyRRSIG validates that every in-zone RRset in msg is covered by at


### PR DESCRIPTION
## Problem

Two DNSSEC leaves dominate the field profile, and both spend most of their bytes on a buffer sized for a message rather than for the work: `DNSKEY.ToDS` at **3.83%** of everything the process allocates, and `RRSIG.Verify` at **7.94%**.

Checking a delegation asks one question — does this key hash to the parent's DS digest — and answered it by building the DS record the key would produce, then comparing the two hexadecimal renderings. Per candidate key, per DS, per delegation, that is a 4096-octet key buffer, a 255-octet owner buffer, the `dns.DS` itself, its key tag and a hex string. The digest is the only part anyone wanted.

Verifying a signature is the same shape. The library packs the canonical signed data into a fixed 4096-octet buffer for every signature of every response, whatever the RRset's actual size, and re-derives the key material and key tag on each one.

## Change

**DS digest.** The digest is computed straight into the comparison: canonical owner name, flags, protocol, algorithm and the decoded public key, hashed and matched against the parent's digest bytes. The parent's digest is decoded once for the whole candidate set instead of being re-rendered per candidate. The work accounting is unchanged — `runDSDigestMatch` charges the request tree exactly as `runDSDigest` did, so an attacker-driven key set still meets the same ceiling.

**Signature verification.** The canonical signed data is this package's own — the construction the wide-exponent RSA path has always used — and the cryptography stays in the standard library. RSA, ECDSA P-256/P-384 and Ed25519 are implemented; any other algorithm is refused rather than guessed at, and stays on the library's path.

Both keep the library's acceptance envelope deliberately. `ToDS` packs into a fixed buffer, so a key larger than 4092 octets produces no DS and could never match; computing the digest directly has no ceiling of its own, and gaining one silently would let a key the library refuses become a chain of trust. The limit is applied to the *encoded* length, before the decode — an attacker-supplied DNSKEY can be as large as the message allows, and deciding it is too big after materializing it pays for the very thing being refused.

## Divergences, on purpose

Three, each of them narrowing what is accepted, each with a test that fails if the divergence closes or widens:

- **ECDSA signature length.** RFC 6605 §4 fixes r and s at the curve's width. The library splits whatever it is handed in half and lets leading zeros pass; a zero-padded 66-octet P-256 signature is not a P-256 signature, and is refused here.
- **DS digest type 5.** miekg names its constant `SHA512`, following an expired draft. IANA assigns 5 to GOST R 34.11-2012 (RFC 9558), and this resolver's `IsSupportedDSDigest` admits only 1, 2 and 4. Treating a GOST digest as a SHA-512 one is the error worth refusing, so type 5 is not computed.
- **Signer containment.** The library tests it with a plain string suffix — its own comment concedes that is the best it can do without SOA context — which reads `evilexample.com.` as inside `example.com.` It is now a label boundary, through the shared helper described below.

A fourth is the RSA modulus bounds, in both directions and both narrowing: below 1024 bits each path refuses by default, but the library's floor is crypto/rsa's and lifts under `GODEBUG=rsa1024min=0` while this package's own does not; above 4096 bits the library has no bound and this package refuses.

## Zone containment is decided on labels

Review found a defect in the shared containment helper, and it predates this branch. `NameInZone` tested containment with a string suffix, and an escaped dot is not a label separator: `foo\.example.com.` is the two labels `foo.example` and `com`, outside `example.com.` entirely, while ending with its text. A validly signed RRset with that owner authenticated against the zone's own key on the production `VerifyRRSIG` path — a zone operator could sign answers for owners no delegation ever gave them.

The fix is in the one helper every containment check in the resolver comes through, and is escape-aware: a dot is a separator exactly when an even number of backslashes precede it. It also compares in place instead of building `"."+zone` per call — free on the stack for a short zone, a heap allocation once the zone name reaches the runtime's 32-octet temporary buffer, which ordinary delegation names do.

Both levels are pinned: a table over the helper, and a signed `VerifyRRSIG` regression that authenticates nothing while the genuine `foo.zone.example.` still validates.

## The size check runs before the decode, on the path a query takes

The first version of the DS limit was applied inside `dsDigestMatches`, and the test that proved it measured `dsDigestMatches`. `VerifyDS` reaches `usableDSCandidate` first, and that begins with `KeyTag` — which packs the key into a buffer of its own and decodes the material to fill it. Nothing about that decode depends on which DS is being considered, so a DS RRset naming the same key repeatedly paid for it once per mention:

| 48 KiB key, 32 DS records | allocated per `VerifyDS` |
|---|---|
| limit after `KeyTag` | 1,580,192 B |
| limit before `KeyTag` | **5,792 B** (−99.6%) |

The remainder is the deduplication and sort of 32 DS records, which allocate by design. The regression measures `VerifyDS` itself, in bytes, with a ceiling of one key's worth of material: crossing it means at least one decode happened.

One narrowing came with it and is fixed rather than documented. The decoder skips CR and LF, so a key at exactly the maximum, wrapped into lines, measures longer than the limit while decoding to a packable key. The check counts line breaks out — on the oversized branch only, and bounded by the limit rather than by what was sent: once limit+1 octets of material have been seen, nothing in the rest can bring the decoded length back under it. The unwrapped case, which is every real one, is settled by two byte searches instead of a walk. Refusing the 32-record set above costs **12 µs**, against 62 µs for the full walk.

`resolver.go`'s key-map build is deliberately left alone. It calls `KeyTag` once per DNSKEY and is bounded by the message that carried them, so there is no amplification to remove; and the same map feeds `VerifyRRSIGWithWork`, where a ceiling that exists because `ToDS` packs into a fixed buffer has no business deciding which keys may verify a signature. Removing that cost properly means computing the key tag without the library's buffer, which is a change of its own.

## Canonical ordering

Writing the differential tests surfaced a defect in this package's own signed-data construction, not the library's. RFC 4034 §6.3 orders an RRset by canonical **RDATA**; the code claimed to reproduce `rawSignatureData` and instead sorted whole wire records, owner name included. Every RR in an RRset shares an owner, so the prefix is identical and the comparison usually reaches the RDATA anyway — but not when RDLENGTH differs, which is where the ordering matters.

The fix computes the RDATA offset once by walking the label lengths of the shared owner, and sorts from there. No unpack, no per-record string, no parallel slice: the benchmark is unchanged. A `TXT "a" "zzzz"` / `TXT "b"` fixture pins it — a single-string TXT cannot tell the two orderings apart, because its RDATA begins with a length octet that correlates with RDLENGTH.

## Measurements

DS digest, same key and digest type, matching the library's own digest:

| | `ToDS` + compare | digest compare |
|---|---|---|
| bytes/op | 4,992 B | **356 B** (−93%) |
| allocs/op | 9 | **5** |
| ns/op | ~630 | **~235** |

Signature verification, per signature, bytes/op — the fixed buffer, gone:

| algorithm | library | owned |
|---|---|---|
| RSASHA256 | 6,584 B | **2,832 B** (−57%) |
| RSASHA512 | 6,712 B | **2,960 B** (−56%) |
| ECDSAP256SHA256 | 6,632 B | **2,800 B** (−58%) |
| ECDSAP384SHA384 | 7,168 B | **3,336 B** (−53%) |
| ED25519 | 5,016 B | **1,168 B** (−77%) |

`ns/op` is within noise on every algorithm — the crypto dominates, and that is the point: the bytes go without paying for them.

## Tests

The digest and the signature must be the library's verdict, not merely a plausible one, so the tests are differential.

Digest, across nine keys — RSA/SHA-256, RSA/SHA-512, ECDSA P-256 and P-384, Ed25519, the root zone, a shouted owner name, an IDN label, a revoked key and a zone-signing key (the flags are hashed, so those are distinct inputs) — and every digest type the library computes: it accepts exactly what `ToDS` produces; refuses a digest altered in one bit, a truncated one, and any other key's; refuses the digest types the library refuses; folds the owner name before hashing; and refuses an oversized key in **0 allocations**, which is what pins the limit ahead of the decode rather than behind it.

Signature, for each of the six algorithms: the signature as signed, one altered octet, an RRset altered after signing, a truncated RRset, another key of the same algorithm, and each binding the preflight owns — key tag, signer, covered type, label count, zone flag, protocol. Every one of them must reach the same verdict as `dns.RRSIG.Verify`.

Wide-exponent RSA keeps its own coverage, including a recorded ccTLD vector, and now checks that the path rejects as well as accepts.

`go test ./... -race`, `go vet` and `golangci-lint` are clean.
