### PR TITLE
dnssec: sum a key tag without decoding the key

### DIFF
--- a/internal/authority/server.go
+++ b/internal/authority/server.go
@@ -18,24 +18,34 @@ type Server struct {
 	Addr      string
 	IPVersion IPVersion
 
+	// canonical records that Addr was printed from a decoded address and is
+	// therefore already the identity spelling — what duplicate suppression
+	// compares and what the retry guard keys on. Deriving that identity by
+	// parsing Addr and printing it back produced a string per server per
+	// lookup, for a string this constructor had just built.
+	//
+	// It sits next to IPVersion so it lands in the padding those two share,
+	// and knowing this costs the Server nothing. False only when Addr was
+	// never an IP:port literal, where the spelling is not the identity and
+	// callers must normalize.
+	canonical bool
+
 	// UDPAddr is Addr pre-parsed as *net.UDPAddr so the upstream
 	// exchange path can use net.DialUDP directly instead of going
 	// through Dialer.DialContext's string-parsing + dialParallel
 	// machinery. Nil only if Addr failed to parse — callers fall
 	// back to the string path in that case.
 	UDPAddr *net.UDPAddr
+}
 
-	// Endpoint is this server's identity as a comparable value: the same
-	// address Addr spells, before it was spelled. Duplicate suppression and
-	// the retry guard both key on the endpoint, and deriving that key by
-	// parsing Addr and printing it back produced a string per server per
-	// lookup — for a string the constructor had just built from this very
-	// value.
-	//
-	// Zero when Addr is not an IP:port literal, which is the only case
-	// where the spelling is the identity; callers fall back to canonical
-	// normalization there.
-	Endpoint netip.AddrPort
+// CanonicalAddr returns Addr together with whether it is already in the
+// canonical spelling. A caller that keys on the endpoint can use the string
+// as-is when this reports true, and must normalize it otherwise.
+func (a *Server) CanonicalAddr() (string, bool) {
+	if a == nil {
+		return "", false
+	}
+	return a.Addr, a.canonical
 }
 
 // IPVersion type.
@@ -89,7 +99,7 @@ func NewServerFromAddrPort(ap netip.AddrPort) *Server {
 		Addr:      ap.String(),
 		IPVersion: version,
 		UDPAddr:   net.UDPAddrFromAddrPort(ap),
-		Endpoint:  ap,
+		canonical: true,
 	}
 }
 

--- a/internal/authority/server.go
+++ b/internal/authority/server.go
@@ -99,7 +99,10 @@ func NewServerFromAddrPort(ap netip.AddrPort) *Server {
 		Addr:      ap.String(),
 		IPVersion: version,
 		UDPAddr:   net.UDPAddrFromAddrPort(ap),
-		canonical: true,
+		// The zero AddrPort prints as "invalid AddrPort", which is a
+		// spelling and not an address. No producer hands one over, but the
+		// marker is a promise about Addr and must not be made about that.
+		canonical: ap.IsValid(),
 	}
 }
 

--- a/internal/authority/server.go
+++ b/internal/authority/server.go
@@ -24,6 +24,18 @@ type Server struct {
 	// machinery. Nil only if Addr failed to parse — callers fall
 	// back to the string path in that case.
 	UDPAddr *net.UDPAddr
+
+	// Endpoint is this server's identity as a comparable value: the same
+	// address Addr spells, before it was spelled. Duplicate suppression and
+	// the retry guard both key on the endpoint, and deriving that key by
+	// parsing Addr and printing it back produced a string per server per
+	// lookup — for a string the constructor had just built from this very
+	// value.
+	//
+	// Zero when Addr is not an IP:port literal, which is the only case
+	// where the spelling is the identity; callers fall back to canonical
+	// normalization there.
+	Endpoint netip.AddrPort
 }
 
 // IPVersion type.
@@ -77,6 +89,7 @@ func NewServerFromAddrPort(ap netip.AddrPort) *Server {
 		Addr:      ap.String(),
 		IPVersion: version,
 		UDPAddr:   net.UDPAddrFromAddrPort(ap),
+		Endpoint:  ap,
 	}
 }
 

