### PR TITLE
dnsname: walk labels without materializing them

### DIFF
--- a/internal/dnsname/dnsname.go
+++ b/internal/dnsname/dnsname.go
@@ -84,127 +84,89 @@ func Suffixes(name string) iter.Seq[int] {
 	}
 }
 
-// maxWireLabels is the most labels a name that fits DNS wire format can
-// carry: 127 one-octet labels in a 255-octet name. A presentation string
-// long enough to exceed it cannot have come off the wire; CanonicalCompare
-// falls back to an allocating walk for those rather than answer wrongly.
-const maxWireLabels = 127
-
-// CanonicalCompare orders a and b per RFC 4034 §6.1: labels compared
-// right to left, case-insensitively, with the name that runs out of labels
-// first sorting first. It is the ordering every NSEC coverage proof stands
-// on, and the previous implementation lowercased, rooted and split both
-// names to compute it.
+// CanonicalCompare orders a and b per RFC 4034 §6.3: the canonical DNS name
+// order — labels compared right to left as the octets they decode to,
+// ASCII-folded, with the name that runs out of labels first sorting first.
+// It is the ordering every NSEC coverage proof stands on.
 //
-// The fold is ASCII, which is both what the RFC's canonical form specifies
-// and what the library's own comparisons do. (The implementation this
-// replaces folded through strings.ToLower, whose non-ASCII case mappings
-// have no business in DNS names; names that reach this function come from
-// packed messages, whose presentation form escapes non-ASCII bytes.)
+// The octets, not the spelling. A presentation label is an encoding — `\065`
+// is the octet 0x41, the same label as `a`; `\.` inside a label is the octet
+// 0x2E, which sorts before `0` — and the comparison this replaces ordered
+// the escape text instead, so wire-equal names compared unequal and names
+// around the escapes could invert. Every escape is decoded as it is read —
+// exactly as the library's packer decodes it, wrap quirk included (see
+// decodeOctet) — and nothing is materialized. A dangling backslash, which
+// no valid name contains, decodes as a literal one, keeping the order total
+// for inputs only a hand can construct.
 //
-// A second deliberate divergence, also unreachable from a packed message: a
-// raw multi-byte rune directly before a backslash run at the end of a name
-// trips a rune-versus-byte miscount in the library's IsFqdn, which the old
-// implementation inherited through Fqdn — it declared such names unrooted,
-// rooted them a second time, and compared a phantom empty label. This walk
-// counts bytes and does not.
+// The fold is ASCII, which is what the RFC's canonical form specifies. (The
+// old implementation folded through strings.ToLower, whose non-ASCII case
+// mappings have no business in DNS names.)
 //
