### PR TITLE
resolver: keep an endpoint's identity instead of deriving it per lookup

### DIFF
--- a/internal/authority/server.go
+++ b/internal/authority/server.go
@@ -18,24 +18,34 @@ type Server struct {
 	Addr      string
 	IPVersion IPVersion
 
+	// canonical records that Addr was printed from a decoded address and is
+	// therefore already the identity spelling — what duplicate suppression
+	// compares and what the retry guard keys on. Deriving that identity by
+	// parsing Addr and printing it back produced a string per server per
+	// lookup, for a string this constructor had just built.
+	//
+	// It sits next to IPVersion so it lands in the padding those two share,
+	// and knowing this costs the Server nothing. False only when Addr was
+	// never an IP:port literal, where the spelling is not the identity and
+	// callers must normalize.
+	canonical bool
+
 	// UDPAddr is Addr pre-parsed as *net.UDPAddr so the upstream
 	// exchange path can use net.DialUDP directly instead of going
 	// through Dialer.DialContext's string-parsing + dialParallel
 	// machinery. Nil only if Addr failed to parse — callers fall
 	// back to the string path in that case.
 	UDPAddr *net.UDPAddr
+}
 
-	// Endpoint is this server's identity as a comparable value: the same
-	// address Addr spells, before it was spelled. Duplicate suppression and
-	// the retry guard both key on the endpoint, and deriving that key by
-	// parsing Addr and printing it back produced a string per server per
-	// lookup — for a string the constructor had just built from this very
-	// value.
-	//
-	// Zero when Addr is not an IP:port literal, which is the only case
-	// where the spelling is the identity; callers fall back to canonical
-	// normalization there.
-	Endpoint netip.AddrPort
+// CanonicalAddr returns Addr together with whether it is already in the
+// canonical spelling. A caller that keys on the endpoint can use the string
+// as-is when this reports true, and must normalize it otherwise.
+func (a *Server) CanonicalAddr() (string, bool) {
+	if a == nil {
+		return "", false
+	}
+	return a.Addr, a.canonical
 }
 
 // IPVersion type.
@@ -89,7 +99,7 @@ func NewServerFromAddrPort(ap netip.AddrPort) *Server {
 		Addr:      ap.String(),
 		IPVersion: version,
 		UDPAddr:   net.UDPAddrFromAddrPort(ap),
-		Endpoint:  ap,
+		canonical: true,
 	}
 }
 

--- a/internal/authority/server.go
+++ b/internal/authority/server.go
@@ -99,7 +99,10 @@ func NewServerFromAddrPort(ap netip.AddrPort) *Server {
 		Addr:      ap.String(),
 		IPVersion: version,
 		UDPAddr:   net.UDPAddrFromAddrPort(ap),
-		canonical: true,
+		// The zero AddrPort prints as "invalid AddrPort", which is a
+		// spelling and not an address. No producer hands one over, but the
+		// marker is a promise about Addr and must not be made about that.
+		canonical: ap.IsValid(),
 	}
 }
 

--- a/internal/authority/server.go
+++ b/internal/authority/server.go
@@ -24,6 +24,18 @@ type Server struct {
 	// machinery. Nil only if Addr failed to parse — callers fall
 	// back to the string path in that case.
 	UDPAddr *net.UDPAddr
+
+	// Endpoint is this server's identity as a comparable value: the same
+	// address Addr spells, before it was spelled. Duplicate suppression and
+	// the retry guard both key on the endpoint, and deriving that key by
+	// parsing Addr and printing it back produced a string per server per
+	// lookup — for a string the constructor had just built from this very
+	// value.
+	//
+	// Zero when Addr is not an IP:port literal, which is the only case
+	// where the spelling is the identity; callers fall back to canonical
+	// normalization there.
+	Endpoint netip.AddrPort
 }
 
 // IPVersion type.
@@ -77,6 +89,7 @@ func NewServerFromAddrPort(ap netip.AddrPort) *Server {
 		Addr:      ap.String(),
 		IPVersion: version,
 		UDPAddr:   net.UDPAddrFromAddrPort(ap),
+		Endpoint:  ap,
 	}
 }
 

