### PR TITLE
context: trim the per-query cancellation and value-plumbing overhead

### DIFF
--- a/internal/contextutil/lazy_deadline.go
+++ b/internal/contextutil/lazy_deadline.go
@@ -57,6 +57,12 @@ type lazyDeadlinePin struct {
 	value atomic.Value
 }
 
+// lazyDeadlineOverflow holds every pin beyond the first. It is allocated only
+// when a second distinct key is pinned, so a request that pins one value — a
+// terminal cache hit carries just the recursion-work ledger — pays no extra
+// LazyDeadline footprint for the table.
+type lazyDeadlineOverflow [lazyDeadlinePins - 1]lazyDeadlinePin
+
 type LazyDeadline struct {
 	parent   context.Context
 	deadline time.Time
@@ -67,7 +73,8 @@ type LazyDeadline struct {
 	active atomic.Pointer[lazyDeadlineHolder]
 
 	valueProvider atomic.Value
-	pins          [lazyDeadlinePins]lazyDeadlinePin
+	pin0          lazyDeadlinePin
+	pinOverflow   atomic.Pointer[lazyDeadlineOverflow]
 	pinCount      atomic.Int32
 }
 
@@ -189,17 +196,27 @@ func TryPinValue(ctx context.Context, key, value any) bool {
 
 	lazy.pinMu.Lock()
 	defer lazy.pinMu.Unlock()
-	n := lazy.pinCount.Load()
-	for i := int32(0); i < n; i++ {
-		if lazy.pins[i].key == key {
-			return false
-		}
+	if lazy.pin(key) != nil {
+		return false
 	}
+	n := lazy.pinCount.Load()
 	if n == lazyDeadlinePins {
 		return false
 	}
-	lazy.pins[n].key = key
-	lazy.pins[n].value.Store(value)
+	if n == 0 {
+		lazy.pin0.key = key
+		lazy.pin0.value.Store(value)
+	} else {
+		overflow := lazy.pinOverflow.Load()
+		if overflow == nil {
+			overflow = new(lazyDeadlineOverflow)
+			// Published before the count store below, so a reader that
+			// observes a count above one also observes this pointer.
+			lazy.pinOverflow.Store(overflow)
+		}
+		overflow[n-1].key = key
+		overflow[n-1].value.Store(value)
+	}
 	lazy.pinCount.Store(n + 1)
 	return true
 }
@@ -222,12 +239,22 @@ func PinnedValue(ctx context.Context, key any) (any, bool) {
 }
 
 // pin returns the slot pinned under key, or nil. Safe without the lock: the
-// pin-count store publishes each slot's key, which never changes afterwards.
+// pin-count store publishes each slot's key and the overflow pointer, and
+// neither changes afterwards.
 func (c *LazyDeadline) pin(key any) *lazyDeadlinePin {
-	n := int(c.pinCount.Load())
-	for i := 0; i < n; i++ {
-		if c.pins[i].key == key {
-			return &c.pins[i]
+	n := c.pinCount.Load()
+	if n == 0 {
+		return nil
+	}
+	if c.pin0.key == key {
+		return &c.pin0
+	}
+	if n > 1 {
+		overflow := c.pinOverflow.Load()
+		for i := int32(0); i < n-1; i++ {
+			if overflow[i].key == key {
+				return &overflow[i]
+			}
 		}
 	}
 	return nil

--- a/internal/contextutil/lazy_deadline.go
+++ b/internal/contextutil/lazy_deadline.go
@@ -43,6 +43,20 @@ type lazyDeadlineHolder struct {
 // while preserving the same deadline for cache misses, child contexts and
 // blocking transport operations. A LazyDeadline must not be reused across
 // requests: child contexts and cancellation callbacks may retain it.
+// lazyDeadlinePins bounds the request-lifetime value slots. The size mirrors
+// the in-tree pinners (recursion-work ledger, resolution-attempt guard,
+// request ID, NSEC3 hash memo); a pin that finds the table full falls back to
+// an ordinary context.WithValue at the call site.
+const lazyDeadlinePins = 4
+
+// lazyDeadlinePin is one request-lifetime slot. The key is written under
+// pinMu and published by the pin-count store, after which it never changes;
+// lock-free readers see it only through the count's acquire load.
+type lazyDeadlinePin struct {
+	key   any
+	value atomic.Value
+}
+
 type LazyDeadline struct {
 	parent   context.Context
 	deadline time.Time
@@ -53,9 +67,8 @@ type LazyDeadline struct {
 	active atomic.Pointer[lazyDeadlineHolder]
 
 	valueProvider atomic.Value
-	pinnedKey     any
-	pinnedValue   atomic.Value
-	pinned        atomic.Bool
+	pins          [lazyDeadlinePins]lazyDeadlinePin
+	pinCount      atomic.Int32
 }
 
 // WithLazyTimeout returns a LazyDeadline whose deadline is no later than the
@@ -163,7 +176,8 @@ func TrySetValueProvider(ctx context.Context, provider ValueProvider) bool {
 // the LazyDeadline reachable through ctx. The pin survives pooled metadata
 // reuse without allocating a context.WithValue node. It is deliberately not
 // exposed through Context.Value: callers must use PinnedValue, keeping the
-// ordinary context value chain immutable. A second distinct pin fails.
+// ordinary context value chain immutable. Re-pinning a key that is already
+// pinned fails, as does pinning into a full table.
 func TryPinValue(ctx context.Context, key, value any) bool {
 	if ctx == nil || key == nil || value == nil {
 		return false
@@ -175,27 +189,48 @@ func TryPinValue(ctx context.Context, key, value any) bool {
 
 	lazy.pinMu.Lock()
 	defer lazy.pinMu.Unlock()
-	if lazy.pinned.Load() {
+	n := lazy.pinCount.Load()
+	for i := int32(0); i < n; i++ {
+		if lazy.pins[i].key == key {
+			return false
+		}
+	}
+	if n == lazyDeadlinePins {
 		return false
 	}
-	lazy.pinnedKey = key
-	lazy.pinnedValue.Store(value)
-	lazy.pinned.Store(true)
+	lazy.pins[n].key = key
+	lazy.pins[n].value.Store(value)
+	lazy.pinCount.Store(n + 1)
 	return true
 }
 
 // PinnedValue returns the exact value stored in the LazyDeadline's
-// request-lifetime slot. Unlike ctx.Value, it never falls through to a value
-// provider or parent context.
+// request-lifetime slot for key. Unlike ctx.Value, it never falls through to
+// a value provider or parent context.
 func PinnedValue(ctx context.Context, key any) (any, bool) {
 	if ctx == nil || key == nil {
 		return nil, false
 	}
 	lazy, _ := ctx.Value(lazyDeadlineCarrierKey).(*LazyDeadline)
-	if lazy == nil || !lazy.pinned.Load() || key != lazy.pinnedKey {
+	if lazy == nil {
 		return nil, false
 	}
-	return lazy.pinnedValue.Load(), true
+	if pin := lazy.pin(key); pin != nil {
+		return pin.value.Load(), true
+	}
+	return nil, false
+}
+
+// pin returns the slot pinned under key, or nil. Safe without the lock: the
+// pin-count store publishes each slot's key, which never changes afterwards.
+func (c *LazyDeadline) pin(key any) *lazyDeadlinePin {
+	n := int(c.pinCount.Load())
+	for i := 0; i < n; i++ {
+		if c.pins[i].key == key {
+			return &c.pins[i]
+		}
+	}
+	return nil
 }
 
 // TryUpdatePinnedValueLocked computes and installs a replacement while holding
@@ -225,12 +260,16 @@ func TryUpdatePinnedValueLocked[T comparable](
 
 	lazy.pinMu.Lock()
 	defer lazy.pinMu.Unlock()
-	current, typeOK := lazy.pinnedValue.Load().(T)
-	if !lazy.pinned.Load() || key != lazy.pinnedKey || !typeOK || current != old {
+	pin := lazy.pin(key)
+	if pin == nil {
+		return zero, false
+	}
+	current, typeOK := pin.value.Load().(T)
+	if !typeOK || current != old {
 		return current, false
 	}
 	value := update()
-	lazy.pinnedValue.Store(value)
+	pin.value.Store(value)
 	return value, true
 }
 

--- a/internal/contextutil/lazy_deadline.go
+++ b/internal/contextutil/lazy_deadline.go
@@ -49,18 +49,27 @@ type lazyDeadlineHolder struct {
 // an ordinary context.WithValue at the call site.
 const lazyDeadlinePins = 4
 
-// lazyDeadlinePin is one request-lifetime slot. The key is written under
-// pinMu and published by the pin-count store, after which it never changes;
-// lock-free readers see it only through the count's acquire load.
+// lazyDeadlinePin is one request-lifetime slot. The non-nil value is both
+// the occupancy sentinel and the publication barrier: the key is written
+// first, under pinMu, and becomes visible through the value's release store.
+// A reader may look at a slot's key only after observing a non-nil value.
+// Pinned values are never a bare nil interface (TryPinValue rejects it), so
+// an occupied slot cannot read as free.
 type lazyDeadlinePin struct {
 	key   any
 	value atomic.Value
 }
 
+// match reports whether the slot is occupied under key, in the only order
+// the publication protocol allows.
+func (p *lazyDeadlinePin) match(key any) bool {
+	return p.value.Load() != nil && p.key == key
+}
+
 // lazyDeadlineOverflow holds every pin beyond the first. It is allocated only
 // when a second distinct key is pinned, so a request that pins one value — a
-// terminal cache hit carries just the recursion-work ledger — pays no extra
-// LazyDeadline footprint for the table.
+// terminal cache hit carries just the recursion-work ledger — keeps the
+// LazyDeadline in its original size and allocation class (gated by test).
 type lazyDeadlineOverflow [lazyDeadlinePins - 1]lazyDeadlinePin
 
 type LazyDeadline struct {
@@ -75,7 +84,6 @@ type LazyDeadline struct {
 	valueProvider atomic.Value
 	pin0          lazyDeadlinePin
 	pinOverflow   atomic.Pointer[lazyDeadlineOverflow]
-	pinCount      atomic.Int32
 }
 
 // WithLazyTimeout returns a LazyDeadline whose deadline is no later than the
@@ -199,26 +207,26 @@ func TryPinValue(ctx context.Context, key, value any) bool {
 	if lazy.pin(key) != nil {
 		return false
 	}
-	n := lazy.pinCount.Load()
-	if n == lazyDeadlinePins {
-		return false
-	}
-	if n == 0 {
+	if lazy.pin0.value.Load() == nil {
 		lazy.pin0.key = key
 		lazy.pin0.value.Store(value)
-	} else {
-		overflow := lazy.pinOverflow.Load()
-		if overflow == nil {
-			overflow = new(lazyDeadlineOverflow)
-			// Published before the count store below, so a reader that
-			// observes a count above one also observes this pointer.
-			lazy.pinOverflow.Store(overflow)
-		}
-		overflow[n-1].key = key
-		overflow[n-1].value.Store(value)
+		return true
 	}
-	lazy.pinCount.Store(n + 1)
-	return true
+	overflow := lazy.pinOverflow.Load()
+	if overflow == nil {
+		// Safe to publish empty: every slot reads as free until its value
+		// store, which is what publishes the slot's key.
+		overflow = new(lazyDeadlineOverflow)
+		lazy.pinOverflow.Store(overflow)
+	}
+	for i := range overflow {
+		if overflow[i].value.Load() == nil {
+			overflow[i].key = key
+			overflow[i].value.Store(value)
+			return true
+		}
+	}
+	return false
 }
 
 // PinnedValue returns the exact value stored in the LazyDeadline's
@@ -238,21 +246,16 @@ func PinnedValue(ctx context.Context, key any) (any, bool) {
 	return nil, false
 }
 
-// pin returns the slot pinned under key, or nil. Safe without the lock: the
-// pin-count store publishes each slot's key and the overflow pointer, and
-// neither changes afterwards.
+// pin returns the slot pinned under key, or nil. Safe without the lock: an
+// occupied slot's key was published by its value store and neither changes
+// afterwards.
 func (c *LazyDeadline) pin(key any) *lazyDeadlinePin {
-	n := c.pinCount.Load()
-	if n == 0 {
-		return nil
-	}
-	if c.pin0.key == key {
+	if c.pin0.match(key) {
 		return &c.pin0
 	}
-	if n > 1 {
-		overflow := c.pinOverflow.Load()
-		for i := int32(0); i < n-1; i++ {
-			if overflow[i].key == key {
+	if overflow := c.pinOverflow.Load(); overflow != nil {
+		for i := range overflow {
+			if overflow[i].match(key) {
 				return &overflow[i]
 			}
 		}

--- a/internal/contextutil/lazy_deadline_test.go
+++ b/internal/contextutil/lazy_deadline_test.go
@@ -7,6 +7,7 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+	"unsafe"
 )
 
 type lazyDeadlineKey struct{}
@@ -197,6 +198,47 @@ func TestLazyDeadlinePinTableHoldsDistinctKeysUpToItsBound(t *testing.T) {
 // pinShapeKeys are package-level so key boxing costs nothing in the
 // allocation-shape assertions below.
 var pinShapeKeys = [lazyDeadlinePins]*int{new(int), new(int), new(int), new(int)}
+
+// TestLazyDeadlineSizeGate keeps the pin machinery out of the struct's
+// allocation class: at 128 bytes a LazyDeadline sits exactly on a size-class
+// boundary, and one more word moves every request into the next class. The
+// allocation-count tests cannot see that, so the size is gated directly.
+func TestLazyDeadlineSizeGate(t *testing.T) {
+	if size := unsafe.Sizeof(LazyDeadline{}); size > 128 {
+		t.Fatalf("LazyDeadline is %d bytes; 128 is the allocation-class boundary", size)
+	}
+}
+
+// TestLazyDeadlinePinPublicationRace exercises the sentinel protocol under
+// the race detector: slot keys are plain fields published by the value's
+// release store, and lock-free readers must only touch a key after observing
+// a non-nil value.
+func TestLazyDeadlinePinPublicationRace(t *testing.T) {
+	ctx := WithLazyTimeout(context.Background(), time.Minute)
+	defer ctx.Cancel()
+
+	var wg sync.WaitGroup
+	for _, key := range pinShapeKeys {
+		wg.Add(2)
+		go func(key *int) {
+			defer wg.Done()
+			TryPinValue(ctx, key, "v")
+		}(key)
+		go func(key *int) {
+			defer wg.Done()
+			for range 100 {
+				PinnedValue(ctx, key)
+			}
+		}(key)
+	}
+	wg.Wait()
+
+	for _, key := range pinShapeKeys {
+		if got, ok := PinnedValue(ctx, key); !ok || got != "v" {
+			t.Fatalf("pin lost after concurrent publication: %v, %v", got, ok)
+		}
+	}
+}
 
 // TestLazyDeadlinePinAllocationShape pins the overflow contract: a request
 // pinning a single value carries it inline, and the overflow block is

--- a/internal/contextutil/lazy_deadline_test.go
+++ b/internal/contextutil/lazy_deadline_test.go
@@ -194,6 +194,42 @@ func TestLazyDeadlinePinTableHoldsDistinctKeysUpToItsBound(t *testing.T) {
 	}
 }
 
+// pinShapeKeys are package-level so key boxing costs nothing in the
+// allocation-shape assertions below.
+var pinShapeKeys = [lazyDeadlinePins]*int{new(int), new(int), new(int), new(int)}
+
+// TestLazyDeadlinePinAllocationShape pins the overflow contract: a request
+// pinning a single value carries it inline, and the overflow block is
+// allocated exactly once when a second distinct key arrives.
+func TestLazyDeadlinePinAllocationShape(t *testing.T) {
+	// One allocation per run: the LazyDeadline itself. The single pin is inline.
+	single := testing.AllocsPerRun(100, func() {
+		ctx := WithLazyTimeout(context.Background(), time.Minute)
+		if !TryPinValue(ctx, pinShapeKeys[0], "v") {
+			t.Fatal("pin failed")
+		}
+		ctx.Cancel()
+	})
+	if single != 1 {
+		t.Fatalf("single-pin request allocated %.0f times, want 1 (the LazyDeadline alone)", single)
+	}
+
+	// A second distinct key costs exactly the one overflow block; the third
+	// and fourth reuse it.
+	full := testing.AllocsPerRun(100, func() {
+		ctx := WithLazyTimeout(context.Background(), time.Minute)
+		for _, key := range pinShapeKeys {
+			if !TryPinValue(ctx, key, "v") {
+				t.Fatal("pin failed")
+			}
+		}
+		ctx.Cancel()
+	})
+	if full != 2 {
+		t.Fatalf("four-pin request allocated %.0f times, want 2 (LazyDeadline + one overflow block)", full)
+	}
+}
+
 func TestLazyDeadlinePinnedValueAllocsNothing(t *testing.T) {
 	ctx := WithLazyTimeout(context.Background(), time.Minute)
 	defer ctx.Cancel()

--- a/internal/contextutil/lazy_deadline_test.go
+++ b/internal/contextutil/lazy_deadline_test.go
@@ -155,8 +155,60 @@ func TestLazyDeadlineCarriesProviderAndInternalPinWithoutMaterializing(t *testin
 	if ctx.active.Load() != nil {
 		t.Fatal("request-local values materialized the deadline context")
 	}
-	if TryPinValue(wrapped, new(int), "second") {
-		t.Fatal("second distinct request-local pin unexpectedly succeeded")
+	if TryPinValue(wrapped, pinnedKey, "again") {
+		t.Fatal("re-pinning an already-pinned key unexpectedly succeeded")
+	}
+}
+
+func TestLazyDeadlinePinTableHoldsDistinctKeysUpToItsBound(t *testing.T) {
+	ctx := WithLazyTimeout(context.Background(), time.Minute)
+	defer ctx.Cancel()
+
+	keys := make([]*int, lazyDeadlinePins)
+	for i := range keys {
+		keys[i] = new(int)
+		if !TryPinValue(ctx, keys[i], i) {
+			t.Fatalf("pin %d of %d failed with free slots left", i+1, lazyDeadlinePins)
+		}
+	}
+	if TryPinValue(ctx, new(int), "overflow") {
+		t.Fatal("a pin beyond the table bound unexpectedly succeeded")
+	}
+	for i, key := range keys {
+		got, ok := PinnedValue(ctx, key)
+		if !ok || got != i {
+			t.Fatalf("pin %d read back %v, %v; want %d, true", i, got, ok, i)
+		}
+	}
+
+	// Each slot updates independently under its own key.
+	value, updated := TryUpdatePinnedValueLocked(ctx, keys[1], 1, func() int { return 100 })
+	if !updated || value != 100 {
+		t.Fatalf("slot update = %v, %v; want 100, true", value, updated)
+	}
+	if got, _ := PinnedValue(ctx, keys[0]); got != 0 {
+		t.Fatalf("neighbouring slot changed to %v", got)
+	}
+	if _, updated := TryUpdatePinnedValueLocked(ctx, new(int), 0, func() int { return 1 }); updated {
+		t.Fatal("an update under an unpinned key unexpectedly succeeded")
+	}
+}
+
+func TestLazyDeadlinePinnedValueAllocsNothing(t *testing.T) {
+	ctx := WithLazyTimeout(context.Background(), time.Minute)
+	defer ctx.Cancel()
+
+	key := new(int)
+	if !TryPinValue(ctx, key, "pinned") {
+		t.Fatal("pin failed")
+	}
+	allocs := testing.AllocsPerRun(100, func() {
+		if _, ok := PinnedValue(ctx, key); !ok {
+			t.Fatal("pinned value lost")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("PinnedValue allocated %.0f times per read, want 0", allocs)
 	}
 }
 

--- a/internal/dnsclient/interrupt_group.go
+++ b/internal/dnsclient/interrupt_group.go
@@ -1,0 +1,116 @@
+package dnsclient
+
+import (
+	"context"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// interruptGroupSlots bounds the connections one group can watch at a time.
+// A lookup's in-flight exchanges rarely exceed its parallel fan-out; an
+// exchange that finds the group full falls back to its own registration.
+const interruptGroupSlots = 8
+
+// InterruptGroup makes a set of synchronous connection operations observe one
+// context's cancellation through a single registration. Each per-exchange
+// context.AfterFunc costs an afterFuncCtx, a closure and a children-map entry;
+// a group pays that once per cancellation domain and hands out array slots.
+//
+// The reuse contract matches CancelInterrupt.Stop: once Disarm returns, the
+// group never touches that connection again, and a fire already touching it
+// has finished — both guaranteed by the group mutex.
+type InterruptGroup struct {
+	mu    sync.Mutex
+	fired bool
+	stop  func() bool
+	conns [interruptGroupSlots]net.Conn
+}
+
+// NewInterruptGroup registers one cancellation callback on ctx and returns
+// the group armed connections are interrupted through. A context without a
+// Done channel needs no interruption; the nil group it returns makes
+// ExchangeInterruptible take the ordinary path.
+func NewInterruptGroup(ctx context.Context) *InterruptGroup {
+	if ctx.Done() == nil {
+		return nil
+	}
+	g := &InterruptGroup{}
+	g.stop = context.AfterFunc(ctx, g.fire)
+	return g
+}
+
+func (g *InterruptGroup) fire() {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	g.fired = true
+	now := time.Now()
+	for _, conn := range g.conns {
+		if conn != nil {
+			_ = conn.SetDeadline(now)
+		}
+	}
+}
+
+// arm registers conn for interruption and reports the slot to disarm. When
+// the group already fired, the operation about to start must still observe
+// the cancellation — mirroring context.AfterFunc on an already-canceled
+// context — so the deadline is applied here and now. ok is false only when
+// every slot is taken (or conn is nil); the caller falls back to its own
+// registration.
+func (g *InterruptGroup) arm(conn net.Conn) (slot int, ok bool) {
+	if conn == nil {
+		return 0, false
+	}
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	for i := range g.conns {
+		if g.conns[i] == nil {
+			g.conns[i] = conn
+			if g.fired {
+				_ = conn.SetDeadline(time.Now())
+			}
+			return i, true
+		}
+	}
+	return 0, false
+}
+
+// disarm releases a slot. The mutex doubles as the join barrier: a fire
+// holding the lock finishes every SetDeadline before disarm proceeds, so the
+// connection is free for reuse the moment disarm returns.
+func (g *InterruptGroup) disarm(slot int) {
+	g.mu.Lock()
+	g.conns[slot] = nil
+	g.mu.Unlock()
+}
+
+// Close detaches the context registration. It does not join a fire already
+// in flight: any connection still armed belongs to an operation that has not
+// disarmed yet, and interrupting it remains correct — per-connection reuse
+// safety is disarm's guarantee, not Close's. Callers cancel their domain
+// before closing, so stragglers are interrupted, not stranded.
+func (g *InterruptGroup) Close() {
+	if g == nil {
+		return
+	}
+	if g.stop != nil {
+		g.stop()
+	}
+}
+
+// ExchangeInterruptible performs Exchange bound to g's cancellation domain,
+// falling back to the per-operation ExchangeContext registration when the
+// group is nil or full. The caller still owns dialing and the ordinary
+// network deadline.
+func (co *Conn) ExchangeInterruptible(ctx context.Context, g *InterruptGroup, m *dns.Msg) (r *dns.Msg, rtt time.Duration, err error) {
+	if g != nil {
+		if slot, ok := g.arm(co.Conn); ok {
+			defer g.disarm(slot)
+			return co.Exchange(m)
+		}
+	}
+	return co.ExchangeContext(ctx, m)
+}

--- a/internal/dnsclient/interrupt_group_test.go
+++ b/internal/dnsclient/interrupt_group_test.go
@@ -1,0 +1,274 @@
+package dnsclient
+
+import (
+	"context"
+	"net"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// recordingConn records SetDeadline calls. A non-nil entered/gate pair makes
+// SetDeadline announce itself and then block until the gate closes, so tests
+// can hold a fire in flight at a known point.
+type recordingConn struct {
+	net.Conn
+	entered   chan struct{}
+	gate      chan struct{}
+	mu        sync.Mutex
+	deadlines []time.Time
+}
+
+func (c *recordingConn) SetDeadline(t time.Time) error {
+	if c.entered != nil {
+		c.entered <- struct{}{}
+	}
+	if c.gate != nil {
+		<-c.gate
+	}
+	c.mu.Lock()
+	c.deadlines = append(c.deadlines, t)
+	c.mu.Unlock()
+	return nil
+}
+
+func (c *recordingConn) count() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return len(c.deadlines)
+}
+
+func waitForCount(t *testing.T, c *recordingConn, want int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for c.count() < want {
+		if time.Now().After(deadline) {
+			t.Fatalf("SetDeadline count stuck at %d, want %d", c.count(), want)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
+
+func TestInterruptGroup_NoDoneChannel(t *testing.T) {
+	g := NewInterruptGroup(context.Background())
+	if g != nil {
+		t.Fatal("a context without a Done channel must not build a group")
+	}
+	g.Close() // nil receiver must be safe
+}
+
+func TestInterruptGroup_CancelInterruptsArmed(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	g := NewInterruptGroup(ctx)
+	defer g.Close()
+
+	conn := &recordingConn{}
+	if _, ok := g.arm(conn); !ok {
+		t.Fatal("arm on a fresh group must succeed")
+	}
+
+	cancel()
+	waitForCount(t, conn, 1)
+}
+
+func TestInterruptGroup_DisarmedConnNeverTouched(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	g := NewInterruptGroup(ctx)
+	defer g.Close()
+
+	released := &recordingConn{}
+	sentinel := &recordingConn{}
+	slot, ok := g.arm(released)
+	if !ok {
+		t.Fatal("arm failed")
+	}
+	if _, ok := g.arm(sentinel); !ok {
+		t.Fatal("arm failed")
+	}
+	g.disarm(slot)
+
+	cancel()
+	// The sentinel proves the fire ran; the disarmed conn must stay clean.
+	waitForCount(t, sentinel, 1)
+	if released.count() != 0 {
+		t.Fatal("a disarmed connection was interrupted")
+	}
+}
+
+func TestInterruptGroup_ArmAfterFire(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	g := NewInterruptGroup(ctx)
+	defer g.Close()
+
+	sentinel := &recordingConn{}
+	if _, ok := g.arm(sentinel); !ok {
+		t.Fatal("arm failed")
+	}
+	cancel()
+	waitForCount(t, sentinel, 1) // the fire has run to completion
+
+	// An operation arming after the domain died must still observe the
+	// cancellation — context.AfterFunc on a canceled context runs its
+	// callback too; the group applies the deadline right in arm.
+	late := &recordingConn{}
+	if _, ok := g.arm(late); !ok {
+		t.Fatal("arm after fire must still hand out a slot")
+	}
+	if late.count() != 1 {
+		t.Fatal("arming after the fire must interrupt immediately")
+	}
+}
+
+// TestInterruptGroup_DisarmJoinsFire pins the reuse contract: disarm may not
+// return while a fire is still touching connections, because the caller
+// releases the connection to a pool the moment disarm returns.
+func TestInterruptGroup_DisarmJoinsFire(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	g := NewInterruptGroup(ctx)
+	defer g.Close()
+
+	gate := make(chan struct{})
+	blocked := &recordingConn{entered: make(chan struct{}, 1), gate: gate}
+	other := &recordingConn{}
+	if _, ok := g.arm(blocked); !ok {
+		t.Fatal("arm failed")
+	}
+	otherSlot, ok := g.arm(other)
+	if !ok {
+		t.Fatal("arm failed")
+	}
+
+	cancel()          // the fire starts and blocks inside blocked.SetDeadline
+	<-blocked.entered // the fire now holds the group lock
+
+	disarmed := make(chan struct{})
+	go func() {
+		g.disarm(otherSlot)
+		close(disarmed)
+	}()
+
+	select {
+	case <-disarmed:
+		t.Fatal("disarm returned while the fire was still running")
+	case <-time.After(50 * time.Millisecond):
+		// expected: disarm is blocked on the group lock
+	}
+
+	close(gate) // let the fire finish
+	select {
+	case <-disarmed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("disarm never returned after the fire completed")
+	}
+	if other.count() != 1 {
+		t.Fatal("a conn armed throughout the fire must have been interrupted")
+	}
+}
+
+func TestInterruptGroup_SlotExhaustionFallsBack(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	g := NewInterruptGroup(ctx)
+	defer g.Close()
+
+	conns := make([]*recordingConn, interruptGroupSlots)
+	for i := range conns {
+		conns[i] = &recordingConn{}
+		if _, ok := g.arm(conns[i]); !ok {
+			t.Fatalf("slot %d must be free", i)
+		}
+	}
+	if _, ok := g.arm(&recordingConn{}); ok {
+		t.Fatal("a full group must refuse to arm")
+	}
+	if _, ok := g.arm(nil); ok {
+		t.Fatal("a nil conn must not be armed")
+	}
+}
+
+func TestInterruptGroup_ArmDisarmAllocsNothing(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	g := NewInterruptGroup(ctx)
+	defer g.Close()
+
+	conn := &recordingConn{}
+	allocs := testing.AllocsPerRun(100, func() {
+		slot, ok := g.arm(conn)
+		if !ok {
+			t.Fatal("arm failed")
+		}
+		g.disarm(slot)
+	})
+	if allocs != 0 {
+		t.Fatalf("arm/disarm allocated %.0f times per cycle, want 0", allocs)
+	}
+}
+
+func TestExchangeInterruptible_ServesAndReleasesSlot(t *testing.T) {
+	req := new(dns.Msg)
+	req.SetQuestion("example.com.", dns.TypeA)
+	req.Id = 0x2222
+
+	resp := new(dns.Msg)
+	resp.SetQuestion("example.com.", dns.TypeA)
+	resp.Response = true
+	resp.Id = 0x2222
+	wire, err := resp.Pack()
+	if err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	g := NewInterruptGroup(ctx)
+	defer g.Close()
+
+	co := &Conn{
+		Conn:    &fakeSeqPacketConn{datagrams: [][]byte{wire}},
+		UDPSize: 512,
+	}
+	got, _, err := co.ExchangeInterruptible(ctx, g, req)
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	if got.Id != req.Id {
+		t.Fatalf("wrong response id %#x", got.Id)
+	}
+
+	// The exchange must have released its slot: all slots arm again.
+	for i := 0; i < interruptGroupSlots; i++ {
+		if _, ok := g.arm(&recordingConn{}); !ok {
+			t.Fatalf("slot %d still held after ExchangeInterruptible returned", i)
+		}
+	}
+}
+
+func TestExchangeInterruptible_NilGroupFallsBack(t *testing.T) {
+	req := new(dns.Msg)
+	req.SetQuestion("example.com.", dns.TypeA)
+	req.Id = 0x3333
+
+	resp := new(dns.Msg)
+	resp.SetQuestion("example.com.", dns.TypeA)
+	resp.Response = true
+	resp.Id = 0x3333
+	wire, err := resp.Pack()
+	if err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+
+	co := &Conn{
+		Conn:    &fakeSeqPacketConn{datagrams: [][]byte{wire}},
+		UDPSize: 512,
+	}
+	got, _, err := co.ExchangeInterruptible(context.Background(), nil, req)
+	if err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	if got.Id != req.Id {
+		t.Fatalf("wrong response id %#x", got.Id)
+	}
+}

--- a/middleware/chain.go
+++ b/middleware/chain.go
@@ -585,12 +585,14 @@ func WithForkedCut(ctx context.Context) (context.Context, *ResponseMeta) {
 	}
 	host := parent.ensureLedgerHost()
 
-	// The tree's own guard, unless one is already pinned — a detached or
+	// The tree's own guard, unless one is already anchored — a detached or
 	// custom context can carry a guard this meta does not own, and shadowing
-	// it would silently move that sub-query's accounting somewhere else.
+	// it would silently move that sub-query's accounting somewhere else. The
+	// anchor is read through the same selection helper as every other guard
+	// consumer, so a pinned anchor counts too.
 	guard := &host.guard
-	if pinned, _ := ctx.Value(resolutionAttemptContextKey).(*ResolutionAttemptGuard); pinned != nil {
-		guard = pinned
+	if anchored := resolutionAttemptGuardAnchored(ctx); anchored != nil {
+		guard = anchored
 	}
 
 	forked := &forkedCutContext{Context: ctx, guard: guard}

--- a/middleware/resolution_attempt.go
+++ b/middleware/resolution_attempt.go
@@ -12,6 +12,7 @@ import (
 	"sync"
 
 	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/contextutil"
 )
 
 // RFC 9520 section 3.1 limits a single resolution to three attempts for the
@@ -249,15 +250,26 @@ type resolutionAttemptKeyType struct{}
 
 var resolutionAttemptContextKey = &resolutionAttemptKeyType{}
 
-// WithResolutionAttemptGuard pins guard into ctx. Pinning is required for
+// WithResolutionAttemptGuard anchors guard to ctx. Anchoring is required for
 // detached work because its originating ResponseMeta can be reset and reused.
+// The request tree carries exactly one guard, so a request-lifetime pin on
+// the deadline carrier is the preferred anchor — every internal sub-query
+// then finds it without deriving a context. A foreign context (detached
+// work, tests) falls back to an ordinary value node.
 func WithResolutionAttemptGuard(ctx context.Context, guard *ResolutionAttemptGuard) context.Context {
+	if pinned, ok := contextutil.PinnedValue(ctx, resolutionAttemptContextKey); ok && pinned == guard {
+		return ctx
+	}
+	if contextutil.TryPinValue(ctx, resolutionAttemptContextKey, guard) {
+		return ctx
+	}
 	return context.WithValue(ctx, resolutionAttemptContextKey, guard)
 }
 
-// ResolutionAttemptGuardFrom returns the request tree's retry guard.
+// ResolutionAttemptGuardFrom returns the request tree's retry guard. The pin
+// is read first: the tree has one guard, so a pinned answer is never stale.
 func ResolutionAttemptGuardFrom(ctx context.Context) *ResolutionAttemptGuard {
-	if guard, _ := ctx.Value(resolutionAttemptContextKey).(*ResolutionAttemptGuard); guard != nil {
+	if guard := resolutionAttemptGuardAnchored(ctx); guard != nil {
 		return guard
 	}
 	if meta := ResponseMetaFrom(ctx); meta != nil {
@@ -266,11 +278,24 @@ func ResolutionAttemptGuardFrom(ctx context.Context) *ResolutionAttemptGuard {
 	return nil
 }
 
-// EnsureResolutionAttemptGuard establishes and pins the request tree's retry
-// guard. Unlike recursion-work accounting, this RFC safeguard is always on.
+// resolutionAttemptGuardAnchored returns the guard anchored directly to ctx
+// (pin or value node), without the ResponseMeta fallback.
+func resolutionAttemptGuardAnchored(ctx context.Context) *ResolutionAttemptGuard {
+	if pinned, ok := contextutil.PinnedValue(ctx, resolutionAttemptContextKey); ok {
+		if guard, _ := pinned.(*ResolutionAttemptGuard); guard != nil {
+			return guard
+		}
+	}
+	guard, _ := ctx.Value(resolutionAttemptContextKey).(*ResolutionAttemptGuard)
+	return guard
+}
+
+// EnsureResolutionAttemptGuard establishes and anchors the request tree's
+// retry guard. Unlike recursion-work accounting, this RFC safeguard is
+// always on.
 func EnsureResolutionAttemptGuard(ctx context.Context) (context.Context, *ResolutionAttemptGuard) {
 	if guard := ResolutionAttemptGuardFrom(ctx); guard != nil {
-		if pinned, _ := ctx.Value(resolutionAttemptContextKey).(*ResolutionAttemptGuard); pinned != guard {
+		if resolutionAttemptGuardAnchored(ctx) != guard {
 			ctx = WithResolutionAttemptGuard(ctx, guard)
 		}
 		return ctx, guard

--- a/middleware/resolution_attempt.go
+++ b/middleware/resolution_attempt.go
@@ -252,12 +252,13 @@ var resolutionAttemptContextKey = &resolutionAttemptKeyType{}
 
 // WithResolutionAttemptGuard anchors guard to ctx. Anchoring is required for
 // detached work because its originating ResponseMeta can be reset and reused.
-// The request tree carries exactly one guard, so a request-lifetime pin on
-// the deadline carrier is the preferred anchor — every internal sub-query
-// then finds it without deriving a context. A foreign context (detached
-// work, tests) falls back to an ordinary value node.
+// The first anchor of a request tree lands in the deadline carrier's
+// request-lifetime pin — every internal sub-query then finds it without
+// deriving a context. Anchoring a different guard over an existing pin, or
+// anchoring on a foreign context, derives an ordinary value node, which
+// shadows the pin for that subtree.
 func WithResolutionAttemptGuard(ctx context.Context, guard *ResolutionAttemptGuard) context.Context {
-	if pinned, ok := contextutil.PinnedValue(ctx, resolutionAttemptContextKey); ok && pinned == guard {
+	if resolutionAttemptGuardAnchored(ctx) == guard {
 		return ctx
 	}
 	if contextutil.TryPinValue(ctx, resolutionAttemptContextKey, guard) {
@@ -266,8 +267,7 @@ func WithResolutionAttemptGuard(ctx context.Context, guard *ResolutionAttemptGua
 	return context.WithValue(ctx, resolutionAttemptContextKey, guard)
 }
 
-// ResolutionAttemptGuardFrom returns the request tree's retry guard. The pin
-// is read first: the tree has one guard, so a pinned answer is never stale.
+// ResolutionAttemptGuardFrom returns the request tree's retry guard.
 func ResolutionAttemptGuardFrom(ctx context.Context) *ResolutionAttemptGuard {
 	if guard := resolutionAttemptGuardAnchored(ctx); guard != nil {
 		return guard
@@ -278,16 +278,20 @@ func ResolutionAttemptGuardFrom(ctx context.Context) *ResolutionAttemptGuard {
 	return nil
 }
 
-// resolutionAttemptGuardAnchored returns the guard anchored directly to ctx
-// (pin or value node), without the ResponseMeta fallback.
+// resolutionAttemptGuardAnchored returns the guard anchored to ctx, without
+// the ResponseMeta fallback. The ordinary value chain is read before the
+// request-lifetime pin: a derived context may deliberately shadow the pinned
+// guard (forked cuts, custom flows), and the nearest anchor must win exactly
+// as it did when every anchor was a value node.
 func resolutionAttemptGuardAnchored(ctx context.Context) *ResolutionAttemptGuard {
-	if pinned, ok := contextutil.PinnedValue(ctx, resolutionAttemptContextKey); ok {
-		if guard, _ := pinned.(*ResolutionAttemptGuard); guard != nil {
-			return guard
-		}
+	if guard, _ := ctx.Value(resolutionAttemptContextKey).(*ResolutionAttemptGuard); guard != nil {
+		return guard
 	}
-	guard, _ := ctx.Value(resolutionAttemptContextKey).(*ResolutionAttemptGuard)
-	return guard
+	if pinned, ok := contextutil.PinnedValue(ctx, resolutionAttemptContextKey); ok {
+		guard, _ := pinned.(*ResolutionAttemptGuard)
+		return guard
+	}
+	return nil
 }
 
 // EnsureResolutionAttemptGuard establishes and anchors the request tree's

--- a/middleware/resolution_attempt.go
+++ b/middleware/resolution_attempt.go
@@ -252,16 +252,19 @@ var resolutionAttemptContextKey = &resolutionAttemptKeyType{}
 
 // WithResolutionAttemptGuard anchors guard to ctx. Anchoring is required for
 // detached work because its originating ResponseMeta can be reset and reused.
-// The first anchor of a request tree lands in the deadline carrier's
+// The request tree's first anchor lands in the deadline carrier's
 // request-lifetime pin — every internal sub-query then finds it without
-// deriving a context. Anchoring a different guard over an existing pin, or
-// anchoring on a foreign context, derives an ordinary value node, which
-// shadows the pin for that subtree.
+// deriving a context. Anchoring over any existing, different anchor always
+// derives an ordinary value node instead: the pin lives on the carrier the
+// whole tree shares, so pinning an override would hand the new guard to the
+// base and sibling contexts while the target subtree kept its nearer anchor
+// — the exact opposite of the caller's intent.
 func WithResolutionAttemptGuard(ctx context.Context, guard *ResolutionAttemptGuard) context.Context {
-	if resolutionAttemptGuardAnchored(ctx) == guard {
+	anchored := resolutionAttemptGuardAnchored(ctx)
+	if anchored == guard {
 		return ctx
 	}
-	if contextutil.TryPinValue(ctx, resolutionAttemptContextKey, guard) {
+	if anchored == nil && contextutil.TryPinValue(ctx, resolutionAttemptContextKey, guard) {
 		return ctx
 	}
 	return context.WithValue(ctx, resolutionAttemptContextKey, guard)

--- a/middleware/resolution_attempt_test.go
+++ b/middleware/resolution_attempt_test.go
@@ -6,8 +6,10 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/contextutil"
 )
 
 func TestResolutionAttemptGuardCanonicalTupleLimit(t *testing.T) {
@@ -228,5 +230,79 @@ func TestCanonicalResolutionEndpoint(t *testing.T) {
 		if got := CanonicalResolutionEndpoint(input); got != want {
 			t.Errorf("CanonicalResolutionEndpoint(%q) = %q, want %q", input, got, want)
 		}
+	}
+}
+
+// TestEnsureResolutionAttemptGuardPinsOnDeadlineCarrier pins the anchoring
+// contract on the ordinary request path: the guard lands in the deadline
+// carrier's request-lifetime slot, so establishing and re-establishing it
+// derives no context, and every sub-query sees the same guard.
+func TestEnsureResolutionAttemptGuardPinsOnDeadlineCarrier(t *testing.T) {
+	lazy := contextutil.WithLazyTimeout(context.Background(), time.Minute)
+	defer lazy.Cancel()
+	meta := new(ResponseMeta)
+	ctx := WithResponseMeta(lazy, meta)
+
+	got, guard := EnsureResolutionAttemptGuard(ctx)
+	if guard == nil {
+		t.Fatal("no guard established")
+	}
+	if got != ctx {
+		t.Fatal("anchoring the guard on a deadline-carried request derived a context")
+	}
+	if meta.ResolutionAttemptGuard() != guard {
+		t.Fatal("guard is not the request meta's guard")
+	}
+
+	again, guard2 := EnsureResolutionAttemptGuard(got)
+	if again != got || guard2 != guard {
+		t.Fatal("re-establishing the guard was not the identity")
+	}
+	if ResolutionAttemptGuardFrom(got) != guard {
+		t.Fatal("guard not readable back through the pin")
+	}
+
+	// The anchor must survive meta reuse: a reader holding only the context
+	// still sees the original guard after the pooled meta was reset.
+	meta.Reset()
+	if ResolutionAttemptGuardFrom(got) != guard {
+		t.Fatal("guard lost after the originating ResponseMeta was reset")
+	}
+}
+
+func TestEnsureResolutionAttemptGuardForeignContextFallsBack(t *testing.T) {
+	meta := new(ResponseMeta)
+	ctx := WithResponseMeta(context.Background(), meta)
+
+	got, guard := EnsureResolutionAttemptGuard(ctx)
+	if guard == nil {
+		t.Fatal("no guard established")
+	}
+	if got == ctx {
+		t.Fatal("a foreign context cannot anchor without deriving a value node")
+	}
+	if ResolutionAttemptGuardFrom(got) != guard {
+		t.Fatal("guard not readable from the derived context")
+	}
+
+	again, guard2 := EnsureResolutionAttemptGuard(got)
+	if again != got || guard2 != guard {
+		t.Fatal("re-establishing on the derived context was not the identity")
+	}
+}
+
+func TestEnsureResolutionAttemptGuardReestablishAllocsNothing(t *testing.T) {
+	lazy := contextutil.WithLazyTimeout(context.Background(), time.Minute)
+	defer lazy.Cancel()
+	ctx, guard := EnsureResolutionAttemptGuard(WithResponseMeta(lazy, new(ResponseMeta)))
+
+	allocs := testing.AllocsPerRun(100, func() {
+		got, g := EnsureResolutionAttemptGuard(ctx)
+		if got != ctx || g != guard {
+			t.Fatal("re-establish diverged")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("re-establishing the pinned guard allocated %.0f times, want 0", allocs)
 	}
 }

--- a/middleware/resolution_attempt_test.go
+++ b/middleware/resolution_attempt_test.go
@@ -322,6 +322,40 @@ func TestResolutionAttemptGuardShadowingWinsOverPin(t *testing.T) {
 	}
 }
 
+// TestGuardOverrideStaysOnItsSubtree pins the P1 review finding: overriding
+// a value- or fork-anchored guard while the shared carrier has no guard pin
+// must scope the override to the target subtree. Pinning it instead hands
+// the override to the base and sibling contexts — RFC 9520 attempt
+// accounting split across scopes — while the target keeps its old guard.
+func TestGuardOverrideStaysOnItsSubtree(t *testing.T) {
+	lazy := contextutil.WithLazyTimeout(context.Background(), time.Minute)
+	defer lazy.Cancel()
+	base := WithResponseMeta(lazy, new(ResponseMeta))
+
+	// The forked cut exposes the host guard through its own Value hook; the
+	// carrier's pin table stays guard-free.
+	forked, meta := WithForkedCut(base)
+	if meta == nil {
+		t.Fatal("no meta to fork")
+	}
+	hostGuard := ResolutionAttemptGuardFrom(forked)
+	if hostGuard == nil {
+		t.Fatal("forked cut carries no guard")
+	}
+
+	override := new(ResponseMeta).EnsureResolutionAttemptGuard()
+	overridden := WithResolutionAttemptGuard(forked, override)
+	if got := ResolutionAttemptGuardFrom(overridden); got != override {
+		t.Fatal("the target subtree did not receive its override")
+	}
+	if got := ResolutionAttemptGuardFrom(forked); got != hostGuard {
+		t.Fatal("the forked context lost its own guard")
+	}
+	if got := ResolutionAttemptGuardFrom(base); got != hostGuard {
+		t.Fatal("the override leaked through the shared carrier to the base context")
+	}
+}
+
 // TestWithForkedCutHonorsAnchoredGuards pins that a forked cut selects the
 // anchored guard through the same helper as every other consumer: the pin on
 // the ordinary path, and a shadowing value node when one is nearer.

--- a/middleware/resolution_attempt_test.go
+++ b/middleware/resolution_attempt_test.go
@@ -291,6 +291,60 @@ func TestEnsureResolutionAttemptGuardForeignContextFallsBack(t *testing.T) {
 	}
 }
 
+// TestResolutionAttemptGuardShadowingWinsOverPin pins the anchor precedence:
+// a derived value node must shadow the request's pinned guard for its
+// subtree, exactly as it did when every anchor was a value node — otherwise
+// custom or forked flows would account retries against the wrong guard.
+func TestResolutionAttemptGuardShadowingWinsOverPin(t *testing.T) {
+	lazy := contextutil.WithLazyTimeout(context.Background(), time.Minute)
+	defer lazy.Cancel()
+	ctx, first := EnsureResolutionAttemptGuard(WithResponseMeta(lazy, new(ResponseMeta)))
+
+	second := new(ResponseMeta).EnsureResolutionAttemptGuard()
+	if second == first {
+		t.Fatal("fixture guards must differ")
+	}
+	shadowed := WithResolutionAttemptGuard(ctx, second)
+	if shadowed == ctx {
+		t.Fatal("anchoring a different guard over the pin must derive a context")
+	}
+	if got := ResolutionAttemptGuardFrom(shadowed); got != second {
+		t.Fatalf("subtree sees the pinned guard instead of its shadowing anchor")
+	}
+	if got := ResolutionAttemptGuardFrom(ctx); got != first {
+		t.Fatal("the outer context lost its pinned guard")
+	}
+
+	// Shadowing back to the pinned guard inside the subtree works too.
+	back := WithResolutionAttemptGuard(shadowed, first)
+	if got := ResolutionAttemptGuardFrom(back); got != first {
+		t.Fatal("re-shadowing the pinned guard was hidden")
+	}
+}
+
+// TestWithForkedCutHonorsAnchoredGuards pins that a forked cut selects the
+// anchored guard through the same helper as every other consumer: the pin on
+// the ordinary path, and a shadowing value node when one is nearer.
+func TestWithForkedCutHonorsAnchoredGuards(t *testing.T) {
+	lazy := contextutil.WithLazyTimeout(context.Background(), time.Minute)
+	defer lazy.Cancel()
+	ctx, guard := EnsureResolutionAttemptGuard(WithResponseMeta(lazy, new(ResponseMeta)))
+
+	forked, meta := WithForkedCut(ctx)
+	if meta == nil {
+		t.Fatal("no meta to fork")
+	}
+	if got := ResolutionAttemptGuardFrom(forked); got != guard {
+		t.Fatal("forked cut did not adopt the pinned guard")
+	}
+
+	shadow := new(ResponseMeta).EnsureResolutionAttemptGuard()
+	forkedShadow, _ := WithForkedCut(WithResolutionAttemptGuard(ctx, shadow))
+	if got := ResolutionAttemptGuardFrom(forkedShadow); got != shadow {
+		t.Fatal("forked cut ignored the nearest shadowing anchor")
+	}
+}
+
 func TestEnsureResolutionAttemptGuardReestablishAllocsNothing(t *testing.T) {
 	lazy := contextutil.WithLazyTimeout(context.Background(), time.Minute)
 	defer lazy.Cancel()

--- a/middleware/resolver/client.go
+++ b/middleware/resolver/client.go
@@ -22,3 +22,10 @@ var (
 	AcquireBuf = dnsclient.AcquireBuf
 	ReleaseBuf = dnsclient.ReleaseBuf
 )
+
+// InterruptGroup shares one cancellation registration across a lookup's
+// exchanges instead of paying context.AfterFunc per upstream attempt.
+type InterruptGroup = dnsclient.InterruptGroup
+
+// NewInterruptGroup registers the lookup's cancellation domain.
+var NewInterruptGroup = dnsclient.NewInterruptGroup

--- a/middleware/resolver/dnssec/nsec3_memo.go
+++ b/middleware/resolver/dnssec/nsec3_memo.go
@@ -6,6 +6,8 @@ import (
 	"encoding/binary"
 	"sync"
 	"sync/atomic"
+
+	"github.com/semihalev/sdns/internal/contextutil"
 )
 
 // A request tree cannot legitimately need an unbounded number of distinct
@@ -191,16 +193,18 @@ type nsec3HashMemoContextState struct {
 // EnsureNSEC3HashMemo attaches one bounded memo to ctx unless the request tree
 // already carries one. Cache and resolver entrypoints both call this helper,
 // which keeps cache-less pipelines safe and makes nested Queryer pipelines
-// inherit the same digest results.
+// inherit the same digest results. The memo state is request-lifetime, so a
+// pin on the deadline carrier is preferred over deriving a value context; a
+// foreign context (detached enrichment, tests) falls back to a value node.
 func EnsureNSEC3HashMemo(ctx context.Context) context.Context {
 	if ctx == nil || NSEC3HashMemoFromContext(ctx) != nil {
 		return ctx
 	}
-	return context.WithValue(
-		ctx,
-		nsec3HashMemoContextKey,
-		new(nsec3HashMemoContextState),
-	)
+	state := new(nsec3HashMemoContextState)
+	if contextutil.TryPinValue(ctx, nsec3HashMemoContextKey, state) {
+		return ctx
+	}
+	return context.WithValue(ctx, nsec3HashMemoContextKey, state)
 }
 
 // NSEC3HashMemoFromContext returns the request tree's memo, if installed.
@@ -216,7 +220,7 @@ func NSEC3HashMemoFromContextScope(
 	if ctx == nil {
 		return nil
 	}
-	value := ctx.Value(nsec3HashMemoContextKey)
+	value := nsec3HashMemoStateFrom(ctx)
 	if state, ok := value.(*nsec3HashMemoContextState); ok &&
 		scope < nsec3HashMemoScopeCount {
 		return &state.memos[scope]
@@ -230,16 +234,25 @@ func NSEC3HashMemoFromContextScope(
 	return nil
 }
 
+// nsec3HashMemoStateFrom reads the memo state wherever the request anchored
+// it: the request-lifetime pin first, then the ordinary value chain.
+func nsec3HashMemoStateFrom(ctx context.Context) any {
+	if value, ok := contextutil.PinnedValue(ctx, nsec3HashMemoContextKey); ok {
+		return value
+	}
+	return ctx.Value(nsec3HashMemoContextKey)
+}
+
 // InheritNSEC3HashMemos copies only the opaque request-tree memo state from
 // parent into ctx. Detached-but-retained resolver enrichment uses this instead
 // of inheriting the full parent context, which would also leak cancellation,
 // response metadata, and unrelated request values into background work.
 func InheritNSEC3HashMemos(ctx, parent context.Context) context.Context {
 	if ctx == nil || parent == nil ||
-		ctx.Value(nsec3HashMemoContextKey) != nil {
+		nsec3HashMemoStateFrom(ctx) != nil {
 		return ctx
 	}
-	state := parent.Value(nsec3HashMemoContextKey)
+	state := nsec3HashMemoStateFrom(parent)
 	if state == nil {
 		return ctx
 	}

--- a/middleware/resolver/dnssec/nsec3_memo_test.go
+++ b/middleware/resolver/dnssec/nsec3_memo_test.go
@@ -7,8 +7,10 @@ import (
 	"sync"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/contextutil"
 )
 
 var errNSEC3MemoTestWork = errors.New("test NSEC3 memo work failure")
@@ -398,5 +400,60 @@ func TestNSEC3HashMemoCanonicalNamesCoalesceAndTupleChangesPartition(t *testing.
 	}
 	if got, want := work.calls.Load(), uint32(7); got != want {
 		t.Fatalf("partitioned ring hash debits = %d, want %d", got, want)
+	}
+}
+
+// TestEnsureNSEC3HashMemoPinsOnDeadlineCarrier pins the anchoring contract:
+// on a deadline-carried request the memo state lives in the request-lifetime
+// pin, so ensuring it derives no context and repeated ensures are free.
+func TestEnsureNSEC3HashMemoPinsOnDeadlineCarrier(t *testing.T) {
+	lazy := contextutil.WithLazyTimeout(context.Background(), time.Minute)
+	defer lazy.Cancel()
+
+	ctx := EnsureNSEC3HashMemo(lazy)
+	if ctx != context.Context(lazy) {
+		t.Fatal("ensuring the memo on a deadline-carried request derived a context")
+	}
+	memo := NSEC3HashMemoFromContext(ctx)
+	if memo == nil {
+		t.Fatal("memo not readable back through the pin")
+	}
+	for scope := NSEC3HashMemoScope(0); scope < nsec3HashMemoScopeCount; scope++ {
+		if NSEC3HashMemoFromContextScope(ctx, scope) == nil {
+			t.Fatalf("scope %d compartment missing", scope)
+		}
+	}
+	if again := EnsureNSEC3HashMemo(ctx); again != ctx {
+		t.Fatal("re-ensuring the memo was not the identity")
+	}
+
+	allocs := testing.AllocsPerRun(100, func() {
+		if EnsureNSEC3HashMemo(ctx) != ctx {
+			t.Fatal("re-ensure diverged")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("re-ensuring the pinned memo allocated %.0f times, want 0", allocs)
+	}
+}
+
+func TestInheritNSEC3HashMemosReadsThePinnedParent(t *testing.T) {
+	lazy := contextutil.WithLazyTimeout(context.Background(), time.Minute)
+	defer lazy.Cancel()
+	parent := EnsureNSEC3HashMemo(lazy)
+	memo := NSEC3HashMemoFromContext(parent)
+	if memo == nil {
+		t.Fatal("parent memo missing")
+	}
+
+	detached := InheritNSEC3HashMemos(context.Background(), parent)
+	if got := NSEC3HashMemoFromContext(detached); got != memo {
+		t.Fatal("detached context did not inherit the pinned memo state")
+	}
+
+	// A context already carrying state must keep its own.
+	own := EnsureNSEC3HashMemo(context.Background())
+	if InheritNSEC3HashMemos(own, parent) != own {
+		t.Fatal("inherit overwrote a context that already carries memo state")
 	}
 }

--- a/middleware/resolver/exchange_cancel_test.go
+++ b/middleware/resolver/exchange_cancel_test.go
@@ -39,7 +39,7 @@ func TestExchangeCancellationInterruptsInFlightUDPRead(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	result := make(chan error, 1)
 	go func() {
-		_, exchangeErr := r.exchange(ctx, &resolveState{}, "udp", req, server, 0)
+		_, exchangeErr := r.exchange(ctx, &resolveState{}, nil, "udp", req, server, 0)
 		result <- exchangeErr
 	}()
 
@@ -56,6 +56,60 @@ func TestExchangeCancellationInterruptsInFlightUDPRead(t *testing.T) {
 		}
 	case <-time.After(300 * time.Millisecond):
 		t.Fatal("resolver UDP read ignored context cancellation")
+	}
+	if got := atomic.LoadInt64(&server.Count); got != 0 {
+		t.Fatalf("canceled exchange updated RTT sample count to %d", got)
+	}
+}
+
+// TestExchangeCancellationInterruptsThroughGroup covers the same in-flight
+// interruption through the lookup's shared InterruptGroup instead of the
+// per-exchange fallback registration.
+func TestExchangeCancellationInterruptsThroughGroup(t *testing.T) {
+	packet, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer packet.Close()
+
+	received := make(chan struct{})
+	go func() {
+		buf := make([]byte, 512)
+		_, _, readErr := packet.ReadFrom(buf)
+		if readErr == nil {
+			close(received)
+		}
+	}()
+
+	r := &Resolver{
+		cfg:        new(config.Config),
+		netTimeout: 5 * time.Second,
+	}
+	server := authority.NewServer(packet.LocalAddr().String(), authority.IPv4)
+	req := new(dns.Msg)
+	req.SetQuestion("cancel-group.example.", dns.TypeA)
+	ctx, cancel := context.WithCancel(context.Background())
+	interrupts := NewInterruptGroup(ctx)
+	defer interrupts.Close()
+	result := make(chan error, 1)
+	go func() {
+		_, exchangeErr := r.exchange(ctx, &resolveState{}, interrupts, "udp", req, server, 0)
+		result <- exchangeErr
+	}()
+
+	select {
+	case <-received:
+	case <-time.After(time.Second):
+		t.Fatal("upstream did not receive the in-flight resolver query")
+	}
+	cancel()
+	select {
+	case exchangeErr := <-result:
+		if !errors.Is(exchangeErr, context.Canceled) {
+			t.Fatalf("exchange error = %v, want context.Canceled", exchangeErr)
+		}
+	case <-time.After(300 * time.Millisecond):
+		t.Fatal("group-armed resolver UDP read ignored context cancellation")
 	}
 	if got := atomic.LoadInt64(&server.Count); got != 0 {
 		t.Fatalf("canceled exchange updated RTT sample count to %d", got)

--- a/middleware/resolver/handler.go
+++ b/middleware/resolver/handler.go
@@ -84,9 +84,13 @@ func (h *DNSHandler) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 
 	w, req := ch.Writer, ch.Request
 
-	// Ensure request ID is in context for tracking
-	if ctx.Value(contextKeyRequestID) == nil {
-		ctx = context.WithValue(ctx, contextKeyRequestID, req.Id)
+	// Ensure request ID is in context for tracking. It is request-lifetime
+	// state, so pin it to the deadline carrier when there is one; a foreign
+	// context still gets a value node.
+	if requestIDFromContext(ctx) == nil {
+		if !contextutil.TryPinValue(ctx, contextKeyRequestID, req.Id) {
+			ctx = context.WithValue(ctx, contextKeyRequestID, req.Id)
+		}
 	}
 	// Ensure a ResponseMeta sink exists so resolve() can report the
 	// delegation-cut deadline that bounds caching of this answer.
@@ -188,6 +192,16 @@ func (h *DNSHandler) handle(ctx context.Context, req *dns.Msg) *dns.Msg {
 	}
 
 	return resp
+}
+
+// requestIDFromContext reads the request's tracking ID wherever the request
+// anchored it: the request-lifetime pin first, then the ordinary value chain
+// (detached v6 lookups carry it as a value node).
+func requestIDFromContext(ctx context.Context) any {
+	if v, ok := contextutil.PinnedValue(ctx, contextKeyRequestID); ok {
+		return v
+	}
+	return ctx.Value(contextKeyRequestID)
 }
 
 // noopCancel is returned by withQueryDeadline when the parent context needs

--- a/middleware/resolver/handler.go
+++ b/middleware/resolver/handler.go
@@ -144,8 +144,7 @@ func (h *DNSHandler) handle(ctx context.Context, req *dns.Msg) *dns.Msg {
 	}
 
 	// Set query timeout
-	deadline := time.Now().Add(h.cfg.QueryTimeout.Duration)
-	ctx, cancel := context.WithDeadline(ctx, deadline)
+	ctx, cancel := withQueryDeadline(ctx, h.cfg.QueryTimeout.Duration)
 	defer cancel()
 
 	// Start recursive resolution from root servers
@@ -189,6 +188,24 @@ func (h *DNSHandler) handle(ctx context.Context, req *dns.Msg) *dns.Msg {
 	}
 
 	return resp
+}
+
+// noopCancel is returned by withQueryDeadline when the parent context needs
+// no child; a shared value keeps the call-site's defer allocation-free.
+var noopCancel context.CancelFunc = func() {}
+
+// withQueryDeadline bounds ctx by the configured query timeout. The server
+// bounds every request context the same way on entry, so on the ordinary
+// path the parent's deadline is this one shifted earlier by the queueing
+// delay — deriving a child context there would allocate a cancelCtx whose
+// deadline can never fire first. Only a context that arrives unbounded, or
+// bounded later than the timeout, gets a child.
+func withQueryDeadline(ctx context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
+	deadline := time.Now().Add(timeout)
+	if parent, ok := ctx.Deadline(); ok && !parent.After(deadline) {
+		return ctx, noopCancel
+	}
+	return context.WithDeadline(ctx, deadline)
 }
 
 func (h *DNSHandler) nsStats(req *dns.Msg) *dns.Msg {

--- a/middleware/resolver/handler_test.go
+++ b/middleware/resolver/handler_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/contextutil"
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/sdns/middleware/edns"
@@ -215,4 +216,52 @@ func Test_HandlerServe(t *testing.T) {
 
 	h.ServeDNS(context.Background(), ch)
 	assert.Equal(t, true, ch.Writer.Written())
+}
+
+func Test_withQueryDeadline(t *testing.T) {
+	timeout := 10 * time.Second
+
+	// A parent already bounded at or before the timeout is returned as is:
+	// a child there could never fire first.
+	bounded, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	got, gotCancel := withQueryDeadline(bounded, timeout)
+	assert.Equal(t, bounded, got, "an earlier-bounded parent must not grow a child")
+	parentDeadline, _ := bounded.Deadline()
+	gotDeadline, ok := got.Deadline()
+	assert.True(t, ok)
+	assert.Equal(t, parentDeadline, gotDeadline)
+	gotCancel()
+	assert.NoError(t, bounded.Err(), "the no-op cancel must not cancel the parent")
+
+	// An unbounded parent gets the timeout.
+	got, gotCancel = withQueryDeadline(context.Background(), timeout)
+	defer gotCancel()
+	gotDeadline, ok = got.Deadline()
+	assert.True(t, ok, "an unbounded parent must gain a deadline")
+	assert.InDelta(t, time.Until(gotDeadline).Seconds(), timeout.Seconds(), 1.0)
+
+	// A parent bounded later than the timeout is tightened.
+	loose, cancel2 := context.WithTimeout(context.Background(), time.Hour)
+	defer cancel2()
+	got, gotCancel = withQueryDeadline(loose, timeout)
+	defer gotCancel()
+	gotDeadline, _ = got.Deadline()
+	looseDeadline, _ := loose.Deadline()
+	assert.True(t, gotDeadline.Before(looseDeadline), "a later-bounded parent must be tightened")
+}
+
+// Test_withQueryDeadline_LazyParentAllocsNothing pins the point of the guard:
+// the server bounds every request with a LazyDeadline at entry, so the
+// handler's per-request query-timeout derivation must be free on that path.
+func Test_withQueryDeadline_LazyParentAllocsNothing(t *testing.T) {
+	parent := contextutil.WithLazyTimeout(context.Background(), time.Second)
+	defer parent.Cancel()
+
+	allocs := testing.AllocsPerRun(100, func() {
+		ctx, cancel := withQueryDeadline(parent, 10*time.Second)
+		cancel()
+		_ = ctx
+	})
+	assert.Zero(t, allocs, "deriving the query deadline under a server-bounded parent must not allocate")
 }

--- a/middleware/resolver/handler_test.go
+++ b/middleware/resolver/handler_test.go
@@ -251,6 +251,27 @@ func Test_withQueryDeadline(t *testing.T) {
 	assert.True(t, gotDeadline.Before(looseDeadline), "a later-bounded parent must be tightened")
 }
 
+func Test_requestIDFromContext(t *testing.T) {
+	lazy := contextutil.WithLazyTimeout(context.Background(), time.Second)
+	defer lazy.Cancel()
+
+	if !contextutil.TryPinValue(lazy, contextKeyRequestID, uint16(0xBEEF)) {
+		t.Fatal("pin failed")
+	}
+	if got := requestIDFromContext(lazy); got != uint16(0xBEEF) {
+		t.Fatalf("pinned request ID = %v, want 0xBEEF", got)
+	}
+
+	// A detached context carries the ID as an ordinary value node.
+	detached := context.WithValue(context.Background(), contextKeyRequestID, uint16(0xCAFE))
+	if got := requestIDFromContext(detached); got != uint16(0xCAFE) {
+		t.Fatalf("value-carried request ID = %v, want 0xCAFE", got)
+	}
+	if got := requestIDFromContext(context.Background()); got != nil {
+		t.Fatalf("empty context yielded %v", got)
+	}
+}
+
 // Test_withQueryDeadline_LazyParentAllocsNothing pins the point of the guard:
 // the server bounds every request with a LazyDeadline at entry, so the
 // handler's per-request query-timeout derivation must be free on that path.

--- a/middleware/resolver/recursion_work_test.go
+++ b/middleware/resolver/recursion_work_test.go
@@ -273,7 +273,7 @@ func TestRecursionWorkOutboundCapAppliesWithCD(t *testing.T) {
 			rs := &resolveState{req: req, requestID: req.Id, work: ledger}
 
 			before := wire.count()
-			resp, err := r.exchange(context.Background(), rs, "udp", req, server, 0)
+			resp, err := r.exchange(context.Background(), rs, nil, "udp", req, server, 0)
 			if err != nil {
 				t.Fatalf("first exchange error = %v", err)
 			}
@@ -281,7 +281,7 @@ func TestRecursionWorkOutboundCapAppliesWithCD(t *testing.T) {
 				t.Fatalf("first exchange response = %v, want success", resp)
 			}
 
-			_, err = r.exchange(context.Background(), rs, "udp", req, server, 0)
+			_, err = r.exchange(context.Background(), rs, nil, "udp", req, server, 0)
 			if !errors.Is(err, middleware.ErrRecursionWorkLimit) {
 				t.Fatalf("second exchange error = %v, want recursion work limit", err)
 			}
@@ -328,7 +328,7 @@ func TestRecursionWorkOutboundRetryCap(t *testing.T) {
 	server := authority.NewServer(packet.LocalAddr().String(), authority.IPv4)
 	rs := &resolveState{req: req, requestID: req.Id, work: ledger}
 
-	_, err = r.exchange(context.Background(), rs, "udp", req, server, 0)
+	_, err = r.exchange(context.Background(), rs, nil, "udp", req, server, 0)
 	if !errors.Is(err, middleware.ErrRecursionWorkLimit) {
 		t.Fatalf("retry exchange error = %v, want recursion work limit", err)
 	}

--- a/middleware/resolver/resolution_attempt_test.go
+++ b/middleware/resolver/resolution_attempt_test.go
@@ -46,7 +46,7 @@ func TestResolverResolutionAttemptGuardClosesEDNSRetryEscape(t *testing.T) {
 	ctx, _ := middleware.EnsureResolutionAttemptGuard(context.Background())
 	ctx = middleware.WithRecursionWork(ctx, ledger)
 
-	_, err := r.exchange(ctx, rs, "tcp", req, server, 0)
+	_, err := r.exchange(ctx, rs, nil, "tcp", req, server, 0)
 	if !errors.Is(err, middleware.ErrResolutionAttemptLimit) {
 		t.Fatalf("exchange error = %v, want ErrResolutionAttemptLimit", err)
 	}

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -381,7 +381,7 @@ func (r *Resolver) Resolve(ctx context.Context, req *dns.Msg, servers *authority
 	}
 
 	reqid := req.Id
-	if v := ctx.Value(contextKeyRequestID); v != nil {
+	if v := requestIDFromContext(ctx); v != nil {
 		if id, ok := v.(uint16); ok {
 			reqid = id
 		}
@@ -2493,7 +2493,7 @@ func (r *Resolver) subQuery(ctx context.Context, req *dns.Msg) (*dns.Msg, error)
 	req.AuthenticatedData = false
 
 	reqid := req.Id
-	if v := ctx.Value(contextKeyRequestID); v != nil {
+	if v := requestIDFromContext(ctx); v != nil {
 		if id, ok := v.(uint16); ok {
 			reqid = id
 		}
@@ -3511,7 +3511,7 @@ func (r *Resolver) processDelegation(ctx context.Context, rs *resolveState, resp
 	// used to leak goroutines and mutate authservers long
 	// after the query returned.
 	if r.cfg.IPv6Access {
-		reqid := ctx.Value(contextKeyRequestID)
+		reqid := requestIDFromContext(ctx)
 		work := rs.work
 		attemptGuard := middleware.ResolutionAttemptGuardFrom(ctx)
 		var releaseWork func()

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -1368,6 +1368,13 @@ func (r *Resolver) lookup(ctx context.Context, rs *resolveState, req *dns.Msg, s
 	left := len(serversList)
 
 	ctx, cancel := context.WithCancel(ctx)
+	// One cancellation registration for every exchange this lookup fans
+	// out, instead of a context.AfterFunc per upstream attempt. Deferred
+	// before cancel so cancel runs first (LIFO): the exit cancellation
+	// still interrupts straggler reads through the group, and only then
+	// is the registration detached.
+	interrupts := NewInterruptGroup(ctx)
+	defer interrupts.Close()
 	defer cancel()
 
 	// Start queries to top 2 servers immediately for faster response
@@ -1395,7 +1402,7 @@ mainloop:
 		select {
 		case r.maxConcurrent <- struct{}{}:
 			// Got a slot, start the query
-			go r.queryServer(ctx, rs, originalID, serverReq, server, results)
+			go r.queryServer(ctx, rs, interrupts, originalID, serverReq, server, results)
 		case <-ctx.Done():
 			// Context cancelled while waiting for slot —
 			// return the pre-copied pooled message before
@@ -1582,7 +1589,7 @@ type lookupResult struct {
 // launching the goroutine, and the pooled reqCopy buffer; both are
 // released before the result send so the main loop can keep launching
 // workers while we queue.
-func (r *Resolver) queryServer(ctx context.Context, rs *resolveState, originalID uint16, reqCopy *dns.Msg, server *authority.Server, results chan<- lookupResult) {
+func (r *Resolver) queryServer(ctx context.Context, rs *resolveState, interrupts *InterruptGroup, originalID uint16, reqCopy *dns.Msg, server *authority.Server, results chan<- lookupResult) {
 	defer ReleaseMsg(reqCopy)
 
 	// releaseSlot frees the semaphore slot acquired by the main
@@ -1611,7 +1618,7 @@ func (r *Resolver) queryServer(ctx context.Context, rs *resolveState, originalID
 		return
 	default:
 		reqCopy.Id = dns.Id() // anti-spoofing
-		resp, err := r.exchange(ctx, rs, "udp", reqCopy, server, 0)
+		resp, err := r.exchange(ctx, rs, interrupts, "udp", reqCopy, server, 0)
 		if resp != nil {
 			resp.Id = originalID
 		}
@@ -1710,7 +1717,7 @@ func pickFallbackResponse(responseErrors, configErrors []*dns.Msg, fatalErrors [
 	return nil, fatalError(errNoRootServers)
 }
 
-func (r *Resolver) exchange(ctx context.Context, rs *resolveState, proto string, req *dns.Msg, server *authority.Server, retried int) (*dns.Msg, error) {
+func (r *Resolver) exchange(ctx context.Context, rs *resolveState, interrupts *InterruptGroup, proto string, req *dns.Msg, server *authority.Server, retried int) (*dns.Msg, error) {
 	if ctxErr := contextutil.EffectiveError(ctx); ctxErr != nil {
 		return nil, ctxErr
 	}
@@ -1826,7 +1833,7 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, proto string,
 	}
 	_ = co.SetDeadline(deadline)
 
-	resp, rtt, err = co.ExchangeContext(ctx, req)
+	resp, rtt, err = co.ExchangeInterruptible(ctx, interrupts, req)
 	if ctxErr := contextutil.EffectiveError(ctx); ctxErr != nil {
 		resp = nil
 		err = ctxErr
@@ -1847,7 +1854,7 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, proto string,
 			}
 			// retry
 			retried++
-			return r.exchange(ctx, rs, proto, req, server, retried)
+			return r.exchange(ctx, rs, interrupts, proto, req, server, retried)
 		}
 
 		return nil, err
@@ -1865,20 +1872,20 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, proto string,
 	ReleaseConn(co)
 
 	if resp != nil && resp.Truncated && proto == "udp" {
-		return r.exchange(ctx, rs, "tcp", req, server, retried)
+		return r.exchange(ctx, rs, interrupts, "tcp", req, server, retried)
 	}
 
 	if resp != nil && !resp.Truncated && proto == "udp" && resp.Len() > dnsutil.DefaultMsgSize {
 		// If response is too large, switch to TCP
 		zlog.Debug("Response too large, switching to TCP", "query", dnsutil.FormatQuestion(q), "upstream", server.Addr,
 			"size", resp.Len(), "maxSize", dnsutil.DefaultMsgSize, "retried", retried)
-		return r.exchange(ctx, rs, "tcp", req, server, retried)
+		return r.exchange(ctx, rs, interrupts, "tcp", req, server, retried)
 	}
 
 	if resp != nil && resp.Rcode == dns.RcodeFormatError && req.IsEdns0() != nil {
 		// try again without edns tags, some weird servers didn't implement that
 		req = dnsutil.ClearOPT(req)
-		return r.exchange(ctx, rs, proto, req, server, retried)
+		return r.exchange(ctx, rs, interrupts, proto, req, server, retried)
 	}
 
 	return resp, nil

--- a/middleware/resolver/resolver_tcp_test.go
+++ b/middleware/resolver/resolver_tcp_test.go
@@ -47,7 +47,7 @@ func TestResolverTCPPoolIntegration(t *testing.T) {
 	req := new(dns.Msg)
 	req.SetQuestion(".", dns.TypeNS)
 
-	resp, err := r.exchange(context.Background(), &resolveState{requestID: req.Id}, "tcp", req, r.rootServers.List[0], 0)
+	resp, err := r.exchange(context.Background(), &resolveState{requestID: req.Id}, nil, "tcp", req, r.rootServers.List[0], 0)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
@@ -61,7 +61,7 @@ func TestResolverTCPPoolIntegration(t *testing.T) {
 	assert.Equal(t, 1, active)        // Connection should be pooled
 
 	// Test 2: Second query should reuse connection
-	resp2, err := r.exchange(context.Background(), &resolveState{requestID: req.Id}, "tcp", req, r.rootServers.List[0], 0)
+	resp2, err := r.exchange(context.Background(), &resolveState{requestID: req.Id}, nil, "tcp", req, r.rootServers.List[0], 0)
 	require.NoError(t, err)
 	require.NotNil(t, resp2)
 
@@ -123,7 +123,7 @@ func TestResolverTCPPoolConcurrent(t *testing.T) {
 			req.SetQuestion(".", dns.TypeNS)
 			req.Id = uint16(id) //nolint:gosec // G115 - test ID
 
-			_, err := r.exchange(context.Background(), &resolveState{requestID: req.Id}, "tcp", req, authServer, 0)
+			_, err := r.exchange(context.Background(), &resolveState{requestID: req.Id}, nil, "tcp", req, authServer, 0)
 			if err != nil {
 				errors <- err
 			}
@@ -173,7 +173,7 @@ func TestResolverTCPPoolWithEDNSKeepalive(t *testing.T) {
 	req := new(dns.Msg)
 	req.SetQuestion(".", dns.TypeNS)
 
-	resp, err := r.exchange(context.Background(), &resolveState{requestID: req.Id}, "tcp", req, authServer, 0)
+	resp, err := r.exchange(context.Background(), &resolveState{requestID: req.Id}, nil, "tcp", req, authServer, 0)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 


### PR DESCRIPTION
## Why

Live profiling puts the context cluster at **11.3% of all allocated objects and 15.45% of allocated bytes** (556MB): stdlib cancelCtx children maps, afterFuncCtx registrations, lazy done channels, and a request's worth of `context.WithValue` nodes. Three cuts, one commit each:

## 1. resolver: query-timeout child only when it can fire (`018fd01`)

The server bounds every request with the same query timeout at entry, so the handler's unconditional `WithDeadline` derived a child whose deadline trailed the parent's by the queueing delay — the profile's 1.39M-object `WithDeadlineCause→WithCancel` fast-path hit is exactly this child. It also forced the LazyDeadline to materialize at handler entry. Now the child is derived only when the incoming context is unbounded or bounded later (foreign/detached callers), which preserves the old behavior there.

## 2. dnsclient: one cancellation registration per lookup (`daf1b11`)

**98.9% of `context.AfterFunc` objects (1.57M) came from `BeginCancelInterrupt`** — one registration per upstream attempt, ~3 objects each (afterFuncCtx + closure + children-map entry). The deadline-expiry half of that registration was dead weight: both exchange paths already clamp the socket deadline to `min(netTimeout, ctx.Deadline)`, so the socket always wakes first; only early cancellation needs observing.

`InterruptGroup` registers **once per lookup cancellation domain** and hands out array slots to exchanges — arm/disarm are allocation-free (pinned by test). Safety properties preserved:
- **Conn-reuse join contract** (was `CancelInterrupt.Stop`): after `disarm` returns, no fire touches that conn, and an in-flight fire has finished — the group mutex is the join barrier (pinned by `TestInterruptGroup_DisarmJoinsFire`).
- **Straggler interruption at lookup exit**: the lookup cancels its domain before detaching the group (defer order), so parked reads still unblock.
- **Arm-after-fire parity** with `context.AfterFunc` on a canceled context: the deadline is applied in `arm`.
- Full group or foreign context falls back to the per-exchange registration; `dnsclient.Client` (forwarder/failover/DoH) keeps the stdlib path.

## 3. contextutil: pin table for request-lifetime values (`999252d`)

The single pin slot held the recursion-work ledger; the attempt guard, request ID and NSEC3 hash memo each still cost a `WithValue` node per request — plus a **re-anchoring node on every internal sub-query** (`pipelineQueryer.Query → EnsureResolutionAttemptGuard`, 13.7% of all WithValue objects). These are one-per-request-tree by construction, so they now share a 4-slot pin table on the deadline carrier (same TryPinValue/PinnedValue contract, lock-free reads). On the ordinary path `Ensure*` is now the identity — re-establishing allocates zero (pinned by tests). Foreign contexts (detached v6 lookups, cache-less pipelines) fall back to value nodes verbatim.

**Deliberately not migrated:** per-hop shadowed values (CNAME chase depth, queryer depth, loop-check lists — `WithValue` models their scoping correctly), and ResponseMeta (pooled lifetime shorter than the request tree). LazyDeadline pooling remains off the table.

## Expected effect

From the profile arithmetic: ~0.8M objects from the handler child, ~1M from per-exchange registrations, ~0.6M from the value migrations — roughly **2.5–4% of all allocated objects and a proportionally larger byte share** (children maps and done channels are byte-heavy). To be confirmed with a canary profile after deploy.

## Tests

- `TestInterruptGroup_*`: fire-interrupts-armed, disarm join barrier, disarmed-never-touched, arm-after-fire, slot exhaustion fallback, zero-alloc arm/disarm
- `TestExchangeCancellationInterruptsThroughGroup`: real in-flight UDP read interrupted through the group (mirror of the existing fallback-path test)
- `TestLazyDeadlinePinTableHoldsDistinctKeysUpToItsBound`, zero-alloc `PinnedValue`
- Guard/memo/requestID: pin-path identity + foreign-context fallback + meta-reset survival + zero-alloc re-ensure
- Full suite with `-race` green, `golangci-lint` clean