### PR TITLE
middleware: fold five question formatters into dnsutil, guard hot debug lines

### DIFF
--- a/internal/dnsutil/question.go
+++ b/internal/dnsutil/question.go
@@ -1,0 +1,14 @@
+package dnsutil
+
+import (
+	"strings"
+
+	"github.com/miekg/dns"
+)
+
+// FormatQuestion renders a question for log lines: the lowercased qname,
+// class, and type, space-separated ("example.com. IN A"). Every middleware
+// used to carry its own copy of this; they all funnel here now.
+func FormatQuestion(q dns.Question) string {
+	return strings.ToLower(q.Name) + " " + dns.ClassToString[q.Qclass] + " " + dns.TypeToString[q.Qtype]
+}

--- a/internal/dnsutil/question_test.go
+++ b/internal/dnsutil/question_test.go
@@ -1,0 +1,36 @@
+package dnsutil
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func TestFormatQuestion(t *testing.T) {
+	for _, tc := range []struct {
+		q    dns.Question
+		want string
+	}{
+		{dns.Question{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}, "example.com. IN A"},
+		{dns.Question{Name: "EXAMPLE.Com.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}, "example.com. IN AAAA"},
+		{dns.Question{Name: ".", Qtype: dns.TypeNS, Qclass: dns.ClassCHAOS}, ". CH NS"},
+	} {
+		if got := FormatQuestion(tc.q); got != tc.want {
+			t.Errorf("FormatQuestion(%+v) = %q, want %q", tc.q, got, tc.want)
+		}
+	}
+}
+
+var formatQuestionSink string
+
+// TestFormatQuestionAllocsOnce pins the single-concatenation shape: an
+// already-lowercase name costs exactly one allocation, the result string.
+func TestFormatQuestionAllocsOnce(t *testing.T) {
+	q := dns.Question{Name: "already.lower.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	allocs := testing.AllocsPerRun(100, func() {
+		formatQuestionSink = FormatQuestion(q)
+	})
+	if allocs != 1 {
+		t.Fatalf("FormatQuestion allocated %.0f times per call, want 1", allocs)
+	}
+}

--- a/middleware/accesslog/accesslog.go
+++ b/middleware/accesslog/accesslog.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/dnsutil"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/zlog/v2"
 )
@@ -66,7 +67,7 @@ func (a *Log) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		record := []string{
 			w.RemoteIP().String() + " -",
 			"[" + time.Now().Format("02/Jan/2006:15:04:05 -0700") + "]",
-			formatQuestion(ch.Request.Question[0]),
+			"\"" + dnsutil.FormatQuestion(ch.Request.Question[0]) + "\"",
 			w.Proto(),
 			cd,
 			dns.RcodeToString[w.Rcode()],
@@ -78,10 +79,6 @@ func (a *Log) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 			zlog.Error("Access log write failed", "error", strings.Trim(err.Error(), "\n"))
 		}
 	}
-}
-
-func formatQuestion(q dns.Question) string {
-	return "\"" + strings.ToLower(q.Name) + " " + dns.ClassToString[q.Qclass] + " " + dns.TypeToString[q.Qtype] + "\""
 }
 
 const name = "accesslog"

--- a/middleware/cache/prefetch_queue.go
+++ b/middleware/cache/prefetch_queue.go
@@ -82,7 +82,7 @@ func (pq *PrefetchQueue) Add(req PrefetchRequest) bool {
 		return true
 	default:
 		// Queue is full, drop the request
-		zlog.Debug("Prefetch queue full, dropping request", "query", formatQuestion(req.Request.Question[0]))
+		zlog.Debug("Prefetch queue full, dropping request", "query", dnsutil.FormatQuestion(req.Request.Question[0]))
 		return false
 	}
 }
@@ -130,7 +130,7 @@ func (pq *PrefetchQueue) processPrefetch(req PrefetchRequest) {
 		ctx = middleware.MarkClientECS(ctx)
 	}
 
-	zlog.Debug("Processing prefetch", "query", formatQuestion(req.Request.Question[0]))
+	zlog.Debug("Processing prefetch", "query", dnsutil.FormatQuestion(req.Request.Question[0]))
 
 	// Copy the original client request so upstream mutations
 	// (CD bit, EDNS options) don't bleed into the shared Request