-// Rooted and unrooted spellings compare equal — the labels are read without
-// their separators, so the trailing root dot contributes nothing. The
-// previous implementation rooted both names first for the same effect.
+// Rooted and unrooted spellings compare equal: labels are read without
+// their separators, so the trailing root dot contributes nothing.
+//
+// The walk is forward, in label lockstep after aligning the starts, and the
+// verdict is the rightmost pair that differed — right-to-left order without
+// offset arrays, so the frame stays flat instead of carrying two of them.
 func CanonicalCompare(a, b string) int {
-	// A name ending in an unescaped backslash is a quirk the fuzzer found:
-	// the rooting dot the old implementation appended lands behind the
-	// backslash and becomes a literal, changing the final label. No packed
-	// message can produce the shape — a literal backslash presents as \\ —
-	// but parity is the contract, so it keeps the old walk.
-	if escapedTail(a, len(a)) || escapedTail(b, len(b)) {
-		return canonicalCompareSlow(a, b)
+	ca, cb := canonicalLabelCount(a), canonicalLabelCount(b)
+	offA, offB := 0, 0
+	for i := ca; i > cb; i-- {
+		offA, _ = dns.NextLabel(a, offA)
+	}
+	for i := cb; i > ca; i-- {
+		offB, _ = dns.NextLabel(b, offB)
 	}
 
-	var bufA, bufB [maxWireLabels]int
-	na, okA := labelOffsets(a, &bufA)
-	nb, okB := labelOffsets(b, &bufB)
-	if !okA || !okB {
-		// Beyond any wire-legal name: correctness over thrift. The rooted
-		// canonical walk the old implementation did, for the inputs only a
-		// hand can construct.
-		return canonicalCompareSlow(a, b)
-	}
-
-	i, j := na-1, nb-1
-	for i >= 0 && j >= 0 {
-		if c := compareFold(labelAt(a, &bufA, na, i), labelAt(b, &bufB, nb, j)); c != 0 {
-			return c
+	// Rightmost difference wins: labels are compared left to right and the
+	// last nonzero verdict kept, which is the same answer a right-to-left
+	// walk stops at.
+	verdict := 0
+	for i := min(ca, cb); i > 0; i-- {
+		var labelA, labelB string
+		labelA, offA = canonicalLabel(a, offA, i == 1)
+		labelB, offB = canonicalLabel(b, offB, i == 1)
+		if c := compareDecodedFold(labelA, labelB); c != 0 {
+			verdict = c
 		}
-		i--
-		j--
+	}
+	if verdict != 0 {
+		return verdict
 	}
 	switch {
-	case na < nb:
+	case ca < cb:
 		return -1
-	case na > nb:
+	case ca > cb:
 		return 1
 	}
 	return 0
 }
 
-// canonicalCompareSlow is CanonicalCompare for names carrying more labels
-// than wire format allows: the allocating split, kept off the ordinary path.
-func canonicalCompareSlow(a, b string) int {
-	al := dns.SplitDomainName(dns.Fqdn(a))
-	bl := dns.SplitDomainName(dns.Fqdn(b))
-	i, j := len(al)-1, len(bl)-1
-	for i >= 0 && j >= 0 {
-		if c := compareFold(al[i], bl[j]); c != 0 {
-			return c
-		}
-		i--
-		j--
+// canonicalLabelCount is the label count CanonicalCompare walks: the
+// library's, except that the empty string counts as the root, which is what
+// rooting it first — as the old implementation did — made of it.
+func canonicalLabelCount(name string) int {
+	if name == "" || name == "." {
+		return 0
 	}
-	switch {
-	case len(al) < len(bl):
-		return -1
-	case len(al) > len(bl):
-		return 1
-	}
-	return 0
+	return dns.CountLabel(name)
 }
 
-// labelOffsets writes the label start offsets of name into buf, reporting
-// how many and whether they fit. The buffer travels as an array pointer that
-// is never retained, which is what keeps it on the caller's stack.
-func labelOffsets(name string, buf *[maxWireLabels]int) (n int, ok bool) {
-	if name == "." || name == "" {
-		return 0, true
+// canonicalLabel returns the label starting at off, without its separator,
+// and the offset of the next one. The final label sheds a trailing root dot
+// if it has one; NextLabel decided the boundary, so the dot before a
+// returned offset is never an escaped one.
+func canonicalLabel(name string, off int, last bool) (string, int) {
+	if !last {
+		next, _ := dns.NextLabel(name, off)
+		return name[off : next-1], next
 	}
-	off := 0
-	for {
-		if n == len(buf) {
-			return n, false
-		}
-		buf[n] = off
-		n++
-		next, end := dns.NextLabel(name, off)
-		if end {
-			return n, true
-		}
-		off = next
+	label := name[off:]
+	if len(label) > 1 && label[len(label)-1] == '.' && !escapedTail(label, len(label)-1) {
+		label = label[:len(label)-1]
 	}
-}
-
-// labelAt returns the i-th of n labels without its separator: the trailing
-// dot for a middle label, the root dot for a rooted final one.
-func labelAt(name string, buf *[maxWireLabels]int, n, i int) string {
-	start := buf[i]
-	if i+1 < n {
-		return name[start : buf[i+1]-1]
-	}
-	label := name[start:]
-	if len(label) > 0 && label[len(label)-1] == '.' && !escapedTail(name, len(name)-1) {
-		return label[:len(label)-1]
-	}
-	return label
+	return label, len(name)
 }
 
 // escapedTail reports whether the byte at i is escaped: preceded by an odd
@@ -216,6 +178,55 @@ func escapedTail(s string, i int) bool {
 	}
 	return backslashes%2 == 1
 }
+
+// compareDecodedFold orders two presentation labels as the octet strings
+// they decode to, ASCII-folded: RFC 4034 §6.3's within-label order.
+func compareDecodedFold(a, b string) int {
+	i, j := 0, 0
+	for i < len(a) && j < len(b) {
+		var octA, octB byte
+		octA, i = decodeOctet(a, i)
+		octB, j = decodeOctet(b, j)
+		if octA >= 'A' && octA <= 'Z' {
+			octA |= 'a' - 'A'
+		}
+		if octB >= 'A' && octB <= 'Z' {
+			octB |= 'a' - 'A'
+		}
+		switch {
+		case octA < octB:
+			return -1
+		case octA > octB:
+			return 1
+		}
+	}
+	switch {
+	case i < len(a):
+		return 1
+	case j < len(b):
+		return -1
+	}
+	return 0
+}
+
+// decodeOctet reads one octet of a presentation label: a plain byte, an
+// escaped one (`\.`), or a decimal escape (`\046`). The decoding is the
+// library's, quirk included: its dddToByte computes `\DDD` in byte
+// arithmetic, so a value past 255 wraps modulo 256 rather than erroring —
+// no valid name carries one, and matching the authoritative decoder is what
+// keeps the order aligned with the wire for the names that do.
+func decodeOctet(s string, i int) (byte, int) {
+	c := s[i]
+	if c != '\\' || i+1 >= len(s) {
+		return c, i + 1
+	}
+	if isDigit(s[i+1]) && i+3 < len(s) && isDigit(s[i+2]) && isDigit(s[i+3]) {
+		return (s[i+1]-'0')*100 + (s[i+2]-'0')*10 + (s[i+3] - '0'), i + 4
+	}
+	return s[i+1], i + 2
+}
+
+func isDigit(c byte) bool { return c >= '0' && c <= '9' }
 
 // equalFold is the library's own label equality: same length, ASCII case
 // folded, nothing else.
@@ -236,31 +247,4 @@ func equalFold(a, b string) bool {
 		}
 	}
 	return true
-}
-
-// compareFold orders two labels byte-wise under the same ASCII fold.
-func compareFold(a, b string) int {
-	n := min(len(a), len(b))
-	for i := range n {
-		ai, bi := a[i], b[i]
-		if ai >= 'A' && ai <= 'Z' {
-			ai |= 'a' - 'A'
-		}
-		if bi >= 'A' && bi <= 'Z' {
-			bi |= 'a' - 'A'
-		}
-		switch {
-		case ai < bi:
-			return -1
-		case ai > bi:
-			return 1
-		}
-	}
-	switch {
-	case len(a) < len(b):
-		return -1
-	case len(a) > len(b):
-		return 1
-	}
-	return 0
 }

--- a/internal/dnsname/dnsname.go
+++ b/internal/dnsname/dnsname.go
@@ -1,0 +1,266 @@
+// Package dnsname walks domain-name labels without allocating.
+//
+// The library answers every label question by materializing it: Split builds
+// an index slice, SplitDomainName a string slice, and CompareDomainName two
+// index slices — per call, for answers that are a handful of comparisons. In
+// the field the two of them were 4.3% of every object the resolver
+// allocated. The functions here give the same answers out of a single
+// forward walk, using the library's own NextLabel for boundary and escape
+// handling, so there is no second implementation of `\.` to get wrong.
+package dnsname
+
+import (
+	"iter"
+
+	"github.com/miekg/dns"
+)
+
+// CompareSuffix returns how many labels a and b share, counted from the
+// right and stopping at the first inequality — dns.CompareDomainName's
+// answer without its two index slices.
+//
+// The library's exact comparison is preserved: ASCII case folding only, the
+// final label read to the end of the string (so a rooted and an unrooted
+// spelling of the same name do not match on it), and every other label read
+// through its separating dot.
+func CompareSuffix(a, b string) int {
+	if a == "." || b == "." {
+		return 0
+	}
+	ca, cb := dns.CountLabel(a), dns.CountLabel(b)
+	offA, offB := 0, 0
+	for ; ca > cb; ca-- {
+		offA, _ = dns.NextLabel(a, offA)
+	}
+	for ; cb > ca; cb-- {
+		offB, _ = dns.NextLabel(b, offB)
+	}
+
+	// With the starts aligned, one forward pass in lockstep. The shared
+	// suffix is the trailing run of equal labels, so the counter resets on
+	// every mismatch and holds the run's length at the end.
+	n := 0
+	for ; ca > 1; ca-- {
+		nextA, _ := dns.NextLabel(a, offA)
+		nextB, _ := dns.NextLabel(b, offB)
+		if equalFold(a[offA:nextA], b[offB:nextB]) {
+			n++
+		} else {
+			n = 0
+		}
+		offA, offB = nextA, nextB
+	}
+	if ca == 1 && equalFold(a[offA:], b[offB:]) {
+		return n + 1
+	}
+	return 0
+}
+
+// Sub reports whether name sits at or below zone — dns.IsSubDomain's answer,
+// which is CompareSuffix covering every label of the zone.
+func Sub(zone, name string) bool {
+	return CompareSuffix(zone, name) == dns.CountLabel(zone)
+}
+
+// Suffixes yields the start offset of every label in name, in order —
+// dns.Split's answer as an iteration instead of a slice. The root name
+// yields nothing, exactly as Split returns nil for it.
+func Suffixes(name string) iter.Seq[int] {
+	return func(yield func(int) bool) {
+		if name == "." {
+			return
+		}
+		off := 0
+		for {
+			if !yield(off) {
+				return
+			}
+			next, end := dns.NextLabel(name, off)
+			if end {
+				return
+			}
+			off = next
+		}
+	}
+}
+
+// maxWireLabels is the most labels a name that fits DNS wire format can
+// carry: 127 one-octet labels in a 255-octet name. A presentation string
+// long enough to exceed it cannot have come off the wire; CanonicalCompare
+// falls back to an allocating walk for those rather than answer wrongly.
+const maxWireLabels = 127
+
+// CanonicalCompare orders a and b per RFC 4034 §6.1: labels compared
+// right to left, case-insensitively, with the name that runs out of labels
+// first sorting first. It is the ordering every NSEC coverage proof stands
+// on, and the previous implementation lowercased, rooted and split both
+// names to compute it.
+//
+// The fold is ASCII, which is both what the RFC's canonical form specifies
+// and what the library's own comparisons do. (The implementation this
+// replaces folded through strings.ToLower, whose non-ASCII case mappings
+// have no business in DNS names; names that reach this function come from
+// packed messages, whose presentation form escapes non-ASCII bytes.)
+//
+// A second deliberate divergence, also unreachable from a packed message: a
+// raw multi-byte rune directly before a backslash run at the end of a name
+// trips a rune-versus-byte miscount in the library's IsFqdn, which the old
+// implementation inherited through Fqdn — it declared such names unrooted,
+// rooted them a second time, and compared a phantom empty label. This walk
+// counts bytes and does not.
+//
+// Rooted and unrooted spellings compare equal — the labels are read without
+// their separators, so the trailing root dot contributes nothing. The
+// previous implementation rooted both names first for the same effect.
+func CanonicalCompare(a, b string) int {
+	// A name ending in an unescaped backslash is a quirk the fuzzer found:
+	// the rooting dot the old implementation appended lands behind the
+	// backslash and becomes a literal, changing the final label. No packed
+	// message can produce the shape — a literal backslash presents as \\ —
+	// but parity is the contract, so it keeps the old walk.
+	if escapedTail(a, len(a)) || escapedTail(b, len(b)) {
+		return canonicalCompareSlow(a, b)
+	}
+
+	var bufA, bufB [maxWireLabels]int
+	na, okA := labelOffsets(a, &bufA)
+	nb, okB := labelOffsets(b, &bufB)
+	if !okA || !okB {
+		// Beyond any wire-legal name: correctness over thrift. The rooted
+		// canonical walk the old implementation did, for the inputs only a
+		// hand can construct.
+		return canonicalCompareSlow(a, b)
+	}
+
+	i, j := na-1, nb-1
+	for i >= 0 && j >= 0 {
+		if c := compareFold(labelAt(a, &bufA, na, i), labelAt(b, &bufB, nb, j)); c != 0 {
+			return c
+		}
+		i--
+		j--
+	}
+	switch {
+	case na < nb:
+		return -1
+	case na > nb:
+		return 1
+	}
+	return 0
+}
+
+// canonicalCompareSlow is CanonicalCompare for names carrying more labels
+// than wire format allows: the allocating split, kept off the ordinary path.
+func canonicalCompareSlow(a, b string) int {
+	al := dns.SplitDomainName(dns.Fqdn(a))
+	bl := dns.SplitDomainName(dns.Fqdn(b))
+	i, j := len(al)-1, len(bl)-1
+	for i >= 0 && j >= 0 {
+		if c := compareFold(al[i], bl[j]); c != 0 {
+			return c
+		}
+		i--
+		j--
+	}
+	switch {
+	case len(al) < len(bl):
+		return -1
+	case len(al) > len(bl):
+		return 1
+	}
+	return 0
+}
+
+// labelOffsets writes the label start offsets of name into buf, reporting
+// how many and whether they fit. The buffer travels as an array pointer that
+// is never retained, which is what keeps it on the caller's stack.
+func labelOffsets(name string, buf *[maxWireLabels]int) (n int, ok bool) {
+	if name == "." || name == "" {
+		return 0, true
+	}
+	off := 0
+	for {
+		if n == len(buf) {
+			return n, false
+		}
+		buf[n] = off
+		n++
+		next, end := dns.NextLabel(name, off)
+		if end {
+			return n, true
+		}
+		off = next
+	}
+}
+
+// labelAt returns the i-th of n labels without its separator: the trailing
+// dot for a middle label, the root dot for a rooted final one.
+func labelAt(name string, buf *[maxWireLabels]int, n, i int) string {
+	start := buf[i]
+	if i+1 < n {
+		return name[start : buf[i+1]-1]
+	}
+	label := name[start:]
+	if len(label) > 0 && label[len(label)-1] == '.' && !escapedTail(name, len(name)-1) {
+		return label[:len(label)-1]
+	}
+	return label
+}
+
+// escapedTail reports whether the byte at i is escaped: preceded by an odd
+// number of backslashes.
+func escapedTail(s string, i int) bool {
+	backslashes := 0
+	for j := i - 1; j >= 0 && s[j] == '\\'; j-- {
+		backslashes++
+	}
+	return backslashes%2 == 1
+}
+
+// equalFold is the library's own label equality: same length, ASCII case
+// folded, nothing else.
+func equalFold(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := len(a) - 1; i >= 0; i-- {
+		ai, bi := a[i], b[i]
+		if ai >= 'A' && ai <= 'Z' {
+			ai |= 'a' - 'A'
+		}
+		if bi >= 'A' && bi <= 'Z' {
+			bi |= 'a' - 'A'
+		}
+		if ai != bi {
+			return false
+		}
+	}
+	return true
+}
+
+// compareFold orders two labels byte-wise under the same ASCII fold.
+func compareFold(a, b string) int {
+	n := min(len(a), len(b))
+	for i := range n {
+		ai, bi := a[i], b[i]
+		if ai >= 'A' && ai <= 'Z' {
+			ai |= 'a' - 'A'
+		}
+		if bi >= 'A' && bi <= 'Z' {
+			bi |= 'a' - 'A'
+		}
+		switch {
+		case ai < bi:
+			return -1
+		case ai > bi:
+			return 1
+		}
+	}
+	switch {
+	case len(a) < len(b):
+		return -1
+	case len(a) > len(b):
+		return 1
+	}
+	return 0
+}

--- a/internal/dnsname/dnsname_alloc_test.go
+++ b/internal/dnsname/dnsname_alloc_test.go
@@ -1,0 +1,37 @@
+//go:build !race
+
+package dnsname
+
+import "testing"
+
+// TestWalkersDoNotAllocate is the reason this package exists: every answer
+// out of a forward walk, nothing materialized. CanonicalCompare's offset
+// buffers must stay on the stack — an array pointer that escaped would put
+// two kilobytes on the heap per comparison and quietly cancel the whole
+// point.
+func TestWalkersDoNotAllocate(t *testing.T) {
+	allocs := testing.AllocsPerRun(200, func() {
+		if CompareSuffix("www.miek.nl.", "miek.nl.") != 2 {
+			t.Fatal("wrong answer")
+		}
+		if !Sub("example.com.", "a.b.example.com.") {
+			t.Fatal("wrong answer")
+		}
+		n := 0
+		for range Suffixes("a.b.c.d.example.com.") {
+			n++
+		}
+		if n != 6 {
+			t.Fatal("wrong count")
+		}
+		if CanonicalCompare("b.example.com.", "Z.EXAMPLE.COM.") != -1 {
+			t.Fatal("wrong order")
+		}
+		if CanonicalCompare(`foo\.bar.example.com.`, "foo.bar.example.com.") == 0 {
+			t.Fatal("an escaped dot compared as a separator")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("the walkers cost %.0f allocations", allocs)
+	}
+}

--- a/internal/dnsname/dnsname_alloc_test.go
+++ b/internal/dnsname/dnsname_alloc_test.go
@@ -5,10 +5,8 @@ package dnsname
 import "testing"
 
 // TestWalkersDoNotAllocate is the reason this package exists: every answer
-// out of a forward walk, nothing materialized. CanonicalCompare's offset
-// buffers must stay on the stack — an array pointer that escaped would put
-// two kilobytes on the heap per comparison and quietly cancel the whole
-// point.
+// out of a forward walk, nothing materialized — CanonicalCompare included,
+// whose escape decoding happens octet by octet as the labels are read.
 func TestWalkersDoNotAllocate(t *testing.T) {
 	allocs := testing.AllocsPerRun(200, func() {
 		if CompareSuffix("www.miek.nl.", "miek.nl.") != 2 {

--- a/internal/dnsname/dnsname_test.go
+++ b/internal/dnsname/dnsname_test.go
@@ -1,0 +1,281 @@
+package dnsname
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// nameCorpus is every shape the walkers have to agree on: ordinary names,
+// case differences, rooted and unrooted spellings, escapes in every position
+// the scanner could misread, and the degenerate strings the library defines
+// behavior for.
+var nameCorpus = []string{
+	".", "", "com.", "com", "example.com.", "example.com",
+	"www.example.com.", "WWW.EXAMPLE.COM.", "wWw.eXaMpLe.CoM.",
+	"a.b.c.d.e.f.example.com.", "*.example.com.",
+	`foo\.bar.example.com.`, `foo\\.example.com.`, `foo\\\.bar.example.com.`,
+	`\..`, `\\.`, `a\.`, `a\\.`, `end\.`,
+	"xn--nme-qla.example.", "_dmarc.example.com.",
+	"a.example.com.", "z.example.com.", "example.net.",
+	"miek.nl.", "www.miek.nl.", "www.bla.nl.", "nl.", "nl",
+	"very-long-label-that-goes-on-and-on-and-on-and-on-and-on-and-onx.example.",
+	"1.2.0.192.in-addr.arpa.",
+}
+
+// TestCompareSuffixMatchesLibrary is the contract: dns.CompareDomainName's
+// answer for every pair in the corpus.
+func TestCompareSuffixMatchesLibrary(t *testing.T) {
+	for _, a := range nameCorpus {
+		for _, b := range nameCorpus {
+			if got, want := CompareSuffix(a, b), dns.CompareDomainName(a, b); got != want {
+				t.Errorf("CompareSuffix(%q, %q) = %d, library says %d",
+					a, b, got, want)
+			}
+		}
+	}
+}
+
+// TestSubMatchesLibrary pins dns.IsSubDomain parity over the same pairs.
+func TestSubMatchesLibrary(t *testing.T) {
+	for _, zone := range nameCorpus {
+		for _, name := range nameCorpus {
+			if got, want := Sub(zone, name), dns.IsSubDomain(zone, name); got != want {
+				t.Errorf("Sub(%q, %q) = %v, library says %v",
+					zone, name, got, want)
+			}
+		}
+	}
+}
+
+// TestSuffixesMatchesLibrary pins dns.Split parity: the same offsets, in the
+// same order, including the degenerate strings.
+func TestSuffixesMatchesLibrary(t *testing.T) {
+	for _, name := range nameCorpus {
+		var got []int
+		for off := range Suffixes(name) {
+			got = append(got, off)
+		}
+		want := dns.Split(name)
+		if !slices.Equal(got, want) {
+			t.Errorf("Suffixes(%q) = %v, library says %v", name, got, want)
+		}
+	}
+}
+
+// canonicalReference is the implementation CanonicalCompare replaces, with
+// one deliberate change: the ASCII fold this package uses instead of
+// strings.ToLower, whose non-ASCII case mappings have no business in DNS
+// names. For the ASCII corpus the two are the same function.
+func canonicalReference(a, b string) int {
+	al := dns.SplitDomainName(dns.Fqdn(a))
+	bl := dns.SplitDomainName(dns.Fqdn(b))
+	i, j := len(al)-1, len(bl)-1
+	for i >= 0 && j >= 0 {
+		if c := strings.Compare(asciiLower(al[i]), asciiLower(bl[j])); c != 0 {
+			return c
+		}
+		i--
+		j--
+	}
+	switch {
+	case len(al) < len(bl):
+		return -1
+	case len(al) > len(bl):
+		return 1
+	}
+	return 0
+}
+
+// mixesHighBytesAndBackslash marks the input space where the library's
+// IsFqdn rune bug can fire. Wider than the exact trigger on purpose: the
+// oracle cedes only inputs no packed message can present.
+func mixesHighBytesAndBackslash(s string) bool {
+	high, backslash := false, false
+	for i := range len(s) {
+		switch {
+		case s[i] >= 0x80:
+			high = true
+		case s[i] == '\\':
+			backslash = true
+		}
+	}
+	return high && backslash
+}
+
+func asciiLower(s string) string {
+	b := []byte(s)
+	for i, c := range b {
+		if c >= 'A' && c <= 'Z' {
+			b[i] |= 'a' - 'A'
+		}
+	}
+	return string(b)
+}
+
+// TestCanonicalCompareMatchesReference pins the RFC 4034 §6.1 ordering
+// against the reference for every pair, and the ordering laws on top: the
+// relation must be antisymmetric and rooted/unrooted spellings must compare
+// equal, or NSEC coverage proofs built on it would flicker with the
+// spelling.
+func TestCanonicalCompareMatchesReference(t *testing.T) {
+	for _, a := range nameCorpus {
+		for _, b := range nameCorpus {
+			got := CanonicalCompare(a, b)
+			if want := canonicalReference(a, b); got != want {
+				t.Errorf("CanonicalCompare(%q, %q) = %d, reference says %d",
+					a, b, got, want)
+			}
+			if back := CanonicalCompare(b, a); back != -got {
+				t.Errorf("CanonicalCompare(%q, %q) = %d but reversed = %d",
+					a, b, got, back)
+			}
+		}
+	}
+
+	for _, name := range nameCorpus {
+		if name == "" || name == "." || dns.IsFqdn(name) {
+			continue
+		}
+		if CanonicalCompare(name, dns.Fqdn(name)) != 0 {
+			t.Errorf("%q does not compare equal to its rooted spelling", name)
+		}
+	}
+
+	// The disagreement plain string order gets wrong, pinned by name.
+	if CanonicalCompare("example.com.", "a.example.com.") != -1 {
+		t.Error("the parent must sort before its child")
+	}
+	if CanonicalCompare("z.example.com.", "a.example.com.") != 1 {
+		t.Error("right-to-left label order was not applied")
+	}
+}
+
+// TestCanonicalCompareBeyondWireLabels pins the slow path: names with more
+// labels than wire format allows still order correctly, against the same
+// reference.
+func TestCanonicalCompareBeyondWireLabels(t *testing.T) {
+	long := strings.Repeat("a.", maxWireLabels+3) + "example.com."
+	longer := "z." + long
+	for _, pair := range [][2]string{
+		{long, long},
+		{long, longer},
+		{long, "example.com."},
+		{longer, "b." + long},
+	} {
+		if got, want := CanonicalCompare(pair[0], pair[1]),
+			canonicalReference(pair[0], pair[1]); got != want {
+			t.Errorf("beyond-wire pair: got %d, reference says %d", got, want)
+		}
+	}
+}
+
+// FuzzLabelWalkers drives all four walkers against their library oracles
+// over arbitrary strings. The escape and boundary handling lives in the
+// library's NextLabel either way, but the walks around it — alignment,
+// streak counting, final-label slicing — are this package's own, and a
+// hand-written corpus finds only the mistakes someone imagined.
+func FuzzLabelWalkers(f *testing.F) {
+	for _, name := range nameCorpus {
+		f.Add(name, "example.com.")
+	}
+	f.Add(`a\`, `a\`)
+	f.Add(`\\\\\.`, `\.`)
+
+	f.Fuzz(func(t *testing.T, a, b string) {
+		if got, want := CompareSuffix(a, b), dns.CompareDomainName(a, b); got != want {
+			t.Fatalf("CompareSuffix(%q, %q) = %d, library says %d", a, b, got, want)
+		}
+		if got, want := Sub(a, b), dns.IsSubDomain(a, b); got != want {
+			t.Fatalf("Sub(%q, %q) = %v, library says %v", a, b, got, want)
+		}
+		var got []int
+		for off := range Suffixes(a) {
+			got = append(got, off)
+		}
+		if want := dns.Split(a); !slices.Equal(got, want) {
+			t.Fatalf("Suffixes(%q) = %v, library says %v", a, got, want)
+		}
+
+		// The canonical reference goes through Fqdn, whose IsFqdn miscounts
+		// backslashes behind a raw multi-byte rune — a rune-versus-byte bug
+		// this package deliberately does not inherit, documented on
+		// CanonicalCompare. Presentation names are ASCII, so parity is
+		// asserted wherever the shape that trips it cannot occur; on the
+		// shapes that do, the ordering laws still have to hold.
+		if mixesHighBytesAndBackslash(a) || mixesHighBytesAndBackslash(b) {
+			if got, back := CanonicalCompare(a, b), CanonicalCompare(b, a); back != -got {
+				t.Fatalf("CanonicalCompare(%q, %q) = %d but reversed = %d",
+					a, b, got, back)
+			}
+			return
+		}
+		if got, want := CanonicalCompare(a, b), canonicalReference(a, b); got != want {
+			t.Fatalf("CanonicalCompare(%q, %q) = %d, reference says %d",
+				a, b, got, want)
+		}
+	})
+}
+
+func BenchmarkCompareSuffix(b *testing.B) {
+	b.Run("owned", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			if CompareSuffix("www.miek.nl.", "miek.nl.") != 2 {
+				b.Fatal("wrong answer")
+			}
+		}
+	})
+	b.Run("library", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			if dns.CompareDomainName("www.miek.nl.", "miek.nl.") != 2 {
+				b.Fatal("wrong answer")
+			}
+		}
+	})
+}
+
+func BenchmarkSuffixes(b *testing.B) {
+	b.Run("owned", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			n := 0
+			for range Suffixes("a.b.c.d.example.com.") {
+				n++
+			}
+			if n != 6 {
+				b.Fatal("wrong count")
+			}
+		}
+	})
+	b.Run("library", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			if len(dns.Split("a.b.c.d.example.com.")) != 6 {
+				b.Fatal("wrong count")
+			}
+		}
+	})
+}
+
+func BenchmarkCanonicalCompare(b *testing.B) {
+	b.Run("owned", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			if CanonicalCompare("b.example.com.", "Z.EXAMPLE.COM.") != -1 {
+				b.Fatal("wrong order")
+			}
+		}
+	})
+	b.Run("reference", func(b *testing.B) {
+		b.ReportAllocs()
+		for b.Loop() {
+			if canonicalReference("b.example.com.", "Z.EXAMPLE.COM.") != -1 {
+				b.Fatal("wrong order")
+			}
+		}
+	})
+}

--- a/internal/dnsname/dnsname_test.go
+++ b/internal/dnsname/dnsname_test.go
@@ -65,67 +65,105 @@ func TestSuffixesMatchesLibrary(t *testing.T) {
 	}
 }
 
-// canonicalReference is the implementation CanonicalCompare replaces, with
-// one deliberate change: the ASCII fold this package uses instead of
-// strings.ToLower, whose non-ASCII case mappings have no business in DNS
-// names. For the ASCII corpus the two are the same function.
-func canonicalReference(a, b string) int {
-	al := dns.SplitDomainName(dns.Fqdn(a))
-	bl := dns.SplitDomainName(dns.Fqdn(b))
-	i, j := len(al)-1, len(bl)-1
+// canonicalWireReference is the independent oracle: the name packed to wire
+// by the library — which is the authoritative decoder of presentation
+// escapes — and RFC 4034 §6.3 applied to the resulting label octets. The
+// comparator must agree with this, not with the implementation it replaced,
+// whose ordering of escape text is the bug being fixed. ok=false marks a
+// pair the packer refuses, where wire order is undefined.
+func canonicalWireReference(a, b string) (int, bool) {
+	// A name ending in a dangling backslash has no defined wire form, and
+	// the library does not refuse it — Fqdn's appended root dot lands
+	// behind the backslash and PackDomainName then collapses the whole
+	// name to the root, silently. The oracle only binds where the wire
+	// form is real; on these shapes the ordering laws still hold and are
+	// asserted separately.
+	if escapedTail(a, len(a)) || escapedTail(b, len(b)) {
+		return 0, false
+	}
+	// Nor does it bind where the library disagrees with itself about the
+	// rooting: IsFqdn counts trailing backslashes with rune arithmetic on a
+	// byte question, so a multi-byte rune before the run flips its answer,
+	// Fqdn roots (or fails to root) accordingly, and the packed form no
+	// longer corresponds to the name. Both fuzz-found shapes of this are
+	// pinned in the corpus.
+	if fqdnDisagrees(a) || fqdnDisagrees(b) {
+		return 0, false
+	}
+	la, okA := wireLabels(a)
+	lb, okB := wireLabels(b)
+	if !okA || !okB {
+		return 0, false
+	}
+	i, j := len(la)-1, len(lb)-1
 	for i >= 0 && j >= 0 {
-		if c := strings.Compare(asciiLower(al[i]), asciiLower(bl[j])); c != 0 {
-			return c
+		if c := strings.Compare(asciiLowerBytes(la[i]), asciiLowerBytes(lb[j])); c != 0 {
+			return c, true
 		}
 		i--
 		j--
 	}
 	switch {
-	case len(al) < len(bl):
-		return -1
-	case len(al) > len(bl):
-		return 1
+	case len(la) < len(lb):
+		return -1, true
+	case len(la) > len(lb):
+		return 1, true
 	}
-	return 0
+	return 0, true
 }
 
-// mixesHighBytesAndBackslash marks the input space where the library's
-// IsFqdn rune bug can fire. Wider than the exact trigger on purpose: the
-// oracle cedes only inputs no packed message can present.
-func mixesHighBytesAndBackslash(s string) bool {
-	high, backslash := false, false
-	for i := range len(s) {
-		switch {
-		case s[i] >= 0x80:
-			high = true
-		case s[i] == '\\':
-			backslash = true
+// fqdnDisagrees reports the shapes where the library's IsFqdn — rune
+// arithmetic on a byte question — answers differently from a byte count of
+// the trailing backslashes.
+func fqdnDisagrees(s string) bool {
+	byteFqdn := len(s) > 0 && s[len(s)-1] == '.' && !escapedTail(s, len(s)-1)
+	return dns.IsFqdn(s) != byteFqdn
+}
+
+func wireLabels(name string) ([][]byte, bool) {
+	buf := make([]byte, 1024)
+	n, err := dns.PackDomainName(dns.Fqdn(name), buf, 0, nil, false)
+	if err != nil {
+		return nil, false
+	}
+	wire := buf[:n]
+	var labels [][]byte
+	for off := 0; off < len(wire); {
+		l := int(wire[off])
+		off++
+		if l == 0 {
+			break
 		}
+		if off+l > len(wire) {
+			return nil, false
+		}
+		labels = append(labels, wire[off:off+l])
+		off += l
 	}
-	return high && backslash
+	return labels, true
 }
 
-func asciiLower(s string) string {
-	b := []byte(s)
+func asciiLowerBytes(b []byte) string {
+	out := make([]byte, len(b))
 	for i, c := range b {
 		if c >= 'A' && c <= 'Z' {
-			b[i] |= 'a' - 'A'
+			c |= 'a' - 'A'
 		}
+		out[i] = c
 	}
-	return string(b)
+	return string(out)
 }
 
-// TestCanonicalCompareMatchesReference pins the RFC 4034 §6.1 ordering
-// against the reference for every pair, and the ordering laws on top: the
-// relation must be antisymmetric and rooted/unrooted spellings must compare
-// equal, or NSEC coverage proofs built on it would flicker with the
-// spelling.
-func TestCanonicalCompareMatchesReference(t *testing.T) {
+// TestCanonicalCompareMatchesWireOrder pins the RFC 4034 §6.3 ordering
+// against the wire oracle for every packable pair, antisymmetry for every
+// pair packable or not, and rooted/unrooted equivalence — an ordering NSEC
+// coverage proofs stand on must not flicker with the spelling.
+func TestCanonicalCompareMatchesWireOrder(t *testing.T) {
 	for _, a := range nameCorpus {
 		for _, b := range nameCorpus {
 			got := CanonicalCompare(a, b)
-			if want := canonicalReference(a, b); got != want {
-				t.Errorf("CanonicalCompare(%q, %q) = %d, reference says %d",
+			if want, ok := canonicalWireReference(a, b); ok && got != want {
+				t.Errorf("CanonicalCompare(%q, %q) = %d, wire order says %d",
 					a, b, got, want)
 			}
 			if back := CanonicalCompare(b, a); back != -got {
@@ -153,22 +191,58 @@ func TestCanonicalCompareMatchesReference(t *testing.T) {
 	}
 }
 
-// TestCanonicalCompareBeyondWireLabels pins the slow path: names with more
-// labels than wire format allows still order correctly, against the same
-// reference.
-func TestCanonicalCompareBeyondWireLabels(t *testing.T) {
-	long := strings.Repeat("a.", maxWireLabels+3) + "example.com."
-	longer := "z." + long
+// TestCanonicalCompareDecodesEscapes pins the defect this ordering exists to
+// fix, in the three shapes review demonstrated it with: presentation text is
+// an encoding, and the order belongs to the octets behind it. The old
+// comparator — and the first version of this one, which mirrored it —
+// ordered the escape text, inverting names around `\` (0x5C) and splitting
+// wire-equal spellings apart.
+func TestCanonicalCompareDecodesEscapes(t *testing.T) {
+	// `\046` is the octet 0x2E, which sorts before `0` (0x30); the escape
+	// text starts with `\` (0x5C), which sorts after it.
+	if got := CanonicalCompare(`\046.example.`, "0.example."); got != -1 {
+		t.Errorf(`\046 vs 0: got %d, want -1 (0x2E < 0x30)`, got)
+	}
+	// `\065` is the octet 0x41 — the label `a` after the fold.
+	if got := CanonicalCompare(`\065.example.`, "a.example."); got != 0 {
+		t.Errorf(`\065 vs a: got %d, want 0`, got)
+	}
+	// One label, spelled two ways: an escaped dot and its decimal escape.
+	if got := CanonicalCompare(`a\.b`, `a\046b`); got != 0 {
+		t.Errorf(`a\.b vs a\046b: got %d, want 0`, got)
+	}
+	// And each agrees with the wire oracle, so the pins cannot drift from
+	// the reference.
 	for _, pair := range [][2]string{
-		{long, long},
-		{long, longer},
-		{long, "example.com."},
-		{longer, "b." + long},
+		{`\046.example.`, "0.example."},
+		{`\065.example.`, "a.example."},
+		{`a\.b`, `a\046b`},
 	} {
-		if got, want := CanonicalCompare(pair[0], pair[1]),
-			canonicalReference(pair[0], pair[1]); got != want {
-			t.Errorf("beyond-wire pair: got %d, reference says %d", got, want)
+		want, ok := canonicalWireReference(pair[0], pair[1])
+		if !ok {
+			t.Fatalf("oracle refused %q vs %q", pair[0], pair[1])
 		}
+		if got := CanonicalCompare(pair[0], pair[1]); got != want {
+			t.Errorf("%q vs %q: got %d, wire order says %d",
+				pair[0], pair[1], got, want)
+		}
+	}
+}
+
+// TestCanonicalCompareManyLabels pins that the walk has no label-count
+// ceiling: a name past wire limits still orders by the same rules, and the
+// relation stays antisymmetric.
+func TestCanonicalCompareManyLabels(t *testing.T) {
+	long := strings.Repeat("a.", 150) + "example.com."
+	longer := "z." + long
+	if CanonicalCompare(long, longer) != -1 {
+		t.Error("the shorter suffix must sort first")
+	}
+	if CanonicalCompare(longer, long) != 1 {
+		t.Error("antisymmetry lost on long names")
+	}
+	if CanonicalCompare(long, long) != 0 {
+		t.Error("a long name does not equal itself")
 	}
 }
 
@@ -199,22 +273,17 @@ func FuzzLabelWalkers(f *testing.F) {
 			t.Fatalf("Suffixes(%q) = %v, library says %v", a, got, want)
 		}
 
-		// The canonical reference goes through Fqdn, whose IsFqdn miscounts
-		// backslashes behind a raw multi-byte rune — a rune-versus-byte bug
-		// this package deliberately does not inherit, documented on
-		// CanonicalCompare. Presentation names are ASCII, so parity is
-		// asserted wherever the shape that trips it cannot occur; on the
-		// shapes that do, the ordering laws still have to hold.
-		if mixesHighBytesAndBackslash(a) || mixesHighBytesAndBackslash(b) {
-			if got, back := CanonicalCompare(a, b), CanonicalCompare(b, a); back != -got {
-				t.Fatalf("CanonicalCompare(%q, %q) = %d but reversed = %d",
-					a, b, got, back)
-			}
-			return
+		// Canonical order is defined on wire octets, so the oracle is the
+		// packed name; a string the packer refuses has no wire order, and
+		// there only the ordering laws bind.
+		order := CanonicalCompare(a, b)
+		if back := CanonicalCompare(b, a); back != -order {
+			t.Fatalf("CanonicalCompare(%q, %q) = %d but reversed = %d",
+				a, b, order, back)
 		}
-		if got, want := CanonicalCompare(a, b), canonicalReference(a, b); got != want {
-			t.Fatalf("CanonicalCompare(%q, %q) = %d, reference says %d",
-				a, b, got, want)
+		if want, ok := canonicalWireReference(a, b); ok && order != want {
+			t.Fatalf("CanonicalCompare(%q, %q) = %d, wire order says %d",
+				a, b, order, want)
 		}
 	})
 }
@@ -270,10 +339,31 @@ func BenchmarkCanonicalCompare(b *testing.B) {
 			}
 		}
 	})
-	b.Run("reference", func(b *testing.B) {
+	b.Run("previous", func(b *testing.B) {
+		// The implementation this replaced: lower, root and split both
+		// names, then compare label text.
+		previous := func(a, c string) int {
+			al := dns.SplitDomainName(strings.ToLower(dns.Fqdn(a)))
+			bl := dns.SplitDomainName(strings.ToLower(dns.Fqdn(c)))
+			i, j := len(al)-1, len(bl)-1
+			for i >= 0 && j >= 0 {
+				if r := strings.Compare(al[i], bl[j]); r != 0 {
+					return r
+				}
+				i--
+				j--
+			}
+			switch {
+			case len(al) < len(bl):
+				return -1
+			case len(al) > len(bl):
+				return 1
+			}
+			return 0
+		}
 		b.ReportAllocs()
 		for b.Loop() {
-			if canonicalReference("b.example.com.", "Z.EXAMPLE.COM.") != -1 {
+			if previous("b.example.com.", "Z.EXAMPLE.COM.") != -1 {
 				b.Fatal("wrong order")
 			}
 		}

--- a/internal/dnsname/testdata/fuzz/FuzzLabelWalkers/140b75866f203937
+++ b/internal/dnsname/testdata/fuzz/FuzzLabelWalkers/140b75866f203937
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("0")
+string("\\512")

--- a/internal/dnsname/testdata/fuzz/FuzzLabelWalkers/2fba0a04a706b9b4
+++ b/internal/dnsname/testdata/fuzz/FuzzLabelWalkers/2fba0a04a706b9b4
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("ѹ\\\\.")
+string("0")

--- a/internal/dnsname/testdata/fuzz/FuzzLabelWalkers/65cf2cda6b50fb88
+++ b/internal/dnsname/testdata/fuzz/FuzzLabelWalkers/65cf2cda6b50fb88
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("A\\ ")
+string("A\\")

--- a/internal/dnsname/testdata/fuzz/FuzzLabelWalkers/cbcef42b9a848e96
+++ b/internal/dnsname/testdata/fuzz/FuzzLabelWalkers/cbcef42b9a848e96
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("\U00102717\\")
+string("0")

--- a/internal/dnsname/testdata/fuzz/FuzzLabelWalkers/da678637cf398958
+++ b/internal/dnsname/testdata/fuzz/FuzzLabelWalkers/da678637cf398958
@@ -1,0 +1,3 @@
+go test fuzz v1
+string("˔\\.")
+string("0")

--- a/internal/dnsutil/response.go
+++ b/internal/dnsutil/response.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/dnsname"
 )
 
 // ResponseType represents the classification of a DNS response.
@@ -113,7 +114,7 @@ func isDelegation(msg *dns.Msg) bool {
 	for _, rr := range msg.Ns {
 		if ns, ok := rr.(*dns.NS); ok {
 			// It's a delegation if the NS record is for a subdomain
-			if dns.IsSubDomain(ns.Header().Name, msg.Question[0].Name) {
+			if dnsname.Sub(ns.Header().Name, msg.Question[0].Name) {
 				return true
 			}
 		}

--- a/internal/dnsutil/rrset.go
+++ b/internal/dnsutil/rrset.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/dnsname"
 )
 
 // ExtractRRSet returns every RR in `in` whose owner equals `name`
@@ -170,7 +171,7 @@ func DnameTarget(msg *dns.Msg) string {
 			// labels than qname — neither can apply.
 			return ""
 		}
-		if dns.CompareDomainName(dname.Header().Name, q.Name) != ownerLabels {
+		if dnsname.CompareSuffix(dname.Header().Name, q.Name) != ownerLabels {
 			// Shared trailing-label count is less than the DNAME
 			// owner's full name, meaning the owner is a cousin or
 			// unrelated sibling, not an ancestor of qname.

--- a/middleware/cache/denial_proof_cache.go
+++ b/middleware/cache/denial_proof_cache.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/dnsname"
 	"github.com/semihalev/sdns/middleware/resolver/dnssec"
 )
 
@@ -463,7 +464,7 @@ func (c *denialProofCache) extract(
 		return nil, false
 	}
 	if q.Qclass == 0 || q.Qclass == dns.ClassANY || q.Qclass == dns.ClassNONE ||
-		!dns.IsSubDomain(zone, qname) {
+		!dnsname.Sub(zone, qname) {
 		return nil, false
 	}
 
@@ -507,12 +508,12 @@ func (c *denialProofCache) extract(
 
 		case *dns.NSEC:
 			if record == nil || record.Hdr.Rrtype != dns.TypeNSEC ||
-				!dns.IsSubDomain(zone, owner) {
+				!dnsname.Sub(zone, owner) {
 				continue
 			}
 			next := dns.CanonicalName(record.NextDomain)
 			if _, valid := dns.IsDomainName(next); !valid ||
-				!dns.IsSubDomain(zone, next) {
+				!dnsname.Sub(zone, next) {
 				return nil, false
 			}
 			sawNSEC = true
@@ -538,7 +539,7 @@ func (c *denialProofCache) extract(
 
 		case *dns.NSEC3:
 			if record == nil || record.Hdr.Rrtype != dns.TypeNSEC3 ||
-				!dns.IsSubDomain(zone, owner) {
+				!dnsname.Sub(zone, owner) {
 				continue
 			}
 			params, ownerHash, nextHash, valid := denialProofNSEC3Identity(record, zone)
@@ -600,7 +601,7 @@ func (c *denialProofCache) extract(
 		}
 		owner := dns.CanonicalName(sig.Hdr.Name)
 		if _, valid := dns.IsDomainName(owner); !valid ||
-			!dns.IsSubDomain(zone, owner) {
+			!dnsname.Sub(zone, owner) {
 			continue
 		}
 
@@ -832,14 +833,19 @@ func denialProofNSEC3Identity(
 		return denialProofNSEC3Params{}, "", "", false
 	}
 	owner := dns.CanonicalName(record.Hdr.Name)
-	ownerLabels := dns.SplitDomainName(owner)
-	zoneLabels := dns.SplitDomainName(zone)
-	if len(ownerLabels) != len(zoneLabels)+1 ||
-		!dns.IsSubDomain(zone, owner) {
+	// One label below the zone, checked by count rather than by splitting
+	// both names into label slices — the counts and the first label's end
+	// come out of the same forward walk the split would have done.
+	if dns.CountLabel(owner) != dns.CountLabel(zone)+1 ||
+		!dnsname.Sub(zone, owner) {
+		return denialProofNSEC3Params{}, "", "", false
+	}
+	next, end := dns.NextLabel(owner, 0)
+	if end {
 		return denialProofNSEC3Params{}, "", "", false
 	}
 
-	ownerHash, ok := denialProofCanonicalNSEC3Hash(ownerLabels[0])
+	ownerHash, ok := denialProofCanonicalNSEC3Hash(owner[:next-1])
 	if !ok {
 		return denialProofNSEC3Params{}, "", "", false
 	}

--- a/middleware/cache/nxdomain_cut.go
+++ b/middleware/cache/nxdomain_cut.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/dnsname"
 	"github.com/semihalev/sdns/internal/dnsutil"
 	"github.com/semihalev/sdns/middleware"
 )
@@ -170,7 +171,7 @@ func (c *nxDomainCutCache) record(msg *dns.Msg, deniedName, zone string, cutUnti
 	// The signer-zone apex cannot be absent while its SOA exists. Rejecting
 	// this impossible provenance locally prevents it becoming a zone-wide cut.
 	if deniedName == "." || deniedName == zone ||
-		!dns.IsSubDomain(zone, deniedName) {
+		!dnsname.Sub(zone, deniedName) {
 		return false
 	}
 
@@ -286,7 +287,7 @@ func nxDomainCutProof(msg *dns.Msg, deniedName, zone string) (*dns.Msg, *dns.SOA
 	useNSEC3 := false
 	for _, rr := range msg.Ns {
 		nsec3, ok := rr.(*dns.NSEC3)
-		if !ok || !dns.IsSubDomain(zone, dns.CanonicalName(nsec3.Hdr.Name)) {
+		if !ok || !dnsname.Sub(zone, dns.CanonicalName(nsec3.Hdr.Name)) {
 			continue
 		}
 		useNSEC3 = true
@@ -320,7 +321,7 @@ func nxDomainCutProof(msg *dns.Msg, deniedName, zone string) (*dns.Msg, *dns.SOA
 
 	for _, rr := range msg.Ns {
 		owner := dns.CanonicalName(rr.Header().Name)
-		if !dns.IsSubDomain(zone, owner) || rr.Header().Class != soa.Hdr.Class {
+		if !dnsname.Sub(zone, owner) || rr.Header().Class != soa.Hdr.Class {
 			continue
 		}
 
@@ -339,7 +340,7 @@ func nxDomainCutProof(msg *dns.Msg, deniedName, zone string) (*dns.Msg, *dns.SOA
 			// Filtering just this RDATA would leave the retained RRSIG
 			// covering a different RRset. Fail closed for shared cut
 			// admission instead; the exact negative answer remains cached.
-			if !dns.IsSubDomain(zone, next) {
+			if !dnsname.Sub(zone, next) {
 				return nil, nil, false
 			}
 			key = rrsetKey{owner: owner, rtype: dns.TypeNSEC, qclass: record.Hdr.Class}
@@ -356,7 +357,7 @@ func nxDomainCutProof(msg *dns.Msg, deniedName, zone string) (*dns.Msg, *dns.SOA
 		retained[key] = struct{}{}
 	}
 
-	if len(proofKeys) == 0 || !dns.IsSubDomain(zone, deniedName) {
+	if len(proofKeys) == 0 || !dnsname.Sub(zone, deniedName) {
 		return nil, nil, false
 	}
 
@@ -436,7 +437,7 @@ func (c *nxDomainCutCache) lookup(q dns.Question) (*nxDomainCutEntry, bool) {
 
 	name := dns.CanonicalName(q.Name)
 	now := time.Now()
-	for _, offset := range dns.Split(name) {
+	for offset := range dnsname.Suffixes(name) {
 		candidate := name[offset:]
 		id := nxDomainCutID{deniedName: candidate, qclass: q.Qclass}
 
@@ -498,7 +499,7 @@ func (c *nxDomainCutCache) purge(q dns.Question) {
 	name := dns.CanonicalName(q.Name)
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	for _, offset := range dns.Split(name) {
+	for offset := range dnsname.Suffixes(name) {
 		candidate := name[offset:]
 		id := nxDomainCutID{deniedName: candidate, qclass: q.Qclass}
 		if entry := c.entries[id]; entry != nil {

--- a/middleware/resolver/dnssec/nsec.go
+++ b/middleware/resolver/dnssec/nsec.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/dnsname"
 	"github.com/semihalev/sdns/internal/dnsutil"
 )
 
@@ -89,18 +90,16 @@ func VerifyNameErrorNSEC(msg *dns.Msg, nsecSet []dns.RR) error {
 // §3.1.3.2, the result must be a proper ancestor of qname.
 func closestEncloserFromNSEC(qname string, nsec *dns.NSEC) string {
 	qn := strings.ToLower(dns.Fqdn(qname))
-	qLabels := dns.SplitDomainName(qn)
+	qLabelCount := dns.CountLabel(qn)
 
+	// CompareSuffix folds case on its own, so only qn needs lowering — the
+	// result is a slice of it. An unrooted owner or next is rooted first,
+	// exactly as the old label split did; names off the wire already are.
 	shared := func(other string) int {
-		ol := dns.SplitDomainName(strings.ToLower(dns.Fqdn(other)))
-		count := 0
-		for i, j := len(qLabels)-1, len(ol)-1; i >= 0 && j >= 0; i, j = i-1, j-1 {
-			if qLabels[i] != ol[j] {
-				break
-			}
-			count++
+		if !dns.IsFqdn(other) {
+			other = dns.Fqdn(other)
 		}
-		return count
+		return dnsname.CompareSuffix(qn, other)
 	}
 
 	n := shared(nsec.Header().Name)
@@ -108,16 +107,19 @@ func closestEncloserFromNSEC(qname string, nsec *dns.NSEC) string {
 		n = s
 	}
 	// The closest encloser is a proper ancestor of qname, so cap at
-	// len(qLabels)-1 even if owner or next happens to share all labels
+	// qLabelCount-1 even if owner or next happens to share all labels
 	// (which would only occur for a malformed NSEC covering its own
 	// name).
-	if n >= len(qLabels) {
-		n = len(qLabels) - 1
+	if n >= qLabelCount {
+		n = qLabelCount - 1
 	}
 	if n <= 0 {
 		return "."
 	}
-	return dns.Fqdn(strings.Join(qLabels[len(qLabels)-n:], "."))
+	// The encloser is qn's last n labels: a suffix of a rooted, lowered
+	// name, sliced instead of joined back together.
+	prev, _ := dns.PrevLabel(qn, n)
+	return qn[prev:]
 }
 
 // VerifyNODATANSEC verifies NODATA using NSEC records (RFC 4035 §3.1.3.1).
@@ -214,24 +216,12 @@ func VerifyNODATANSEC(msg *dns.Msg, nsecSet []dns.RR) error {
 // disagrees with this order for names like "example.com." vs
 // "a.example.com.", so any proof built on byte-wise compares produces
 // both false positives and false negatives.
+//
+// The ordering itself lives in dnsname, which computes it out of a forward
+// walk; this used to lower, root and split both names per comparison, for
+// every NSEC of every aggressive-cache probe.
 func canonicalNameCompare(a, b string) int {
-	aLabels := dns.SplitDomainName(strings.ToLower(dns.Fqdn(a)))
-	bLabels := dns.SplitDomainName(strings.ToLower(dns.Fqdn(b)))
-	i, j := len(aLabels)-1, len(bLabels)-1
-	for i >= 0 && j >= 0 {
-		if c := strings.Compare(aLabels[i], bLabels[j]); c != 0 {
-			return c
-		}
-		i--
-		j--
-	}
-	switch {
-	case len(aLabels) < len(bLabels):
-		return -1
-	case len(aLabels) > len(bLabels):
-		return 1
-	}
-	return 0
+	return dnsname.CanonicalCompare(a, b)
 }
 
 // nsecCovers reports whether an NSEC whose owner is `owner` and whose

--- a/middleware/resolver/dnssec/nsec3.go
+++ b/middleware/resolver/dnssec/nsec3.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/dnsname"
 	"github.com/semihalev/sdns/internal/dnsutil"
 )
 
@@ -365,12 +366,14 @@ func findClosestEncloserWithWork(
 	name string,
 	evaluator *nsec3RingEvaluator,
 ) (nsec3ClosestEncloserProof, error) {
-	labelIndices := dns.Split(name)
 	nc := name
 
-	// RFC 5155 Section 7.2.1: Start from the full name and work up
-	for i := 0; i < len(labelIndices); i++ {
-		z := name[labelIndices[i]:]
+	// RFC 5155 Section 7.2.1: Start from the full name and work up. The
+	// walk carries the previous label's offset instead of materializing the
+	// index slice the old dns.Split call built per proof.
+	prev := -1
+	for offset := range dnsname.Suffixes(name) {
+		z := name[offset:]
 
 		// Check if this ancestor has a matching NSEC3
 		types, err := findMatchingWithWork(z, evaluator)
@@ -378,12 +381,13 @@ func findClosestEncloserWithWork(
 			if err != ErrNSECMissingCoverage {
 				return nsec3ClosestEncloserProof{}, err
 			}
+			prev = offset
 			continue
 		}
 
 		// Found a matching NSEC3 for this ancestor
-		if i != 0 {
-			nc = name[labelIndices[i-1]:]
+		if prev >= 0 {
+			nc = name[prev:]
 		}
 
 		// Return the closest encloser and next closer name

--- a/middleware/resolver/dnssec/nsec_bench_test.go
+++ b/middleware/resolver/dnssec/nsec_bench_test.go
@@ -1,0 +1,40 @@
+package dnssec
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// BenchmarkNSECCovers exercises the canonical-order comparisons every NSEC
+// coverage decision makes — three per candidate record, for every record of
+// every aggressive-cache probe.
+func BenchmarkNSECCovers(b *testing.B) {
+	b.ReportAllocs()
+	for b.Loop() {
+		if !nsecCovers("a.example.com.", "m.example.com.", "b.example.com.") {
+			b.Fatal("coverage lost")
+		}
+		if nsecCovers("a.example.com.", "m.example.com.", "z.example.com.") {
+			b.Fatal("false coverage")
+		}
+	}
+}
+
+// BenchmarkClosestEncloserFromNSEC exercises the shared-suffix walk and the
+// encloser reconstruction.
+func BenchmarkClosestEncloserFromNSEC(b *testing.B) {
+	nsec := &dns.NSEC{
+		Hdr: dns.RR_Header{
+			Name: "alpha.example.com.", Rrtype: dns.TypeNSEC,
+			Class: dns.ClassINET, Ttl: 300,
+		},
+		NextDomain: "delta.example.com.",
+	}
+	b.ReportAllocs()
+	for b.Loop() {
+		if closestEncloserFromNSEC("b.c.example.com.", nsec) != "example.com." {
+			b.Fatal("wrong encloser")
+		}
+	}
+}

--- a/middleware/resolver/dnssec/verify.go
+++ b/middleware/resolver/dnssec/verify.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/dnsname"
 	"github.com/semihalev/sdns/internal/dnsutil"
 )
 
@@ -802,7 +803,7 @@ func isSynthesizedCNAME(cname *dns.CNAME, dnames []*dns.DNAME) bool {
 		if dnameLabels == 0 || ownerLabels <= dnameLabels {
 			continue
 		}
-		n := dns.CompareDomainName(d.Header().Name, owner)
+		n := dnsname.CompareSuffix(d.Header().Name, owner)
 		if n != dnameLabels {
 			continue
 		}

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -19,6 +19,7 @@ import (
 	"github.com/semihalev/sdns/internal/authority"
 	"github.com/semihalev/sdns/internal/cache"
 	"github.com/semihalev/sdns/internal/contextutil"
+	"github.com/semihalev/sdns/internal/dnsname"
 	"github.com/semihalev/sdns/internal/dnsutil"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/sdns/middleware/resolver/dnssec"
@@ -758,7 +759,7 @@ func (r *Resolver) checkGlueRR(resp *dns.Msg, hosts hostSet, level int) (*author
 
 				i, _ := dns.PrevLabel(qname, level)
 
-				if dns.CompareDomainName(name, qname[i:]) < level {
+				if dnsname.CompareSuffix(name, qname[i:]) < level {
 					// we cannot trust that glue, out of bailiwick.
 					continue
 				}
@@ -2037,7 +2038,7 @@ func (r *Resolver) searchCache(q dns.Question, cd bool, origin string) delegatio
 		return delegationMatch{
 			servers:  ns.Servers,
 			parentDS: ns.DSSet,
-			level:    dns.CompareDomainName(origin, q.Name),
+			level:    dnsname.CompareSuffix(origin, q.Name),
 			deadline: ns.ExpiresAt,
 			key:      key,
 		}
@@ -2144,11 +2145,20 @@ func (r *Resolver) findDS(ctx context.Context, signer, qname string, parentDS []
 
 		if signer == "" {
 			// generally auth server directly return answer without DS records
-			n := dns.CompareDomainName(dsname, qname)
-			nsplit := dns.SplitDomainName(qname)
+			n := dnsname.CompareSuffix(dsname, qname)
+			qnameLabels := dns.CountLabel(qname)
 
-			for len(nsplit)-n > 0 {
-				candidate := dns.Fqdn(strings.Join(nsplit[len(nsplit)-n-1:], "."))
+			for qnameLabels-n > 0 {
+				// The candidate is qname's last n+1 labels — a suffix of a
+				// name that is already rooted, so it is sliced rather than
+				// split, joined and rooted again. The rooting guard costs a
+				// byte check and keeps an unrooted caller, if one ever
+				// appears, on the old behavior.
+				prev, _ := dns.PrevLabel(qname, n+1)
+				candidate := qname[prev:]
+				if !dns.IsFqdn(candidate) {
+					candidate = dns.Fqdn(candidate)
+				}
 
 				dsResp, err := r.lookupDS(ctx, candidate, cd)
 				if err != nil {
@@ -2160,7 +2170,7 @@ func (r *Resolver) findDS(ctx context.Context, signer, qname string, parentDS []
 					break
 				}
 
-				n = dns.CompareDomainName(candidate, qname)
+				n = dnsname.CompareSuffix(candidate, qname)
 			}
 
 		} else if dsname != signer {
@@ -2219,10 +2229,15 @@ func (r *Resolver) isZoneSecure(ctx context.Context, qname string, parentDS []dn
 	// zone cuts (RFC 4034 §5 — DS only exists at delegation points).
 	probeName := zone
 	if probeName == "" {
-		// No zone info available; fall back to probing the parent of qname.
+		// No zone info available; fall back to probing the parent of qname:
+		// everything past the first label, sliced rather than split and
+		// rejoined.
 		probeName = qname
-		if labels := dns.SplitDomainName(qname); len(labels) > 1 {
-			probeName = dns.Fqdn(strings.Join(labels[1:], "."))
+		if off, end := dns.NextLabel(qname, 0); !end {
+			probeName = qname[off:]
+			if !dns.IsFqdn(probeName) {
+				probeName = dns.Fqdn(probeName)
+			}
 		}
 	}
 
@@ -2264,14 +2279,16 @@ func (r *Resolver) provenInsecureDelegation(ctx context.Context, zone, qname str
 		return false
 	}
 
-	labels := dns.SplitDomainName(qname)
+	qnameLabels := dns.CountLabel(qname)
 	zoneCount := dns.CountLabel(zone)
 	curDS := parentDS
 	curSigner := zone
 
-	// Candidates from just below `zone` (least specific) toward qname.
-	for n := zoneCount + 1; n <= len(labels); n++ {
-		candidate := dns.Fqdn(strings.Join(labels[len(labels)-n:], "."))
+	// Candidates from just below `zone` (least specific) toward qname:
+	// each is a suffix of qname, which is already canonical and rooted.
+	for n := zoneCount + 1; n <= qnameLabels; n++ {
+		prev, _ := dns.PrevLabel(qname, n)
+		candidate := qname[prev:]
 
 		dsset, insecure, err := r.authenticatedDelegationDS(ctx, curSigner, candidate, curDS)
 		if err != nil {
@@ -3304,13 +3321,13 @@ func minRRSetTTL(rrs []dns.RR) uint32 {
 // rejected, so a former child cannot reinsert its own delegation and an
 // off-path server cannot inject one (GHSA-mqfw-f48p-2vc8).
 func progressingReferral(referral, authZone, qname string) bool {
-	if !dns.IsSubDomain(authZone, referral) {
+	if !dnsname.Sub(authZone, referral) {
 		return false // out of bailiwick
 	}
 	if strings.EqualFold(dns.CanonicalName(referral), dns.CanonicalName(authZone)) {
 		return false // same zone — not strictly below the authority
 	}
-	return dns.IsSubDomain(referral, qname) // must be on the path to qname
+	return dnsname.Sub(referral, qname) // must be on the path to qname
 }
 
 // validReferral applies one coherent rule at both lookup winner selection and

--- a/middleware/resolver/utils.go
+++ b/middleware/resolver/utils.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/dnsname"
 	"github.com/semihalev/zlog/v2"
 )
 
@@ -147,7 +148,7 @@ func sortHosts(hosts hostSet, qname string) []string {
 
 	slices.Sort(list)
 	slices.SortFunc(list, func(a, b string) int {
-		return dns.CompareDomainName(qname, b) - dns.CompareDomainName(qname, a)
+		return dnsname.CompareSuffix(qname, b) - dnsname.CompareSuffix(qname, a)
 	})
 
 	return list


### PR DESCRIPTION
## Problem

`dns.Split` + `dns.SplitDomainName` are 22.02 MB / 663,557 objects per profile interval — 2.50% of bytes, **4.31% of all objects** — and every byte of it is scaffolding: an index slice built to compare two names, a string slice built to count labels or slice a suffix, discarded on return. `CompareDomainName` builds two of them per call, and `nsecCovers` makes three canonical comparisons per candidate NSEC of every aggressive-cache probe.

## Change

`internal/dnsname`: the same answers out of a single forward walk, with boundary and escape handling delegated to the library's own `NextLabel` — so there is no second implementation of `\.` to get wrong.

- `CompareSuffix` / `Sub` — `dns.CompareDomainName` / `dns.IsSubDomain` parity, including the exact quirks: ASCII-only fold, the final label compared to the end of the string (rooted vs unrooted spellings don't match on it), middle labels read through their separating dot.
- `Suffixes` — `dns.Split` parity as a range-over-func iterator.
- `CanonicalCompare` — the RFC 4034 §6.3 canonical order (right-to-left, folded, shorter-suffix-first) that every NSEC coverage proof stands on, computed over **the octets the labels decode to, not their presentation spelling**. Review caught the first version — like the comparator it replaced — ordering escape text: `\065` *is* the label `a`, `\046` is the octet 0x2E which sorts before `0`, and comparing the text instead split wire-equal names apart and inverted names around the backslash. Escapes are decoded as they are read; nothing is materialized. The walk is forward in label lockstep with the **rightmost differing pair kept as the verdict** — review's suggestion — which removed both the offset arrays and their 2,144-byte stack frame: `CanonicalCompare`'s frame is now 120 bytes, and there is no label-count ceiling or slow path left.

**Callers moved** (all the profile's hot sites): `sortHosts`, the glue bailiwick checks, `searchCache`'s DS-walk, `provenInsecureDelegation`, `progressingReferral`, the nameserver-cache level compute, `nxDomainCutCache.lookup`/`purge`, every `IsSubDomain` in the denial-proof and nxdomain-cut caches, the DNAME checks in `dnsutil`, `findClosestEncloserWithWork`, and the two `nsec.go` functions. Suffix reconstruction changed shape with them: qname's last *n* labels were split, joined, and rooted back into the suffix they already were — now `qname[dns.PrevLabel(qname, n):]`, with a byte-check rooting guard where an unrooted caller would previously have been rooted by the join.

## The canonical comparator's contract changed in review — from parity to correctness

Review found that the old comparator, and the first version of this one which mirrored it for parity, ordered **presentation escape text instead of the octets it encodes**. That is not a spelling nit: `\046.example.` sorted *after* `0.example.` when its decoded octet 0x2E sorts before, and `\065.example.` did not equal `a.example.` when they are the same wire name — orderings NSEC coverage proofs stand on. All three review shapes are pinned as named tests.

So `CanonicalCompare` is no longer defined as "what the old code did": it is defined against **RFC 4034 §6.3 on wire octets**, and the test oracle is independent — each name packed to wire by the library (the authoritative escape decoder), then §6.3 applied to the label octets. Where the oracle cannot bind, the ordering laws (antisymmetry, rooted≡unrooted) still must hold. The oracle abstains on exactly three shapes, all fuzz-found, all impossible in the presentation form of a packed message:

- names the packer refuses (over-long labels, empty labels);
- names ending in a dangling backslash, where `Fqdn`'s appended root dot becomes a literal and `PackDomainName` then **silently collapses the whole name to the root**;
- names where the library disagrees with itself about rooting: `IsFqdn` does rune arithmetic on a byte question, so a multi-byte rune before a trailing backslash run flips its answer and the packed form no longer corresponds to the name.

A fourth fuzz finding was folded into the decoder instead of excluded: the library's `dddToByte` computes `\DDD` in byte arithmetic, so `\512` **wraps modulo 256** rather than erroring — `decodeOctet` mirrors it, since matching the authoritative decoder is what keeps the order aligned with the wire. The collapse and `IsFqdn` quirks are worth an upstream note alongside the RSAMD5 KeyTag panic. The ASCII fold (rather than the old `strings.ToLower`) is what §6.3 specifies and is covered by the wire oracle directly.

## Measurements

Primitives:

| | library | dnsname |
|---|---|---|
| `CompareDomainName` | 48 B / 2 allocs / 38 ns | **0 / 0 / 24 ns** |
| `Split` (6 labels) | 72 B / 2 allocs / 29 ns | **0 / 0 / 16 ns** |
| canonical compare | 296 B / 12 allocs / 185 ns | **0 / 0 / 45 ns** |

Migrated paths, same benchmark on both trees:

| | main | this branch |
|---|---|---|
| `nsecCovers` | 1,632 B / 48 allocs / 873 ns | **0 / 0 / 275 ns** |
| `closestEncloserFromNSEC` | 488 B / 15 allocs / 284 ns | **0 / 0 / 99 ns** |

## Tests

- Corpus parity for all four primitives against their library oracles — every pair of 30 names covering case, rooted/unrooted, wildcards, escapes in every position (`\.`, `\\.`, `\\\.`), IDN labels, and the degenerate strings the library defines behavior for; ordering laws (antisymmetry, rooted≡unrooted) on top; the beyond-wire-labels slow path against the same reference.
- **`FuzzLabelWalkers`: 76.6M executions clean** — after it earned its keep twice, finding both divergences above on its first two runs. The finding inputs are pinned in the corpus.
- Zero-allocation gate over all four walkers, `//go:build !race` per repo convention.
- Full suite, `-race` on every touched package, `go vet`, `golangci-lint`, 32-bit vet (arm/mips/386) clean.
