### PR TITLE
dnsname follow-up: root-zone NSEC3 admission, and the wildcard acceptance boundary

### DIFF
--- a/middleware/cache/denial_proof_cache.go
+++ b/middleware/cache/denial_proof_cache.go
@@ -840,11 +840,12 @@ func denialProofNSEC3Identity(
 		!dnsname.Sub(zone, owner) {
 		return denialProofNSEC3Params{}, "", "", false
 	}
-	next, end := dns.NextLabel(owner, 0)
-	if end {
-		return denialProofNSEC3Params{}, "", "", false
-	}
-
+	// NextLabel's end answer is not a validity verdict here: a root-zone
+	// NSEC3 owner is the single label <hash>., for which end is true and
+	// next still lands past the root dot — owner[:next-1] is the hash label
+	// either way. The count and containment checks above already proved the
+	// shape; refusing on end rejected every root-zone proof.
+	next, _ := dns.NextLabel(owner, 0)
 	ownerHash, ok := denialProofCanonicalNSEC3Hash(owner[:next-1])
 	if !ok {
 		return denialProofNSEC3Params{}, "", "", false

--- a/middleware/cache/denial_proof_root_test.go
+++ b/middleware/cache/denial_proof_root_test.go
@@ -1,0 +1,66 @@
+package cache
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// rootNSEC3 builds a plausible root-zone NSEC3: a single hash label directly
+// under the root, which is the shortest owner an NSEC3 can have.
+func rootNSEC3(owner, next string) *dns.NSEC3 {
+	return &dns.NSEC3{
+		Hdr: dns.RR_Header{
+			Name: owner + ".", Rrtype: dns.TypeNSEC3,
+			Class: dns.ClassINET, Ttl: 300,
+		},
+		Hash:       dns.SHA1,
+		Iterations: 0,
+		SaltLength: 0,
+		Salt:       "",
+		HashLength: 20,
+		NextDomain: next,
+		TypeBitMap: []uint16{dns.TypeNS, dns.TypeSOA},
+	}
+}
+
+// TestDenialProofAdmitsRootZoneNSEC3 pins the regression review found: a
+// root-zone NSEC3 owner is one label — <hash>. — and NextLabel legitimately
+// answers end=true for it. Treating that answer as invalid rejected every
+// root-zone proof, which the split-based code this replaced accepted; the
+// failure was fail-closed, but a root that serves NSEC3 lost aggressive
+// denial caching entirely.
+func TestDenialProofAdmitsRootZoneNSEC3(t *testing.T) {
+	ownerHash := strings.Repeat("v", 32) // base32hex, SHA-1 width
+	nextHash := strings.Repeat("0", 32)
+
+	params, gotOwner, gotNext, ok := denialProofNSEC3Identity(
+		rootNSEC3(ownerHash, nextHash), ".")
+	if !ok {
+		t.Fatal("a root-zone NSEC3 was refused admission")
+	}
+	if gotOwner != strings.ToUpper(ownerHash) && gotOwner != ownerHash {
+		t.Fatalf("owner hash = %q, want the owner label's hash", gotOwner)
+	}
+	if gotNext == "" || params.hash != dns.SHA1 {
+		t.Fatalf("identity = (%+v, %q, %q)", params, gotOwner, gotNext)
+	}
+
+	// The deeper shape stays admitted, and the shape checks stay real: an
+	// owner two labels below its zone is still refused.
+	if _, _, _, ok := denialProofNSEC3Identity(
+		rootNSEC3(ownerHash, nextHash), "example.com."); ok {
+		t.Fatal("an owner outside its zone was admitted")
+	}
+	deep := rootNSEC3(ownerHash, nextHash)
+	deep.Hdr.Name = ownerHash + ".example.com."
+	if _, _, _, ok := denialProofNSEC3Identity(deep, "example.com."); !ok {
+		t.Fatal("an ordinary in-zone NSEC3 was refused")
+	}
+	deeper := rootNSEC3(ownerHash, nextHash)
+	deeper.Hdr.Name = ownerHash + ".sub.example.com."
+	if _, _, _, ok := denialProofNSEC3Identity(deeper, "example.com."); ok {
+		t.Fatal("an owner two labels below the zone was admitted")
+	}
+}

--- a/middleware/resolver/dnssec/canonical_order_test.go
+++ b/middleware/resolver/dnssec/canonical_order_test.go
@@ -137,6 +137,40 @@ func libraryCanonicalRRset(tb testing.TB, rrset []dns.RR, sig *dns.RRSIG) []byte
 	return buf
 }
 
+// TestCanonicalRRsetLabelsZeroStaysRejected pins the acceptance boundary
+// review caught this construction drifting across. For Labels=0 the RFC's
+// wildcard arithmetic yields "*.", a name that would verify a root-wildcard
+// signature — but the library's construction yields "*.." and the packer
+// rejects it, so such signatures have always failed verification, there and
+// here. Accepting them may well be the RFC's intent; it is also a wider
+// acceptance than the library's, and this package promises never to be
+// wider. Root-wildcard support, if ever wanted, is a deliberate change with
+// its own cryptographic and denial-proof tests — not a side effect of an
+// allocation rewrite.
+func TestCanonicalRRsetLabelsZeroStaysRejected(t *testing.T) {
+	rrset := []dns.RR{mustSignatureRR(t, "foo. 300 IN A 192.0.2.1")}
+
+	for _, labels := range []uint8{0, 1} {
+		sig := &dns.RRSIG{
+			Hdr: dns.RR_Header{
+				Name: "foo.", Rrtype: dns.TypeRRSIG,
+				Class: dns.ClassINET, Ttl: 300,
+			},
+			TypeCovered: dns.TypeA, Algorithm: dns.RSASHA256, Labels: labels,
+			OrigTtl: 300, Expiration: 2000000000, Inception: 1000000000,
+			KeyTag: 1234, SignerName: ".",
+		}
+		_, err := canonicalRRset(rrset, sig)
+		if labels == 0 && err == nil {
+			t.Fatal("a Labels=0 reconstruction was accepted; the library " +
+				"rejects the *.. spelling it produces")
+		}
+		if labels == 1 && err != nil {
+			t.Fatalf("an exact-owner signature was rejected: %v", err)
+		}
+	}
+}
+
 func sortByRdata(tb testing.TB, wires [][]byte) {
 	tb.Helper()
 	rdata := func(wire []byte) []byte {

--- a/middleware/resolver/dnssec/rsa.go
+++ b/middleware/resolver/dnssec/rsa.go
@@ -255,11 +255,20 @@ func canonicalRRset(rrset []dns.RR, s *dns.RRSIG) ([]byte, error) {
 		h.Ttl = s.OrigTtl
 		// RFC 4035 §5.3.2 wildcard reconstruction: the owner shrinks to its
 		// last Labels labels behind a *. The suffix is sliced from the name
-		// rather than split and joined back; CanonicalName roots the result
-		// either way, exactly as it rooted the join.
+		// rather than split and joined back.
+		//
+		// The Fqdn is not decoration. For Labels=0 the suffix is empty, and
+		// the old join produced "*.." — a name the packer rejects, so such
+		// signatures failed verification, in this package and in the
+		// library alike. A bare "*." would verify a root-wildcard signature
+		// instead, which is the RFC's own arithmetic but a wider acceptance
+		// than the library's; this package promises never to be wider, so
+		// the empty suffix is rooted into the same rejected spelling. For
+		// every real Labels value the suffix is already rooted and Fqdn
+		// returns it untouched.
 		if dns.CountLabel(h.Name) > int(s.Labels) {
 			prev, _ := dns.PrevLabel(h.Name, int(s.Labels))
-			h.Name = "*." + h.Name[prev:]
+			h.Name = "*." + dns.Fqdn(h.Name[prev:])
 		}
 		h.Name = dns.CanonicalName(h.Name)
 		canonicalizeRdataNames(r1)

--- a/middleware/resolver/dnssec/rsa.go
+++ b/middleware/resolver/dnssec/rsa.go
@@ -10,7 +10,6 @@ import (
 	"hash"
 	"math/big"
 	"sort"
-	"strings"
 
 	"github.com/miekg/dns"
 )
@@ -254,9 +253,13 @@ func canonicalRRset(rrset []dns.RR, s *dns.RRSIG) ([]byte, error) {
 		r1 := dns.Copy(r)
 		h := r1.Header()
 		h.Ttl = s.OrigTtl
-		labels := dns.SplitDomainName(h.Name)
-		if len(labels) > int(s.Labels) {
-			h.Name = "*." + strings.Join(labels[len(labels)-int(s.Labels):], ".") + "."
+		// RFC 4035 §5.3.2 wildcard reconstruction: the owner shrinks to its
+		// last Labels labels behind a *. The suffix is sliced from the name
+		// rather than split and joined back; CanonicalName roots the result
+		// either way, exactly as it rooted the join.
+		if dns.CountLabel(h.Name) > int(s.Labels) {
+			prev, _ := dns.PrevLabel(h.Name, int(s.Labels))
+			h.Name = "*." + h.Name[prev:]
 		}
 		h.Name = dns.CanonicalName(h.Name)
 		canonicalizeRdataNames(r1)

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -792,7 +792,7 @@ func (r *Resolver) checkGlueRR(resp *dns.Msg, hosts hostSet, level int) (*author
 
 			i, _ := dns.PrevLabel(qname, level)
 
-			if dns.CompareDomainName(name, qname[i:]) < level {
+			if dnsname.CompareSuffix(name, qname[i:]) < level {
 				// we cannot trust that glue, it doesn't cover in the origin name.
 				continue
 			}


### PR DESCRIPTION
## What this is

Two things with one cause. #553's merge took the branch head from before its final review-fix commit, so main is missing the fixes review had already confirmed — and that same commit contained a Labels=0 acceptance widening review then caught. This PR restores the former and closes the latter.

## Restored (the orphaned `28f4bf3`, cherry-picked)

- **Root-zone NSEC3 admission**: the identity check treated `NextLabel`'s `end=true` as a validity verdict, but a root-zone NSEC3 owner is the single label `<hash>.` for which that answer is legitimate — `next` lands past the root dot either way, and the count/containment checks above already prove the shape. Every root-zone proof was being refused (fail-closed: no unsafe acceptance, but a root serving NSEC3 lost aggressive denial caching entirely). Regression test covers the root shape, the ordinary one, and both refusals around them; mutation-checked.
- **IPv4 glue bailiwick check** → `dnsname.CompareSuffix` — the IPv6 arm's migration missed it because the two identical lines differ by one level of indentation.
- **Wildcard reconstruction** (`canonicalRRset`) → suffix slice instead of split-and-join.

## Closed (review's P2 on that last item)

For **Labels=0** the sliced suffix is empty and `"*." + ""` is `"*."` — a name that would **verify a root-wildcard signature**, where the old join produced `"*.."` and the packer refused it, in this package and in the library alike. That reading is arguably the RFC's own arithmetic (RFC 4035 §5.3.2), but this package promises never to accept more than the library, and an allocation rewrite is not where that promise changes. The empty suffix is rooted — `"*." + dns.Fqdn(suffix)` — restoring the rejected spelling exactly; every real suffix is already rooted and passes through `Fqdn` untouched, so the allocation win stays (wildcard path 13→7 allocs per review's measurement). `TestCanonicalRRsetLabelsZeroStaysRejected` pins the boundary, mutation-checked: removing the `Fqdn` fails it with the widening named.

Root-wildcard support, if ever wanted, is a deliberate change of its own: a documented divergence, real Labels=0 cryptographic fixtures, and the root wildcard denial-proof path (`nsec.go` today skips the proof at the root — review notes RFC 4592 §4.2 does not actually forbid root wildcards). Happy to open that as a tracked follow-up.

## Verification

Full suite, `-race` on cache/resolver/dnssec, `go vet`, `golangci-lint` clean. Both new tests mutation-checked.