--- a/internal/authority/server_test.go
+++ b/internal/authority/server_test.go
@@ -3,6 +3,7 @@ package authority
 import (
 	"fmt"
 	"math/rand"
+	"net"
 	"net/netip"
 	"testing"
 	"time"
@@ -11,16 +12,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// serverWithoutCanonical is Server as it stood before it recorded whether its
+// address is canonical. It is the reference the size test compares against, so
+// the claim being made is "the marker is free" rather than a byte count that
+// is only true on one ABI.
+type serverWithoutCanonical struct {
+	Rtt       int64
+	Count     int64
+	Addr      string
+	IPVersion IPVersion
+	UDPAddr   *net.UDPAddr
+}
+
 // TestServerLayoutStaysSmall pins that knowing an address is canonical costs
 // nothing. There is one Server per authority per delegation and they are
 // allocated as the resolver reads referrals, so a field that pushes this into
-// the next size class is paid for continuously. canonical fits in the padding
+// the next size class is paid for continuously; canonical fits in the padding
 // IPVersion already leaves.
 func TestServerLayoutStaysSmall(t *testing.T) {
-	const want = 48
+	want := unsafe.Sizeof(serverWithoutCanonical{})
 	if got := unsafe.Sizeof(Server{}); got != want {
-		t.Fatalf("Server is %d B, want %d; a new field left the padding "+
-			"IPVersion shares", got, want)
+		t.Fatalf("Server is %d B against a reference of %d B; a field left "+
+			"the padding IPVersion shares", got, want)
 	}
 }
 

--- a/internal/authority/server_test.go
+++ b/internal/authority/server_test.go
@@ -6,9 +6,23 @@ import (
 	"net/netip"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// TestServerLayoutStaysSmall pins that knowing an address is canonical costs
+// nothing. There is one Server per authority per delegation and they are
+// allocated as the resolver reads referrals, so a field that pushes this into
+// the next size class is paid for continuously. canonical fits in the padding
+// IPVersion already leaves.
+func TestServerLayoutStaysSmall(t *testing.T) {
+	const want = 48
+	if got := unsafe.Sizeof(Server{}); got != want {
+		t.Fatalf("Server is %d B, want %d; a new field left the padding "+
+			"IPVersion shares", got, want)
+	}
+}
 
 func Test_TrySort(t *testing.T) {
 	s := &Servers{

--- a/middleware/resolution_attempt.go
+++ b/middleware/resolution_attempt.go
@@ -55,19 +55,54 @@ func (e *ResolutionAttemptLimitError) Unwrap() error { return ErrResolutionAttem
 
 type resolutionAttemptKey struct {
 	qname     string
-	qtype     uint16
-	qclass    uint16
 	endpoint  string
 	transport string
+	qtype     uint16
+	qclass    uint16
+}
+
+func (k resolutionAttemptKey) limitError() error {
+	return &ResolutionAttemptLimitError{
+		Question:  dns.Question{Name: k.qname, Qtype: k.qtype, Qclass: k.qclass},
+		Endpoint:  k.endpoint,
+		Transport: k.transport,
+	}
+}
+
+// resolutionAttemptEntry is one recorded tuple in the guard's inline table.
+type resolutionAttemptEntry struct {
+	key   resolutionAttemptKey
+	count uint8
 }
 
 // ResolutionAttemptGuard owns retry state and exact terminal request-local
 // response provenance for one complete client request tree. A mutex keeps both
 // maps atomic across resolver fan-out.
 type ResolutionAttemptGuard struct {
-	mu                    sync.Mutex
+	mu sync.Mutex
+	// table holds the first few tuples without a map. A request tree that
+	// resolves normally records a handful of attempts and then goes away,
+	// and building and growing a map for them was the guard's whole cost.
+	//
+	// It hangs off a pointer rather than sitting in the struct because most
+	// requests are answered from cache and record no attempt at all; those
+	// must not carry the table's weight for a tuple they never had. The
+	// map takes the overflow, for the trees that fan out.
+	table                 *resolutionAttemptTable
 	attempts              map[resolutionAttemptKey]uint8
 	localFailureResponses map[*dns.Msg]error
+}
+
+// resolutionAttemptOverflowHint sizes the map the moment the inline table is
+// full, so a tree that fans out grows it once instead of rehashing its way up
+// from nothing.
+const resolutionAttemptOverflowHint = 8
+
+// resolutionAttemptTable is the guard's inline storage: allocated on the
+// tree's first attempt and never grown, since the map takes over from there.
+type resolutionAttemptTable struct {
+	len   int
+	slots [8]resolutionAttemptEntry
 }
 
 // NewResolutionAttemptGuard returns an empty request-tree retry guard.
@@ -84,28 +119,71 @@ func (g *ResolutionAttemptGuard) Begin(q dns.Question, endpoint, transport strin
 		return nil
 	}
 
-	key := resolutionAttemptKey{
+	return g.BeginCanonical(q, CanonicalResolutionEndpoint(endpoint), transport)
+}
+
+// BeginCanonical is Begin for a caller whose endpoint is already spelled the
+// way CanonicalResolutionEndpoint would spell it — the delegation path, where
+// the address was decoded from glue and its "IP:port" form was printed from
+// that value once, at construction. Normalizing it again parses the string
+// and prints an identical one back, per attempt.
+//
+// The promise matters: a spelling that is not canonical splits one tuple's
+// counter in two, and the RFC 9520 limit is what the counter enforces. Callers
+// that cannot make the promise must use Begin.
+func (g *ResolutionAttemptGuard) BeginCanonical(q dns.Question, endpoint, transport string) error {
+	if g == nil {
+		return nil
+	}
+	return g.begin(resolutionAttemptKey{
 		qname:     dns.CanonicalName(q.Name),
 		qtype:     q.Qtype,
 		qclass:    q.Qclass,
-		endpoint:  CanonicalResolutionEndpoint(endpoint),
+		endpoint:  endpoint,
 		transport: canonicalResolutionTransport(transport),
-	}
+	})
+}
 
+func (g *ResolutionAttemptGuard) begin(key resolutionAttemptKey) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
-	if g.attempts == nil {
-		g.attempts = make(map[resolutionAttemptKey]uint8)
-	}
-	if g.attempts[key] >= maxResolutionAttempts {
-		return &ResolutionAttemptLimitError{
-			Question:  dns.Question{Name: key.qname, Qtype: key.qtype, Qclass: key.qclass},
-			Endpoint:  key.endpoint,
-			Transport: key.transport,
+	// A tuple lives in exactly one of the two stores, so a hit in the table
+	// is conclusive and the map is never consulted for it.
+	if g.table != nil {
+		for i := range g.table.len {
+			entry := &g.table.slots[i]
+			if entry.key != key {
+				continue
+			}
+			if entry.count >= maxResolutionAttempts {
+				return key.limitError()
+			}
+			entry.count++
+			return nil
 		}
 	}
-	g.attempts[key]++
+
+	if count, recorded := g.attempts[key]; recorded {
+		if count >= maxResolutionAttempts {
+			return key.limitError()
+		}
+		g.attempts[key] = count + 1
+		return nil
+	}
+
+	if g.table == nil {
+		g.table = new(resolutionAttemptTable)
+	}
+	if g.table.len < len(g.table.slots) {
+		g.table.slots[g.table.len] = resolutionAttemptEntry{key: key, count: 1}
+		g.table.len++
+		return nil
+	}
+	if g.attempts == nil {
+		g.attempts = make(map[resolutionAttemptKey]uint8, resolutionAttemptOverflowHint)
+	}
+	g.attempts[key] = 1
 	return nil
 }
 
@@ -212,6 +290,20 @@ func EnsureResolutionAttemptGuard(ctx context.Context) (context.Context, *Resolu
 func BeginResolutionAttempt(ctx context.Context, q dns.Question, endpoint, transport string) error {
 	if guard := ResolutionAttemptGuardFrom(ctx); guard != nil {
 		return guard.Begin(q, endpoint, transport)
+	}
+	return nil
+}
+
+// BeginResolutionAttemptCanonical is BeginResolutionAttempt for a caller whose
+// endpoint is already canonically spelled. See BeginCanonical for what that
+// promise means.
+func BeginResolutionAttemptCanonical(
+	ctx context.Context,
+	q dns.Question,
+	endpoint, transport string,
+) error {
+	if guard := ResolutionAttemptGuardFrom(ctx); guard != nil {
+		return guard.BeginCanonical(q, endpoint, transport)
 	}
 	return nil
 }

--- a/middleware/resolution_attempt.go
+++ b/middleware/resolution_attempt.go
@@ -80,29 +80,30 @@ type resolutionAttemptEntry struct {
 // maps atomic across resolver fan-out.
 type ResolutionAttemptGuard struct {
 	mu sync.Mutex
-	// table holds the first few tuples without a map. A request tree that
-	// resolves normally records a handful of attempts and then goes away,
-	// and building and growing a map for them was the guard's whole cost.
-	//
-	// It hangs off a pointer rather than sitting in the struct because most
-	// requests are answered from cache and record no attempt at all; those
-	// must not carry the table's weight for a tuple they never had. The
-	// map takes the overflow, for the trees that fan out.
-	table                 *resolutionAttemptTable
-	attempts              map[resolutionAttemptKey]uint8
+	// attempts holds the tree's recorded tuples. It hangs off a pointer
+	// because most requests are answered from cache and record none; those
+	// must not carry storage for a tuple they never had.
+	attempts              *resolutionAttemptStore
 	localFailureResponses map[*dns.Msg]error
 }
 
-// resolutionAttemptOverflowHint sizes the map the moment the inline table is
-// full, so a tree that fans out grows it once instead of rehashing its way up
-// from nothing.
+// resolutionAttemptOverflowHint sizes the overflow map the moment the slots
+// are full, so a tree that fans out grows it once instead of rehashing its way
+// up from nothing.
 const resolutionAttemptOverflowHint = 8
 
-// resolutionAttemptTable is the guard's inline storage: allocated on the
-// tree's first attempt and never grown, since the map takes over from there.
-type resolutionAttemptTable struct {
-	len   int
-	slots [8]resolutionAttemptEntry
+// resolutionAttemptStore is the guard's storage: a fixed set of slots for the
+// tuples a request tree normally records, and a map for the trees that fan out
+// past them.
+//
+// The two live together under one pointer rather than beside each other in the
+// guard. The guard is embedded in the request tree's ledgers, so a second
+// pointer there is eight bytes on every request that resolves anything, while
+// here it lands inside the allocation the slots already needed.
+type resolutionAttemptStore struct {
+	len      int
+	slots    [8]resolutionAttemptEntry
+	overflow map[resolutionAttemptKey]uint8
 }
 
 // NewResolutionAttemptGuard returns an empty request-tree retry guard.
@@ -148,42 +149,42 @@ func (g *ResolutionAttemptGuard) begin(key resolutionAttemptKey) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
-	// A tuple lives in exactly one of the two stores, so a hit in the table
-	// is conclusive and the map is never consulted for it.
-	if g.table != nil {
-		for i := range g.table.len {
-			entry := &g.table.slots[i]
-			if entry.key != key {
-				continue
-			}
-			if entry.count >= maxResolutionAttempts {
-				return key.limitError()
-			}
-			entry.count++
-			return nil
+	if g.attempts == nil {
+		g.attempts = new(resolutionAttemptStore)
+	}
+	store := g.attempts
+
+	// A tuple lives in exactly one place, so a hit in the slots is
+	// conclusive and the overflow map is never consulted for it.
+	for i := range store.len {
+		entry := &store.slots[i]
+		if entry.key != key {
+			continue
 		}
+		if entry.count >= maxResolutionAttempts {
+			return key.limitError()
+		}
+		entry.count++
+		return nil
 	}
 
-	if count, recorded := g.attempts[key]; recorded {
+	if count, recorded := store.overflow[key]; recorded {
 		if count >= maxResolutionAttempts {
 			return key.limitError()
 		}
-		g.attempts[key] = count + 1
+		store.overflow[key] = count + 1
 		return nil
 	}
 
-	if g.table == nil {
-		g.table = new(resolutionAttemptTable)
-	}
-	if g.table.len < len(g.table.slots) {
-		g.table.slots[g.table.len] = resolutionAttemptEntry{key: key, count: 1}
-		g.table.len++
+	if store.len < len(store.slots) {
+		store.slots[store.len] = resolutionAttemptEntry{key: key, count: 1}
+		store.len++
 		return nil
 	}
-	if g.attempts == nil {
-		g.attempts = make(map[resolutionAttemptKey]uint8, resolutionAttemptOverflowHint)
+	if store.overflow == nil {
+		store.overflow = make(map[resolutionAttemptKey]uint8, resolutionAttemptOverflowHint)
 	}
-	g.attempts[key] = 1
+	store.overflow[key] = 1
 	return nil
 }
 

--- a/middleware/resolution_attempt_alloc_test.go
+++ b/middleware/resolution_attempt_alloc_test.go
@@ -3,7 +3,10 @@ package middleware
 import (
 	"errors"
 	"net/netip"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"unsafe"
 
 	"github.com/miekg/dns"
 )
@@ -99,7 +102,7 @@ func TestBeginCanonicalReportsTheEndpoint(t *testing.T) {
 func TestGuardCostsNothingWithoutAnAttempt(t *testing.T) {
 	allocs := testing.AllocsPerRun(200, func() {
 		var guard ResolutionAttemptGuard
-		if guard.table != nil {
+		if guard.attempts != nil {
 			t.Fatal("a guard allocated storage before recording an attempt")
 		}
 	})
@@ -146,8 +149,8 @@ func TestBeginCanonicalCostsOneAllocationForATypicalRecursion(t *testing.T) {
 // would either lose its count or double it.
 func TestResolutionAttemptGuardCountsAcrossTheOverflow(t *testing.T) {
 	trace := resolutionAttemptTrace(4, 4)
-	if len(trace) <= len(new(resolutionAttemptTable).slots) {
-		t.Fatal("fixture is wrong: the trace does not overflow the inline table")
+	if len(trace) <= len(new(resolutionAttemptStore).slots) {
+		t.Fatal("fixture is wrong: the trace does not overflow the slots")
 	}
 	guard := NewResolutionAttemptGuard()
 
@@ -163,6 +166,56 @@ func TestResolutionAttemptGuardCountsAcrossTheOverflow(t *testing.T) {
 		if err := guard.BeginCanonical(step.q, step.endpoint, "udp"); err == nil {
 			t.Fatalf("tuple %d admitted attempt %d", i, maxResolutionAttempts+1)
 		}
+	}
+}
+
+// TestResolutionAttemptGuardConcurrentOverflow drives the slots-to-map
+// boundary from many goroutines at once. The transition mutates the store's
+// shape, so a tuple recorded while it happens is where a lost or doubled count
+// would appear.
+func TestResolutionAttemptGuardConcurrentOverflow(t *testing.T) {
+	trace := resolutionAttemptTrace(4, 4)
+	if len(trace) <= len(new(resolutionAttemptStore).slots) {
+		t.Fatal("fixture is wrong: the trace does not overflow the slots")
+	}
+	guard := NewResolutionAttemptGuard()
+
+	// Every tuple is offered one more time than the limit allows, from its
+	// own goroutine; exactly maxResolutionAttempts must be admitted.
+	const offers = maxResolutionAttempts + 1
+	admitted := make([]atomic.Int32, len(trace))
+	var wg sync.WaitGroup
+	for i, step := range trace {
+		for range offers {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := guard.BeginCanonical(step.q, step.endpoint, "udp"); err == nil {
+					admitted[i].Add(1)
+				}
+			}()
+		}
+	}
+	wg.Wait()
+
+	for i := range trace {
+		if got := admitted[i].Load(); got != maxResolutionAttempts {
+			t.Fatalf("tuple %d admitted %d attempts, want %d",
+				i, got, maxResolutionAttempts)
+		}
+	}
+}
+
+// TestGuardLayoutStaysSmall pins what this change is for. The guard is
+// embedded in every request tree's ledgers, so a field added here is bytes on
+// every request that resolves anything — including the ones that never record
+// an attempt. The store's own size matters far less: it is allocated once per
+// resolving tree, and only for those.
+func TestGuardLayoutStaysSmall(t *testing.T) {
+	const wantGuard = 24 // a mutex and two pointers
+	if got := unsafe.Sizeof(ResolutionAttemptGuard{}); got != wantGuard {
+		t.Fatalf("ResolutionAttemptGuard is %d B, want %d; a field here is "+
+			"carried by every request tree", got, wantGuard)
 	}
 }
 

--- a/middleware/resolution_attempt_alloc_test.go
+++ b/middleware/resolution_attempt_alloc_test.go
@@ -206,16 +206,28 @@ func TestResolutionAttemptGuardConcurrentOverflow(t *testing.T) {
 	}
 }
 
+// guardLayoutReference is what the guard is allowed to be: a mutex and the two
+// pointers it stores through. Comparing against it rather than a byte count
+// keeps the claim — "no third field, and the slots and their overflow share
+// one pointer" — true on every ABI rather than only a 64-bit one.
+// Only the shapes matter, so the fields are unnamed: a mutex, the pointer the
+// slots and their overflow share, and the failure-response map.
+type guardLayoutReference struct {
+	_ sync.Mutex
+	_ *resolutionAttemptStore
+	_ map[*dns.Msg]error
+}
+
 // TestGuardLayoutStaysSmall pins what this change is for. The guard is
 // embedded in every request tree's ledgers, so a field added here is bytes on
 // every request that resolves anything — including the ones that never record
 // an attempt. The store's own size matters far less: it is allocated once per
 // resolving tree, and only for those.
 func TestGuardLayoutStaysSmall(t *testing.T) {
-	const wantGuard = 24 // a mutex and two pointers
-	if got := unsafe.Sizeof(ResolutionAttemptGuard{}); got != wantGuard {
-		t.Fatalf("ResolutionAttemptGuard is %d B, want %d; a field here is "+
-			"carried by every request tree", got, wantGuard)
+	want := unsafe.Sizeof(guardLayoutReference{})
+	if got := unsafe.Sizeof(ResolutionAttemptGuard{}); got != want {
+		t.Fatalf("ResolutionAttemptGuard is %d B against a reference of %d B; "+
+			"the extra is carried by every request tree", got, want)
 	}
 }
 

--- a/middleware/resolution_attempt_alloc_test.go
+++ b/middleware/resolution_attempt_alloc_test.go
@@ -1,0 +1,199 @@
+package middleware
+
+import (
+	"errors"
+	"net/netip"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// resolutionAttemptStep is one recorded attempt: a question, and the endpoint
+// it was asked of in the canonical spelling the delegation path already holds.
+type resolutionAttemptStep struct {
+	q        dns.Question
+	endpoint string
+}
+
+// resolutionAttemptTrace is the shape a recursion presents to the guard: a
+// handful of questions, each asked of a handful of endpoints, every tuple
+// distinct.
+func resolutionAttemptTrace(questions, endpoints int) []resolutionAttemptStep {
+	names := []string{
+		"example.com.", "www.example.com.", "cdn.example.com.",
+		"a.deep.example.com.", "mail.example.com.", "api.example.com.",
+	}
+	trace := make([]resolutionAttemptStep, 0, questions*endpoints)
+	for i := range questions {
+		q := dns.Question{
+			Name:   names[i%len(names)],
+			Qtype:  dns.TypeA,
+			Qclass: dns.ClassINET,
+		}
+		for j := range endpoints {
+			addr := netip.AddrPortFrom(
+				netip.AddrFrom4([4]byte{192, 0, 2, byte(j + 1)}), 53)
+			trace = append(trace, resolutionAttemptStep{q, addr.String()})
+		}
+	}
+	return trace
+}
+
+// TestBeginCanonicalMatchesBegin pins that the two entry points are the same
+// guard: an attempt recorded through either must count against the other, or
+// the RFC 9520 limit could be evaded by alternating between them.
+func TestBeginCanonicalMatchesBegin(t *testing.T) {
+	q := dns.Question{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	const canonical = "192.0.2.1:53"
+
+	guard := NewResolutionAttemptGuard()
+	for i := range maxResolutionAttempts {
+		var err error
+		if i%2 == 0 {
+			err = guard.BeginCanonical(q, canonical, "udp")
+		} else {
+			// A spelling the normalizer has to fold to the same identity.
+			err = guard.Begin(q, " 192.0.2.1:53 ", "UDP")
+		}
+		if err != nil {
+			t.Fatalf("attempt %d rejected: %v", i+1, err)
+		}
+	}
+	if err := guard.BeginCanonical(q, canonical, "udp"); err == nil {
+		t.Fatal("the fourth attempt was admitted; alternating entry points " +
+			"split one tuple into two counters")
+	}
+	if err := guard.Begin(q, "192.0.2.1:53", "udp"); err == nil {
+		t.Fatal("the fourth attempt was admitted through the spelled path")
+	}
+}
+
+// TestBeginCanonicalReportsTheEndpoint keeps the limit error legible.
+func TestBeginCanonicalReportsTheEndpoint(t *testing.T) {
+	q := dns.Question{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	const canonical = "192.0.2.1:53"
+
+	guard := NewResolutionAttemptGuard()
+	for range maxResolutionAttempts {
+		if err := guard.BeginCanonical(q, canonical, "udp"); err != nil {
+			t.Fatalf("attempt rejected: %v", err)
+		}
+	}
+	err := guard.BeginCanonical(q, canonical, "udp")
+	if err == nil {
+		t.Fatal("the fourth attempt was admitted")
+	}
+	var limit *ResolutionAttemptLimitError
+	if !errors.As(err, &limit) {
+		t.Fatalf("error is %T, want *ResolutionAttemptLimitError", err)
+	}
+	if limit.Endpoint != canonical {
+		t.Fatalf("limit error names endpoint %q, want %q",
+			limit.Endpoint, canonical)
+	}
+}
+
+// TestGuardCostsNothingWithoutAnAttempt pins the cache-hit case. Most requests
+// are answered without touching the network, and the guard's storage must not
+// be part of what they carry.
+func TestGuardCostsNothingWithoutAnAttempt(t *testing.T) {
+	allocs := testing.AllocsPerRun(200, func() {
+		var guard ResolutionAttemptGuard
+		if guard.table != nil {
+			t.Fatal("a guard allocated storage before recording an attempt")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("an unused guard cost %.0f allocations", allocs)
+	}
+}
+
+// TestBeginCanonicalCostsOneAllocationForATypicalRecursion pins the guard's
+// cost against the shape a real request tree presents: the inline table, once,
+// and nothing else. The endpoint arrives already spelled, so recording an
+// attempt does not normalize it, and a handful of tuples does not need a map.
+func TestBeginCanonicalCostsOneAllocationForATypicalRecursion(t *testing.T) {
+	const runs = 200
+	trace := resolutionAttemptTrace(2, 2)
+
+	// A fresh guard per run, built outside the measurement: the guard
+	// itself is one allocation the request tree pays anyway, and what is
+	// being measured is what recording attempts adds to it.
+	guards := make([]*ResolutionAttemptGuard, runs+2)
+	for i := range guards {
+		guards[i] = NewResolutionAttemptGuard()
+	}
+	run := 0
+
+	allocs := testing.AllocsPerRun(runs, func() {
+		guard := guards[run]
+		run++
+		for _, step := range trace {
+			if err := guard.BeginCanonical(step.q, step.endpoint, "udp"); err != nil {
+				t.Fatalf("attempt rejected: %v", err)
+			}
+		}
+	})
+	if allocs != 1 {
+		t.Fatalf("a %d-attempt request tree cost %.0f allocations, want 1 "+
+			"(the inline table)", len(trace), allocs)
+	}
+}
+
+// TestResolutionAttemptGuardCountsAcrossTheOverflow pins the limit through the
+// boundary between the inline table and the map. A tuple lives in one store or
+// the other, and a tuple that moved between them — or was recorded in both —
+// would either lose its count or double it.
+func TestResolutionAttemptGuardCountsAcrossTheOverflow(t *testing.T) {
+	trace := resolutionAttemptTrace(4, 4)
+	if len(trace) <= len(new(resolutionAttemptTable).slots) {
+		t.Fatal("fixture is wrong: the trace does not overflow the inline table")
+	}
+	guard := NewResolutionAttemptGuard()
+
+	// Every tuple admits exactly maxResolutionAttempts, wherever it lives.
+	for attempt := range maxResolutionAttempts {
+		for i, step := range trace {
+			if err := guard.BeginCanonical(step.q, step.endpoint, "udp"); err != nil {
+				t.Fatalf("tuple %d rejected on attempt %d: %v", i, attempt+1, err)
+			}
+		}
+	}
+	for i, step := range trace {
+		if err := guard.BeginCanonical(step.q, step.endpoint, "udp"); err == nil {
+			t.Fatalf("tuple %d admitted attempt %d", i, maxResolutionAttempts+1)
+		}
+	}
+}
+
+func BenchmarkResolutionAttemptGuard(b *testing.B) {
+	for _, shape := range []struct {
+		name      string
+		questions int
+		endpoints int
+	}{
+		{"attempts=4", 2, 2},
+		{"attempts=12", 3, 4},
+		{"attempts=36", 6, 6},
+	} {
+		trace := resolutionAttemptTrace(shape.questions, shape.endpoints)
+		b.Run(shape.name+"/canonical", func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				guard := NewResolutionAttemptGuard()
+				for _, step := range trace {
+					_ = guard.BeginCanonical(step.q, step.endpoint, "udp")
+				}
+			}
+		})
+		b.Run(shape.name+"/spelled", func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				guard := NewResolutionAttemptGuard()
+				for _, step := range trace {
+					_ = guard.Begin(step.q, step.endpoint, "udp")
+				}
+			}
+		})
+	}
+}

--- a/middleware/resolver/dedupe_test.go
+++ b/middleware/resolver/dedupe_test.go
@@ -1,0 +1,186 @@
+package resolver
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/semihalev/sdns/internal/authority"
+	"github.com/semihalev/sdns/middleware"
+)
+
+// authorityServers builds a delegation's worth of servers the way the
+// resolver's own producers do — from decoded glue addresses.
+func authorityServers(tb testing.TB, count int) []*authority.Server {
+	tb.Helper()
+	servers := make([]*authority.Server, 0, count)
+	for i := range count {
+		addr := netip.AddrPortFrom(
+			netip.AddrFrom4([4]byte{192, 0, 2, byte(i + 1)}), 53)
+		servers = append(servers, authority.NewServerFromAddrPort(addr))
+	}
+	return servers
+}
+
+func serverAddrs(servers []*authority.Server) []string {
+	addrs := make([]string, 0, len(servers))
+	for _, s := range servers {
+		addrs = append(addrs, s.Addr)
+	}
+	return addrs
+}
+
+func TestDedupeAuthorityServers(t *testing.T) {
+	t.Run("keeps first occurrence and order", func(t *testing.T) {
+		servers := authorityServers(t, 3)
+		input := []*authority.Server{
+			servers[2], servers[0], servers[2], servers[1], servers[0],
+		}
+		got := serverAddrs(dedupeAuthorityServers(input))
+		want := []string{servers[2].Addr, servers[0].Addr, servers[1].Addr}
+		if len(got) != len(want) {
+			t.Fatalf("deduped to %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("deduped to %v, want %v", got, want)
+			}
+		}
+	})
+
+	t.Run("drops nil entries", func(t *testing.T) {
+		servers := authorityServers(t, 2)
+		got := dedupeAuthorityServers(
+			[]*authority.Server{nil, servers[0], nil, servers[1], nil})
+		if len(got) != 2 {
+			t.Fatalf("deduped to %d servers, want 2", len(got))
+		}
+	})
+
+	t.Run("distinct pointers with one address collapse", func(t *testing.T) {
+		addr := netip.AddrPortFrom(netip.AddrFrom4([4]byte{192, 0, 2, 1}), 53)
+		got := dedupeAuthorityServers([]*authority.Server{
+			authority.NewServerFromAddrPort(addr),
+			authority.NewServerFromAddrPort(addr),
+		})
+		if len(got) != 1 {
+			t.Fatalf("two servers for one address deduped to %d, want 1", len(got))
+		}
+	})
+
+	t.Run("a non-literal address still dedupes", func(t *testing.T) {
+		// No netip identity to compare, so these fall back to the
+		// canonical-spelling path.
+		got := dedupeAuthorityServers([]*authority.Server{
+			authority.NewServer("NS1.Example.Com:53", authority.IPv4),
+			authority.NewServer("ns1.example.com:53", authority.IPv4),
+		})
+		if len(got) != 1 {
+			t.Fatalf("one host under two spellings deduped to %d, want 1", len(got))
+		}
+	})
+
+	t.Run("empty and single", func(t *testing.T) {
+		if got := dedupeAuthorityServers(nil); len(got) != 0 {
+			t.Fatalf("nil deduped to %d servers", len(got))
+		}
+		one := authorityServers(t, 1)
+		if got := dedupeAuthorityServers(one); len(got) != 1 {
+			t.Fatalf("one server deduped to %d", len(got))
+		}
+	})
+}
+
+// TestDedupeAuthorityServersDoesNotAllocate pins the delegation-sized case.
+// Every lookup dedupes its authority list, the addresses were canonical the
+// moment they were decoded, and re-deriving that identity per server per
+// lookup was the second-largest allocation site in the resolver.
+func TestDedupeAuthorityServersDoesNotAllocate(t *testing.T) {
+	for _, count := range []int{2, 8, 13} {
+		servers := authorityServers(t, count)
+		input := make([]*authority.Server, len(servers))
+
+		allocs := testing.AllocsPerRun(200, func() {
+			copy(input, servers)
+			if got := dedupeAuthorityServers(input); len(got) != count {
+				t.Fatalf("%d servers deduped to %d", count, len(got))
+			}
+		})
+		if allocs != 0 {
+			t.Fatalf("deduping %d servers cost %.0f allocations", count, allocs)
+		}
+	}
+}
+
+// TestServerAddrIsAlreadyCanonical pins the promise the retry guard's fast
+// path is built on.
+//
+// queryServer hands Addr to BeginCanonical instead of normalizing it, which is
+// only sound while a server carrying a decoded Endpoint spells that endpoint
+// exactly as CanonicalResolutionEndpoint would. If a constructor ever stored a
+// different spelling, one tuple would count under two keys and the RFC 9520
+// attempt limit would admit twice what it should — silently.
+func TestServerAddrIsAlreadyCanonical(t *testing.T) {
+	for _, spelling := range []string{
+		"192.0.2.1:53",
+		"[2001:db8::1]:53",
+		// 4-in-6 and an uppercase v6 literal: both are addresses the
+		// constructor is expected to fold.
+		"[::ffff:192.0.2.1]:53",
+		"[2001:DB8::1]:53",
+		"[2001:db8:0:0:0:0:0:1]:53",
+	} {
+		for _, server := range []*authority.Server{
+			authority.NewServer(spelling, authority.IPv4),
+			mustServerFromSpelling(t, spelling),
+		} {
+			if !server.Endpoint.IsValid() {
+				t.Fatalf("%q produced no decoded endpoint", spelling)
+			}
+			if got := middleware.CanonicalResolutionEndpoint(server.Addr); got != server.Addr {
+				t.Fatalf("%q stored Addr %q, which canonicalizes to %q; the "+
+					"guard's fast path would key it under two identities",
+					spelling, server.Addr, got)
+			}
+			if server.Addr != server.Endpoint.String() {
+				t.Fatalf("%q stored Addr %q but Endpoint %q",
+					spelling, server.Addr, server.Endpoint)
+			}
+		}
+	}
+}
+
+func mustServerFromSpelling(tb testing.TB, spelling string) *authority.Server {
+	tb.Helper()
+	ap, err := netip.ParseAddrPort(spelling)
+	if err != nil {
+		tb.Fatalf("ParseAddrPort(%q): %v", spelling, err)
+	}
+	return authority.NewServerFromAddrPort(ap)
+}
+
+func BenchmarkDedupeAuthorityServers(b *testing.B) {
+	for _, count := range []int{2, 4, 13, 64} {
+		servers := authorityServers(b, count)
+		input := make([]*authority.Server, len(servers))
+		b.Run(serverCountName(count), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				copy(input, servers)
+				dedupeAuthorityServers(input)
+			}
+		})
+	}
+}
+
+func serverCountName(count int) string {
+	switch count {
+	case 2:
+		return "servers=2"
+	case 4:
+		return "servers=4"
+	case 13:
+		return "servers=13"
+	default:
+		return "servers=64"
+	}
+}

--- a/middleware/resolver/dedupe_test.go
+++ b/middleware/resolver/dedupe_test.go
@@ -111,6 +111,13 @@ func TestDedupeAuthorityServers(t *testing.T) {
 				t.Fatalf("at %d servers: linear kept %d, indexed kept %d",
 					count, len(linear), len(indexed))
 			}
+			// Length before contents: a wrapper that dropped nothing would
+			// still match on every position the shorter result has.
+			if len(chosen) != len(linear) {
+				t.Fatalf("at %d servers: the threshold kept %d, both "+
+					"implementations kept %d",
+					count, len(chosen), len(linear))
+			}
 			for i := range linear {
 				if linear[i] != indexed[i] {
 					t.Fatalf("at %d servers, position %d: linear %q, "+

--- a/middleware/resolver/dedupe_test.go
+++ b/middleware/resolver/dedupe_test.go
@@ -80,27 +80,46 @@ func TestDedupeAuthorityServers(t *testing.T) {
 	})
 
 	t.Run("across the linear/indexed threshold", func(t *testing.T) {
-		// The two implementations must agree, and the boundary is where a
-		// disagreement would hide.
+		// The threshold is on the input length, so the corpus has to be
+		// exactly that long: duplicates come from repeating servers within
+		// it, not from lengthening it.
 		for _, count := range []int{
 			linearDedupeLimit - 1, linearDedupeLimit, linearDedupeLimit + 1,
 		} {
-			servers := authorityServers(t, count)
-			// Every server twice: the result must be the originals, in
-			// order, whichever side of the threshold the input lands on.
-			doubled := make([]*authority.Server, 0, count*2)
-			doubled = append(doubled, servers...)
-			doubled = append(doubled, servers...)
-
-			got := serverAddrs(dedupeAuthorityServers(doubled))
-			if len(got) != count {
-				t.Fatalf("%d duplicated servers deduped to %d, want %d",
-					count*2, len(got), count)
+			unique := authorityServers(t, (count+1)/2)
+			corpus := make([]*authority.Server, count)
+			for i := range corpus {
+				// Repeats interleaved with first occurrences, so order is
+				// something the implementations can disagree about.
+				corpus[i] = unique[(i*3)%len(unique)]
 			}
-			for i, server := range servers {
-				if got[i] != server.Addr {
-					t.Fatalf("at %d servers, position %d is %q, want %q",
-						count, i, got[i], server.Addr)
+			if len(corpus) != count {
+				t.Fatalf("fixture is wrong: corpus is %d long, want %d",
+					len(corpus), count)
+			}
+
+			// Both implementations run on the same corpus, each on its own
+			// copy since they dedupe in place.
+			linear := serverAddrs(dedupeAuthorityServersLinear(
+				append([]*authority.Server(nil), corpus...)))
+			indexed := serverAddrs(dedupeAuthorityServersIndexed(
+				append([]*authority.Server(nil), corpus...)))
+			chosen := serverAddrs(dedupeAuthorityServers(
+				append([]*authority.Server(nil), corpus...)))
+
+			if len(linear) != len(indexed) {
+				t.Fatalf("at %d servers: linear kept %d, indexed kept %d",
+					count, len(linear), len(indexed))
+			}
+			for i := range linear {
+				if linear[i] != indexed[i] {
+					t.Fatalf("at %d servers, position %d: linear %q, "+
+						"indexed %q", count, i, linear[i], indexed[i])
+				}
+				if chosen[i] != linear[i] {
+					t.Fatalf("at %d servers, position %d: the threshold "+
+						"picked %q, both implementations say %q",
+						count, i, chosen[i], linear[i])
 				}
 			}
 		}

--- a/middleware/resolver/dedupe_test.go
+++ b/middleware/resolver/dedupe_test.go
@@ -79,6 +79,33 @@ func TestDedupeAuthorityServers(t *testing.T) {
 		}
 	})
 
+	t.Run("across the linear/indexed threshold", func(t *testing.T) {
+		// The two implementations must agree, and the boundary is where a
+		// disagreement would hide.
+		for _, count := range []int{
+			linearDedupeLimit - 1, linearDedupeLimit, linearDedupeLimit + 1,
+		} {
+			servers := authorityServers(t, count)
+			// Every server twice: the result must be the originals, in
+			// order, whichever side of the threshold the input lands on.
+			doubled := make([]*authority.Server, 0, count*2)
+			doubled = append(doubled, servers...)
+			doubled = append(doubled, servers...)
+
+			got := serverAddrs(dedupeAuthorityServers(doubled))
+			if len(got) != count {
+				t.Fatalf("%d duplicated servers deduped to %d, want %d",
+					count*2, len(got), count)
+			}
+			for i, server := range servers {
+				if got[i] != server.Addr {
+					t.Fatalf("at %d servers, position %d is %q, want %q",
+						count, i, got[i], server.Addr)
+				}
+			}
+		}
+	})
+
 	t.Run("empty and single", func(t *testing.T) {
 		if got := dedupeAuthorityServers(nil); len(got) != 0 {
 			t.Fatalf("nil deduped to %d servers", len(got))
@@ -133,17 +160,14 @@ func TestServerAddrIsAlreadyCanonical(t *testing.T) {
 			authority.NewServer(spelling, authority.IPv4),
 			mustServerFromSpelling(t, spelling),
 		} {
-			if !server.Endpoint.IsValid() {
-				t.Fatalf("%q produced no decoded endpoint", spelling)
+			addr, canonical := server.CanonicalAddr()
+			if !canonical {
+				t.Fatalf("%q was not recognized as a canonical address", spelling)
 			}
-			if got := middleware.CanonicalResolutionEndpoint(server.Addr); got != server.Addr {
+			if got := middleware.CanonicalResolutionEndpoint(addr); got != addr {
 				t.Fatalf("%q stored Addr %q, which canonicalizes to %q; the "+
 					"guard's fast path would key it under two identities",
-					spelling, server.Addr, got)
-			}
-			if server.Addr != server.Endpoint.String() {
-				t.Fatalf("%q stored Addr %q but Endpoint %q",
-					spelling, server.Addr, server.Endpoint)
+					spelling, addr, got)
 			}
 		}
 	}

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -1528,47 +1528,42 @@ func dedupeAuthorityServersLinear(servers []*authority.Server) []*authority.Serv
 }
 
 func dedupeAuthorityServersIndexed(servers []*authority.Server) []*authority.Server {
-	seen := make(map[netip.AddrPort]struct{}, len(servers))
-	var seenSpelled map[string]struct{}
+	seen := make(map[string]struct{}, len(servers))
 	result := servers[:0]
 	for _, server := range servers {
 		if server == nil {
 			continue
 		}
-		if endpoint := server.Endpoint; endpoint.IsValid() {
-			if _, ok := seen[endpoint]; ok {
-				continue
-			}
-			seen[endpoint] = struct{}{}
-			result = append(result, server)
+		key := resolutionEndpointIdentity(server)
+		if _, ok := seen[key]; ok {
 			continue
 		}
-		// Not an IP:port literal: identity is the canonical spelling, and
-		// it is kept apart so a decoded address is never compared against
-		// a printed one.
-		key := middleware.CanonicalResolutionEndpoint(server.Addr)
-		if _, ok := seenSpelled[key]; ok {
-			continue
-		}
-		if seenSpelled == nil {
-			seenSpelled = make(map[string]struct{})
-		}
-		seenSpelled[key] = struct{}{}
+		seen[key] = struct{}{}
 		result = append(result, server)
 	}
 	return result
 }
 
-// sameResolutionEndpoint reports whether two servers name the same upstream.
-// A decoded address compares as a value; anything else falls back to the
-// canonical spelling, and the two kinds never match each other because a
-// literal is exactly what the spelling path cannot produce.
-func sameResolutionEndpoint(a, b *authority.Server) bool {
-	if a.Endpoint.IsValid() || b.Endpoint.IsValid() {
-		return a.Endpoint == b.Endpoint
+// resolutionEndpointIdentity returns the spelling that identifies a server's
+// upstream. A server built from a decoded address already holds it; anything
+// else has to be normalized, and normalization is what produces a string.
+func resolutionEndpointIdentity(server *authority.Server) string {
+	if addr, canonical := server.CanonicalAddr(); canonical {
+		return addr
 	}
-	return middleware.CanonicalResolutionEndpoint(a.Addr) ==
-		middleware.CanonicalResolutionEndpoint(b.Addr)
+	return middleware.CanonicalResolutionEndpoint(server.Addr)
+}
+
+// sameResolutionEndpoint reports whether two servers name the same upstream.
+// Two canonical spellings compare directly; anything else is normalized
+// first, which only the servers whose address never was a literal reach.
+func sameResolutionEndpoint(a, b *authority.Server) bool {
+	aAddr, aCanonical := a.CanonicalAddr()
+	bAddr, bCanonical := b.CanonicalAddr()
+	if aCanonical && bCanonical {
+		return aAddr == bAddr
+	}
+	return resolutionEndpointIdentity(a) == resolutionEndpointIdentity(b)
 }
 
 // lookupResult bundles a single per-server query outcome for the
@@ -1722,8 +1717,8 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, proto string,
 	// again would parse that string and print an identical one back.
 	// A server whose address never was a literal has no such promise.
 	attemptErr := error(nil)
-	if server.Endpoint.IsValid() {
-		attemptErr = middleware.BeginResolutionAttemptCanonical(ctx, q, server.Addr, proto)
+	if addr, canonical := server.CanonicalAddr(); canonical {
+		attemptErr = middleware.BeginResolutionAttemptCanonical(ctx, q, addr, proto)
 	} else {
 		attemptErr = middleware.BeginResolutionAttempt(ctx, q, server.Addr, proto)
 	}

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -1485,21 +1485,90 @@ mainloop:
 	return pickFallbackResponse(responseErrors, configErrors, fatalErrors)
 }
 
+// linearDedupeLimit is the list size below which duplicate suppression
+// compares rather than indexes. A delegation names a handful of servers — the
+// root names thirteen — so the quadratic scan is a few dozen comparisons of
+// values already in registers, against a map that has to be built, sized and
+// discarded on every lookup.
+const linearDedupeLimit = 24
+
 func dedupeAuthorityServers(servers []*authority.Server) []*authority.Server {
-	seen := make(map[string]struct{}, len(servers))
+	if len(servers) <= linearDedupeLimit {
+		return dedupeAuthorityServersLinear(servers)
+	}
+	return dedupeAuthorityServersIndexed(servers)
+}
+
+// dedupeAuthorityServersLinear suppresses duplicates by comparing each server
+// against the ones already kept, in place and without allocating.
+//
+// The addresses arrive decoded — Endpoint is the value the constructor built
+// Addr from — so identity is a comparison of two netip.AddrPorts. Only a
+// server whose address is not an IP:port literal needs its spelling
+// canonicalized, and those never reach this path from the delegation
+// producers.
+func dedupeAuthorityServersLinear(servers []*authority.Server) []*authority.Server {
 	result := servers[:0]
 	for _, server := range servers {
 		if server == nil {
 			continue
 		}
-		key := middleware.CanonicalResolutionEndpoint(server.Addr)
-		if _, ok := seen[key]; ok {
+		duplicate := false
+		for _, kept := range result {
+			if sameResolutionEndpoint(kept, server) {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			result = append(result, server)
+		}
+	}
+	return result
+}
+
+func dedupeAuthorityServersIndexed(servers []*authority.Server) []*authority.Server {
+	seen := make(map[netip.AddrPort]struct{}, len(servers))
+	var seenSpelled map[string]struct{}
+	result := servers[:0]
+	for _, server := range servers {
+		if server == nil {
 			continue
 		}
-		seen[key] = struct{}{}
+		if endpoint := server.Endpoint; endpoint.IsValid() {
+			if _, ok := seen[endpoint]; ok {
+				continue
+			}
+			seen[endpoint] = struct{}{}
+			result = append(result, server)
+			continue
+		}
+		// Not an IP:port literal: identity is the canonical spelling, and
+		// it is kept apart so a decoded address is never compared against
+		// a printed one.
+		key := middleware.CanonicalResolutionEndpoint(server.Addr)
+		if _, ok := seenSpelled[key]; ok {
+			continue
+		}
+		if seenSpelled == nil {
+			seenSpelled = make(map[string]struct{})
+		}
+		seenSpelled[key] = struct{}{}
 		result = append(result, server)
 	}
 	return result
+}
+
+// sameResolutionEndpoint reports whether two servers name the same upstream.
+// A decoded address compares as a value; anything else falls back to the
+// canonical spelling, and the two kinds never match each other because a
+// literal is exactly what the spelling path cannot produce.
+func sameResolutionEndpoint(a, b *authority.Server) bool {
+	if a.Endpoint.IsValid() || b.Endpoint.IsValid() {
+		return a.Endpoint == b.Endpoint
+	}
+	return middleware.CanonicalResolutionEndpoint(a.Addr) ==
+		middleware.CanonicalResolutionEndpoint(b.Addr)
 }
 
 // lookupResult bundles a single per-server query outcome for the
@@ -1648,8 +1717,18 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, proto string,
 		return nil, ctxErr
 	}
 	q := req.Question[0]
-	if err := middleware.BeginResolutionAttempt(ctx, q, server.Addr, proto); err != nil {
-		return nil, err
+	// Addr was printed from a decoded address at construction, so it is
+	// already the canonical spelling the guard keys on; normalizing it
+	// again would parse that string and print an identical one back.
+	// A server whose address never was a literal has no such promise.
+	attemptErr := error(nil)
+	if server.Endpoint.IsValid() {
+		attemptErr = middleware.BeginResolutionAttemptCanonical(ctx, q, server.Addr, proto)
+	} else {
+		attemptErr = middleware.BeginResolutionAttempt(ctx, q, server.Addr, proto)
+	}
+	if attemptErr != nil {
+		return nil, attemptErr
 	}
 	if rs.work != nil {
 		var err error


### PR DESCRIPTION
## Problem

With the DNSSEC leaves gone, the field profile's largest remaining allocation sites in the resolver are two that spend everything they allocate re-deriving something the process already had.

An authority server's address is **decoded** when the delegation is read. `NewServerFromAddrPort` prints it into `Addr` exactly once. Then:

- **Duplicate suppression** (`dedupeAuthorityServers`) runs on every lookup, and derived each server's identity by calling `CanonicalResolutionEndpoint(server.Addr)` — which parses that string and prints an identical one back. One string per server per lookup, into a map built and discarded on every call.
- **The RFC 9520 retry guard** (`ResolutionAttemptGuard.Begin`) did the same for every attempt, then stored the tuple in a map that a request tree builds, grows and drops after a handful of entries.

## Change

`authority.Server` records that its `Addr` was printed from a decoded address and is therefore already the identity spelling. That is a bool, placed next to `IPVersion` so it lands in the padding those two already share: the Server does not grow.

**Duplicate suppression** compares those spellings in place for lists up to two dozen, which is every real delegation (the root names thirteen), and keeps a map beyond that. A server whose address was never an IP:port literal is normalized first, which is the only case that still produces a string.

**The guard** gains `BeginCanonical`, for callers whose spelling is already what `CanonicalResolutionEndpoint` would return. The delegation path uses it; the forwarder and failover paths, whose endpoints are configured strings, keep `Begin`.

That promise is the one thing in this change that could go wrong quietly: a non-canonical spelling handed to `BeginCanonical` would key one tuple under two identities and admit twice the attempts RFC 9520 §3.1 allows. `TestServerAddrIsAlreadyCanonical` pins it across every constructor path and every spelling that folds — 4-in-6, uppercase v6, expanded v6 — and `TestBeginCanonicalMatchesBegin` pins that attempts recorded through either entry point count against the same tuple.

**The guard's storage** is no longer a map for small trees. It is eight slots plus a presized overflow map, together in one store behind one pointer, allocated on the tree's *first* attempt — most requests are answered from cache and record none, so they must not carry it.

Both structures kept their size. The guard is embedded in every request tree's ledgers, so a field there is bytes on every request that resolves anything; the store is allocated once per resolving tree and lands in the size class the slots alone needed. On a 64-bit build:

| | before this branch | mid-branch | now |
|---|---|---|---|
| `authority.Server` | 48 B | 80 B | **48 B** |
| `ResolutionAttemptGuard` | 24 B | 32 B | **24 B** |
| `requestLedgers` | 48 B | 64 B | **48 B** |

Both are pinned by tests, because neither would announce itself if a later field undid it. The tests compare against a reference struct declared without the field under test rather than against a byte count — the claim is "the canonical marker is free" and "the guard has no third pointer", which is what has to hold on the 32-bit ARM and MIPS targets too.

## Measurements

Duplicate suppression, per lookup:

| servers | before | after |
|---|---|---|
| 2 | 32 B / 2 allocs / 90 ns | **0 B / 0 allocs / 8 ns** |
| 4 | 64 B / 4 allocs / 177 ns | **0 B / 0 allocs / 22 ns** |
| 13 (root) | 664 B / 16 allocs / 643 ns | **0 B / 0 allocs / 160 ns** |
| 64 | 4,520 B / 67 allocs / 3,000 ns | **3,496 B / 3 allocs / 1,170 ns** |

The retry guard, per request tree:

| attempts | before | after |
|---|---|---|
| 4 | 712 B / 7 allocs / 438 ns | **600 B / 2 allocs / 179 ns** |
| 12 | 2,032 B / 18 allocs / 1,451 ns | **1,224 B / 4 allocs / 705 ns** |
| 36 | 9,648 B / 46 allocs / 5,372 ns | **4,752 B / 9 allocs / 3,495 ns** |

A request answered from cache records no attempt and now allocates nothing for the guard at all.

## Tests

Neither function had any coverage before this.

Duplicate suppression: first-occurrence-wins ordering, nil entries, two distinct servers for one address, one host under two spellings via the fallback path, empty and single lists, and an allocation gate at 2, 8 and 13.

At 23, 24 and 25 servers — the threshold and either side of it — both implementations run on the same corpus, with the duplicates inside a list of exactly that length rather than appended to it, and must agree with each other and with the side the threshold picked. Making the linear scan miss one duplicate is caught there.

The guard: the two entry points share a counter, the limit error still names the endpoint, a tree that overflows the slots counts every tuple exactly once across the boundary — sequentially and under concurrent pressure through the transition — an unused guard allocates nothing, and a typical recursion costs one allocation. Both the overflow-map lookup and the transport canonicalization were mutation-checked: removing either makes a test name the exact failure.

`go test ./... -race`, `go vet` and `golangci-lint` are clean.

## Not in this change

`resolver.go`'s DNSKEY map build still decodes an oversized key once while computing its key tag. Removing that means computing the tag without the library's fixed buffer, which is its own change and does not belong here.
