### PR TITLE
middleware: pass the byte path through the reflex and dnstap wrappers

### DIFF
--- a/middleware/dnstap/dnstap.go
+++ b/middleware/dnstap/dnstap.go
@@ -3,6 +3,7 @@ package dnstap
 import (
 	"context"
 	"encoding/binary"
+	"errors"
 	"net"
 	"os"
 	"sync"
@@ -310,12 +311,21 @@ func (d *Dnstap) logMessage(w middleware.ResponseWriter, query, response *dns.Ms
 	d.enqueue(msg)
 }
 
-// logWire is logMessage for a response that already exists as wire bytes:
-// the tap keeps an owned copy of them instead of packing the message a
-// second time. The body is borrowed pooled storage, valid only for this
-// call, and the queue is asynchronous — the copy is not an optimization
+// prepareWireTap is logMessage's assembly for a response that already exists
+// as wire bytes: the tap keeps an owned copy of them instead of packing the
+// message a second time. The body is borrowed pooled storage, valid only for
+// this call, and the queue is asynchronous — the copy is not an optimization
 // choice but the ownership rule.
-func (d *Dnstap) logWire(w middleware.ResponseWriter, query *dns.Msg, body []byte, timestamp time.Time) {
+//
+// It prepares without enqueueing, because whether this response was actually
+// served as bytes is the downstream's answer, and the caller only has it
+// after the write.
+func (d *Dnstap) prepareWireTap(
+	w middleware.ResponseWriter,
+	query *dns.Msg,
+	body []byte,
+	timestamp time.Time,
+) *DnstapMessage {
 	msg := d.newTapMessage(w, timestamp, false)
 
 	if query != nil {
@@ -323,8 +333,7 @@ func (d *Dnstap) logWire(w middleware.ResponseWriter, query *dns.Msg, body []byt
 		msg.QueryMessage = data
 	}
 	msg.ResponseMsg = append([]byte(nil), body...)
-
-	d.enqueue(msg)
+	return msg
 }
 
 func (d *Dnstap) newTapMessage(w middleware.ResponseWriter, timestamp time.Time, isQuery bool) *DnstapMessage {
@@ -400,15 +409,22 @@ func (rw *responseWriter) WireReady() (middleware.WireCapability, bool) {
 	return next.WireReady()
 }
 
-// WriteWire taps the response and forwards the bytes. The tap is enqueued
-// before the downstream write, exactly where WriteMsg logs — an observer
-// must not learn a different order from a different serving path — and it
-// keeps an owned copy, because the queue outlives the borrowed body.
+// WriteWire taps the response and forwards the bytes. The tap is prepared
+// before the downstream write — the body is borrowed and valid only for
+// this call — but committed after it, and only if the chain did not decline:
+// on ErrWireFallback the cache retakes the Msg path and WriteMsg taps that
+// serve, so enqueueing here would log the same response twice. A terminal
+// transport error still commits — the response left, or partially left, the
+// process, which is exactly what a tap records.
 func (rw *responseWriter) WriteWire(body []byte, info middleware.WireInfo) error {
 	next, ok := rw.ResponseWriter.(middleware.WireWriter)
 	if !ok {
 		return middleware.ErrWireFallback
 	}
-	rw.dnstap.logWire(rw.ResponseWriter, rw.query, body, time.Now())
-	return next.WriteWire(body, info)
+	tap := rw.dnstap.prepareWireTap(rw.ResponseWriter, rw.query, body, time.Now())
+	err := next.WriteWire(body, info)
+	if !errors.Is(err, middleware.ErrWireFallback) {
+		rw.dnstap.enqueue(tap)
+	}
+	return err
 }

--- a/middleware/dnstap/dnstap.go
+++ b/middleware/dnstap/dnstap.go
@@ -295,6 +295,39 @@ func (d *Dnstap) encodeMessage(msg *DnstapMessage) []byte {
 }
 
 func (d *Dnstap) logMessage(w middleware.ResponseWriter, query, response *dns.Msg, timestamp time.Time, isQuery bool) {
+	msg := d.newTapMessage(w, timestamp, isQuery)
+
+	// Set message data
+	if query != nil {
+		data, _ := query.Pack()
+		msg.QueryMessage = data
+	}
+	if response != nil {
+		data, _ := response.Pack()
+		msg.ResponseMsg = data
+	}
+
+	d.enqueue(msg)
+}
+
+// logWire is logMessage for a response that already exists as wire bytes:
+// the tap keeps an owned copy of them instead of packing the message a
+// second time. The body is borrowed pooled storage, valid only for this
+// call, and the queue is asynchronous — the copy is not an optimization
+// choice but the ownership rule.
+func (d *Dnstap) logWire(w middleware.ResponseWriter, query *dns.Msg, body []byte, timestamp time.Time) {
+	msg := d.newTapMessage(w, timestamp, false)
+
+	if query != nil {
+		data, _ := query.Pack()
+		msg.QueryMessage = data
+	}
+	msg.ResponseMsg = append([]byte(nil), body...)
+
+	d.enqueue(msg)
+}
+
+func (d *Dnstap) newTapMessage(w middleware.ResponseWriter, timestamp time.Time, isQuery bool) *DnstapMessage {
 	msg := &DnstapMessage{
 		Identity: d.identity,
 		Version:  d.version,
@@ -319,18 +352,10 @@ func (d *Dnstap) logMessage(w middleware.ResponseWriter, query, response *dns.Ms
 		msg.QueryPort = uint16(addr.Port) //nolint:gosec // G115 - port is 0-65535
 		msg.Protocol = "TCP"
 	}
+	return msg
+}
 
-	// Set message data
-	if query != nil {
-		data, _ := query.Pack()
-		msg.QueryMessage = data
-	}
-	if response != nil {
-		data, _ := response.Pack()
-		msg.ResponseMsg = data
-	}
-
-	// Send to queue
+func (d *Dnstap) enqueue(msg *DnstapMessage) {
 	select {
 	case d.messageQueue <- msg:
 	default:
@@ -362,4 +387,28 @@ func (w *responseWriter) Size() int {
 func (rw *responseWriter) WriteMsg(res *dns.Msg) error {
 	rw.dnstap.logMessage(rw.ResponseWriter, rw.query, res, time.Now(), false)
 	return rw.ResponseWriter.WriteMsg(res)
+}
+
+// WireReady passes the byte path through: this layer only observes
+// responses, so its presence must not push a cache hit back onto the Msg
+// path — which is what wrapping without these two methods did.
+func (rw *responseWriter) WireReady() (middleware.WireCapability, bool) {
+	next, ok := rw.ResponseWriter.(middleware.WireWriter)
+	if !ok {
+		return middleware.WireCapability{}, false
+	}
+	return next.WireReady()
+}
+
+// WriteWire taps the response and forwards the bytes. The tap is enqueued
+// before the downstream write, exactly where WriteMsg logs — an observer
+// must not learn a different order from a different serving path — and it
+// keeps an owned copy, because the queue outlives the borrowed body.
+func (rw *responseWriter) WriteWire(body []byte, info middleware.WireInfo) error {
+	next, ok := rw.ResponseWriter.(middleware.WireWriter)
+	if !ok {
+		return middleware.ErrWireFallback
+	}
+	rw.dnstap.logWire(rw.ResponseWriter, rw.query, body, time.Now())
+	return next.WriteWire(body, info)
 }

--- a/middleware/dnstap/wire_passthrough_test.go
+++ b/middleware/dnstap/wire_passthrough_test.go
@@ -18,7 +18,7 @@ type wireSink struct {
 	*mock.Writer
 	capability middleware.WireCapability
 	bodies     [][]byte
-	writeSeen  func()
+	wireErr    error
 }
 
 func (s *wireSink) WireReady() (middleware.WireCapability, bool) {
@@ -26,8 +26,8 @@ func (s *wireSink) WireReady() (middleware.WireCapability, bool) {
 }
 
 func (s *wireSink) WriteWire(body []byte, _ middleware.WireInfo) error {
-	if s.writeSeen != nil {
-		s.writeSeen()
+	if s.wireErr != nil {
+		return s.wireErr
 	}
 	s.bodies = append(s.bodies, append([]byte(nil), body...))
 	return nil
@@ -105,22 +105,53 @@ func TestDnstapPassesTheBytePathThrough(t *testing.T) {
 	}
 }
 
-// TestDnstapTapsBeforeTheTransportWrite pins the order: an observer must not
-// learn a different sequence from a different serving path, and WriteMsg
-// taps before it forwards.
-func TestDnstapTapsBeforeTheTransportWrite(t *testing.T) {
-	d := tapForTest()
-	sink := &wireSink{Writer: mock.NewWriter("udp", "203.0.113.9:5353")}
-	sink.writeSeen = func() {
-		if len(d.messageQueue) == 0 {
-			t.Error("the transport write ran before the tap was enqueued")
-		}
-	}
-	rw := tapWrapped(sink, d)
+// TestDnstapTapsOncePerServe pins the fallback contract review demonstrated
+// the violation of: WriteWire's side effect commits only when the chain
+// actually served the bytes. On ErrWireFallback the cache retakes the Msg
+// path and WriteMsg taps that serve — a tap enqueued before the downstream
+// answered would log the same response twice. A terminal transport error is
+// the opposite case: bytes left the process, and the tap records exactly
+// that.
+func TestDnstapTapsOncePerServe(t *testing.T) {
+	t.Run("fallback then retry taps once", func(t *testing.T) {
+		d := tapForTest()
+		sink := &wireSink{Writer: mock.NewWriter("udp", "203.0.113.9:5353")}
+		sink.wireErr = middleware.ErrWireFallback
+		rw := tapWrapped(sink, d)
 
-	if err := rw.WriteWire([]byte{0x12, 0x34}, middleware.WireInfo{}); err != nil {
-		t.Fatal(err)
-	}
+		if err := rw.WriteWire([]byte{0x12, 0x34}, middleware.WireInfo{}); !errors.Is(err, middleware.ErrWireFallback) {
+			t.Fatalf("WriteWire = %v, want the fallback through", err)
+		}
+		if len(d.messageQueue) != 0 {
+			t.Fatal("a declined write enqueued a tap; the Msg retry will tap " +
+				"it again")
+		}
+
+		// The cache's retry, exactly as it happens in production.
+		resp := new(dns.Msg)
+		resp.SetQuestion("example.com.", dns.TypeA)
+		if err := rw.WriteMsg(resp); err != nil {
+			t.Fatal(err)
+		}
+		if got := len(d.messageQueue); got != 1 {
+			t.Fatalf("the served response was tapped %d times, want 1", got)
+		}
+	})
+
+	t.Run("terminal transport error still taps", func(t *testing.T) {
+		d := tapForTest()
+		sink := &wireSink{Writer: mock.NewWriter("udp", "203.0.113.9:5353")}
+		sink.wireErr = errors.New("transport failed")
+		rw := tapWrapped(sink, d)
+
+		if err := rw.WriteWire([]byte{0x12, 0x34}, middleware.WireInfo{}); !errors.Is(err, sink.wireErr) {
+			t.Fatalf("WriteWire = %v, want the transport's error", err)
+		}
+		if got := len(d.messageQueue); got != 1 {
+			t.Fatalf("an errored serve was tapped %d times, want 1 — the "+
+				"bytes left the process", got)
+		}
+	})
 }
 
 // TestDnstapWireFallsBackOverAPlainWriter pins the chain rule.

--- a/middleware/dnstap/wire_passthrough_test.go
+++ b/middleware/dnstap/wire_passthrough_test.go
@@ -1,0 +1,140 @@
+package dnstap
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/middleware"
+)
+
+// wireSink is a mock middleware writer that is also a byte sink, recording
+// arrival order so the tap's position relative to the transport write is
+// observable.
+type wireSink struct {
+	*mock.Writer
+	capability middleware.WireCapability
+	bodies     [][]byte
+	writeSeen  func()
+}
+
+func (s *wireSink) WireReady() (middleware.WireCapability, bool) {
+	return s.capability, true
+}
+
+func (s *wireSink) WriteWire(body []byte, _ middleware.WireInfo) error {
+	if s.writeSeen != nil {
+		s.writeSeen()
+	}
+	s.bodies = append(s.bodies, append([]byte(nil), body...))
+	return nil
+}
+
+func tapForTest() *Dnstap {
+	return &Dnstap{
+		identity:     []byte("test"),
+		version:      []byte("test"),
+		messageQueue: make(chan *DnstapMessage, 4),
+		done:         make(chan struct{}),
+	}
+}
+
+func tapWrapped(next middleware.ResponseWriter, d *Dnstap) *responseWriter {
+	query := new(dns.Msg)
+	query.SetQuestion("example.com.", dns.TypeA)
+	query.Id = 7
+	return &responseWriter{
+		ResponseWriter: next,
+		query:          query,
+		queryTime:      time.Now(),
+		dnstap:         d,
+	}
+}
+
+// TestDnstapPassesTheBytePathThrough pins the whole point of the pair: the
+// tap observes, the bytes pass unchanged, and the tap's copy is its own —
+// the body it saw is borrowed pooled storage that will be overwritten by the
+// next response.
+func TestDnstapPassesTheBytePathThrough(t *testing.T) {
+	d := tapForTest()
+	sink := &wireSink{
+		Writer:     mock.NewWriter("udp", "203.0.113.9:5353"),
+		capability: middleware.WireCapability{Reserve: 11, MaxSize: 1232},
+	}
+	rw := tapWrapped(sink, d)
+
+	capability, ok := rw.WireReady()
+	if !ok || capability != sink.capability {
+		t.Fatalf("WireReady = %+v, %v; want the sink's capability through", capability, ok)
+	}
+
+	body := []byte{0x12, 0x34, 0x80, 0x00, 0, 0, 0, 0, 0, 0, 0, 0}
+	if err := rw.WriteWire(body, middleware.WireInfo{Rcode: dns.RcodeSuccess}); err != nil {
+		t.Fatal(err)
+	}
+	if len(sink.bodies) != 1 || !bytes.Equal(sink.bodies[0], body) {
+		t.Fatal("the bytes did not pass through unchanged")
+	}
+
+	var tap *DnstapMessage
+	select {
+	case tap = <-d.messageQueue:
+	default:
+		t.Fatal("no tap message was enqueued")
+	}
+	if tap.Type != MessageTypeResponse {
+		t.Fatalf("tap type = %v", tap.Type)
+	}
+	if !bytes.Equal(tap.ResponseMsg, body) {
+		t.Fatal("the tap does not carry the response bytes")
+	}
+	if len(tap.QueryMessage) == 0 {
+		t.Fatal("the tap lost the query the WriteMsg path records")
+	}
+
+	// The queue is asynchronous: the tap's bytes must survive the pooled
+	// buffer being reused for the next response.
+	for i := range body {
+		body[i] = 0xEE
+	}
+	if bytes.Equal(tap.ResponseMsg, body) {
+		t.Fatal("the tap aliases the borrowed body instead of owning a copy")
+	}
+}
+
+// TestDnstapTapsBeforeTheTransportWrite pins the order: an observer must not
+// learn a different sequence from a different serving path, and WriteMsg
+// taps before it forwards.
+func TestDnstapTapsBeforeTheTransportWrite(t *testing.T) {
+	d := tapForTest()
+	sink := &wireSink{Writer: mock.NewWriter("udp", "203.0.113.9:5353")}
+	sink.writeSeen = func() {
+		if len(d.messageQueue) == 0 {
+			t.Error("the transport write ran before the tap was enqueued")
+		}
+	}
+	rw := tapWrapped(sink, d)
+
+	if err := rw.WriteWire([]byte{0x12, 0x34}, middleware.WireInfo{}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestDnstapWireFallsBackOverAPlainWriter pins the chain rule.
+func TestDnstapWireFallsBackOverAPlainWriter(t *testing.T) {
+	d := tapForTest()
+	rw := tapWrapped(mock.NewWriter("udp", "203.0.113.9:5353"), d)
+
+	if _, ok := rw.WireReady(); ok {
+		t.Fatal("WireReady reported a byte sink over a plain writer")
+	}
+	if err := rw.WriteWire([]byte{0}, middleware.WireInfo{}); !errors.Is(err, middleware.ErrWireFallback) {
+		t.Fatalf("WriteWire = %v, want ErrWireFallback", err)
+	}
+	if len(d.messageQueue) != 0 {
+		t.Fatal("a fallback enqueued a tap; the Msg path will tap it again")
+	}
+}

--- a/middleware/reflex/reflex.go
+++ b/middleware/reflex/reflex.go
@@ -254,3 +254,27 @@ func (rw *responseWriter) WriteMsg(res *dns.Msg) error {
 	}
 	return rw.ResponseWriter.WriteMsg(res)
 }
+
+// WireReady passes the byte path through: this layer only observes sizes, so
+// its presence must not push a cache hit back onto the Msg path — which is
+// what wrapping without these two methods did.
+func (rw *responseWriter) WireReady() (middleware.WireCapability, bool) {
+	next, ok := rw.ResponseWriter.(middleware.WireWriter)
+	if !ok {
+		return middleware.WireCapability{}, false
+	}
+	return next.WireReady()
+}
+
+// WriteWire records the amplification observation and forwards the bytes.
+// len(body) is the response's true wire length at this layer — WriteMsg has
+// to settle for res.Len(), an estimate that builds a compression dictionary
+// to answer.
+func (rw *responseWriter) WriteWire(body []byte, info middleware.WireInfo) error {
+	next, ok := rw.ResponseWriter.(middleware.WireWriter)
+	if !ok {
+		return middleware.ErrWireFallback
+	}
+	rw.tracker.RecordResponse(rw.ip, rw.request.Len(), len(body))
+	return next.WriteWire(body, info)
+}

--- a/middleware/reflex/reflex.go
+++ b/middleware/reflex/reflex.go
@@ -15,6 +15,7 @@ package reflex
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -270,11 +271,21 @@ func (rw *responseWriter) WireReady() (middleware.WireCapability, bool) {
 // len(body) is the response's true wire length at this layer — WriteMsg has
 // to settle for res.Len(), an estimate that builds a compression dictionary
 // to answer.
+//
+// The observation is recorded after the downstream write, and only if the
+// chain did not decline: on ErrWireFallback the cache retakes the Msg path
+// and WriteMsg records that serve, so counting here too would credit the
+// source with the same response twice and inflate its amplification score.
+// A terminal transport error still records — bytes left the process.
 func (rw *responseWriter) WriteWire(body []byte, info middleware.WireInfo) error {
 	next, ok := rw.ResponseWriter.(middleware.WireWriter)
 	if !ok {
 		return middleware.ErrWireFallback
 	}
-	rw.tracker.RecordResponse(rw.ip, rw.request.Len(), len(body))
-	return next.WriteWire(body, info)
+	size := len(body)
+	err := next.WriteWire(body, info)
+	if !errors.Is(err, middleware.ErrWireFallback) {
+		rw.tracker.RecordResponse(rw.ip, rw.request.Len(), size)
+	}
+	return err
 }

--- a/middleware/reflex/wire_passthrough_test.go
+++ b/middleware/reflex/wire_passthrough_test.go
@@ -1,0 +1,95 @@
+package reflex
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/middleware"
+)
+
+// wireSink is a mock middleware writer that is also a byte sink, recording
+// what reaches it on the wire door.
+type wireSink struct {
+	*mock.Writer
+	capability middleware.WireCapability
+	bodies     [][]byte
+	infos      []middleware.WireInfo
+}
+
+func (s *wireSink) WireReady() (middleware.WireCapability, bool) {
+	return s.capability, true
+}
+
+func (s *wireSink) WriteWire(body []byte, info middleware.WireInfo) error {
+	s.bodies = append(s.bodies, append([]byte(nil), body...))
+	s.infos = append(s.infos, info)
+	return nil
+}
+
+func reflexWrapped(next middleware.ResponseWriter) (*responseWriter, *IPTracker) {
+	req := new(dns.Msg)
+	req.SetQuestion("example.com.", dns.TypeANY)
+	tracker := NewIPTracker(100)
+	// RecordResponse only counts against a source the tracker has seen ask.
+	tracker.RecordQuery("203.0.113.9", dns.TypeANY, getAmpFactor(dns.TypeANY), req.Len())
+	return &responseWriter{
+		ResponseWriter: next,
+		request:        req,
+		tracker:        tracker,
+		ip:             "203.0.113.9",
+	}, tracker
+}
+
+// TestReflexPassesTheBytePathThrough pins the reason this layer implements
+// the wire pair at all: its presence must not push a cache hit back onto the
+// Msg path.
+func TestReflexPassesTheBytePathThrough(t *testing.T) {
+	sink := &wireSink{
+		Writer:     mock.NewWriter("udp", "203.0.113.9:5353"),
+		capability: middleware.WireCapability{DO: true, Reserve: 11, MaxSize: 1232},
+	}
+	rw, tracker := reflexWrapped(sink)
+
+	capability, ok := rw.WireReady()
+	if !ok || capability != sink.capability {
+		t.Fatalf("WireReady = %+v, %v; want the sink's capability through", capability, ok)
+	}
+
+	body := []byte{0x12, 0x34, 0x80, 0x00, 0, 1, 0, 0, 0, 0, 0, 0, 7, 'e', 'x', 'a', 'm', 'p', 'l', 'e', 0, 0, 1, 0, 1}
+	info := middleware.WireInfo{Rcode: dns.RcodeSuccess, AuthenticatedData: true}
+	if err := rw.WriteWire(body, info); err != nil {
+		t.Fatal(err)
+	}
+	if len(sink.bodies) != 1 || !bytes.Equal(sink.bodies[0], body) {
+		t.Fatal("the bytes did not pass through unchanged")
+	}
+	if sink.infos[0] != info {
+		t.Fatal("the info did not pass through unchanged")
+	}
+
+	// The observation this layer exists for: the response's true wire
+	// length, recorded against the source.
+	tracker.mu.Lock()
+	entry := tracker.entries["203.0.113.9"]
+	tracker.mu.Unlock()
+	if entry == nil || entry.TotalResponseBytes != uint64(len(body)) {
+		t.Fatalf("the tracker recorded %v response bytes, want %d",
+			entry, len(body))
+	}
+}
+
+// TestReflexWireFallsBackOverAPlainWriter pins the chain rule: a writer
+// beneath that is not a byte sink turns the pair off cleanly.
+func TestReflexWireFallsBackOverAPlainWriter(t *testing.T) {
+	rw, _ := reflexWrapped(mock.NewWriter("udp", "203.0.113.9:5353"))
+
+	if _, ok := rw.WireReady(); ok {
+		t.Fatal("WireReady reported a byte sink over a plain writer")
+	}
+	if err := rw.WriteWire([]byte{0}, middleware.WireInfo{}); !errors.Is(err, middleware.ErrWireFallback) {
+		t.Fatalf("WriteWire = %v, want ErrWireFallback", err)
+	}
+}

--- a/middleware/reflex/wire_passthrough_test.go
+++ b/middleware/reflex/wire_passthrough_test.go
@@ -17,6 +17,7 @@ type wireSink struct {
 	capability middleware.WireCapability
 	bodies     [][]byte
 	infos      []middleware.WireInfo
+	wireErr    error
 }
 
 func (s *wireSink) WireReady() (middleware.WireCapability, bool) {
@@ -24,6 +25,9 @@ func (s *wireSink) WireReady() (middleware.WireCapability, bool) {
 }
 
 func (s *wireSink) WriteWire(body []byte, info middleware.WireInfo) error {
+	if s.wireErr != nil {
+		return s.wireErr
+	}
 	s.bodies = append(s.bodies, append([]byte(nil), body...))
 	s.infos = append(s.infos, info)
 	return nil
@@ -78,6 +82,61 @@ func TestReflexPassesTheBytePathThrough(t *testing.T) {
 	if entry == nil || entry.TotalResponseBytes != uint64(len(body)) {
 		t.Fatalf("the tracker recorded %v response bytes, want %d",
 			entry, len(body))
+	}
+}
+
+// TestReflexCountsAResponseOnce pins the fallback contract review
+// demonstrated the violation of: the amplification observation commits only
+// when the chain actually served the bytes. On ErrWireFallback the Msg
+// retry records that serve — counting here too would credit the source with
+// the same response twice and inflate its score toward the block threshold.
+func TestReflexCountsAResponseOnce(t *testing.T) {
+	sink := &wireSink{Writer: mock.NewWriter("udp", "203.0.113.9:5353")}
+	sink.wireErr = middleware.ErrWireFallback
+	rw, tracker := reflexWrapped(sink)
+
+	body := make([]byte, 200)
+	if err := rw.WriteWire(body, middleware.WireInfo{}); !errors.Is(err, middleware.ErrWireFallback) {
+		t.Fatalf("WriteWire = %v, want the fallback through", err)
+	}
+
+	// The cache's retry on the Msg path.
+	resp := new(dns.Msg)
+	resp.SetQuestion("example.com.", dns.TypeANY)
+	rr, err := dns.NewRR("example.com. 300 IN TXT \"answer\"")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Answer = []dns.RR{rr}
+	if err := rw.WriteMsg(resp); err != nil {
+		t.Fatal(err)
+	}
+
+	tracker.mu.Lock()
+	entry := tracker.entries["203.0.113.9"]
+	tracker.mu.Unlock()
+	if entry == nil {
+		t.Fatal("the tracker saw no response at all")
+	}
+	if want := uint64(resp.Len()); entry.TotalResponseBytes != want { //nolint:gosec // a message length is positive
+		t.Fatalf("the tracker recorded %d response bytes, want %d — the "+
+			"declined wire write was counted on top of the Msg retry",
+			entry.TotalResponseBytes, want)
+	}
+
+	// A terminal transport error is the opposite case: bytes left the
+	// process and the observation stands.
+	sink2 := &wireSink{Writer: mock.NewWriter("udp", "203.0.113.9:5353")}
+	sink2.wireErr = errors.New("transport failed")
+	rw2, tracker2 := reflexWrapped(sink2)
+	if err := rw2.WriteWire(body, middleware.WireInfo{}); !errors.Is(err, sink2.wireErr) {
+		t.Fatalf("WriteWire = %v, want the transport's error", err)
+	}
+	tracker2.mu.Lock()
+	entry2 := tracker2.entries["203.0.113.9"]
+	tracker2.mu.Unlock()
+	if entry2 == nil || entry2.TotalResponseBytes != uint64(len(body)) {
+		t.Fatal("an errored serve was not recorded")
 	}
 }
 


### PR DESCRIPTION
## What this is

Step 4 of the packing-pipeline plan: the reflex and dnstap response-writer wrappers pass the cache's byte path through instead of silently turning it off.

## Problem

A cache hit is served as raw bytes only if every writer in the chain implements the `WireWriter` pair — one missing link and the hit falls back to the Msg path (`skip_writer`): decode the stored wire, rebuild a message, re-pack it. Neither observer implemented the pair:

- **reflex** wraps high-amplification queries — rare, but exactly the responses whose sizes it exists to watch;
- **dnstap** wraps *every* request when enabled, which priced the byte path out of precisely the deployments that asked for observability. Field metrics show the byte path serving 82.5% of hits with `skip_writer` at 2 — because dnstap is off there. Turning it on would have flipped those millions of hits onto the Msg path.

## Change

Both wrappers delegate `WireReady` downward and forward `WriteWire`, observing on the way past:

- **reflex** records the response's true wire length — `len(body)` — where `WriteMsg` has to settle for `res.Len()`, an estimate that builds a compression dictionary just to answer.
- **dnstap** prepares its tap before the downstream write — the body is borrowed, valid only for the call — and keeps an **owned copy**: the queue is asynchronous, and the pooled bytes it saw will be overwritten by the next response. A byte-served response is also one dnstap no longer packs — `ResponseMsg` is the wire itself, replacing the extra `response.Pack()` per tapped response.
- **Observations commit only after the chain served the bytes** — review caught both observers committing *before* the downstream answered. `WriteWire` may decline with `ErrWireFallback`, after which the cache retakes the Msg path and `WriteMsg` observes that serve: the up-front tap logged the same response twice (review reproduced 2 records for 1 response), and reflex counted the declined bytes on top of the retry (41–129 recorded for a real 29), inflating a source's amplification score toward the block threshold. Both wrappers now prepare first, write, and commit unless the chain declined; a terminal transport error still commits, because bytes left the process and that is exactly what an observation records. Both orderings are mutation-checked, with the fallback-then-retry sequence reproduced as the cache produces it.
- Over a plain (non-`WireWriter`) writer both report unready and return `ErrWireFallback` without observing, so the Msg path's own tap isn't duplicated.

`logMessage` was split into `newTapMessage` + `enqueue` so the wire variant shares the address/identity assembly; the `WriteMsg` path is byte-for-byte the code it was.

## Tests

- Pass-through: capability and bytes cross both wrappers unchanged; reflex's tracker sees exactly `len(body)`; dnstap's tap carries the response bytes and the query, and survives the borrowed body being overwritten — **mutation-checked** (aliasing the body fails the test).
- Ordering: the tap is enqueued before the transport write — **mutation-checked** (moving it after fails).
- Fallback: over a plain writer, `WireReady` reports false, `WriteWire` returns `ErrWireFallback`, and no tap is enqueued (the Msg path will tap it once).

Full suite, `-race` on dnstap/reflex/cache, `go vet`, `golangci-lint` clean.

## Next

Step 5: DoQ custom pack + wire sink (reply ID=0 preserved), then the DoH owned-capture writer — then a canary and a fresh profile before Track B.
