### PR TITLE
middleware: pack responses directly onto declared SDNS-owned transports

### DIFF
--- a/middleware/chain.go
+++ b/middleware/chain.go
@@ -847,3 +847,20 @@ func (ch *Chain) Reset(w dns.ResponseWriter, r *dns.Msg) {
 	ch.pos = 0
 	ch.count = len(ch.handlers)
 }
+
+// AllowDirectPack declares that the transport beneath this chain's writer is
+// an SDNS-owned UDP, TCP or DoT sink whose Write sends raw wire bytes
+// unchanged, so WriteMsg may pack in pooled storage and skip the library's
+// per-message allocations.
+//
+// It is a declaration with one intended caller — the server's owned-listener
+// ingress, immediately after Reset — never an inference from address types
+// or proto strings, which plugin writers can share without sharing the
+// byte-sink property. Reset clears it, so a pooled chain cannot carry the
+// capability to the next request. A chain whose writer was replaced by a
+// custom ResponseWriter implementation is left alone.
+func (ch *Chain) AllowDirectPack() {
+	if w, ok := ch.Writer.(*responseWriter); ok {
+		w.directPack = true
+	}
+}

--- a/middleware/direct_pack_alloc_test.go
+++ b/middleware/direct_pack_alloc_test.go
@@ -1,0 +1,63 @@
+//go:build !race
+
+package middleware
+
+import (
+	"net"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// discardSink is a transport double that swallows bytes without recording
+// them, so a measurement over it sees the write path and nothing else.
+type discardSink struct{ wrote int }
+
+func (s *discardSink) Write(b []byte) (int, error) { s.wrote = len(b); return len(b), nil }
+func (s *discardSink) WriteMsg(*dns.Msg) error     { s.wrote = -1; return nil }
+func (s *discardSink) LocalAddr() net.Addr {
+	return &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 53}
+}
+func (s *discardSink) RemoteAddr() net.Addr {
+	return &net.UDPAddr{IP: net.IPv4(203, 0, 113, 9), Port: 5353}
+}
+func (s *discardSink) Close() error        { return nil }
+func (s *discardSink) TsigStatus() error   { return nil }
+func (s *discardSink) TsigTimersOnly(bool) {}
+func (s *discardSink) Hijack()             {}
+
+// TestDirectPackWriteDoesNotAllocate is the point of the whole path: writing
+// an ordinary answer to an owned transport costs neither the library's
+// compression dictionary nor its output buffer nor anything of this layer's
+// own.
+//
+// Excluded under the race detector, whose sync.Pool instrumentation is what
+// an allocation count taken there would measure.
+func TestDirectPackWriteDoesNotAllocate(t *testing.T) {
+	sink := &discardSink{}
+	req := new(dns.Msg)
+	req.SetQuestion("example.com.", dns.TypeA)
+	resp, _ := directPackResponse(t)
+
+	// Reset happens once per query regardless of how the response leaves;
+	// what this measures is the write. Rewinding the written marker is the
+	// one piece of test scaffolding inside the loop, and it allocates
+	// nothing.
+	ch := NewChain(nil)
+	ch.Reset(sink, req)
+	ch.AllowDirectPack()
+	w := ch.Writer.(*responseWriter)
+
+	allocs := testing.AllocsPerRun(200, func() {
+		w.size = -1
+		if err := w.WriteMsg(resp); err != nil {
+			t.Fatal(err)
+		}
+		if sink.wrote <= 0 {
+			t.Fatal("the direct path did not write raw bytes")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("a direct response write cost %.0f allocations", allocs)
+	}
+}

--- a/middleware/direct_pack_test.go
+++ b/middleware/direct_pack_test.go
@@ -1,0 +1,223 @@
+package middleware
+
+import (
+	"bytes"
+	"errors"
+	"net"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// byteSink is a transport double that records what arrives on each of the
+// two doors: raw bytes through Write, messages through WriteMsg. The direct
+// path must use exactly one of them.
+type byteSink struct {
+	raw      [][]byte
+	msgs     []*dns.Msg
+	writeErr error
+	remote   net.Addr
+}
+
+func (s *byteSink) Write(b []byte) (int, error) {
+	if s.writeErr != nil {
+		return 0, s.writeErr
+	}
+	// Copied: the slice is borrowed pooled storage, valid only for the call.
+	s.raw = append(s.raw, append([]byte(nil), b...))
+	return len(b), nil
+}
+
+func (s *byteSink) WriteMsg(m *dns.Msg) error { s.msgs = append(s.msgs, m); return nil }
+func (s *byteSink) LocalAddr() net.Addr       { return &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 53} }
+func (s *byteSink) RemoteAddr() net.Addr      { return s.remote }
+func (s *byteSink) Close() error              { return nil }
+func (s *byteSink) TsigStatus() error         { return nil }
+func (s *byteSink) TsigTimersOnly(bool)       {}
+func (s *byteSink) Hijack()                   {}
+
+func externalUDPSink() *byteSink {
+	return &byteSink{remote: &net.UDPAddr{IP: net.IPv4(203, 0, 113, 9), Port: 5353}}
+}
+
+func directPackResponse(tb testing.TB) (*dns.Msg, []byte) {
+	tb.Helper()
+	resp := new(dns.Msg)
+	resp.SetQuestion("example.com.", dns.TypeA)
+	resp.Id = 99
+	resp.Response = true
+	rr, err := dns.NewRR("example.com. 300 IN A 192.0.2.1")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	resp.Answer = []dns.RR{rr}
+	resp.Compress = true
+	want, err := resp.Copy().Pack()
+	if err != nil {
+		tb.Fatal(err)
+	}
+	return resp, want
+}
+
+func directPackChain(tb testing.TB, sink dns.ResponseWriter) *Chain {
+	tb.Helper()
+	req := new(dns.Msg)
+	req.SetQuestion("example.com.", dns.TypeA)
+	ch := NewChain(nil)
+	ch.Reset(sink, req)
+	return ch
+}
+
+// TestDirectPackWritesRawBytes pins the declared path end to end at the
+// writer level: raw library-parity bytes through Write, nothing through
+// WriteMsg, and the observable state — Written, Size, Rcode, Msg with
+// pointer identity — exactly as the Msg path would leave it.
+func TestDirectPackWritesRawBytes(t *testing.T) {
+	sink := externalUDPSink()
+	ch := directPackChain(t, sink)
+	ch.AllowDirectPack()
+
+	resp, want := directPackResponse(t)
+	if err := ch.Writer.WriteMsg(resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(sink.msgs) != 0 {
+		t.Fatal("the direct path handed the transport a message")
+	}
+	if len(sink.raw) != 1 || !bytes.Equal(sink.raw[0], want) {
+		t.Fatalf("raw writes = %d, parity = %v",
+			len(sink.raw), len(sink.raw) == 1 && bytes.Equal(sink.raw[0], want))
+	}
+	if !ch.Writer.Written() {
+		t.Fatal("not marked written")
+	}
+	if got := ResponseSize(ch.Writer); got != len(want) {
+		t.Fatalf("Size() = %d, want %d", got, len(want))
+	}
+	if ch.Writer.Rcode() != resp.Rcode {
+		t.Fatalf("Rcode() = %d", ch.Writer.Rcode())
+	}
+	if ch.Writer.Msg() != resp {
+		t.Fatal("Msg() lost pointer identity; request-local provenance is keyed on it")
+	}
+
+	// A second write is refused, exactly as on the Msg path.
+	if err := ch.Writer.WriteMsg(resp); !errors.Is(err, errAlreadyWritten) {
+		t.Fatalf("second write: %v", err)
+	}
+}
+
+// TestDirectPackIsDeclaredNotInferred pins the capability model: a writer
+// that merely looks like a datagram transport gets the Msg path unless the
+// owned-listener ingress declared otherwise.
+func TestDirectPackIsDeclaredNotInferred(t *testing.T) {
+	sink := externalUDPSink()
+	ch := directPackChain(t, sink) // no AllowDirectPack
+
+	resp, _ := directPackResponse(t)
+	if err := ch.Writer.WriteMsg(resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(sink.raw) != 0 {
+		t.Fatal("an undeclared writer received raw bytes")
+	}
+	if len(sink.msgs) != 1 || sink.msgs[0] != resp {
+		t.Fatal("the Msg path did not carry the message")
+	}
+}
+
+// TestDirectPackDoesNotSurviveReset pins the pooled-chain hazard: the
+// capability is per-request, and a chain reused for the next writer must not
+// carry it over.
+func TestDirectPackDoesNotSurviveReset(t *testing.T) {
+	first := externalUDPSink()
+	ch := directPackChain(t, first)
+	ch.AllowDirectPack()
+
+	second := externalUDPSink()
+	req := new(dns.Msg)
+	req.SetQuestion("example.com.", dns.TypeA)
+	ch.Reset(second, req)
+
+	resp, _ := directPackResponse(t)
+	if err := ch.Writer.WriteMsg(resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(second.raw) != 0 {
+		t.Fatal("the capability leaked across Reset")
+	}
+	if len(second.msgs) != 1 {
+		t.Fatal("the Msg path did not carry the message")
+	}
+}
+
+// TestDirectPackFallsBackThroughTheMsgPath pins the fallback: a message
+// TryPack cannot handle takes the library path with zero raw bytes written
+// first.
+func TestDirectPackFallsBackThroughTheMsgPath(t *testing.T) {
+	sink := externalUDPSink()
+	ch := directPackChain(t, sink)
+	ch.AllowDirectPack()
+
+	// An extended rcode with no OPT to carry it: the library's own error
+	// belongs to the library, so the direct path steps aside.
+	resp := new(dns.Msg)
+	resp.SetQuestion("example.com.", dns.TypeA)
+	resp.Rcode = dns.RcodeBadVers
+	_ = ch.Writer.WriteMsg(resp)
+
+	if len(sink.raw) != 0 {
+		t.Fatal("bytes were written before the fallback")
+	}
+	if len(sink.msgs) != 1 {
+		t.Fatal("the fallback did not reach the transport's WriteMsg")
+	}
+}
+
+// TestDirectPackTransportErrorIsFinal pins the no-retry contract: after a
+// transport error, bytes may be partially out — the response is marked
+// written and nothing writes a second one.
+func TestDirectPackTransportErrorIsFinal(t *testing.T) {
+	sink := externalUDPSink()
+	sink.writeErr = errors.New("transport failed")
+	ch := directPackChain(t, sink)
+	ch.AllowDirectPack()
+
+	resp, want := directPackResponse(t)
+	if err := ch.Writer.WriteMsg(resp); !errors.Is(err, sink.writeErr) {
+		t.Fatalf("WriteMsg = %v, want the transport's error", err)
+	}
+	if len(sink.msgs) != 0 {
+		t.Fatal("a message was written after the transport error")
+	}
+	if !ch.Writer.Written() {
+		t.Fatal("an errored write must still mark the response written")
+	}
+	if got := ResponseSize(ch.Writer); got != len(want) {
+		t.Fatalf("Size() = %d, want %d", got, len(want))
+	}
+	if err := ch.Writer.WriteMsg(resp); !errors.Is(err, errAlreadyWritten) {
+		t.Fatalf("second write: %v", err)
+	}
+}
+
+// TestDirectPackSkipsInternalQueries pins the internal exclusion: a
+// sub-query's consumer wants the message, and packing it would only be
+// unpacked again.
+func TestDirectPackSkipsInternalQueries(t *testing.T) {
+	sink := &byteSink{remote: &net.UDPAddr{IP: internalIP, Port: 0}}
+	ch := directPackChain(t, sink)
+	ch.AllowDirectPack()
+
+	resp, _ := directPackResponse(t)
+	if err := ch.Writer.WriteMsg(resp); err != nil {
+		t.Fatal(err)
+	}
+	if len(sink.raw) != 0 {
+		t.Fatal("an internal query was served raw bytes")
+	}
+	if len(sink.msgs) != 1 || sink.msgs[0] != resp {
+		t.Fatal("the internal query lost its message")
+	}
+}

--- a/middleware/response_writer.go
+++ b/middleware/response_writer.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/internal/wire"
 	"github.com/semihalev/sdns/server/doq"
 )
 
@@ -30,6 +31,16 @@ type responseWriter struct {
 	proto    string
 	remoteip net.IP
 	internal bool
+
+	// directPack records that the transport beneath this writer is an
+	// SDNS-owned UDP, TCP or DoT sink whose Write sends raw wire bytes
+	// unchanged. It is a declaration, never an inference: the server's
+	// owned-listener ingress is the only caller of AllowDirectPack, so a
+	// plugin writer that merely looks like a datagram transport — same
+	// RemoteAddr type, same proto string — never receives packed bytes it
+	// might re-decode or reshape. Reset clears it, so a pooled chain
+	// cannot carry the capability to a writer that did not declare it.
+	directPack bool
 }
 
 var _ ResponseWriter = &responseWriter{}
@@ -52,6 +63,7 @@ func (w *responseWriter) Reset(rw dns.ResponseWriter) {
 	w.proto = ""
 	w.remoteip = nil
 	w.internal = false
+	w.directPack = false
 
 	switch a := rw.RemoteAddr().(type) {
 	case *net.UDPAddr:
@@ -126,6 +138,31 @@ func (w *responseWriter) Write(m []byte) (int, error) {
 func (w *responseWriter) WriteMsg(m *dns.Msg) error {
 	if w.Written() {
 		return errAlreadyWritten
+	}
+
+	// The direct path: pack in pooled storage and hand the transport raw
+	// bytes, skipping the library's per-message dictionary and buffer. Only
+	// on a declared SDNS-owned sink — see directPack — and never for an
+	// internal sub-query, whose consumer wants the message, not bytes.
+	//
+	// The bookkeeping runs inside the consumer, before the transport write:
+	// the size marks the response written even if the transport then
+	// errors, so nothing retries a wire that may be partially out. Msg()
+	// keeps returning the caller's message, pointer identity included —
+	// request-local provenance is keyed on it. A message TryPack cannot
+	// handle falls through untouched to the library path below, which is
+	// byte-identical by TryPack's contract.
+	if w.directPack && !w.internal {
+		handled, err := wire.TryPack(m, func(body []byte) error {
+			w.msg = m
+			w.rcode = m.Rcode
+			w.size = len(body)
+			_, werr := w.ResponseWriter.Write(body)
+			return werr
+		})
+		if handled {
+			return err
+		}
 	}
 
 	w.msg = m

--- a/server/direct_pack_e2e_test.go
+++ b/server/direct_pack_e2e_test.go
@@ -1,0 +1,111 @@
+package server
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/middleware"
+)
+
+// directPackStub answers every query with a fixed compressed response.
+type directPackStub struct{}
+
+func (directPackStub) Name() string { return "direct-pack-stub" }
+
+func (directPackStub) ServeDNS(_ context.Context, ch *middleware.Chain) {
+	resp := new(dns.Msg)
+	resp.SetReply(ch.Request)
+	resp.Compress = true
+	rr, err := dns.NewRR("e2e.example. 300 IN A 192.0.2.77")
+	if err == nil {
+		resp.Answer = []dns.RR{rr}
+	}
+	_ = ch.Writer.WriteMsg(resp)
+	ch.Cancel()
+}
+
+// TestDirectPackOverRealSockets sends real queries through the SDNS-owned
+// UDP and TCP listeners, which are constructed with the direct handler: the
+// response travels as pooled-packed bytes through the transport's raw Write —
+// with its two-byte length prefix on the stream side — and a stock DNS
+// client has to parse it as if nothing changed.
+func TestDirectPackOverRealSockets(t *testing.T) {
+	middleware.Reset()
+	t.Cleanup(middleware.Reset)
+	middleware.Register("direct-pack-stub", func(*config.Config) middleware.Handler {
+		return directPackStub{}
+	})
+	cfg := &config.Config{Bind: "127.0.0.1:0"}
+	middleware.Setup(cfg)
+	s := New(cfg)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	udp, ok := s.listeners[0].(*udpListener)
+	if !ok {
+		t.Fatalf("listener 0 is %T, want the UDP listener", s.listeners[0])
+	}
+	tcp, ok := s.listeners[1].(*tcpListener)
+	if !ok {
+		t.Fatalf("listener 1 is %T, want the TCP listener", s.listeners[1])
+	}
+	if err := udp.Bind(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if err := tcp.Bind(ctx); err != nil {
+		t.Fatal(err)
+	}
+	go func() { _ = udp.Serve(ctx) }()
+	go func() { _ = tcp.Serve(ctx) }()
+	t.Cleanup(func() {
+		sctx, scancel := context.WithTimeout(context.Background(), time.Second)
+		defer scancel()
+		_ = udp.Shutdown(sctx)
+		_ = tcp.Shutdown(sctx)
+	})
+
+	udp.mu.Lock()
+	udpAddr := udp.pcs[0].LocalAddr().String()
+	udp.mu.Unlock()
+	tcp.mu.Lock()
+	tcpAddr := tcp.ln.Addr().String()
+	tcp.mu.Unlock()
+
+	for _, tc := range []struct {
+		net  string
+		addr string
+	}{
+		{"udp", udpAddr},
+		{"tcp", tcpAddr},
+	} {
+		t.Run(tc.net, func(t *testing.T) {
+			req := new(dns.Msg)
+			req.SetQuestion("e2e.example.", dns.TypeA)
+
+			client := &dns.Client{Net: tc.net, Timeout: 3 * time.Second}
+			var resp *dns.Msg
+			var err error
+			// The listener goroutines may still be coming up.
+			for range 20 {
+				resp, _, err = client.Exchange(req, tc.addr)
+				if err == nil {
+					break
+				}
+				time.Sleep(50 * time.Millisecond)
+			}
+			if err != nil {
+				t.Fatalf("exchange over %s: %v", tc.net, err)
+			}
+			if resp.Id != req.Id {
+				t.Fatalf("response ID %d, want %d", resp.Id, req.Id)
+			}
+			if len(resp.Answer) != 1 || resp.Answer[0].Header().Name != "e2e.example." {
+				t.Fatalf("unexpected answer: %v", resp.Answer)
+			}
+		})
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -44,12 +44,17 @@ func New(cfg *config.Config) *Server {
 	s := &Server{cfg: cfg, pipeline: middleware.GlobalPipeline()}
 
 	timeout := cfg.QueryTimeout.Duration
+	// The classic transports get the direct handler: their miekg writers
+	// send raw bytes unchanged, so responses may be packed in pooled
+	// storage. DoH and DoQ keep the public entry — one reshapes bytes and
+	// the other rewrites the reply ID, so neither is a raw sink.
+	direct := directHandler{srv: s}
 	s.listeners = []Listener{
-		newUDPListener(cfg.Bind, s, timeout),
-		newTCPListener(cfg.Bind, s, timeout),
+		newUDPListener(cfg.Bind, direct, timeout),
+		newTCPListener(cfg.Bind, direct, timeout),
 	}
 	if cfg.BindTLS != "" {
-		s.listeners = append(s.listeners, newTLSListener(cfg.BindTLS, s, s, timeout))
+		s.listeners = append(s.listeners, newTLSListener(cfg.BindTLS, direct, s, timeout))
 	}
 	if cfg.BindDOH != "" {
 		s.listeners = append(s.listeners,
@@ -69,12 +74,28 @@ func (s *Server) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
 	s.ServeDNSContext(context.Background(), w, r)
 }
 
+// directHandler is the dns.Handler the SDNS-owned UDP, TCP and DoT listeners
+// are constructed with. It is the one road to the direct-pack capability:
+// embedded or plugin callers reach the server through the public ServeDNS and
+// ServeDNSContext, whose writers made no byte-sink promise and therefore
+// never receive raw packed bytes — however much their addresses or proto
+// strings resemble a datagram transport.
+type directHandler struct{ srv *Server }
+
+func (h directHandler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
+	h.srv.serveDNSContext(context.Background(), w, r, true)
+}
+
 // ServeDNSContext serves one decoded DNS request under the transport's
 // lifetime and the configured end-to-end middleware/resolution timeout.
 // DNS-over-HTTP and DNS-over-QUIC supply client-aware parents; classic
 // dns.Handler transports start from a background parent but still receive the
 // same pipeline-ingress deadline.
 func (s *Server) ServeDNSContext(parent context.Context, w dns.ResponseWriter, r *dns.Msg) {
+	s.serveDNSContext(parent, w, r, false)
+}
+
+func (s *Server) serveDNSContext(parent context.Context, w dns.ResponseWriter, r *dns.Msg, directPack bool) {
 	if parent == nil {
 		parent = context.Background()
 	}
@@ -109,6 +130,9 @@ func (s *Server) ServeDNSContext(parent context.Context, w dns.ResponseWriter, r
 	defer s.pipeline.PutChain(ch)
 
 	ch.Reset(w, r)
+	if directPack {
+		ch.AllowDirectPack()
+	}
 	ch.Next(ctx)
 }
 


### PR DESCRIPTION
## What this is

Step 3 of the packing-pipeline plan: responses leaving over classic UDP, TCP and DoT are packed in pooled storage and written to the transport as raw bytes. This is the network half of the profile's packing cost — cache admission (step 2, merged in #550) was the other.

## The capability model

Direct packing is enabled by **declaration, never inference** — the design the plan mandated after the first integration attempt showed why: `proto == "udp"` is a statement about a remote address's type, not about whether the writer underneath consumes raw bytes unchanged. A mock writer carries a UDP address and *unpacks* what it is written; a plugin writer can do anything.

- The SDNS-owned UDP/TCP/DoT listeners are constructed with a **private handler** (`directHandler`), which is the only road to the capability.
- The public `ServeDNS` / `ServeDNSContext` — embedded callers, plugins, DoH, DoQ — never grant it.
- `Chain.AllowDirectPack()` sets a bool on the pooled base writer; `Reset` unconditionally clears it, so a pooled chain cannot carry the capability to the next request's writer.
- Internal sub-queries are excluded even under the flag: their consumers want the message, not bytes.
- Zero per-request allocation for the plumbing: the flag lives on the already-pooled writer, the handler is a two-word struct on the listener.

## The write

On the direct path, `WriteMsg` packs via `TryPack` and writes through the transport's raw `Write` — never through the middleware `Write`, which decodes. Bookkeeping runs **before** the transport write: a transport error still marks the response written, so nothing retries a wire that may be partially out. `Msg()` keeps returning the caller's message with pointer identity intact (request-local provenance is keyed on it — the exact failure the first attempt hit), and `Size()` reports the true wire length. Anything `TryPack` cannot handle falls through untouched to the transport's `WriteMsg`, byte-identical by contract. TSIG is not used in this deployment and the direct path does not implement it.

miekg's transport writers consume synchronously — a datagram send, a length-prefixed stream write — so the pooled buffer is released the moment `Write` returns.

## Measurements

The response write itself, ordinary answer, owned transport:

| | bytes | allocs |
|---|---|---|
| library `WriteMsg` | 336 B (dictionary + buffer) | 3 |
| direct path | **0 B** | **0** |

Per query this closes the ~57% network share of the packing cost the profile attributed to `Msg.Pack` under `WriteMsg`; admission's ~43% went in #550.

## Tests

- **End-to-end over real sockets**: queries through the actual owned UDP and TCP listeners (the same construction `New` uses), answered through the pipeline, parsed by a stock `dns.Client` — the TCP leg exercises the stream length prefix.
- **Writer contract**, against a transport double recording both doors: parity bytes through `Write` and nothing through `WriteMsg`; `Written`/`Size`/`Rcode`/`Msg` state as the Msg path leaves it; second write refused.
- **No inference**: an undeclared writer with a UDP remote address stays on the Msg path.
- **No leak**: the capability does not survive `Reset` — mutation-checked (removing the clear fails the test).
- **Internal exclusion** — mutation-checked.
- **Fallback**: a message `TryPack` refuses reaches the transport's `WriteMsg` with zero raw bytes written first.
- **Transport error**: returned to the caller, response marked written, no second write.
- **Allocation gate**: a direct response write is **0 allocs** (`//go:build !race`, per repo convention).

Full suite, `-race` on middleware/server/cache, `go vet`, `golangci-lint`, 32-bit vet (arm/mips/386) all clean.

## Next

Step 4: reflex + dnstap `WireWriter` passthrough, then DoQ (ID=0 preserved) and the DoH owned-capture writer — after this lands, a canary and a fresh profile before Track B.