--- a/internal/authority/server_test.go
+++ b/internal/authority/server_test.go
@@ -3,6 +3,7 @@ package authority
 import (
 	"fmt"
 	"math/rand"
+	"net"
 	"net/netip"
 	"testing"
 	"time"
@@ -11,16 +12,28 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// serverWithoutCanonical is Server as it stood before it recorded whether its
+// address is canonical. It is the reference the size test compares against, so
+// the claim being made is "the marker is free" rather than a byte count that
+// is only true on one ABI.
+type serverWithoutCanonical struct {
+	Rtt       int64
+	Count     int64
+	Addr      string
+	IPVersion IPVersion
+	UDPAddr   *net.UDPAddr
+}
+
 // TestServerLayoutStaysSmall pins that knowing an address is canonical costs
 // nothing. There is one Server per authority per delegation and they are
 // allocated as the resolver reads referrals, so a field that pushes this into
-// the next size class is paid for continuously. canonical fits in the padding
+// the next size class is paid for continuously; canonical fits in the padding
 // IPVersion already leaves.
 func TestServerLayoutStaysSmall(t *testing.T) {
-	const want = 48
+	want := unsafe.Sizeof(serverWithoutCanonical{})
 	if got := unsafe.Sizeof(Server{}); got != want {
-		t.Fatalf("Server is %d B, want %d; a new field left the padding "+
-			"IPVersion shares", got, want)
+		t.Fatalf("Server is %d B against a reference of %d B; a field left "+
+			"the padding IPVersion shares", got, want)
 	}
 }
 

--- a/internal/authority/server_test.go
+++ b/internal/authority/server_test.go
@@ -6,9 +6,23 @@ import (
 	"net/netip"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/stretchr/testify/assert"
 )
+
+// TestServerLayoutStaysSmall pins that knowing an address is canonical costs
+// nothing. There is one Server per authority per delegation and they are
+// allocated as the resolver reads referrals, so a field that pushes this into
+// the next size class is paid for continuously. canonical fits in the padding
+// IPVersion already leaves.
+func TestServerLayoutStaysSmall(t *testing.T) {
+	const want = 48
+	if got := unsafe.Sizeof(Server{}); got != want {
+		t.Fatalf("Server is %d B, want %d; a new field left the padding "+
+			"IPVersion shares", got, want)
+	}
+}
 
 func Test_TrySort(t *testing.T) {
 	s := &Servers{

--- a/middleware/resolution_attempt.go
+++ b/middleware/resolution_attempt.go
@@ -55,19 +55,54 @@ func (e *ResolutionAttemptLimitError) Unwrap() error { return ErrResolutionAttem
 
 type resolutionAttemptKey struct {
 	qname     string
-	qtype     uint16
-	qclass    uint16
 	endpoint  string
 	transport string
+	qtype     uint16
+	qclass    uint16
+}
+
+func (k resolutionAttemptKey) limitError() error {
+	return &ResolutionAttemptLimitError{
+		Question:  dns.Question{Name: k.qname, Qtype: k.qtype, Qclass: k.qclass},
+		Endpoint:  k.endpoint,
+		Transport: k.transport,
+	}
+}
+
+// resolutionAttemptEntry is one recorded tuple in the guard's inline table.
+type resolutionAttemptEntry struct {
+	key   resolutionAttemptKey
+	count uint8
 }
 
 // ResolutionAttemptGuard owns retry state and exact terminal request-local
 // response provenance for one complete client request tree. A mutex keeps both
 // maps atomic across resolver fan-out.
 type ResolutionAttemptGuard struct {
-	mu                    sync.Mutex
+	mu sync.Mutex
+	// table holds the first few tuples without a map. A request tree that
+	// resolves normally records a handful of attempts and then goes away,
+	// and building and growing a map for them was the guard's whole cost.
+	//
+	// It hangs off a pointer rather than sitting in the struct because most
+	// requests are answered from cache and record no attempt at all; those
+	// must not carry the table's weight for a tuple they never had. The
+	// map takes the overflow, for the trees that fan out.
+	table                 *resolutionAttemptTable
 	attempts              map[resolutionAttemptKey]uint8
 	localFailureResponses map[*dns.Msg]error
+}
+
+// resolutionAttemptOverflowHint sizes the map the moment the inline table is
+// full, so a tree that fans out grows it once instead of rehashing its way up
+// from nothing.
+const resolutionAttemptOverflowHint = 8
+
+// resolutionAttemptTable is the guard's inline storage: allocated on the
+// tree's first attempt and never grown, since the map takes over from there.
+type resolutionAttemptTable struct {
+	len   int
+	slots [8]resolutionAttemptEntry
 }
 
 // NewResolutionAttemptGuard returns an empty request-tree retry guard.
@@ -84,28 +119,71 @@ func (g *ResolutionAttemptGuard) Begin(q dns.Question, endpoint, transport strin
 		return nil
 	}
 
-	key := resolutionAttemptKey{
+	return g.BeginCanonical(q, CanonicalResolutionEndpoint(endpoint), transport)
+}
+
+// BeginCanonical is Begin for a caller whose endpoint is already spelled the
+// way CanonicalResolutionEndpoint would spell it — the delegation path, where
+// the address was decoded from glue and its "IP:port" form was printed from
+// that value once, at construction. Normalizing it again parses the string
+// and prints an identical one back, per attempt.
+//
+// The promise matters: a spelling that is not canonical splits one tuple's
+// counter in two, and the RFC 9520 limit is what the counter enforces. Callers
+// that cannot make the promise must use Begin.
+func (g *ResolutionAttemptGuard) BeginCanonical(q dns.Question, endpoint, transport string) error {
+	if g == nil {
+		return nil
+	}
+	return g.begin(resolutionAttemptKey{
 		qname:     dns.CanonicalName(q.Name),
 		qtype:     q.Qtype,
 		qclass:    q.Qclass,
-		endpoint:  CanonicalResolutionEndpoint(endpoint),
+		endpoint:  endpoint,
 		transport: canonicalResolutionTransport(transport),
-	}
+	})
+}
 
+func (g *ResolutionAttemptGuard) begin(key resolutionAttemptKey) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
-	if g.attempts == nil {
-		g.attempts = make(map[resolutionAttemptKey]uint8)
-	}
-	if g.attempts[key] >= maxResolutionAttempts {
-		return &ResolutionAttemptLimitError{
-			Question:  dns.Question{Name: key.qname, Qtype: key.qtype, Qclass: key.qclass},
-			Endpoint:  key.endpoint,
-			Transport: key.transport,
+	// A tuple lives in exactly one of the two stores, so a hit in the table
+	// is conclusive and the map is never consulted for it.
+	if g.table != nil {
+		for i := range g.table.len {
+			entry := &g.table.slots[i]
+			if entry.key != key {
+				continue
+			}
+			if entry.count >= maxResolutionAttempts {
+				return key.limitError()
+			}
+			entry.count++
+			return nil
 		}
 	}
-	g.attempts[key]++
+
+	if count, recorded := g.attempts[key]; recorded {
+		if count >= maxResolutionAttempts {
+			return key.limitError()
+		}
+		g.attempts[key] = count + 1
+		return nil
+	}
+
+	if g.table == nil {
+		g.table = new(resolutionAttemptTable)
+	}
+	if g.table.len < len(g.table.slots) {
+		g.table.slots[g.table.len] = resolutionAttemptEntry{key: key, count: 1}
+		g.table.len++
+		return nil
+	}
+	if g.attempts == nil {
+		g.attempts = make(map[resolutionAttemptKey]uint8, resolutionAttemptOverflowHint)
+	}
+	g.attempts[key] = 1
 	return nil
 }
 
@@ -212,6 +290,20 @@ func EnsureResolutionAttemptGuard(ctx context.Context) (context.Context, *Resolu
 func BeginResolutionAttempt(ctx context.Context, q dns.Question, endpoint, transport string) error {
 	if guard := ResolutionAttemptGuardFrom(ctx); guard != nil {
 		return guard.Begin(q, endpoint, transport)
+	}
+	return nil
+}
+
+// BeginResolutionAttemptCanonical is BeginResolutionAttempt for a caller whose
+// endpoint is already canonically spelled. See BeginCanonical for what that
+// promise means.
+func BeginResolutionAttemptCanonical(
+	ctx context.Context,
+	q dns.Question,
+	endpoint, transport string,
+) error {
+	if guard := ResolutionAttemptGuardFrom(ctx); guard != nil {
+		return guard.BeginCanonical(q, endpoint, transport)
 	}
 	return nil
 }

--- a/middleware/resolution_attempt.go
+++ b/middleware/resolution_attempt.go
@@ -80,29 +80,30 @@ type resolutionAttemptEntry struct {
 // maps atomic across resolver fan-out.
 type ResolutionAttemptGuard struct {
 	mu sync.Mutex
-	// table holds the first few tuples without a map. A request tree that
-	// resolves normally records a handful of attempts and then goes away,
-	// and building and growing a map for them was the guard's whole cost.
-	//
-	// It hangs off a pointer rather than sitting in the struct because most
-	// requests are answered from cache and record no attempt at all; those
-	// must not carry the table's weight for a tuple they never had. The
-	// map takes the overflow, for the trees that fan out.
-	table                 *resolutionAttemptTable
-	attempts              map[resolutionAttemptKey]uint8
+	// attempts holds the tree's recorded tuples. It hangs off a pointer
+	// because most requests are answered from cache and record none; those
+	// must not carry storage for a tuple they never had.
+	attempts              *resolutionAttemptStore
 	localFailureResponses map[*dns.Msg]error
 }
 
-// resolutionAttemptOverflowHint sizes the map the moment the inline table is
-// full, so a tree that fans out grows it once instead of rehashing its way up
-// from nothing.
+// resolutionAttemptOverflowHint sizes the overflow map the moment the slots
+// are full, so a tree that fans out grows it once instead of rehashing its way
+// up from nothing.
 const resolutionAttemptOverflowHint = 8
 
-// resolutionAttemptTable is the guard's inline storage: allocated on the
-// tree's first attempt and never grown, since the map takes over from there.
-type resolutionAttemptTable struct {
-	len   int
-	slots [8]resolutionAttemptEntry
+// resolutionAttemptStore is the guard's storage: a fixed set of slots for the
+// tuples a request tree normally records, and a map for the trees that fan out
+// past them.
+//
+// The two live together under one pointer rather than beside each other in the
+// guard. The guard is embedded in the request tree's ledgers, so a second
+// pointer there is eight bytes on every request that resolves anything, while
+// here it lands inside the allocation the slots already needed.
+type resolutionAttemptStore struct {
+	len      int
+	slots    [8]resolutionAttemptEntry
+	overflow map[resolutionAttemptKey]uint8
 }
 
 // NewResolutionAttemptGuard returns an empty request-tree retry guard.
@@ -148,42 +149,42 @@ func (g *ResolutionAttemptGuard) begin(key resolutionAttemptKey) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
-	// A tuple lives in exactly one of the two stores, so a hit in the table
-	// is conclusive and the map is never consulted for it.
-	if g.table != nil {
-		for i := range g.table.len {
-			entry := &g.table.slots[i]
-			if entry.key != key {
-				continue
-			}
-			if entry.count >= maxResolutionAttempts {
-				return key.limitError()
-			}
-			entry.count++
-			return nil
+	if g.attempts == nil {
+		g.attempts = new(resolutionAttemptStore)
+	}
+	store := g.attempts
+
+	// A tuple lives in exactly one place, so a hit in the slots is
+	// conclusive and the overflow map is never consulted for it.
+	for i := range store.len {
+		entry := &store.slots[i]
+		if entry.key != key {
+			continue
 		}
+		if entry.count >= maxResolutionAttempts {
+			return key.limitError()
+		}
+		entry.count++
+		return nil
 	}
 
-	if count, recorded := g.attempts[key]; recorded {
+	if count, recorded := store.overflow[key]; recorded {
 		if count >= maxResolutionAttempts {
 			return key.limitError()
 		}
-		g.attempts[key] = count + 1
+		store.overflow[key] = count + 1
 		return nil
 	}
 
-	if g.table == nil {
-		g.table = new(resolutionAttemptTable)
-	}
-	if g.table.len < len(g.table.slots) {
-		g.table.slots[g.table.len] = resolutionAttemptEntry{key: key, count: 1}
-		g.table.len++
+	if store.len < len(store.slots) {
+		store.slots[store.len] = resolutionAttemptEntry{key: key, count: 1}
+		store.len++
 		return nil
 	}
-	if g.attempts == nil {
-		g.attempts = make(map[resolutionAttemptKey]uint8, resolutionAttemptOverflowHint)
+	if store.overflow == nil {
+		store.overflow = make(map[resolutionAttemptKey]uint8, resolutionAttemptOverflowHint)
 	}
-	g.attempts[key] = 1
+	store.overflow[key] = 1
 	return nil
 }
 

--- a/middleware/resolution_attempt_alloc_test.go
+++ b/middleware/resolution_attempt_alloc_test.go
@@ -3,7 +3,10 @@ package middleware
 import (
 	"errors"
 	"net/netip"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"unsafe"
 
 	"github.com/miekg/dns"
 )
@@ -99,7 +102,7 @@ func TestBeginCanonicalReportsTheEndpoint(t *testing.T) {
 func TestGuardCostsNothingWithoutAnAttempt(t *testing.T) {
 	allocs := testing.AllocsPerRun(200, func() {
 		var guard ResolutionAttemptGuard
-		if guard.table != nil {
+		if guard.attempts != nil {
 			t.Fatal("a guard allocated storage before recording an attempt")
 		}
 	})
@@ -146,8 +149,8 @@ func TestBeginCanonicalCostsOneAllocationForATypicalRecursion(t *testing.T) {
 // would either lose its count or double it.
 func TestResolutionAttemptGuardCountsAcrossTheOverflow(t *testing.T) {
 	trace := resolutionAttemptTrace(4, 4)
-	if len(trace) <= len(new(resolutionAttemptTable).slots) {
-		t.Fatal("fixture is wrong: the trace does not overflow the inline table")
+	if len(trace) <= len(new(resolutionAttemptStore).slots) {
+		t.Fatal("fixture is wrong: the trace does not overflow the slots")
 	}
 	guard := NewResolutionAttemptGuard()
 
@@ -163,6 +166,56 @@ func TestResolutionAttemptGuardCountsAcrossTheOverflow(t *testing.T) {
 		if err := guard.BeginCanonical(step.q, step.endpoint, "udp"); err == nil {
 			t.Fatalf("tuple %d admitted attempt %d", i, maxResolutionAttempts+1)
 		}
+	}
+}
+
+// TestResolutionAttemptGuardConcurrentOverflow drives the slots-to-map
+// boundary from many goroutines at once. The transition mutates the store's
+// shape, so a tuple recorded while it happens is where a lost or doubled count
+// would appear.
+func TestResolutionAttemptGuardConcurrentOverflow(t *testing.T) {
+	trace := resolutionAttemptTrace(4, 4)
+	if len(trace) <= len(new(resolutionAttemptStore).slots) {
+		t.Fatal("fixture is wrong: the trace does not overflow the slots")
+	}
+	guard := NewResolutionAttemptGuard()
+
+	// Every tuple is offered one more time than the limit allows, from its
+	// own goroutine; exactly maxResolutionAttempts must be admitted.
+	const offers = maxResolutionAttempts + 1
+	admitted := make([]atomic.Int32, len(trace))
+	var wg sync.WaitGroup
+	for i, step := range trace {
+		for range offers {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := guard.BeginCanonical(step.q, step.endpoint, "udp"); err == nil {
+					admitted[i].Add(1)
+				}
+			}()
+		}
+	}
+	wg.Wait()
+
+	for i := range trace {
+		if got := admitted[i].Load(); got != maxResolutionAttempts {
+			t.Fatalf("tuple %d admitted %d attempts, want %d",
+				i, got, maxResolutionAttempts)
+		}
+	}
+}
+
+// TestGuardLayoutStaysSmall pins what this change is for. The guard is
+// embedded in every request tree's ledgers, so a field added here is bytes on
+// every request that resolves anything — including the ones that never record
+// an attempt. The store's own size matters far less: it is allocated once per
+// resolving tree, and only for those.
+func TestGuardLayoutStaysSmall(t *testing.T) {
+	const wantGuard = 24 // a mutex and two pointers
+	if got := unsafe.Sizeof(ResolutionAttemptGuard{}); got != wantGuard {
+		t.Fatalf("ResolutionAttemptGuard is %d B, want %d; a field here is "+
+			"carried by every request tree", got, wantGuard)
 	}
 }
 

--- a/middleware/resolution_attempt_alloc_test.go
+++ b/middleware/resolution_attempt_alloc_test.go
@@ -206,16 +206,28 @@ func TestResolutionAttemptGuardConcurrentOverflow(t *testing.T) {
 	}
 }
 
+// guardLayoutReference is what the guard is allowed to be: a mutex and the two
+// pointers it stores through. Comparing against it rather than a byte count
+// keeps the claim — "no third field, and the slots and their overflow share
+// one pointer" — true on every ABI rather than only a 64-bit one.
+// Only the shapes matter, so the fields are unnamed: a mutex, the pointer the
+// slots and their overflow share, and the failure-response map.
+type guardLayoutReference struct {
+	_ sync.Mutex
+	_ *resolutionAttemptStore
+	_ map[*dns.Msg]error
+}
+
 // TestGuardLayoutStaysSmall pins what this change is for. The guard is
 // embedded in every request tree's ledgers, so a field added here is bytes on
 // every request that resolves anything — including the ones that never record
 // an attempt. The store's own size matters far less: it is allocated once per
 // resolving tree, and only for those.
 func TestGuardLayoutStaysSmall(t *testing.T) {
-	const wantGuard = 24 // a mutex and two pointers
-	if got := unsafe.Sizeof(ResolutionAttemptGuard{}); got != wantGuard {
-		t.Fatalf("ResolutionAttemptGuard is %d B, want %d; a field here is "+
-			"carried by every request tree", got, wantGuard)
+	want := unsafe.Sizeof(guardLayoutReference{})
+	if got := unsafe.Sizeof(ResolutionAttemptGuard{}); got != want {
+		t.Fatalf("ResolutionAttemptGuard is %d B against a reference of %d B; "+
+			"the extra is carried by every request tree", got, want)
 	}
 }
 

--- a/middleware/resolution_attempt_alloc_test.go
+++ b/middleware/resolution_attempt_alloc_test.go
@@ -1,0 +1,199 @@
+package middleware
+
+import (
+	"errors"
+	"net/netip"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// resolutionAttemptStep is one recorded attempt: a question, and the endpoint
+// it was asked of in the canonical spelling the delegation path already holds.
+type resolutionAttemptStep struct {
+	q        dns.Question
+	endpoint string
+}
+
+// resolutionAttemptTrace is the shape a recursion presents to the guard: a
+// handful of questions, each asked of a handful of endpoints, every tuple
+// distinct.
+func resolutionAttemptTrace(questions, endpoints int) []resolutionAttemptStep {
+	names := []string{
+		"example.com.", "www.example.com.", "cdn.example.com.",
+		"a.deep.example.com.", "mail.example.com.", "api.example.com.",
+	}
+	trace := make([]resolutionAttemptStep, 0, questions*endpoints)
+	for i := range questions {
+		q := dns.Question{
+			Name:   names[i%len(names)],
+			Qtype:  dns.TypeA,
+			Qclass: dns.ClassINET,
+		}
+		for j := range endpoints {
+			addr := netip.AddrPortFrom(
+				netip.AddrFrom4([4]byte{192, 0, 2, byte(j + 1)}), 53)
+			trace = append(trace, resolutionAttemptStep{q, addr.String()})
+		}
+	}
+	return trace
+}
+
+// TestBeginCanonicalMatchesBegin pins that the two entry points are the same
+// guard: an attempt recorded through either must count against the other, or
+// the RFC 9520 limit could be evaded by alternating between them.
+func TestBeginCanonicalMatchesBegin(t *testing.T) {
+	q := dns.Question{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	const canonical = "192.0.2.1:53"
+
+	guard := NewResolutionAttemptGuard()
+	for i := range maxResolutionAttempts {
+		var err error
+		if i%2 == 0 {
+			err = guard.BeginCanonical(q, canonical, "udp")
+		} else {
+			// A spelling the normalizer has to fold to the same identity.
+			err = guard.Begin(q, " 192.0.2.1:53 ", "UDP")
+		}
+		if err != nil {
+			t.Fatalf("attempt %d rejected: %v", i+1, err)
+		}
+	}
+	if err := guard.BeginCanonical(q, canonical, "udp"); err == nil {
+		t.Fatal("the fourth attempt was admitted; alternating entry points " +
+			"split one tuple into two counters")
+	}
+	if err := guard.Begin(q, "192.0.2.1:53", "udp"); err == nil {
+		t.Fatal("the fourth attempt was admitted through the spelled path")
+	}
+}
+
+// TestBeginCanonicalReportsTheEndpoint keeps the limit error legible.
+func TestBeginCanonicalReportsTheEndpoint(t *testing.T) {
+	q := dns.Question{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	const canonical = "192.0.2.1:53"
+
+	guard := NewResolutionAttemptGuard()
+	for range maxResolutionAttempts {
+		if err := guard.BeginCanonical(q, canonical, "udp"); err != nil {
+			t.Fatalf("attempt rejected: %v", err)
+		}
+	}
+	err := guard.BeginCanonical(q, canonical, "udp")
+	if err == nil {
+		t.Fatal("the fourth attempt was admitted")
+	}
+	var limit *ResolutionAttemptLimitError
+	if !errors.As(err, &limit) {
+		t.Fatalf("error is %T, want *ResolutionAttemptLimitError", err)
+	}
+	if limit.Endpoint != canonical {
+		t.Fatalf("limit error names endpoint %q, want %q",
+			limit.Endpoint, canonical)
+	}
+}
+
+// TestGuardCostsNothingWithoutAnAttempt pins the cache-hit case. Most requests
+// are answered without touching the network, and the guard's storage must not
+// be part of what they carry.
+func TestGuardCostsNothingWithoutAnAttempt(t *testing.T) {
+	allocs := testing.AllocsPerRun(200, func() {
+		var guard ResolutionAttemptGuard
+		if guard.table != nil {
+			t.Fatal("a guard allocated storage before recording an attempt")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("an unused guard cost %.0f allocations", allocs)
+	}
+}
+
+// TestBeginCanonicalCostsOneAllocationForATypicalRecursion pins the guard's
+// cost against the shape a real request tree presents: the inline table, once,
+// and nothing else. The endpoint arrives already spelled, so recording an
+// attempt does not normalize it, and a handful of tuples does not need a map.
+func TestBeginCanonicalCostsOneAllocationForATypicalRecursion(t *testing.T) {
+	const runs = 200
+	trace := resolutionAttemptTrace(2, 2)
+
+	// A fresh guard per run, built outside the measurement: the guard
+	// itself is one allocation the request tree pays anyway, and what is
+	// being measured is what recording attempts adds to it.
+	guards := make([]*ResolutionAttemptGuard, runs+2)
+	for i := range guards {
+		guards[i] = NewResolutionAttemptGuard()
+	}
+	run := 0
+
+	allocs := testing.AllocsPerRun(runs, func() {
+		guard := guards[run]
+		run++
+		for _, step := range trace {
+			if err := guard.BeginCanonical(step.q, step.endpoint, "udp"); err != nil {
+				t.Fatalf("attempt rejected: %v", err)
+			}
+		}
+	})
+	if allocs != 1 {
+		t.Fatalf("a %d-attempt request tree cost %.0f allocations, want 1 "+
+			"(the inline table)", len(trace), allocs)
+	}
+}
+
+// TestResolutionAttemptGuardCountsAcrossTheOverflow pins the limit through the
+// boundary between the inline table and the map. A tuple lives in one store or
+// the other, and a tuple that moved between them — or was recorded in both —
+// would either lose its count or double it.
+func TestResolutionAttemptGuardCountsAcrossTheOverflow(t *testing.T) {
+	trace := resolutionAttemptTrace(4, 4)
+	if len(trace) <= len(new(resolutionAttemptTable).slots) {
+		t.Fatal("fixture is wrong: the trace does not overflow the inline table")
+	}
+	guard := NewResolutionAttemptGuard()
+
+	// Every tuple admits exactly maxResolutionAttempts, wherever it lives.
+	for attempt := range maxResolutionAttempts {
+		for i, step := range trace {
+			if err := guard.BeginCanonical(step.q, step.endpoint, "udp"); err != nil {
+				t.Fatalf("tuple %d rejected on attempt %d: %v", i, attempt+1, err)
+			}
+		}
+	}
+	for i, step := range trace {
+		if err := guard.BeginCanonical(step.q, step.endpoint, "udp"); err == nil {
+			t.Fatalf("tuple %d admitted attempt %d", i, maxResolutionAttempts+1)
+		}
+	}
+}
+
+func BenchmarkResolutionAttemptGuard(b *testing.B) {
+	for _, shape := range []struct {
+		name      string
+		questions int
+		endpoints int
+	}{
+		{"attempts=4", 2, 2},
+		{"attempts=12", 3, 4},
+		{"attempts=36", 6, 6},
+	} {
+		trace := resolutionAttemptTrace(shape.questions, shape.endpoints)
+		b.Run(shape.name+"/canonical", func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				guard := NewResolutionAttemptGuard()
+				for _, step := range trace {
+					_ = guard.BeginCanonical(step.q, step.endpoint, "udp")
+				}
+			}
+		})
+		b.Run(shape.name+"/spelled", func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				guard := NewResolutionAttemptGuard()
+				for _, step := range trace {
+					_ = guard.Begin(step.q, step.endpoint, "udp")
+				}
+			}
+		})
+	}
+}

--- a/middleware/resolver/auto_trust_anchor.go
+++ b/middleware/resolver/auto_trust_anchor.go
@@ -140,7 +140,7 @@ func (r *Resolver) AutoTA() {
 		for _, rr := range r.rootKeys {
 			if dnskey, ok := rr.(*dns.DNSKEY); ok {
 				if dnskey.Flags&DNSKEYFlagKSK != 0 {
-					keyTag := dnskey.KeyTag()
+					keyTag := dnssec.KeyTag(dnskey)
 					ta := &TrustAnchor{
 						DNSKey:    dnskey,
 						State:     StateValid,
@@ -230,7 +230,7 @@ func (r *Resolver) AutoTA() {
 		if !ok || dnskey.Flags&DNSKEYFlagKSK == 0 {
 			continue
 		}
-		tag := dnskey.KeyTag()
+		tag := dnssec.KeyTag(dnskey)
 		if _, exists := kskCurrent[tag]; exists {
 			continue
 		}
@@ -268,10 +268,10 @@ func (r *Resolver) AutoTA() {
 	}
 
 	for _, k := range candidate {
-		validTag := k.(*dns.DNSKEY).KeyTag()
+		validTag := dnssec.KeyTag(k.(*dns.DNSKEY))
 		ok := false
 		for _, kv := range r.configuredRootKeys {
-			currTag := kv.(*dns.DNSKEY).KeyTag()
+			currTag := dnssec.KeyTag(kv.(*dns.DNSKEY))
 			if currTag == validTag {
 				ok = true
 			}
@@ -335,7 +335,7 @@ func (r *Resolver) AutoTA() {
 	for _, rr := range resp.Answer {
 		if dnskey, ok := rr.(*dns.DNSKEY); ok {
 			if dnskey.Flags&DNSKEYFlagKSK != 0 {
-				keyTag := dnskey.KeyTag()
+				keyTag := dnssec.KeyTag(dnskey)
 				ta := &TrustAnchor{
 					DNSKey: dnskey,
 					State:  StateStart,
@@ -591,7 +591,7 @@ func (r *Resolver) AutoTA() {
 		zlog.Info("Trust anchor status", "keytag", tag, "state", ta.State.String(), "firstseen", ta.FirstSeen.UTC().Format(time.UnixDate))
 	}
 	for fp, tb := range tombstones {
-		zlog.Info("Trust anchor tombstone", "keytag", tb.DNSKey.KeyTag(), "fp", fp, "firstseen", tb.FirstSeen.UTC().Format(time.UnixDate))
+		zlog.Info("Trust anchor tombstone", "keytag", dnssec.KeyTag(tb.DNSKey), "fp", fp, "firstseen", tb.FirstSeen.UTC().Format(time.UnixDate))
 	}
 
 	if tombErr == nil && stateErr == nil {
@@ -651,7 +651,7 @@ func revocationIsSelfSignedWithWork(
 	}
 	msg := &dns.Msg{Answer: append([]dns.RR(nil), rrs...)}
 	keys := map[uint16][]*dns.DNSKEY{
-		revokedKey.KeyTag(): {revokedKey},
+		dnssec.KeyTag(revokedKey): {revokedKey},
 	}
 	return dnssec.VerifyRRSIGWithWork(revokedKey.Header().Name, keys, msg, work)
 }
@@ -730,7 +730,7 @@ func verifyFetchedKeysWithWork(
 	for _, r := range rootKeys {
 		dnskey := r.(*dns.DNSKEY)
 		if dnskey.Flags&DNSKEYFlagKSK != 0 {
-			tag := dnskey.KeyTag()
+			tag := dnssec.KeyTag(dnskey)
 			currentKeys[tag] = append(currentKeys[tag], dnskey)
 		}
 	}
@@ -752,9 +752,9 @@ func verifyFetchedKeysWithWork(
 		if dnskey.Flags&DNSKEYFlagRevoke == 0 {
 			continue
 		}
-		for _, candidate := range currentKeys[dnskey.KeyTag()-DNSKEYFlagRevoke] {
+		for _, candidate := range currentKeys[dnssec.KeyTag(dnskey)-DNSKEYFlagRevoke] {
 			if sameKeyExceptRevoke(candidate, dnskey) {
-				tag := dnskey.KeyTag()
+				tag := dnssec.KeyTag(dnskey)
 				revokedBootstrap[tag] = append(revokedBootstrap[tag], dnskey)
 				break
 			}

--- a/middleware/resolver/dedupe_test.go
+++ b/middleware/resolver/dedupe_test.go
@@ -1,0 +1,186 @@
+package resolver
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/semihalev/sdns/internal/authority"
+	"github.com/semihalev/sdns/middleware"
+)
+
+// authorityServers builds a delegation's worth of servers the way the
+// resolver's own producers do — from decoded glue addresses.
+func authorityServers(tb testing.TB, count int) []*authority.Server {
+	tb.Helper()
+	servers := make([]*authority.Server, 0, count)
+	for i := range count {
+		addr := netip.AddrPortFrom(
+			netip.AddrFrom4([4]byte{192, 0, 2, byte(i + 1)}), 53)
+		servers = append(servers, authority.NewServerFromAddrPort(addr))
+	}
+	return servers
+}
+
+func serverAddrs(servers []*authority.Server) []string {
+	addrs := make([]string, 0, len(servers))
+	for _, s := range servers {
+		addrs = append(addrs, s.Addr)
+	}
+	return addrs
+}
+
+func TestDedupeAuthorityServers(t *testing.T) {
+	t.Run("keeps first occurrence and order", func(t *testing.T) {
+		servers := authorityServers(t, 3)
+		input := []*authority.Server{
+			servers[2], servers[0], servers[2], servers[1], servers[0],
+		}
+		got := serverAddrs(dedupeAuthorityServers(input))
+		want := []string{servers[2].Addr, servers[0].Addr, servers[1].Addr}
+		if len(got) != len(want) {
+			t.Fatalf("deduped to %v, want %v", got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("deduped to %v, want %v", got, want)
+			}
+		}
+	})
+
+	t.Run("drops nil entries", func(t *testing.T) {
+		servers := authorityServers(t, 2)
+		got := dedupeAuthorityServers(
+			[]*authority.Server{nil, servers[0], nil, servers[1], nil})
+		if len(got) != 2 {
+			t.Fatalf("deduped to %d servers, want 2", len(got))
+		}
+	})
+
+	t.Run("distinct pointers with one address collapse", func(t *testing.T) {
+		addr := netip.AddrPortFrom(netip.AddrFrom4([4]byte{192, 0, 2, 1}), 53)
+		got := dedupeAuthorityServers([]*authority.Server{
+			authority.NewServerFromAddrPort(addr),
+			authority.NewServerFromAddrPort(addr),
+		})
+		if len(got) != 1 {
+			t.Fatalf("two servers for one address deduped to %d, want 1", len(got))
+		}
+	})
+
+	t.Run("a non-literal address still dedupes", func(t *testing.T) {
+		// No netip identity to compare, so these fall back to the
+		// canonical-spelling path.
+		got := dedupeAuthorityServers([]*authority.Server{
+			authority.NewServer("NS1.Example.Com:53", authority.IPv4),
+			authority.NewServer("ns1.example.com:53", authority.IPv4),
+		})
+		if len(got) != 1 {
+			t.Fatalf("one host under two spellings deduped to %d, want 1", len(got))
+		}
+	})
+
+	t.Run("empty and single", func(t *testing.T) {
+		if got := dedupeAuthorityServers(nil); len(got) != 0 {
+			t.Fatalf("nil deduped to %d servers", len(got))
+		}
+		one := authorityServers(t, 1)
+		if got := dedupeAuthorityServers(one); len(got) != 1 {
+			t.Fatalf("one server deduped to %d", len(got))
+		}
+	})
+}
+
+// TestDedupeAuthorityServersDoesNotAllocate pins the delegation-sized case.
+// Every lookup dedupes its authority list, the addresses were canonical the
+// moment they were decoded, and re-deriving that identity per server per
+// lookup was the second-largest allocation site in the resolver.
+func TestDedupeAuthorityServersDoesNotAllocate(t *testing.T) {
+	for _, count := range []int{2, 8, 13} {
+		servers := authorityServers(t, count)
+		input := make([]*authority.Server, len(servers))
+
+		allocs := testing.AllocsPerRun(200, func() {
+			copy(input, servers)
+			if got := dedupeAuthorityServers(input); len(got) != count {
+				t.Fatalf("%d servers deduped to %d", count, len(got))
+			}
+		})
+		if allocs != 0 {
+			t.Fatalf("deduping %d servers cost %.0f allocations", count, allocs)
+		}
+	}
+}
+
+// TestServerAddrIsAlreadyCanonical pins the promise the retry guard's fast
+// path is built on.
+//
+// queryServer hands Addr to BeginCanonical instead of normalizing it, which is
+// only sound while a server carrying a decoded Endpoint spells that endpoint
+// exactly as CanonicalResolutionEndpoint would. If a constructor ever stored a
+// different spelling, one tuple would count under two keys and the RFC 9520
+// attempt limit would admit twice what it should — silently.
+func TestServerAddrIsAlreadyCanonical(t *testing.T) {
+	for _, spelling := range []string{
+		"192.0.2.1:53",
+		"[2001:db8::1]:53",
+		// 4-in-6 and an uppercase v6 literal: both are addresses the
+		// constructor is expected to fold.
+		"[::ffff:192.0.2.1]:53",
+		"[2001:DB8::1]:53",
+		"[2001:db8:0:0:0:0:0:1]:53",
+	} {
+		for _, server := range []*authority.Server{
+			authority.NewServer(spelling, authority.IPv4),
+			mustServerFromSpelling(t, spelling),
+		} {
+			if !server.Endpoint.IsValid() {
+				t.Fatalf("%q produced no decoded endpoint", spelling)
+			}
+			if got := middleware.CanonicalResolutionEndpoint(server.Addr); got != server.Addr {
+				t.Fatalf("%q stored Addr %q, which canonicalizes to %q; the "+
+					"guard's fast path would key it under two identities",
+					spelling, server.Addr, got)
+			}
+			if server.Addr != server.Endpoint.String() {
+				t.Fatalf("%q stored Addr %q but Endpoint %q",
+					spelling, server.Addr, server.Endpoint)
+			}
+		}
+	}
+}
+
+func mustServerFromSpelling(tb testing.TB, spelling string) *authority.Server {
+	tb.Helper()
+	ap, err := netip.ParseAddrPort(spelling)
+	if err != nil {
+		tb.Fatalf("ParseAddrPort(%q): %v", spelling, err)
+	}
+	return authority.NewServerFromAddrPort(ap)
+}
+
+func BenchmarkDedupeAuthorityServers(b *testing.B) {
+	for _, count := range []int{2, 4, 13, 64} {
+		servers := authorityServers(b, count)
+		input := make([]*authority.Server, len(servers))
+		b.Run(serverCountName(count), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				copy(input, servers)
+				dedupeAuthorityServers(input)
+			}
+		})
+	}
+}
+
+func serverCountName(count int) string {
+	switch count {
+	case 2:
+		return "servers=2"
+	case 4:
+		return "servers=4"
+	case 13:
+		return "servers=13"
+	default:
+		return "servers=64"
+	}
+}

--- a/middleware/resolver/dedupe_test.go
+++ b/middleware/resolver/dedupe_test.go
@@ -111,6 +111,13 @@ func TestDedupeAuthorityServers(t *testing.T) {
 				t.Fatalf("at %d servers: linear kept %d, indexed kept %d",
 					count, len(linear), len(indexed))
 			}
+			// Length before contents: a wrapper that dropped nothing would
+			// still match on every position the shorter result has.
+			if len(chosen) != len(linear) {
+				t.Fatalf("at %d servers: the threshold kept %d, both "+
+					"implementations kept %d",
+					count, len(chosen), len(linear))
+			}
 			for i := range linear {
 				if linear[i] != indexed[i] {
 					t.Fatalf("at %d servers, position %d: linear %q, "+

--- a/middleware/resolver/dedupe_test.go
+++ b/middleware/resolver/dedupe_test.go
@@ -80,27 +80,46 @@ func TestDedupeAuthorityServers(t *testing.T) {
 	})
 
 	t.Run("across the linear/indexed threshold", func(t *testing.T) {
-		// The two implementations must agree, and the boundary is where a
-		// disagreement would hide.
+		// The threshold is on the input length, so the corpus has to be
+		// exactly that long: duplicates come from repeating servers within
+		// it, not from lengthening it.
 		for _, count := range []int{
 			linearDedupeLimit - 1, linearDedupeLimit, linearDedupeLimit + 1,
 		} {
-			servers := authorityServers(t, count)
-			// Every server twice: the result must be the originals, in
-			// order, whichever side of the threshold the input lands on.
-			doubled := make([]*authority.Server, 0, count*2)
-			doubled = append(doubled, servers...)
-			doubled = append(doubled, servers...)
-
-			got := serverAddrs(dedupeAuthorityServers(doubled))
-			if len(got) != count {
-				t.Fatalf("%d duplicated servers deduped to %d, want %d",
-					count*2, len(got), count)
+			unique := authorityServers(t, (count+1)/2)
+			corpus := make([]*authority.Server, count)
+			for i := range corpus {
+				// Repeats interleaved with first occurrences, so order is
+				// something the implementations can disagree about.
+				corpus[i] = unique[(i*3)%len(unique)]
 			}
-			for i, server := range servers {
-				if got[i] != server.Addr {
-					t.Fatalf("at %d servers, position %d is %q, want %q",
-						count, i, got[i], server.Addr)
+			if len(corpus) != count {
+				t.Fatalf("fixture is wrong: corpus is %d long, want %d",
+					len(corpus), count)
+			}
+
+			// Both implementations run on the same corpus, each on its own
+			// copy since they dedupe in place.
+			linear := serverAddrs(dedupeAuthorityServersLinear(
+				append([]*authority.Server(nil), corpus...)))
+			indexed := serverAddrs(dedupeAuthorityServersIndexed(
+				append([]*authority.Server(nil), corpus...)))
+			chosen := serverAddrs(dedupeAuthorityServers(
+				append([]*authority.Server(nil), corpus...)))
+
+			if len(linear) != len(indexed) {
+				t.Fatalf("at %d servers: linear kept %d, indexed kept %d",
+					count, len(linear), len(indexed))
+			}
+			for i := range linear {
+				if linear[i] != indexed[i] {
+					t.Fatalf("at %d servers, position %d: linear %q, "+
+						"indexed %q", count, i, linear[i], indexed[i])
+				}
+				if chosen[i] != linear[i] {
+					t.Fatalf("at %d servers, position %d: the threshold "+
+						"picked %q, both implementations say %q",
+						count, i, chosen[i], linear[i])
 				}
 			}
 		}

--- a/middleware/resolver/dedupe_test.go
+++ b/middleware/resolver/dedupe_test.go
@@ -79,6 +79,33 @@ func TestDedupeAuthorityServers(t *testing.T) {
 		}
 	})
 
+	t.Run("across the linear/indexed threshold", func(t *testing.T) {
+		// The two implementations must agree, and the boundary is where a
+		// disagreement would hide.
+		for _, count := range []int{
+			linearDedupeLimit - 1, linearDedupeLimit, linearDedupeLimit + 1,
+		} {
+			servers := authorityServers(t, count)
+			// Every server twice: the result must be the originals, in
+			// order, whichever side of the threshold the input lands on.
+			doubled := make([]*authority.Server, 0, count*2)
+			doubled = append(doubled, servers...)
+			doubled = append(doubled, servers...)
+
+			got := serverAddrs(dedupeAuthorityServers(doubled))
+			if len(got) != count {
+				t.Fatalf("%d duplicated servers deduped to %d, want %d",
+					count*2, len(got), count)
+			}
+			for i, server := range servers {
+				if got[i] != server.Addr {
+					t.Fatalf("at %d servers, position %d is %q, want %q",
+						count, i, got[i], server.Addr)
+				}
+			}
+		}
+	})
+
 	t.Run("empty and single", func(t *testing.T) {
 		if got := dedupeAuthorityServers(nil); len(got) != 0 {
 			t.Fatalf("nil deduped to %d servers", len(got))
@@ -133,17 +160,14 @@ func TestServerAddrIsAlreadyCanonical(t *testing.T) {
 			authority.NewServer(spelling, authority.IPv4),
 			mustServerFromSpelling(t, spelling),
 		} {
-			if !server.Endpoint.IsValid() {
-				t.Fatalf("%q produced no decoded endpoint", spelling)
+			addr, canonical := server.CanonicalAddr()
+			if !canonical {
+				t.Fatalf("%q was not recognized as a canonical address", spelling)
 			}
-			if got := middleware.CanonicalResolutionEndpoint(server.Addr); got != server.Addr {
+			if got := middleware.CanonicalResolutionEndpoint(addr); got != addr {
 				t.Fatalf("%q stored Addr %q, which canonicalizes to %q; the "+
 					"guard's fast path would key it under two identities",
-					spelling, server.Addr, got)
-			}
-			if server.Addr != server.Endpoint.String() {
-				t.Fatalf("%q stored Addr %q but Endpoint %q",
-					spelling, server.Addr, server.Endpoint)
+					spelling, addr, got)
 			}
 		}
 	}

--- a/middleware/resolver/dnssec/fuzz_test.go
+++ b/middleware/resolver/dnssec/fuzz_test.go
@@ -118,10 +118,14 @@ func FuzzKeyTag(f *testing.F) {
 			PublicKey: publicKey,
 		}
 		if algorithm == dns.RSAMD5 {
-			// Not compared: the library panics on part of this input
-			// space, which is why RSAMD5 has no tag here. See KeyTag.
-			if got := KeyTag(key); got != 0 {
-				t.Fatalf("RSAMD5 key=%q: tag %d, want 0", publicKey, got)
+			// The library panics on part of this space, which is why the
+			// RSAMD5 tag is derived here; where it answers, the answers
+			// must match.
+			want, panicked := libraryKeyTag(key)
+			got := KeyTag(key)
+			if !panicked && got != want {
+				t.Fatalf("RSAMD5 key=%q: tag %d, library says %d",
+					publicKey, got, want)
 			}
 			return
 		}

--- a/middleware/resolver/dnssec/fuzz_test.go
+++ b/middleware/resolver/dnssec/fuzz_test.go
@@ -94,6 +94,45 @@ func FuzzTypesSet(f *testing.F) {
 	})
 }
 
+// FuzzKeyTag drives the key tag against the library's for arbitrary key
+// material. The tag decides which key a DS or an RRSIG is matched against, so
+// a disagreement does not fail loudly — it quietly stops the right key from
+// being tried. A checksum read in chunks is exactly the kind of thing that
+// agrees on the inputs someone thought to write down, so this looks for the
+// ones nobody did.
+func FuzzKeyTag(f *testing.F) {
+	f.Add(uint16(257), uint8(3), dns.RSASHA256, "AwEAAcQ8")
+	f.Add(uint16(256), uint8(3), dns.ECDSAP256SHA256, "")
+	f.Add(uint16(0), uint8(0), dns.ED25519, "not base64!!")
+	f.Add(uint16(0xFFFF), uint8(255), dns.RSASHA512, "AAAA=AAA")
+	f.Add(uint16(385), uint8(3), dns.RSAMD5, "AQAB")
+	f.Add(uint16(257), uint8(3), dns.RSASHA256, "AAAA\r\nAAAA")
+
+	f.Fuzz(func(t *testing.T, flags uint16, protocol, algorithm uint8, publicKey string) {
+		key := &dns.DNSKEY{
+			Hdr: dns.RR_Header{
+				Name: "example.com.", Rrtype: dns.TypeDNSKEY,
+				Class: dns.ClassINET, Ttl: 3600,
+			},
+			Flags: flags, Protocol: protocol, Algorithm: algorithm,
+			PublicKey: publicKey,
+		}
+		if algorithm == dns.RSAMD5 {
+			// Not compared: the library panics on part of this input
+			// space, which is why RSAMD5 has no tag here. See KeyTag.
+			if got := KeyTag(key); got != 0 {
+				t.Fatalf("RSAMD5 key=%q: tag %d, want 0", publicKey, got)
+			}
+			return
+		}
+		if got, want := KeyTag(key), key.KeyTag(); got != want {
+			t.Fatalf("flags=%d protocol=%d algorithm=%d key=%q: tag %d, "+
+				"library says %d", flags, protocol, algorithm, publicKey,
+				got, want)
+		}
+	})
+}
+
 // FuzzFindClosestEncloser fuzzes the NSEC3 closest encloser algorithm.
 func FuzzFindClosestEncloser(f *testing.F) {
 	f.Add("sub.example.com.")

--- a/middleware/resolver/dnssec/keytag.go
+++ b/middleware/resolver/dnssec/keytag.go
@@ -12,7 +12,7 @@ import (
 const keyTagChunk = 256
 
 // KeyTag returns the RFC 4034 Appendix B key tag of a DNSKEY, agreeing with
-// dns.DNSKEY.KeyTag on every input.
+// dns.DNSKEY.KeyTag on every input that one can answer for.
 //
 // The tag is a checksum over the record's RDATA, and the library computes it
 // by packing that RDATA into a fixed buffer and summing it. The buffer itself
@@ -25,23 +25,16 @@ const keyTagChunk = 256
 //
 // An encoding the chunked decode cannot read the same way a single decode
 // would is handed to the library rather than guessed at, so the two agree on
-// every input — with one deliberate exception.
+// every input the library can answer for.
 //
-// RSAMD5 has no tag here. It does not use this checksum at all: RFC 4034
-// Appendix B.1 takes the tag from the modulus itself, and the library's
-// implementation of that reads three octets after checking for two, so a
-// DNSKEY whose material decodes to exactly two octets makes it index below
-// the start of a slice and panic. That record is attacker-supplied and the
-// tag is computed before anything has been validated. RFC 8624 §3.1 sets
-// RSAMD5 to MUST NOT for validation and IsSupportedDNSKEYAlgorithm refuses
-// it, so such a key can never validate anything; giving it no tag costs
-// nothing and takes the crash off the path.
+// RSAMD5 is derived here rather than delegated, because the library's
+// derivation of it crashes; see rsamd5KeyTag.
 func KeyTag(key *dns.DNSKEY) uint16 {
 	if key == nil {
 		return 0
 	}
 	if key.Algorithm == dns.RSAMD5 {
-		return 0
+		return rsamd5KeyTag(key.PublicKey)
 	}
 	// The library packs the RDATA into a buffer to sum it, so a key too
 	// large to pack has no tag. Judged on the encoded length, which is why
@@ -91,4 +84,74 @@ func KeyTag(key *dns.DNSKEY) uint16 {
 
 	sum += sum >> 16 & 0xFFFF
 	return uint16(sum & 0xFFFF)
+}
+
+// rsamd5KeyTag derives an RSAMD5 key's tag the way RFC 4034 Appendix B.1 and
+// its errata 193 do: from the two octets below the last one of the modulus,
+// rather than from the checksum every other algorithm uses.
+//
+// It is computed here rather than left to the library because the library
+// reads those three octets after checking only that the modulus has more than
+// one, so material that decodes to exactly two octets indexes below the start
+// of a slice and panics. The record is attacker-supplied and its tag is taken
+// before anything about it has been validated.
+//
+// Returning zero for every RSAMD5 key instead would be its own defect: zero is
+// a tag a supported key can legitimately have, and the trust-anchor state
+// keeps one anchor per tag — an RSAMD5 key mapped to zero could displace a
+// real one. Only material too short to have a tag gets zero, which is what the
+// library returns for it as well.
+func rsamd5KeyTag(publicKey string) uint16 {
+	var (
+		in   [keyTagChunk]byte
+		out  [keyTagChunk / 4 * 3]byte
+		tail [3]byte
+		seen int
+	)
+	for encoded := publicKey; len(encoded) > 0; {
+		// Line breaks are dropped while filling rather than copied in: the
+		// decoder skips them, so leaving them would let one land inside a
+		// chunk and split a group that a single decode would have kept
+		// whole. That is the difference between reading a wrapped key and
+		// failing to.
+		filled, consumed := fillKeyTagChunk(in[:], encoded)
+		encoded = encoded[consumed:]
+
+		// A decode error still yields the octets read before it, which is
+		// the modulus the library would have gone on to use.
+		decoded, err := base64.StdEncoding.Decode(out[:], in[:filled])
+		for i := range decoded {
+			tail[0], tail[1], tail[2] = tail[1], tail[2], out[i]
+			if seen < len(tail) {
+				seen++
+			}
+		}
+		if err != nil {
+			break
+		}
+		// A short chunk with material still to come means padding closed
+		// the stream early, which is where a single decode stops too.
+		if len(encoded) > 0 && decoded < len(out) {
+			break
+		}
+	}
+	if seen < len(tail) {
+		return 0
+	}
+	return uint16(tail[0])<<8 | uint16(tail[1])
+}
+
+// fillKeyTagChunk copies base64 from encoded into dst, leaving out the CR and
+// LF the decoder ignores, and reports how much of each it used.
+func fillKeyTagChunk(dst []byte, encoded string) (filled, consumed int) {
+	for consumed < len(encoded) && filled < len(dst) {
+		c := encoded[consumed]
+		consumed++
+		if c == '\r' || c == '\n' {
+			continue
+		}
+		dst[filled] = c
+		filled++
+	}
+	return filled, consumed
 }

--- a/middleware/resolver/dnssec/keytag.go
+++ b/middleware/resolver/dnssec/keytag.go
@@ -1,0 +1,94 @@
+package dnssec
+
+import (
+	"encoding/base64"
+
+	"github.com/miekg/dns"
+)
+
+// keyTagChunk is how much of the encoded key is decoded at a time. It is a
+// multiple of four so every chunk is whole base64 groups, and small enough
+// that both buffers stay on the stack.
+const keyTagChunk = 256
+
+// KeyTag returns the RFC 4034 Appendix B key tag of a DNSKEY, agreeing with
+// dns.DNSKEY.KeyTag on every input.
+//
+// The tag is a checksum over the record's RDATA, and the library computes it
+// by packing that RDATA into a fixed buffer and summing it. The buffer itself
+// stays on the stack; what does not is the key material, decoded in full so
+// that it can be summed and dropped — one allocation the size of the key, per
+// key, for a number sixteen bits wide.
+//
+// Nothing about the sum needs the octets to exist all at once, so this decodes
+// a few hundred at a time into a stack buffer and accumulates as it goes.
+//
+// An encoding the chunked decode cannot read the same way a single decode
+// would is handed to the library rather than guessed at, so the two agree on
+// every input — with one deliberate exception.
+//
+// RSAMD5 has no tag here. It does not use this checksum at all: RFC 4034
+// Appendix B.1 takes the tag from the modulus itself, and the library's
+// implementation of that reads three octets after checking for two, so a
+// DNSKEY whose material decodes to exactly two octets makes it index below
+// the start of a slice and panic. That record is attacker-supplied and the
+// tag is computed before anything has been validated. RFC 8624 §3.1 sets
+// RSAMD5 to MUST NOT for validation and IsSupportedDNSKEYAlgorithm refuses
+// it, so such a key can never validate anything; giving it no tag costs
+// nothing and takes the crash off the path.
+func KeyTag(key *dns.DNSKEY) uint16 {
+	if key == nil {
+		return 0
+	}
+	if key.Algorithm == dns.RSAMD5 {
+		return 0
+	}
+	// The library packs the RDATA into a buffer to sum it, so a key too
+	// large to pack has no tag. Judged on the encoded length, which is why
+	// an oversized key costs nothing here rather than a decode.
+	if oversizedKeyMaterial(key.PublicKey) {
+		return 0
+	}
+
+	// RDATA is flags, protocol, algorithm, then the key: octets 0 and 2 are
+	// at even offsets and shift, 1 and 3 are odd and do not.
+	sum := uint32(key.Flags>>8)<<8 + uint32(key.Flags&0xFF) +
+		uint32(key.Protocol)<<8 + uint32(key.Algorithm)
+
+	// The key material begins at offset 4, so an octet's offset parity
+	// within it is its parity in the RDATA.
+	var (
+		in      [keyTagChunk]byte
+		out     [keyTagChunk / 4 * 3]byte
+		encoded = key.PublicKey
+	)
+	for len(encoded) > 0 {
+		n := min(len(encoded), keyTagChunk)
+		copy(in[:n], encoded)
+		encoded = encoded[n:]
+
+		decoded, err := base64.StdEncoding.Decode(out[:], in[:n])
+		if err != nil {
+			// Not something a chunked read can judge — line breaks shift
+			// the group boundaries, and a malformed key has to fail the
+			// way the library fails it.
+			return key.KeyTag()
+		}
+		// A short chunk before the end means padding appeared in the
+		// middle, which a single decode would reject and this would not.
+		if len(encoded) > 0 && decoded != len(out) {
+			return key.KeyTag()
+		}
+
+		for i := range decoded {
+			if i&1 == 0 {
+				sum += uint32(out[i]) << 8
+			} else {
+				sum += uint32(out[i])
+			}
+		}
+	}
+
+	sum += sum >> 16 & 0xFFFF
+	return uint16(sum & 0xFFFF)
+}

--- a/middleware/resolver/dnssec/keytag_test.go
+++ b/middleware/resolver/dnssec/keytag_test.go
@@ -142,56 +142,129 @@ func TestKeyTagDoesNotAllocate(t *testing.T) {
 	}
 }
 
-// TestKeyTagGivesRSAMD5NoTag records the one deliberate divergence, and the
-// crash behind it.
-//
-// RFC 4034 Appendix B.1 derives the RSAMD5 tag from the modulus rather than
-// from the checksum. The library implements that by reading three octets from
-// the end of the decoded modulus after checking that it has more than one, so
-// a DNSKEY whose material decodes to exactly two octets indexes below the
-// start of a slice. The record is attacker-supplied and the tag is computed
-// before anything about it has been validated.
-//
-// RFC 8624 §3.1 makes RSAMD5 MUST NOT for validation and
-// IsSupportedDNSKEYAlgorithm refuses it, so a key that carries it can never
-// validate anything and losing its tag costs nothing.
-func TestKeyTagGivesRSAMD5NoTag(t *testing.T) {
-	if IsSupportedDNSKEYAlgorithm(dns.RSAMD5) {
-		t.Fatal("the resolver now validates RSAMD5; this divergence and " +
-			"KeyTag have to be revisited together")
-	}
+// libraryKeyTag returns the library's tag, reporting separately when it
+// crashed instead of answering.
+func libraryKeyTag(key *dns.DNSKEY) (tag uint16, panicked bool) {
+	defer func() {
+		if recover() != nil {
+			panicked = true
+		}
+	}()
+	return key.KeyTag(), false
+}
 
-	rsamd5 := func(publicKey string) *dns.DNSKEY {
-		return &dns.DNSKEY{
-			Hdr: dns.RR_Header{
-				Name: "example.com.", Rrtype: dns.TypeDNSKEY,
-				Class: dns.ClassINET, Ttl: 3600,
-			},
-			Flags: 257, Protocol: 3, Algorithm: dns.RSAMD5,
-			PublicKey: publicKey,
+func rsamd5Key(publicKey string) *dns.DNSKEY {
+	return &dns.DNSKEY{
+		Hdr: dns.RR_Header{
+			Name: "example.com.", Rrtype: dns.TypeDNSKEY,
+			Class: dns.ClassINET, Ttl: 3600,
+		},
+		Flags: 257, Protocol: 3, Algorithm: dns.RSAMD5,
+		PublicKey: publicKey,
+	}
+}
+
+// TestKeyTagDerivesRSAMD5 covers the one algorithm whose tag is not this
+// checksum, and the crash that is the reason it is derived here.
+//
+// RFC 4034 Appendix B.1 with errata 193 takes the RSAMD5 tag from the two
+// octets below the last of the modulus. The library reads those three octets
+// after checking only that the modulus has more than one, so material that
+// decodes to exactly two octets indexes below the start of a slice — on a
+// record that arrives from the network and is tagged before anything about it
+// has been validated.
+//
+// Handing every RSAMD5 key a tag of zero instead would trade the crash for a
+// collision: zero is a tag a supported key can have, and the trust-anchor
+// state keeps one anchor per tag.
+func TestKeyTagDerivesRSAMD5(t *testing.T) {
+	// Where the library answers, the answers must agree.
+	for size := 3; size <= 300; size++ {
+		material := make([]byte, size)
+		for i := range material {
+			material[i] = byte(i*11 + 3)
+		}
+		key := rsamd5Key(base64.StdEncoding.EncodeToString(material))
+		want, panicked := libraryKeyTag(key)
+		if panicked {
+			t.Fatalf("%d octets: the library panicked where it should not", size)
+		}
+		if got := KeyTag(key); got != want {
+			t.Fatalf("%d octets: tag %d, library says %d", size, got, want)
+		}
+		// The tag is the two octets below the last, not the last two.
+		if want != uint16(material[size-3])<<8|uint16(material[size-2]) {
+			t.Fatalf("%d octets: fixture disagrees with RFC 4034 B.1", size)
 		}
 	}
 
-	// The shape that crashes the library: two decoded octets.
-	crasher := rsamd5(base64.StdEncoding.EncodeToString([]byte{0x30, 0x30}))
-	func() {
-		defer func() {
-			if recover() == nil {
-				t.Log("the library no longer panics on a two-octet RSAMD5 " +
-					"modulus; the divergence may be reconsidered")
+	// Below three octets there is no tag to derive. The library agrees at
+	// zero and one, and crashes at two.
+	for _, size := range []int{0, 1, 2} {
+		key := rsamd5Key(base64.StdEncoding.EncodeToString(
+			bytes.Repeat([]byte{0x30}, size)))
+		if got := KeyTag(key); got != 0 {
+			t.Fatalf("%d octets: tag %d, want 0", size, got)
+		}
+		want, panicked := libraryKeyTag(key)
+		switch size {
+		case 2:
+			if !panicked {
+				t.Log("the library no longer crashes on a two-octet RSAMD5 " +
+					"modulus")
 			}
-		}()
-		_ = crasher.KeyTag()
-	}()
-	if got := KeyTag(crasher); got != 0 {
-		t.Fatalf("tag %d for an RSAMD5 key, want 0", got)
+		default:
+			if panicked || want != 0 {
+				t.Fatalf("%d octets: library tag %d panicked=%v, want 0",
+					size, want, panicked)
+			}
+		}
 	}
 
-	// And an ordinary one, which the library handles but we still refuse.
-	ordinary := rsamd5(base64.StdEncoding.EncodeToString(
-		bytes.Repeat([]byte{0x5a}, 130)))
-	if got := KeyTag(ordinary); got != 0 {
-		t.Fatalf("tag %d for an RSAMD5 key, want 0", got)
+	// Wrapped material. The decoder skips CR and LF, so a line break left
+	// inside a chunk would split a group that a single decode keeps whole
+	// and the modulus would end somewhere else entirely.
+	for _, wrap := range []string{"\r", "\n", "\r\n"} {
+		material := []byte{0x11, 0x22, 0x33, 0x44, 0x55, 0x66}
+		flat := base64.StdEncoding.EncodeToString(material)
+		for cut := 1; cut < len(flat); cut++ {
+			key := rsamd5Key(flat[:cut] + wrap + flat[cut:])
+			want, panicked := libraryKeyTag(key)
+			if panicked {
+				t.Fatalf("%q at %d: the library panicked", wrap, cut)
+			}
+			if got := KeyTag(key); got != want {
+				t.Fatalf("%q at %d: tag %d, library says %d",
+					wrap, cut, got, want)
+			}
+		}
+	}
+
+	// Distinct keys keep distinct tags: collapsing them onto one value is
+	// the thing this must not do.
+	seen := make(map[uint16]struct{})
+	for i := range 64 {
+		key := rsamd5Key(base64.StdEncoding.EncodeToString(
+			[]byte{byte(i), byte(i * 7), 0x00}))
+		seen[KeyTag(key)] = struct{}{}
+	}
+	if len(seen) != 64 {
+		t.Fatalf("64 distinct RSAMD5 keys produced %d distinct tags", len(seen))
+	}
+}
+
+// TestKeyTagDerivesRSAMD5WithoutAllocating keeps the derived path on the same
+// footing as the checksum one.
+func TestKeyTagDerivesRSAMD5WithoutAllocating(t *testing.T) {
+	key := rsamd5Key(base64.StdEncoding.EncodeToString(
+		bytes.Repeat([]byte{0x5a}, 300)))
+	allocs := testing.AllocsPerRun(200, func() {
+		if KeyTag(key) == 0 {
+			t.Fatal("no tag")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("an RSAMD5 tag cost %.0f allocations", allocs)
 	}
 }
 

--- a/middleware/resolver/dnssec/keytag_test.go
+++ b/middleware/resolver/dnssec/keytag_test.go
@@ -1,0 +1,267 @@
+package dnssec
+
+import (
+	"bytes"
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// TestKeyTagMatchesLibrary is the contract: for every key a resolver meets,
+// the tag must be the one dns.DNSKEY.KeyTag computes. A tag that differs by
+// one does not fail loudly — it silently stops a DS or an RRSIG from finding
+// the key that would have validated it.
+func TestKeyTagMatchesLibrary(t *testing.T) {
+	for _, key := range dsDigestTestKeys(t) {
+		if got, want := KeyTag(key), key.KeyTag(); got != want {
+			t.Fatalf("%s alg %d: tag %d, library says %d",
+				key.Hdr.Name, key.Algorithm, got, want)
+		}
+	}
+
+	// Flags and protocol are in the sum, so varying them varies the tag.
+	base := dsDigestTestKeys(t)[0]
+	for _, flags := range []uint16{0, 1, 256, 257, 385, 0xFFFF} {
+		for _, protocol := range []uint8{0, 3, 255} {
+			key := *base
+			key.Flags = flags
+			key.Protocol = protocol
+			if got, want := KeyTag(&key), key.KeyTag(); got != want {
+				t.Fatalf("flags %d protocol %d: tag %d, library says %d",
+					flags, protocol, got, want)
+			}
+		}
+	}
+}
+
+// TestKeyTagMatchesLibraryAcrossChunkBoundaries walks the key material past
+// the size the fast path decodes at a time. The sum is position-weighted, so
+// a chunk boundary that lost or shifted a byte's parity would produce a
+// plausible tag that is not the right one.
+func TestKeyTagMatchesLibraryAcrossChunkBoundaries(t *testing.T) {
+	// Every decoded length either side of a chunk, and several chunks deep.
+	const decodedPerChunk = keyTagChunk / 4 * 3
+	var sizes []int
+	for _, chunks := range []int{0, 1, 2, 7} {
+		for _, delta := range []int{-3, -2, -1, 0, 1, 2, 3} {
+			if size := chunks*decodedPerChunk + delta; size > 0 {
+				sizes = append(sizes, size)
+			}
+		}
+	}
+	sizes = append(sizes, 1, 2, 3, maxDSKeyMaterial)
+
+	for _, size := range sizes {
+		material := make([]byte, size)
+		for i := range material {
+			material[i] = byte(i*7 + 1)
+		}
+		key := &dns.DNSKEY{
+			Hdr: dns.RR_Header{
+				Name: "example.com.", Rrtype: dns.TypeDNSKEY,
+				Class: dns.ClassINET, Ttl: 3600,
+			},
+			Flags: 257, Protocol: 3, Algorithm: dns.RSASHA256,
+			PublicKey: base64.StdEncoding.EncodeToString(material),
+		}
+		if got, want := KeyTag(key), key.KeyTag(); got != want {
+			t.Fatalf("%d octets of key material: tag %d, library says %d",
+				size, got, want)
+		}
+	}
+}
+
+// TestKeyTagMatchesLibraryOnMalformedKeys pins the inputs the fast path hands
+// back. Whatever the library makes of them, this must make the same.
+func TestKeyTagMatchesLibraryOnMalformedKeys(t *testing.T) {
+	valid := base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0x5a}, 300))
+	wrapped := valid[:64] + "\r\n" + valid[64:]
+
+	for _, tc := range []struct {
+		name      string
+		publicKey string
+	}{
+		{"empty", ""},
+		{"not base64", "not base64!!"},
+		{"a length that is not whole groups", valid[:len(valid)-1]},
+		{"padding in the middle", valid[:64] + "=" + valid[65:]},
+		{"line breaks the decoder skips", wrapped},
+		{"one octet", base64.StdEncoding.EncodeToString([]byte{0x01})},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			key := &dns.DNSKEY{
+				Hdr: dns.RR_Header{
+					Name: "example.com.", Rrtype: dns.TypeDNSKEY,
+					Class: dns.ClassINET, Ttl: 3600,
+				},
+				Flags: 257, Protocol: 3, Algorithm: dns.RSASHA256,
+				PublicKey: tc.publicKey,
+			}
+			if got, want := KeyTag(key), key.KeyTag(); got != want {
+				t.Fatalf("tag %d, library says %d", got, want)
+			}
+		})
+	}
+}
+
+// TestKeyTagRefusesOversizedWithoutDecoding pins the reason this exists at
+// all for the DS path: a key too large to pack has no tag, and finding that
+// out must not cost the decode the tag would have needed.
+func TestKeyTagRefusesOversizedWithoutDecoding(t *testing.T) {
+	key := oversizedKey(dns.RSASHA256)
+	if tag := key.KeyTag(); tag != 0 {
+		t.Fatalf("fixture is wrong: the library computed tag %d for an "+
+			"unpackable key", tag)
+	}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		if tag := KeyTag(key); tag != 0 {
+			t.Fatalf("tag %d for an unpackable key", tag)
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("refusing an oversized key cost %.0f allocations", allocs)
+	}
+}
+
+// TestKeyTagDoesNotAllocate is the point: a DNSKEY set is read for every
+// validated delegation, and every key in it is tagged.
+func TestKeyTagDoesNotAllocate(t *testing.T) {
+	for _, key := range dsDigestTestKeys(t) {
+		allocs := testing.AllocsPerRun(200, func() {
+			if KeyTag(key) == 0 {
+				t.Fatal("no tag")
+			}
+		})
+		if allocs != 0 {
+			t.Fatalf("%s alg %d cost %.0f allocations",
+				key.Hdr.Name, key.Algorithm, allocs)
+		}
+	}
+}
+
+// TestKeyTagGivesRSAMD5NoTag records the one deliberate divergence, and the
+// crash behind it.
+//
+// RFC 4034 Appendix B.1 derives the RSAMD5 tag from the modulus rather than
+// from the checksum. The library implements that by reading three octets from
+// the end of the decoded modulus after checking that it has more than one, so
+// a DNSKEY whose material decodes to exactly two octets indexes below the
+// start of a slice. The record is attacker-supplied and the tag is computed
+// before anything about it has been validated.
+//
+// RFC 8624 §3.1 makes RSAMD5 MUST NOT for validation and
+// IsSupportedDNSKEYAlgorithm refuses it, so a key that carries it can never
+// validate anything and losing its tag costs nothing.
+func TestKeyTagGivesRSAMD5NoTag(t *testing.T) {
+	if IsSupportedDNSKEYAlgorithm(dns.RSAMD5) {
+		t.Fatal("the resolver now validates RSAMD5; this divergence and " +
+			"KeyTag have to be revisited together")
+	}
+
+	rsamd5 := func(publicKey string) *dns.DNSKEY {
+		return &dns.DNSKEY{
+			Hdr: dns.RR_Header{
+				Name: "example.com.", Rrtype: dns.TypeDNSKEY,
+				Class: dns.ClassINET, Ttl: 3600,
+			},
+			Flags: 257, Protocol: 3, Algorithm: dns.RSAMD5,
+			PublicKey: publicKey,
+		}
+	}
+
+	// The shape that crashes the library: two decoded octets.
+	crasher := rsamd5(base64.StdEncoding.EncodeToString([]byte{0x30, 0x30}))
+	func() {
+		defer func() {
+			if recover() == nil {
+				t.Log("the library no longer panics on a two-octet RSAMD5 " +
+					"modulus; the divergence may be reconsidered")
+			}
+		}()
+		_ = crasher.KeyTag()
+	}()
+	if got := KeyTag(crasher); got != 0 {
+		t.Fatalf("tag %d for an RSAMD5 key, want 0", got)
+	}
+
+	// And an ordinary one, which the library handles but we still refuse.
+	ordinary := rsamd5(base64.StdEncoding.EncodeToString(
+		bytes.Repeat([]byte{0x5a}, 130)))
+	if got := KeyTag(ordinary); got != 0 {
+		t.Fatalf("tag %d for an RSAMD5 key, want 0", got)
+	}
+}
+
+// TestKeyTagSurvivesAdversarialKeys is the property behind the RSAMD5
+// divergence, stated for every algorithm rather than the one that happened to
+// crash: a DNSKEY arrives from the network and its tag is computed before
+// anything about it has been validated, so no key material may do worse than
+// produce a wrong-looking number.
+func TestKeyTagSurvivesAdversarialKeys(t *testing.T) {
+	algorithms := []uint8{
+		dns.RSAMD5, dns.DSA, dns.RSASHA1, dns.RSASHA1NSEC3SHA1,
+		dns.RSASHA256, dns.RSASHA512, dns.ECCGOST, dns.ECDSAP256SHA256,
+		dns.ECDSAP384SHA384, dns.ED25519, dns.ED448, 0, 99, 255,
+	}
+	materials := []string{
+		"", "=", "==", "===", "A", "AA", "AA==", "AAA=", "AAAA",
+		// One and two decoded octets: the lengths the library's RSAMD5
+		// branch admits and then reads three from.
+		base64.StdEncoding.EncodeToString([]byte{0x01}),
+		base64.StdEncoding.EncodeToString([]byte{0x01, 0x02}),
+		base64.StdEncoding.EncodeToString([]byte{0x01, 0x02, 0x03}),
+		"\x00", "\r\n", "AAAA\r\n", strings.Repeat("A", 4096),
+		strings.Repeat("=", 8), "not base64 at all",
+	}
+
+	for _, algorithm := range algorithms {
+		for _, material := range materials {
+			for _, flags := range []uint16{0, 256, 257, 0xFFFF} {
+				key := &dns.DNSKEY{
+					Hdr: dns.RR_Header{
+						Name: "example.com.", Rrtype: dns.TypeDNSKEY,
+						Class: dns.ClassINET, Ttl: 3600,
+					},
+					Flags: flags, Protocol: 3, Algorithm: algorithm,
+					PublicKey: material,
+				}
+				// A panic here fails the test by escaping it; naming the
+				// input is what makes the failure usable.
+				func() {
+					defer func() {
+						if p := recover(); p != nil {
+							t.Fatalf("alg %d flags %d key %q: %v",
+								algorithm, flags, material, p)
+						}
+					}()
+					_ = KeyTag(key)
+				}()
+			}
+		}
+	}
+}
+
+func BenchmarkKeyTag(b *testing.B) {
+	for _, key := range dsDigestTestKeys(b) {
+		name := strings.ToLower(dns.AlgorithmToString[key.Algorithm])
+		b.Run(name+"/owned", func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if KeyTag(key) == 0 {
+					b.Fatal("no tag")
+				}
+			}
+		})
+		b.Run(name+"/library", func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				if key.KeyTag() == 0 {
+					b.Fatal("no tag")
+				}
+			}
+		})
+	}
+}

--- a/middleware/resolver/dnssec/signature.go
+++ b/middleware/resolver/dnssec/signature.go
@@ -30,7 +30,7 @@ func signatureBinding(k *dns.DNSKEY, sig *dns.RRSIG, rrset []dns.RR) error {
 	if k.Protocol != 3 || k.Flags&dns.ZONE == 0 {
 		return ErrMissingDNSKEY
 	}
-	if sig.KeyTag != k.KeyTag() || sig.Algorithm != k.Algorithm ||
+	if sig.KeyTag != KeyTag(k) || sig.Algorithm != k.Algorithm ||
 		sig.Hdr.Class != k.Hdr.Class {
 		return ErrMissingDNSKEY
 	}

--- a/middleware/resolver/dnssec/testdata/fuzz/FuzzKeyTag/3c5b198066e028d1
+++ b/middleware/resolver/dnssec/testdata/fuzz/FuzzKeyTag/3c5b198066e028d1
@@ -1,0 +1,5 @@
+go test fuzz v1
+uint16(298)
+byte('\x03')
+byte('\x01')
+string("000=")

--- a/middleware/resolver/dnssec/testdata/fuzz/FuzzKeyTag/a2ff95001610d6ea
+++ b/middleware/resolver/dnssec/testdata/fuzz/FuzzKeyTag/a2ff95001610d6ea
@@ -1,0 +1,5 @@
+go test fuzz v1
+uint16(65489)
+byte('ÿ')
+byte('\x01')
+string("000\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r\r0")

--- a/middleware/resolver/dnssec/verify.go
+++ b/middleware/resolver/dnssec/verify.go
@@ -294,7 +294,7 @@ func usableDSCandidate(parentDS *dns.DS, key *dns.DNSKEY) bool {
 	if oversizedKeyMaterial(key.PublicKey) {
 		return false
 	}
-	return key.KeyTag() == parentDS.KeyTag &&
+	return KeyTag(key) == parentDS.KeyTag &&
 		key.Algorithm == parentDS.Algorithm &&
 		key.Header().Class == parentDS.Header().Class &&
 		strings.EqualFold(key.Header().Name, parentDS.Header().Name) &&
@@ -723,7 +723,7 @@ func usableSignatureCandidate(sig *dns.RRSIG, key *dns.DNSKEY) bool {
 	if key == nil {
 		return false
 	}
-	return key.KeyTag() == sig.KeyTag &&
+	return KeyTag(key) == sig.KeyTag &&
 		key.Algorithm == sig.Algorithm &&
 		key.Header().Class == sig.Header().Class &&
 		strings.EqualFold(key.Header().Name, sig.SignerName) &&

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -1528,47 +1528,42 @@ func dedupeAuthorityServersLinear(servers []*authority.Server) []*authority.Serv
 }
 
 func dedupeAuthorityServersIndexed(servers []*authority.Server) []*authority.Server {
-	seen := make(map[netip.AddrPort]struct{}, len(servers))
-	var seenSpelled map[string]struct{}
+	seen := make(map[string]struct{}, len(servers))
 	result := servers[:0]
 	for _, server := range servers {
 		if server == nil {
 			continue
 		}
-		if endpoint := server.Endpoint; endpoint.IsValid() {
-			if _, ok := seen[endpoint]; ok {
-				continue
-			}
-			seen[endpoint] = struct{}{}
-			result = append(result, server)
+		key := resolutionEndpointIdentity(server)
+		if _, ok := seen[key]; ok {
 			continue
 		}
-		// Not an IP:port literal: identity is the canonical spelling, and
-		// it is kept apart so a decoded address is never compared against
-		// a printed one.
-		key := middleware.CanonicalResolutionEndpoint(server.Addr)
-		if _, ok := seenSpelled[key]; ok {
-			continue
-		}
-		if seenSpelled == nil {
-			seenSpelled = make(map[string]struct{})
-		}
-		seenSpelled[key] = struct{}{}
+		seen[key] = struct{}{}
 		result = append(result, server)
 	}
 	return result
 }
 
-// sameResolutionEndpoint reports whether two servers name the same upstream.
-// A decoded address compares as a value; anything else falls back to the
-// canonical spelling, and the two kinds never match each other because a
-// literal is exactly what the spelling path cannot produce.
-func sameResolutionEndpoint(a, b *authority.Server) bool {
-	if a.Endpoint.IsValid() || b.Endpoint.IsValid() {
-		return a.Endpoint == b.Endpoint
+// resolutionEndpointIdentity returns the spelling that identifies a server's
+// upstream. A server built from a decoded address already holds it; anything
+// else has to be normalized, and normalization is what produces a string.
+func resolutionEndpointIdentity(server *authority.Server) string {
+	if addr, canonical := server.CanonicalAddr(); canonical {
+		return addr
 	}
-	return middleware.CanonicalResolutionEndpoint(a.Addr) ==
-		middleware.CanonicalResolutionEndpoint(b.Addr)
+	return middleware.CanonicalResolutionEndpoint(server.Addr)
+}
+
+// sameResolutionEndpoint reports whether two servers name the same upstream.
+// Two canonical spellings compare directly; anything else is normalized
+// first, which only the servers whose address never was a literal reach.
+func sameResolutionEndpoint(a, b *authority.Server) bool {
+	aAddr, aCanonical := a.CanonicalAddr()
+	bAddr, bCanonical := b.CanonicalAddr()
+	if aCanonical && bCanonical {
+		return aAddr == bAddr
+	}
+	return resolutionEndpointIdentity(a) == resolutionEndpointIdentity(b)
 }
 
 // lookupResult bundles a single per-server query outcome for the
@@ -1722,8 +1717,8 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, proto string,
 	// again would parse that string and print an identical one back.
 	// A server whose address never was a literal has no such promise.
 	attemptErr := error(nil)
-	if server.Endpoint.IsValid() {
-		attemptErr = middleware.BeginResolutionAttemptCanonical(ctx, q, server.Addr, proto)
+	if addr, canonical := server.CanonicalAddr(); canonical {
+		attemptErr = middleware.BeginResolutionAttemptCanonical(ctx, q, addr, proto)
 	} else {
 		attemptErr = middleware.BeginResolutionAttempt(ctx, q, server.Addr, proto)
 	}

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -2821,7 +2821,7 @@ func (r *Resolver) verifyRootKeys(ctx context.Context, msg *dns.Msg) (bool, erro
 	for _, rr := range rootKeys {
 		dnskey := rr.(*dns.DNSKEY)
 		if dnskey.Flags == 257 {
-			tag := dnskey.KeyTag()
+			tag := dnssec.KeyTag(dnskey)
 			keys[tag] = append(keys[tag], dnskey)
 		}
 	}
@@ -2895,7 +2895,7 @@ func (r *Resolver) verifyDNSSEC(ctx context.Context, signer, signed string, resp
 				continue
 			}
 			if dnskey.Flags == 256 || dnskey.Flags == 257 {
-				tag := dnskey.KeyTag()
+				tag := dnssec.KeyTag(dnskey)
 				keys[tag] = append(keys[tag], dnskey)
 			}
 		}

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -1485,21 +1485,90 @@ mainloop:
 	return pickFallbackResponse(responseErrors, configErrors, fatalErrors)
 }
 
+// linearDedupeLimit is the list size below which duplicate suppression
+// compares rather than indexes. A delegation names a handful of servers — the
+// root names thirteen — so the quadratic scan is a few dozen comparisons of
+// values already in registers, against a map that has to be built, sized and
+// discarded on every lookup.
+const linearDedupeLimit = 24
+
 func dedupeAuthorityServers(servers []*authority.Server) []*authority.Server {
-	seen := make(map[string]struct{}, len(servers))
+	if len(servers) <= linearDedupeLimit {
+		return dedupeAuthorityServersLinear(servers)
+	}
+	return dedupeAuthorityServersIndexed(servers)
+}
+
+// dedupeAuthorityServersLinear suppresses duplicates by comparing each server
+// against the ones already kept, in place and without allocating.
+//
+// The addresses arrive decoded — Endpoint is the value the constructor built
+// Addr from — so identity is a comparison of two netip.AddrPorts. Only a
+// server whose address is not an IP:port literal needs its spelling
+// canonicalized, and those never reach this path from the delegation
+// producers.
+func dedupeAuthorityServersLinear(servers []*authority.Server) []*authority.Server {
 	result := servers[:0]
 	for _, server := range servers {
 		if server == nil {
 			continue
 		}
-		key := middleware.CanonicalResolutionEndpoint(server.Addr)
-		if _, ok := seen[key]; ok {
+		duplicate := false
+		for _, kept := range result {
+			if sameResolutionEndpoint(kept, server) {
+				duplicate = true
+				break
+			}
+		}
+		if !duplicate {
+			result = append(result, server)
+		}
+	}
+	return result
+}
+
+func dedupeAuthorityServersIndexed(servers []*authority.Server) []*authority.Server {
+	seen := make(map[netip.AddrPort]struct{}, len(servers))
+	var seenSpelled map[string]struct{}
+	result := servers[:0]
+	for _, server := range servers {
+		if server == nil {
 			continue
 		}
-		seen[key] = struct{}{}
+		if endpoint := server.Endpoint; endpoint.IsValid() {
+			if _, ok := seen[endpoint]; ok {
+				continue
+			}
+			seen[endpoint] = struct{}{}
+			result = append(result, server)
+			continue
+		}
+		// Not an IP:port literal: identity is the canonical spelling, and
+		// it is kept apart so a decoded address is never compared against
+		// a printed one.
+		key := middleware.CanonicalResolutionEndpoint(server.Addr)
+		if _, ok := seenSpelled[key]; ok {
+			continue
+		}
+		if seenSpelled == nil {
+			seenSpelled = make(map[string]struct{})
+		}
+		seenSpelled[key] = struct{}{}
 		result = append(result, server)
 	}
 	return result
+}
+
+// sameResolutionEndpoint reports whether two servers name the same upstream.
+// A decoded address compares as a value; anything else falls back to the
+// canonical spelling, and the two kinds never match each other because a
+// literal is exactly what the spelling path cannot produce.
+func sameResolutionEndpoint(a, b *authority.Server) bool {
+	if a.Endpoint.IsValid() || b.Endpoint.IsValid() {
+		return a.Endpoint == b.Endpoint
+	}
+	return middleware.CanonicalResolutionEndpoint(a.Addr) ==
+		middleware.CanonicalResolutionEndpoint(b.Addr)
 }
 
 // lookupResult bundles a single per-server query outcome for the
@@ -1648,8 +1717,18 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, proto string,
 		return nil, ctxErr
 	}
 	q := req.Question[0]
-	if err := middleware.BeginResolutionAttempt(ctx, q, server.Addr, proto); err != nil {
-		return nil, err
+	// Addr was printed from a decoded address at construction, so it is
+	// already the canonical spelling the guard keys on; normalizing it
+	// again would parse that string and print an identical one back.
+	// A server whose address never was a literal has no such promise.
+	attemptErr := error(nil)
+	if server.Endpoint.IsValid() {
+		attemptErr = middleware.BeginResolutionAttemptCanonical(ctx, q, server.Addr, proto)
+	} else {
+		attemptErr = middleware.BeginResolutionAttempt(ctx, q, server.Addr, proto)
+	}
+	if attemptErr != nil {
+		return nil, attemptErr
 	}
 	if rs.work != nil {
 		var err error


### PR DESCRIPTION
## Problem

A DNSKEY's key tag is a sixteen-bit checksum over the record's RDATA. `dns.DNSKEY.KeyTag` computes it by packing that RDATA into a fixed buffer and summing the result. The buffer itself stays on the stack — but the key material does not: it is base64-decoded in full so that it can be summed and then dropped.

That is one allocation the size of the key, for every key of every validated delegation, for a number sixteen bits wide. In the field profile it is roughly **9 MiB across 71K allocations**.

It also sits in front of the size check this resolver already has. `usableDSCandidate` and the resolver's DNSKEY map build both reach the tag before anything else, so an oversized key was decoded in full *before* anything could decide it was too large — the one open item left over from #547.

## Change

The sum is accumulated as the key decodes, a few hundred octets at a time into a stack buffer. Nothing about a checksum needs the octets to exist all at once.

Anything the chunked read cannot judge the way a single decode would is handed to the library rather than guessed at: line breaks, which shift the group boundaries the decoder skips them across; padding in the middle, which a single decode rejects and a chunked one would not notice; material that is not whole groups. The two therefore agree on every input.

A key too large to pack has no tag, and that is now decided on the encoded length — so the oversized key that #547 left decoding in the map build is refused without being decoded at all.

Every production call site moved over: the DS candidate check, the RRSIG preflight, the resolver's DNSKEY map build, and the RFC 5011 trust-anchor paths. For every algorithm either can compute, the tag is identical.

## A crash in the library, on an attacker-supplied record



The differential fuzz target added here found one within two seconds.

`KeyTag`'s RSAMD5 branch derives the tag from the modulus rather than from the checksum, per the RFC 4034 Appendix B.1 errata. It reads three octets from the end of the decoded modulus after checking that the modulus has **more than one**:

```go
modulus, _ := fromBase64([]byte(k.PublicKey))
if len(modulus) > 1 {
    x := binary.BigEndian.Uint16(modulus[len(modulus)-3:])
```

A DNSKEY whose material decodes to exactly two octets — `"000="` is one such spelling — makes that slice expression `modulus[-1:]` and panics.

The record comes off the wire, and the tag is computed before anything about it has been validated: the resolver's map build tags every DNSKEY in a response whose owner matches the signer and whose flags are 256 or 257, both attacker-controlled. The recovery middleware catches the panic, so the effect is a lost query rather than a lost process, but it is reachable and it is cheap to reach.

RSAMD5's tag is therefore derived here rather than delegated: the two octets below the last of the modulus, per the errata, read off a rolling tail as the material decodes. Only material shorter than three octets has no tag and gets zero — which is what the library returns for it too.

Giving *every* RSAMD5 key a tag of zero would have traded the crash for a collision. Zero is a tag a supported key can legitimately have, and the trust-anchor state keeps one anchor per tag, so an RSAMD5 key mapped there could displace a real one. A test asserts that 64 distinct RSAMD5 keys keep 64 distinct tags.

This is worth reporting upstream; it is not filed yet.

## Measurements

Per key:

| algorithm | library | owned |
|---|---|---|
| RSASHA256 (1024-bit) | 144 B / 1 alloc / 178 ns | **0 B / 0 allocs / 95 ns** |
| ECDSAP256SHA256 | 80 B / 1 alloc / 125 ns | **0 B / 0 allocs / 60 ns** |
| ECDSAP384SHA384 | 96 B / 1 alloc / 140 ns | **0 B / 0 allocs / 69 ns** |
| ED25519 | 48 B / 1 alloc / 97 ns | **0 B / 0 allocs / 32 ns** |

An oversized key is refused in **0 allocations**, where it previously cost a decode of whatever was sent.

## Tests

The tag decides which key a DS or an RRSIG is matched against, so a disagreement does not fail loudly — it quietly stops the right key from being tried. The tests are differential throughout:

- every key in the existing DS-digest corpus (RSA/SHA-256 and /SHA-512, ECDSA P-256 and P-384, Ed25519, the root zone, a shouted owner, an IDN label, revoked and zone-signing flags), plus flags and protocol swept across their ranges;
- decoded lengths either side of the chunk size and several chunks deep, since the sum is position-weighted and a boundary that shifted a byte's parity would produce a plausible wrong answer;
- the malformed keys the fast path hands back — empty, not base64, not whole groups, padding in the middle, line breaks, a single octet;
- RSAMD5 at every modulus length from three to three hundred octets, at every length below that, wrapped with CR, LF and CRLF at every position, and 64 distinct keys that must keep 64 distinct tags;
- `FuzzKeyTag`, which compares against the library wherever the library answers and only requires no crash where it does not;
- and a property test that no algorithm, flag or material — including every length around the one that crashes the library — can make this panic.

The fuzzer earned its place twice. It found the RSAMD5 crash in under two seconds, and then found that the first version of the derived tag read a wrapped modulus wrongly: line breaks left inside a chunk split a base64 group that a single decode keeps whole, so the modulus ended somewhere else. Chunks are now filled with the line breaks left out, which is what the decoder does with them. The current version has run 6.5M executions clean.

`go test ./... -race`, `go vet` and `golangci-lint` are clean.