@@ -166,7 +166,7 @@ func (pq *PrefetchQueue) processPrefetch(req PrefetchRequest) {
 	// apply; metrics/dnstap/accesslog do not.
 	resp, err := req.Cache.prefetchExchange(ctx, prefetchReq)
 	if err != nil {
-		zlog.Debug("Prefetch failed", "query", formatQuestion(req.Request.Question[0]), "error", err.Error())
+		zlog.Debug("Prefetch failed", "query", dnsutil.FormatQuestion(req.Request.Question[0]), "error", err.Error())
 		return
 	}
 	if resp == nil {
@@ -187,7 +187,7 @@ func (pq *PrefetchQueue) processPrefetch(req PrefetchRequest) {
 	// prefetch may be replaced.
 	cutUntil, cutKey := meta.Cut()
 	if !req.Cache.store.ReplaceIfCurrent(req.Key, req.Entry, resp, cutUntil, cutKey) {
-		zlog.Debug("Prefetch dropped, entry superseded", "query", formatQuestion(req.Request.Question[0]))
+		zlog.Debug("Prefetch dropped, entry superseded", "query", dnsutil.FormatQuestion(req.Request.Question[0]))
 		return
 	}
 	// The cache-less prefetch pipeline bypasses ResponseWriter.WriteMsg, so a
@@ -230,9 +230,9 @@ func (pq *PrefetchQueue) processPrefetch(req PrefetchRequest) {
 				minTTL = rr.Header().Ttl
 			}
 		}
-		zlog.Debug("Prefetch stored in cache", "query", formatQuestion(req.Request.Question[0]), "answers", len(resp.Answer), "minTTL", minTTL)
+		zlog.Debug("Prefetch stored in cache", "query", dnsutil.FormatQuestion(req.Request.Question[0]), "answers", len(resp.Answer), "minTTL", minTTL)
 	} else {
-		zlog.Debug("Prefetch completed", "query", formatQuestion(req.Request.Question[0]), "rcode", dns.RcodeToString[resp.Rcode])
+		zlog.Debug("Prefetch completed", "query", dnsutil.FormatQuestion(req.Request.Question[0]), "rcode", dns.RcodeToString[resp.Rcode])
 	}
 }
 
@@ -243,9 +243,4 @@ func releasePrefetchClaim(entry *CacheEntry) {
 	if entry != nil {
 		entry.prefetch.Store(false)
 	}
-}
-
-// formatQuestion formats a DNS question for logging.
-func formatQuestion(q dns.Question) string {
-	return q.Name + " " + dns.TypeToString[q.Qtype] + " " + dns.ClassToString[q.Qclass]
 }

--- a/middleware/failover/failover.go
+++ b/middleware/failover/failover.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net"
-	"strings"
 	"time"
 
 	"github.com/miekg/dns"
@@ -168,7 +167,7 @@ func (w *ResponseWriter) WriteMsg(m *dns.Msg) error {
 			if errors.Is(err, middleware.ErrRecursionWorkLimit) {
 				return w.writeRecursionWorkFailure(m, err)
 			}
-			zlog.Info("Failover query failed", "query", formatQuestion(req.Question[0]), "error", err.Error())
+			zlog.Info("Failover query failed", "query", dnsutil.FormatQuestion(req.Question[0]), "error", err.Error())
 			continue
 		}
 
@@ -218,10 +217,6 @@ func (w *ResponseWriter) writeRecursionWorkFailure(fallback *dns.Msg, workErr er
 		edeCode,
 		edeText,
 	))
-}
-
-func formatQuestion(q dns.Question) string {
-	return strings.ToLower(q.Name) + " " + dns.ClassToString[q.Qclass] + " " + dns.TypeToString[q.Qtype]
 }
 
 const name = "failover"

--- a/middleware/forwarder/forwarder.go
+++ b/middleware/forwarder/forwarder.go
@@ -284,10 +284,10 @@ func (f *Forwarder) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 			if errors.Is(err, dnsclient.ErrQuestion) {
 				forwarderResponseMismatch.Inc()
 				zlog.Info("forwarder dropped response with mismatched question",
-					"query", formatQuestion(req.Question[0]))
+					"query", dnsutil.FormatQuestion(req.Question[0]))
 			} else {
 				forwarderFailures.Inc()
-				zlog.Info("forwarder query failed", "query", formatQuestion(req.Question[0]), "error", err.Error())
+				zlog.Info("forwarder query failed", "query", dnsutil.FormatQuestion(req.Question[0]), "error", err.Error())
 			}
 			continue
 		}
@@ -348,10 +348,6 @@ func (f *Forwarder) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		return
 	}
 	ch.CancelWithRcode(dns.RcodeServerFailure, true)
-}
-
-func formatQuestion(q dns.Question) string {
-	return strings.ToLower(q.Name) + " " + dns.ClassToString[q.Qclass] + " " + dns.TypeToString[q.Qtype]
 }
 
 const name = "forwarder"

--- a/middleware/resolver/fuzz_test.go
+++ b/middleware/resolver/fuzz_test.go
@@ -50,7 +50,7 @@ func FuzzFormatQuestion(f *testing.F) {
 			Qtype:  qtype,
 			Qclass: qclass,
 		}
-		_ = formatQuestion(q)
+		_ = dnsutil.FormatQuestion(q)
 	})
 }
 

--- a/middleware/resolver/handler.go
+++ b/middleware/resolver/handler.go
@@ -164,7 +164,7 @@ func (h *DNSHandler) handle(ctx context.Context, req *dns.Msg) *dns.Msg {
 
 	if err != nil {
 		classifyResolverErr(err)
-		zlog.Info("Resolve query failed", "query", formatQuestion(q), "error", err.Error())
+		zlog.Info("Resolve query failed", "query", dnsutil.FormatQuestion(q), "error", err.Error())
 
 		// Add Extended DNS Error information for recursor validation failures
 		edeCode, edeText := dnsutil.ErrorToEDE(err)

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -424,7 +424,9 @@ func (r *Resolver) resolve(ctx context.Context, rs *resolveState) (*dns.Msg, err
 	// Current default minimize level 5, if we down to level 3, performance gain 20%
 	minReq, minimized := r.minimize(rs.req, rs.level, rs.nomin)
 
-	zlog.Debug("Query inserted", "reqid", minReq.Id, "zone", rs.servers.Zone, "query", formatQuestion(minReq.Question[0]), "cd", rs.req.CheckingDisabled, "qname-minimize", minimized)
+	if debugLogEnabled() {
+		zlog.Debug("Query inserted", "reqid", minReq.Id, "zone", rs.servers.Zone, "query", dnsutil.FormatQuestion(minReq.Question[0]), "cd", rs.req.CheckingDisabled, "qname-minimize", minimized)
+	}
 
 	resp, err := r.groupLookup(ctx, rs, minReq, rs.servers)
 	if err != nil {
@@ -1001,7 +1003,7 @@ func (r *Resolver) answer(ctx context.Context, req, resp *dns.Msg, parentDS []dn
 				// the unsigned data only if an insecure delegation between
 				// zone and qname is cryptographically proven.
 				if !r.provenInsecureDelegation(ctx, zone, q.Name, parentDS) {
-					zlog.Warn("DNSSEC verify failed (answer)", "query", formatQuestion(q), "error", dnssec.ErrNoSignatures.Error())
+					zlog.Warn("DNSSEC verify failed (answer)", "query", dnsutil.FormatQuestion(q), "error", dnssec.ErrNoSignatures.Error())
 					return nil, dnssec.ErrNoSignatures
 				}
 			}
@@ -1063,7 +1065,7 @@ func (r *Resolver) answer(ctx context.Context, req, resp *dns.Msg, parentDS []dn
 						r.dnssecWork(ctx),
 					)
 					if werr != nil {
-						zlog.Warn("DNSSEC verify failed (wildcard answer)", "query", formatQuestion(q), "error", werr.Error())
+						zlog.Warn("DNSSEC verify failed (wildcard answer)", "query", dnsutil.FormatQuestion(q), "error", werr.Error())
 						return nil, werr
 					}
 					ok = wildcardSecure
@@ -1076,7 +1078,7 @@ func (r *Resolver) answer(ctx context.Context, req, resp *dns.Msg, parentDS []dn
 				if lastErr == nil {
 					lastErr = dnssec.ErrNoSignatures
 				}
-				zlog.Warn("DNSSEC verify failed (answer)", "query", formatQuestion(q), "error", lastErr.Error())
+				zlog.Warn("DNSSEC verify failed (answer)", "query", dnsutil.FormatQuestion(q), "error", lastErr.Error())
 				return nil, lastErr
 			}
 		}
@@ -1163,7 +1165,7 @@ func (r *Resolver) authority(ctx context.Context, req, resp *dns.Msg, parentDS [
 				// shared-authority, no-referral case).
 				if !r.provenInsecureDelegation(ctx, zone, q.Name, parentDS) {
 					err := dnssec.ErrNoSignatures
-					zlog.Warn("DNSSEC verify failed (NXDOMAIN)", "query", formatQuestion(q), "error", err.Error())
+					zlog.Warn("DNSSEC verify failed (NXDOMAIN)", "query", dnsutil.FormatQuestion(q), "error", err.Error())
 					return nil, err
 				}
 			}
@@ -1214,7 +1216,7 @@ func (r *Resolver) authority(ctx context.Context, req, resp *dns.Msg, parentDS [
 				if lastErr == nil {
 					lastErr = dnssec.ErrNoSignatures
 				}
-				zlog.Warn("DNSSEC verify failed (NXDOMAIN)", "query", formatQuestion(q), "error", lastErr.Error())
+				zlog.Warn("DNSSEC verify failed (NXDOMAIN)", "query", dnsutil.FormatQuestion(q), "error", lastErr.Error())
 				return nil, lastErr
 			}
 
@@ -1256,7 +1258,7 @@ func (r *Resolver) authority(ctx context.Context, req, resp *dns.Msg, parentDS [
 								r.dnssecWork(ctx),
 							)
 							if denialErr != nil {
-								zlog.Warn("NSEC3 verify failed (NXDOMAIN)", "query", formatQuestion(q), "error", denialErr.Error())
+								zlog.Warn("NSEC3 verify failed (NXDOMAIN)", "query", dnsutil.FormatQuestion(q), "error", denialErr.Error())
 								return nil, denialErr
 							}
 						} else {
@@ -1267,7 +1269,7 @@ func (r *Resolver) authority(ctx context.Context, req, resp *dns.Msg, parentDS [
 								r.dnssecWork(ctx),
 							)
 							if denialErr != nil {
-								zlog.Warn("NSEC3 verify failed (NODATA)", "query", formatQuestion(q), "error", denialErr.Error())
+								zlog.Warn("NSEC3 verify failed (NODATA)", "query", dnsutil.FormatQuestion(q), "error", denialErr.Error())
 								return nil, denialErr
 							}
 						}
@@ -1287,19 +1289,19 @@ func (r *Resolver) authority(ctx context.Context, req, resp *dns.Msg, parentDS [
 								// so any evaluator miss only withholds shared
 								// provenance.
 								zlog.Debug("NSEC3 proof not eligible for aggressive reuse",
-									"query", formatQuestion(q), "error", err, "classified_rcode", result.Rcode)
+									"query", dnsutil.FormatQuestion(q), "error", err, "classified_rcode", result.Rcode)
 							}
 						}
 					case len(nsecSet) > 0:
 						proofKind = middleware.ValidatedNegativeProofNSEC
 						if resp.Rcode == dns.RcodeNameError {
 							if err := dnssec.VerifyNameErrorNSEC(resp, nsecSet); err != nil {
-								zlog.Warn("NSEC verify failed (NXDOMAIN)", "query", formatQuestion(q), "error", err.Error())
+								zlog.Warn("NSEC verify failed (NXDOMAIN)", "query", dnsutil.FormatQuestion(q), "error", err.Error())
 								return nil, err
 							}
 						} else {
 							if err := dnssec.VerifyNODATANSEC(resp, nsecSet); err != nil {
-								zlog.Warn("NSEC verify failed (NODATA)", "query", formatQuestion(q), "error", err.Error())
+								zlog.Warn("NSEC verify failed (NODATA)", "query", dnsutil.FormatQuestion(q), "error", err.Error())
 								return nil, err
 							}
 						}
@@ -1309,10 +1311,10 @@ func (r *Resolver) authority(ctx context.Context, req, resp *dns.Msg, parentDS [
 							aggressiveEligible = true
 						} else {
 							zlog.Debug("NSEC proof not eligible for aggressive reuse",
-								"query", formatQuestion(q), "error", err, "classified_rcode", result.Rcode)
+								"query", dnsutil.FormatQuestion(q), "error", err, "classified_rcode", result.Rcode)
 						}
 					default:
-						zlog.Warn("Negative answer missing NSEC/NSEC3 denial proof", "query", formatQuestion(q), "rcode", dns.RcodeToString[resp.Rcode])
+						zlog.Warn("Negative answer missing NSEC/NSEC3 denial proof", "query", dnsutil.FormatQuestion(q), "rcode", dns.RcodeToString[resp.Rcode])
 						return nil, dnssec.ErrNSECMissingCoverage
 					}
 				}
@@ -1382,7 +1384,7 @@ mainloop:
 		if activeQueries > maxQueries*9/10 { // Over 90% capacity
 			zlog.Warn("Approaching max concurrent DNS queries limit",
 				"active", activeQueries, "max", maxQueries,
-				"query", formatQuestion(req.Question[0]))
+				"query", dnsutil.FormatQuestion(req.Question[0]))
 		}
 
 		// Make a copy for this server before launching goroutine
@@ -1794,7 +1796,7 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, proto string,
 		// the allocation noise on every upstream query.
 		co.Conn, err = r.dialUDP(server)
 		if err != nil {
-			zlog.Debug("Dial failed to upstream server", "query", formatQuestion(q), "upstream", server.Addr,
+			zlog.Debug("Dial failed to upstream server", "query", dnsutil.FormatQuestion(q), "upstream", server.Addr,
 				"net", proto, "error", err.Error(), "retried", retried)
 			ReleaseConn(co)
 			return nil, err
@@ -1805,7 +1807,7 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, proto string,
 		co.Conn, err = d.DialContext(ctx, proto, dialAddr)
 		releaseDialer(d)
 		if err != nil {
-			zlog.Debug("Dial failed to upstream server", "query", formatQuestion(q), "upstream", server.Addr,
+			zlog.Debug("Dial failed to upstream server", "query", dnsutil.FormatQuestion(q), "upstream", server.Addr,
 				"net", proto, "error", err.Error(), "retried", retried)
 			ReleaseConn(co)
 			return nil, err
@@ -1830,7 +1832,7 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, proto string,
 		err = ctxErr
 	}
 	if err != nil {
-		zlog.Debug("Exchange failed for upstream server", "query", formatQuestion(q), "upstream", server.Addr,
+		zlog.Debug("Exchange failed for upstream server", "query", dnsutil.FormatQuestion(q), "upstream", server.Addr,
 			"net", proto, "rtt", rtt.Round(time.Millisecond).String(), "error", err.Error(), "retried", retried)
 
 		// Don't return connection to pool on error
@@ -1868,7 +1870,7 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, proto string,
 
 	if resp != nil && !resp.Truncated && proto == "udp" && resp.Len() > dnsutil.DefaultMsgSize {
 		// If response is too large, switch to TCP
-		zlog.Debug("Response too large, switching to TCP", "query", formatQuestion(q), "upstream", server.Addr,
+		zlog.Debug("Response too large, switching to TCP", "query", dnsutil.FormatQuestion(q), "upstream", server.Addr,
 			"size", resp.Len(), "maxSize", dnsutil.DefaultMsgSize, "retried", retried)
 		return r.exchange(ctx, rs, "tcp", req, server, retried)
 	}
@@ -2034,7 +2036,9 @@ func (r *Resolver) searchCache(q dns.Question, cd bool, origin string) delegatio
 			q.Name = origin
 			return r.searchCache(q, cd, origin)
 		}
-		zlog.Debug("Nameserver cache hit", "key", key, "query", formatQuestion(q), "cd", cd)
+		if debugLogEnabled() {
+			zlog.Debug("Nameserver cache hit", "key", key, "query", dnsutil.FormatQuestion(q), "cd", cd)
+		}
 		return delegationMatch{
 			servers:  ns.Servers,
 			parentDS: ns.DSSet,
@@ -2630,7 +2634,7 @@ func (r *Resolver) lookupV4Nss(ctx context.Context, q dns.Question, authservers 
 		ctx, loop := r.checkLoop(ctx, name, dns.TypeA)
 		if loop {
 			if _, ok := r.getIPv4Cache(name); !ok {
-				zlog.Debug("Looping during ns ipv4 lookup", "query", formatQuestion(q), "ns", name)
+				zlog.Debug("Looping during ns ipv4 lookup", "query", dnsutil.FormatQuestion(q), "ns", name)
 				continue
 			}
 		}
@@ -2669,10 +2673,10 @@ func (r *Resolver) lookupV4Nss(ctx context.Context, q dns.Question, authservers 
 				// hostname must not prevent trying the delegation's other
 				// hostnames.
 				lastAttemptLimit = err
-				zlog.Debug("Lookup NS ipv4 address reached attempt limit", "query", formatQuestion(q), "ns", name)
+				zlog.Debug("Lookup NS ipv4 address reached attempt limit", "query", dnsutil.FormatQuestion(q), "ns", name)
 				continue
 			}
-			zlog.Debug("Lookup NS ipv4 address failed", "query", formatQuestion(q), "ns", name, "error", err.Error())
+			zlog.Debug("Lookup NS ipv4 address failed", "query", dnsutil.FormatQuestion(q), "ns", name, "error", err.Error())
 			continue
 		}
 
@@ -2745,7 +2749,7 @@ func (r *Resolver) lookupV6Nss(ctx context.Context, q dns.Question, authservers 
 		ctx, loop := r.checkLoop(ctx, name, dns.TypeAAAA)
 		if loop {
 			if _, ok := r.getIPv6Cache(name); !ok {
-				zlog.Debug("Looping during ns ipv6 lookup", "query", formatQuestion(q), "ns", name)
+				zlog.Debug("Looping during ns ipv6 lookup", "query", dnsutil.FormatQuestion(q), "ns", name)
 				continue
 			}
 		}
@@ -2762,7 +2766,7 @@ func (r *Resolver) lookupV6Nss(ctx context.Context, q dns.Question, authservers 
 			// limited) must not prevent subsequent NSs in the
 			// delegation from contributing IPv6 addresses. The IPv4
 			// path in lookupV4Nss uses the same continue semantic.
-			zlog.Debug("Lookup NS ipv6 address failed", "query", formatQuestion(q), "ns", name, "error", err.Error())
+			zlog.Debug("Lookup NS ipv6 address failed", "query", dnsutil.FormatQuestion(q), "ns", name, "error", err.Error())
 			continue
 		}
 
@@ -2953,7 +2957,9 @@ func (r *Resolver) verifyDNSSEC(ctx context.Context, signer, signed string, resp
 		return false, nil
 	}
 
-	zlog.Debug("DNSSEC verified", "signer", signer, "signed", signed, "query", formatQuestion(resp.Question[0]))
+	if debugLogEnabled() {
+		zlog.Debug("DNSSEC verified", "signer", signer, "signed", signed, "query", dnsutil.FormatQuestion(resp.Question[0]))
+	}
 
 	return true, nil
 }
@@ -3132,7 +3138,7 @@ func (r *Resolver) handleLookupError(ctx context.Context, err error, rs *resolve
 			return nil, err
 		}
 
-		zlog.Debug("Received network error from all servers", "query", formatQuestion(minReq.Question[0]))
+		zlog.Debug("Received network error from all servers", "query", dnsutil.FormatQuestion(minReq.Question[0]))
 
 		if atomic.AddUint32(&rs.servers.ErrorCount, 1) == 5 {
 			if ok := r.checkHosts(ctx, rs.servers); ok {
@@ -3455,7 +3461,9 @@ func (r *Resolver) processDelegation(ctx context.Context, rs *resolveState, resp
 		return r.resolveWithCachedNameservers(ctx, rs, cached, key, q, cd)
 	}
 
-	zlog.Debug("Nameserver cache not found", "key", key, "query", formatQuestion(q), "cd", cd)
+	if debugLogEnabled() {
+		zlog.Debug("Nameserver cache not found", "key", key, "query", dnsutil.FormatQuestion(q), "cd", cd)
+	}
 
 	// Check glue records and perform lookups
 	authservers, foundv4, foundv6 := r.checkGlueRR(resp, nsInfo.hosts, rs.level)
@@ -3483,7 +3491,9 @@ func (r *Resolver) processDelegation(ctx context.Context, rs *resolveState, resp
 		// Store the absolute (inherited) deadline verbatim. A past deadline
 		// is not cached (SetUntil skips it).
 		r.delegations.SetUntil(key, rs.parentDS, authservers, childDeadline)
-		zlog.Debug("Nameserver cache insert", "key", key, "query", formatQuestion(q), "cd", cd)
+		if debugLogEnabled() {
+			zlog.Debug("Nameserver cache insert", "key", key, "query", dnsutil.FormatQuestion(q), "cd", cd)
+		}
 	}
 
 	// Start IPv6 lookups in background, bounded by a fixed
@@ -3630,7 +3640,7 @@ func (r *Resolver) validateDelegation(ctx context.Context, req, resp *dns.Msg, q
 		}
 		newDSRR, _, err := r.authenticatedDelegationDS(ctx, parentSigner, q.Name, effectiveParentDS)
 		if err != nil {
-			zlog.Warn("DNSSEC verify failed (delegation)", "query", formatQuestion(q), "error", err.Error())
+			zlog.Warn("DNSSEC verify failed (delegation)", "query", dnsutil.FormatQuestion(q), "error", err.Error())
 			return nil, err
 		}
 		return newDSRR, nil
@@ -3727,7 +3737,7 @@ func (r *Resolver) validateDelegation(ctx context.Context, req, resp *dns.Msg, q
 			nsec3Set,
 			r.dnssecWork(ctx),
 		); err != nil {
-			zlog.Warn("NSEC3 verify failed (delegation)", "query", formatQuestion(q), "error", err.Error())
+			zlog.Warn("NSEC3 verify failed (delegation)", "query", dnsutil.FormatQuestion(q), "error", err.Error())
 			return nil, err
 		}
 		return []dns.RR{}, nil
@@ -3735,19 +3745,21 @@ func (r *Resolver) validateDelegation(ctx context.Context, req, resp *dns.Msg, q
 
 	if nsecSet := dnsutil.FilterRRsToZone(dnsutil.ExtractRRSet(resp.Ns, "", dns.TypeNSEC), chosenSigner); len(nsecSet) > 0 {
 		if err := dnssec.VerifyDelegationNSEC(q.Name, nsecSet); err != nil {
-			zlog.Warn("NSEC verify failed (delegation)", "query", formatQuestion(q), "error", err.Error())
+			zlog.Warn("NSEC verify failed (delegation)", "query", dnsutil.FormatQuestion(q), "error", err.Error())
 			return nil, err
 		}
 		return []dns.RR{}, nil
 	}
 
-	zlog.Warn("Delegation missing DS and NSEC/NSEC3 proof", "query", formatQuestion(q))
+	zlog.Warn("Delegation missing DS and NSEC/NSEC3 proof", "query", dnsutil.FormatQuestion(q))
 	return nil, dnssec.ErrNSECMissingCoverage
 }
 
 // resolveWithCachedNameservers handles resolution with cached nameservers.
 func (r *Resolver) resolveWithCachedNameservers(ctx context.Context, rs *resolveState, cached *authority.Delegation, key uint64, q dns.Question, cd bool) (*dns.Msg, error) {
-	zlog.Debug("Nameserver cache hit", "key", key, "query", formatQuestion(q), "cd", cd)
+	if debugLogEnabled() {
+		zlog.Debug("Nameserver cache hit", "key", key, "query", dnsutil.FormatQuestion(q), "cd", cd)
+	}
 
 	if r.equalServers(cached.Servers, rs.servers) {
 		// Potential loop, decrease depth faster

--- a/middleware/resolver/utils.go
+++ b/middleware/resolver/utils.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"net/netip"
 	"slices"
-	"strings"
 	"sync"
 
 	"github.com/miekg/dns"
@@ -25,14 +24,14 @@ func init() {
 	}
 }
 
-func formatQuestion(q dns.Question) string {
-	var sb strings.Builder
-	sb.WriteString(strings.ToLower(q.Name))
-	sb.WriteByte(' ')
-	sb.WriteString(dns.ClassToString[q.Qclass])
-	sb.WriteByte(' ')
-	sb.WriteString(dns.TypeToString[q.Qtype])
-	return sb.String()
+// debugLogEnabled reports whether debug logging is on. zlog.Debug drops
+// disabled records, but only after the caller has evaluated its arguments —
+// per-query call sites format the question and box it into ...any on every
+// query regardless, which showed up at ~2% of all allocated objects in
+// production with debug off. Sites on the normal query path check this
+// first; rare paths (dial failures, loop detection) are not worth the noise.
+func debugLogEnabled() bool {
+	return zlog.Default().GetLevel() <= zlog.LevelDebug
 }
 
 func shuffleStr(vals []string) []string {

--- a/middleware/resolver/utils_test.go
+++ b/middleware/resolver/utils_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/internal/dnsutil"
 	"github.com/semihalev/sdns/middleware/resolver/dnssec"
+	"github.com/semihalev/zlog/v2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -243,4 +244,31 @@ func Test_filterToZone_NSECNextDomain(t *testing.T) {
 	got := dnsutil.FilterRRsToZone([]dns.RR{crossZone, inZone}, "example.com.")
 	assert.Len(t, got, 1, "NSEC with cross-zone NextDomain must be filtered out")
 	assert.Equal(t, "!.example.com.", got[0].Header().Name)
+}
+
+func Test_debugLogEnabled(t *testing.T) {
+	old := zlog.Default().GetLevel()
+	defer zlog.SetLevel(old)
+
+	zlog.SetLevel(zlog.LevelInfo)
+	assert.False(t, debugLogEnabled())
+	zlog.SetLevel(zlog.LevelDebug)
+	assert.True(t, debugLogEnabled())
+}
+
+// Test_debugLogEnabled_GuardAllocsNothing pins what the guard is for: with
+// debug off, a guarded call site must not format the question or box the
+// arguments. Unguarded, this pattern allocated on every query in production.
+func Test_debugLogEnabled_GuardAllocsNothing(t *testing.T) {
+	old := zlog.Default().GetLevel()
+	defer zlog.SetLevel(old)
+	zlog.SetLevel(zlog.LevelInfo)
+
+	q := dns.Question{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	allocs := testing.AllocsPerRun(100, func() {
+		if debugLogEnabled() {
+			zlog.Debug("Query inserted", "query", dnsutil.FormatQuestion(q))
+		}
+	})
+	assert.Zero(t, allocs, "guarded debug call site must be free when debug is off")
 }


### PR DESCRIPTION
## What

Five middlewares each carried a private `formatQuestion` (resolver, forwarder, failover, accesslog, cache/prefetch). They now share one canonical `dnsutil.FormatQuestion`: lowercased qname, class, type (`example.com. IN A`).

Two copies were quietly different:
- **cache/prefetch** neither lowered the name nor used the shared field order (`name TYPE CLASS`); its prefetch log lines normalize to the standard spelling with this PR — a log-cosmetic change only.
- **accesslog** wraps the question in quotes; that stays, applied at its call site.

## Why now (allocation)

The live profile on the current binary attributes **394,858 objects (1.74% of everything allocated)** to `strings.(*Builder).WriteString`, 100% of it from `resolver.formatQuestion`. Debug logging is off in production — `zlog.Debug` drops the record, but only after the call site has already formatted the question and boxed the `...any` arguments. Per-query debug sites paid that on every query.

Fix: per-query resolver debug sites (query insert, nameserver cache hit/miss/insert, DNSSEC verified) now guard on `debugLogEnabled()` — one atomic load — before evaluating arguments. Rare paths (dial failures, loop detection, exchange errors) stay unguarded to keep the noise down.

The formatter itself also drops from a `strings.Builder` (2+ allocs) to a single concatenation (1 alloc) for the sites that do fire.

## Tests

- `TestFormatQuestion` — format parity incl. case folding; `TestFormatQuestionAllocsOnce` pins the single-allocation shape
- `Test_debugLogEnabled` — tracks the zlog level both ways
- `Test_debugLogEnabled_GuardAllocsNothing` — with debug off, a guarded call site allocates **zero** (the point of the change)
- Full suite with `-race` green; `golangci-lint run` clean