### PR TITLE
cache/dnssec: stop rebuilding the aggressive NSEC set and the hit body per query

### DIFF
--- a/middleware/cache/denial_proof_cache.go
+++ b/middleware/cache/denial_proof_cache.go
@@ -998,14 +998,16 @@ func (c *denialProofCache) publishZoneLocked(key denialProofZoneKey) {
 	if len(snapshot.nsecPrepared) != 0 {
 		// A set that fails validation stays nil: per-query evaluation of
 		// the prepared slice fails the same checks and falls through to
-		// NSEC3 and ordinary resolution, exactly as before.
+		// NSEC3 and ordinary resolution, exactly as before. The owner index
+		// exists only for the validated fast path, so it is not built for a
+		// set that will never take it.
 		if set, err := dnssec.NewAggressiveNSECSet(snapshot.nsecPrepared, key.zone); err == nil {
 			snapshot.nsecSet = set
-		}
-		snapshot.nsecOwners = make(map[dns.RR]*denialProofEntry)
-		for _, entry := range snapshot.nsec {
-			for _, rr := range entry.data {
-				snapshot.nsecOwners[rr] = entry
+			snapshot.nsecOwners = make(map[dns.RR]*denialProofEntry)
+			for _, entry := range snapshot.nsec {
+				for _, rr := range entry.data {
+					snapshot.nsecOwners[rr] = entry
+				}
 			}
 		}
 	}

--- a/middleware/cache/denial_proof_cache.go
+++ b/middleware/cache/denial_proof_cache.go
@@ -90,9 +90,19 @@ type denialProofZoneSnapshot struct {
 	// order. Readers treat it as immutable, as they do the rest of the
 	// snapshot.
 	nsecPrepared []dnssec.PreparedNSEC
-	nsec3        map[denialProofNSEC3Params][]*denialProofEntry
-	nsec3Order   []denialProofNSEC3Params
-	wireBytes    int64
+	// nsecSet is nsecPrepared validated once as an aggressive-answer set,
+	// nil when the set does not validate. A lookup that finds nothing
+	// expired evaluates it directly; re-validating per query rebuilt the
+	// entry table on every negative answer.
+	nsecSet *dnssec.AggressiveNSECSet
+	// nsecOwners maps each published NSEC record to its entry, for proof
+	// selection without building the same map per query. Valid only while
+	// every snapshot entry is live — an expired subset selects through its
+	// own filtered map.
+	nsecOwners map[dns.RR]*denialProofEntry
+	nsec3      map[denialProofNSEC3Params][]*denialProofEntry
+	nsec3Order []denialProofNSEC3Params
+	wireBytes  int64
 }
 
 type denialProofCacheConfig struct {
@@ -985,6 +995,20 @@ func (c *denialProofCache) publishZoneLocked(key denialProofZoneKey) {
 			entry.preparedNSEC...,
 		)
 	}
+	if len(snapshot.nsecPrepared) != 0 {
+		// A set that fails validation stays nil: per-query evaluation of
+		// the prepared slice fails the same checks and falls through to
+		// NSEC3 and ordinary resolution, exactly as before.
+		if set, err := dnssec.NewAggressiveNSECSet(snapshot.nsecPrepared, key.zone); err == nil {
+			snapshot.nsecSet = set
+		}
+		snapshot.nsecOwners = make(map[dns.RR]*denialProofEntry)
+		for _, entry := range snapshot.nsec {
+			for _, rr := range entry.data {
+				snapshot.nsecOwners[rr] = entry
+			}
+		}
+	}
 	snapshot.nsec3Order = make(
 		[]denialProofNSEC3Params,
 		0,
@@ -1409,9 +1433,22 @@ func denialProofEvaluate(
 		prune = denialProofPruneExpired
 	}
 	if len(nsecPrepared) != 0 {
-		result, err := dnssec.EvaluateAggressiveNSECPrepared(q, zone.zone, nsecPrepared)
+		var result dnssec.AggressiveNegativeResult
+		var err error
+		owners := snapshot.nsecOwners
+		if snapshot.nsecSet != nil && len(nsecEntries) == len(snapshot.nsec) {
+			// Nothing expired: the published, pre-validated set is exactly
+			// the live set. This is the per-query allocation-free path.
+			result, err = dnssec.EvaluateAggressiveNSECSet(q, snapshot.nsecSet)
+		} else {
+			// An expired subset (or a set that never validated) takes the
+			// per-query path over the filtered records, with a filtered
+			// owner map to match.
+			owners = nil
+			result, err = dnssec.EvaluateAggressiveNSECPrepared(q, zone.zone, nsecPrepared)
+		}
 		if err == nil {
-			entries, selected := denialProofSelectedEntries(result.Proof, nsecEntries)
+			entries, selected := denialProofSelectedEntries(result.Proof, nsecEntries, owners)
 			if selected {
 				return result, entries, prune, true
 			}
@@ -1434,7 +1471,7 @@ func denialProofEvaluate(
 			}
 			continue
 		}
-		selectedEntries, selected := denialProofSelectedEntries(result.Proof, entries)
+		selectedEntries, selected := denialProofSelectedEntries(result.Proof, entries, nil)
 		if selected {
 			return result, selectedEntries, prune, true
 		}
@@ -1497,28 +1534,34 @@ func denialProofLiveRecords(
 func denialProofSelectedEntries(
 	proof []dns.RR,
 	entries []*denialProofEntry,
+	owners map[dns.RR]*denialProofEntry,
 ) ([]*denialProofEntry, bool) {
 	if len(proof) == 0 {
 		return nil, false
 	}
-	owners := make(map[dns.RR]*denialProofEntry)
-	for _, entry := range entries {
-		for _, rr := range entry.data {
-			owners[rr] = entry
+	if owners == nil {
+		owners = make(map[dns.RR]*denialProofEntry)
+		for _, entry := range entries {
+			for _, rr := range entry.data {
+				owners[rr] = entry
+			}
 		}
 	}
 
 	selected := make([]*denialProofEntry, 0, len(proof))
-	seen := make(map[denialProofID]struct{}, len(proof))
+proof:
 	for _, rr := range proof {
 		entry := owners[rr]
 		if entry == nil {
 			return nil, false
 		}
-		if _, duplicate := seen[entry.id]; duplicate {
-			continue
+		// A proof holds a handful of records; scanning what was already
+		// selected beats allocating a set per query.
+		for _, previous := range selected {
+			if previous.id == entry.id {
+				continue proof
+			}
 		}
-		seen[entry.id] = struct{}{}
 		selected = append(selected, entry)
 	}
 	return selected, len(selected) != 0

--- a/middleware/resolver/dnssec/aggressive_negative.go
+++ b/middleware/resolver/dnssec/aggressive_negative.go
@@ -104,6 +104,63 @@ func EvaluateAggressiveNSECPrepared(
 	return evaluateAggressiveNSECEntries(q, qname, signer, entries)
 }
 
+// AggressiveNSECSet is a prepared NSEC collection whose set-level invariants
+// — class homogeneity, signer containment, interval conflicts — were checked
+// once at construction. Those checks are static properties of the stored
+// set; re-running them per query rebuilt the entry slice on every negative
+// answer, which was the resolver's single largest allocator under
+// NXDOMAIN-heavy load.
+type AggressiveNSECSet struct {
+	entries []aggressiveNSECEntry
+	signer  aggressiveCanonicalName
+	qclass  uint16
+}
+
+// NewAggressiveNSECSet validates prepared as one aggressive-answer set for
+// zone. The checks are exactly EvaluateAggressiveNSECPrepared's set-level
+// checks — a set rejected here would be rejected on every evaluation.
+func NewAggressiveNSECSet(prepared []PreparedNSEC, zone string) (*AggressiveNSECSet, error) {
+	if len(prepared) == 0 {
+		return nil, ErrNSECMissingCoverage
+	}
+	signer, err := newAggressiveCanonicalName(zone)
+	if err != nil {
+		return nil, err
+	}
+	first := prepared[0].entry.rr
+	if first == nil {
+		return nil, aggressiveFallback("NSEC set is not homogeneous")
+	}
+	qclass := first.Header().Class
+	entries, err := aggressiveNSECEntriesFromPrepared(prepared, qclass, signer)
+	if err != nil {
+		return nil, err
+	}
+	return &AggressiveNSECSet{entries: entries, signer: signer, qclass: qclass}, nil
+}
+
+// EvaluateAggressiveNSECSet is EvaluateAggressiveNSECPrepared over a
+// pre-validated set: per query only the question is canonicalized and
+// classified; the entry table is used as stored.
+func EvaluateAggressiveNSECSet(
+	q dns.Question,
+	set *AggressiveNSECSet,
+) (AggressiveNegativeResult, error) {
+	if set == nil || len(set.entries) == 0 {
+		return AggressiveNegativeResult{}, ErrNSECMissingCoverage
+	}
+	qname, err := validateAggressiveQuestionSigner(q, set.signer)
+	if err != nil {
+		return AggressiveNegativeResult{}, err
+	}
+	if q.Qclass != set.qclass {
+		// The stored records' class is uniform; a query in another class
+		// fails the same homogeneity check the per-query path applies.
+		return AggressiveNegativeResult{}, aggressiveFallback("NSEC set is not homogeneous")
+	}
+	return evaluateAggressiveNSECEntries(q, qname, set.signer, set.entries)
+}
+
 func evaluateAggressiveNSECEntries(
 	q dns.Question,
 	qname aggressiveCanonicalName,
@@ -486,26 +543,37 @@ func validateAggressiveQuestion(
 	q dns.Question,
 	zone string,
 ) (aggressiveCanonicalName, aggressiveCanonicalName, error) {
-	if q.Qtype == dns.TypeNone ||
-		q.Qclass == 0 ||
-		q.Qclass == dns.ClassANY ||
-		q.Qclass == dns.ClassNONE {
-		return aggressiveCanonicalName{}, aggressiveCanonicalName{},
-			aggressiveFallback("unsupported question")
-	}
-	qname, err := newAggressiveCanonicalName(q.Name)
-	if err != nil {
-		return aggressiveCanonicalName{}, aggressiveCanonicalName{}, err
-	}
 	signer, err := newAggressiveCanonicalName(zone)
 	if err != nil {
 		return aggressiveCanonicalName{}, aggressiveCanonicalName{}, err
 	}
-	if !qname.isSubdomainOf(signer) {
-		return aggressiveCanonicalName{}, aggressiveCanonicalName{},
-			aggressiveFallback("question is outside signer zone")
+	qname, err := validateAggressiveQuestionSigner(q, signer)
+	if err != nil {
+		return aggressiveCanonicalName{}, aggressiveCanonicalName{}, err
 	}
 	return qname, signer, nil
+}
+
+// validateAggressiveQuestionSigner is validateAggressiveQuestion for a caller
+// that already holds the signer's canonical form.
+func validateAggressiveQuestionSigner(
+	q dns.Question,
+	signer aggressiveCanonicalName,
+) (aggressiveCanonicalName, error) {
+	if q.Qtype == dns.TypeNone ||
+		q.Qclass == 0 ||
+		q.Qclass == dns.ClassANY ||
+		q.Qclass == dns.ClassNONE {
+		return aggressiveCanonicalName{}, aggressiveFallback("unsupported question")
+	}
+	qname, err := newAggressiveCanonicalName(q.Name)
+	if err != nil {
+		return aggressiveCanonicalName{}, err
+	}
+	if !qname.isSubdomainOf(signer) {
+		return aggressiveCanonicalName{}, aggressiveFallback("question is outside signer zone")
+	}
+	return qname, nil
 }
 
 func aggressiveNODATAType(qtype uint16) bool {

--- a/middleware/resolver/dnssec/aggressive_prepared_test.go
+++ b/middleware/resolver/dnssec/aggressive_prepared_test.go
@@ -281,3 +281,182 @@ func TestPrepareAggressiveNSECIsAllocatedOnce(t *testing.T) {
 	}
 	t.Logf("allocations per evaluation: records=%.0f prepared=%.0f", fromRecords, fromPrepared)
 }
+
+// TestEvaluateAggressiveNSECSetMatchesPrepared is the contract that lets the
+// denial-proof cache validate a stored set once at publish instead of on
+// every lookup: a set the constructor accepts must evaluate exactly as the
+// per-query path evaluates the same prepared records, and a set it refuses
+// must be refused for the same reason the per-query path refuses it. The one
+// deliberate route difference is class: construction accepts any uniform
+// class and evaluation refuses the mismatch with the query, so the final
+// verdict is unchanged.
+func TestEvaluateAggressiveNSECSetMatchesPrepared(t *testing.T) {
+	const zone = "example.com."
+
+	cases := []struct {
+		name    string
+		q       dns.Question
+		records []dns.RR
+	}{
+		{
+			name: "nxdomain between two owners",
+			q:    dns.Question{Name: "b.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET},
+			records: []dns.RR{
+				nsecRecord("a.example.com.", "c.example.com.", dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC),
+				nsecRecord("example.com.", "a.example.com.", dns.TypeSOA, dns.TypeNS, dns.TypeRRSIG, dns.TypeNSEC),
+			},
+		},
+		{
+			name: "nodata at an existing owner",
+			q:    dns.Question{Name: "a.example.com.", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET},
+			records: []dns.RR{
+				nsecRecord("a.example.com.", "c.example.com.", dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC),
+			},
+		},
+		{
+			name: "question outside the signer zone",
+			q:    dns.Question{Name: "b.example.org.", Qtype: dns.TypeA, Qclass: dns.ClassINET},
+			records: []dns.RR{
+				nsecRecord("a.example.com.", "c.example.com.", dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC),
+			},
+		},
+		{
+			name: "unsupported question class",
+			q:    dns.Question{Name: "b.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassANY},
+			records: []dns.RR{
+				nsecRecord("a.example.com.", "c.example.com.", dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC),
+			},
+		},
+		{
+			name: "conflicting owners are refused",
+			q:    dns.Question{Name: "b.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET},
+			records: []dns.RR{
+				nsecRecord("a.example.com.", "c.example.com.", dns.TypeA),
+				nsecRecord("a.example.com.", "d.example.com.", dns.TypeA),
+			},
+		},
+		{
+			name: "record crossing the signer zone is refused",
+			q:    dns.Question{Name: "b.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET},
+			records: []dns.RR{
+				nsecRecord("a.example.org.", "c.example.org.", dns.TypeA),
+			},
+		},
+		{
+			name: "non-apex singleton interval is refused",
+			q:    dns.Question{Name: "b.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET},
+			records: []dns.RR{
+				nsecRecord("a.example.com.", "a.example.com.", dns.TypeA),
+			},
+		},
+		{
+			name: "foreign class is refused at evaluation",
+			q:    dns.Question{Name: "b.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET},
+			records: []dns.RR{
+				nsecRecordClass("a.example.com.", "c.example.com.", dns.ClassCHAOS, dns.TypeA),
+			},
+		},
+		{
+			name:    "empty set is refused",
+			q:       dns.Question{Name: "b.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET},
+			records: nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			prepared := make([]PreparedNSEC, 0, len(tc.records))
+			for _, rr := range tc.records {
+				p, err := PrepareAggressiveNSEC(rr.(*dns.NSEC))
+				if err != nil {
+					t.Fatalf("PrepareAggressiveNSEC: %v", err)
+				}
+				prepared = append(prepared, p)
+			}
+
+			wantResult, wantErr := EvaluateAggressiveNSECPrepared(tc.q, zone, prepared)
+
+			set, buildErr := NewAggressiveNSECSet(prepared, zone)
+			if buildErr != nil {
+				if wantErr == nil {
+					t.Fatalf("construction refused (%v) what the per-query path accepts", buildErr)
+				}
+				if buildErr.Error() != wantErr.Error() {
+					t.Fatalf("refusal differs:\n  construction: %v\n  per-query:    %v", buildErr, wantErr)
+				}
+				return
+			}
+
+			gotResult, gotErr := EvaluateAggressiveNSECSet(tc.q, set)
+			switch {
+			case wantErr == nil && gotErr != nil:
+				t.Fatalf("per-query path succeeded but set path failed: %v", gotErr)
+			case wantErr != nil && gotErr == nil:
+				t.Fatalf("per-query path failed (%v) but set path succeeded", wantErr)
+			case wantErr != nil && gotErr != nil:
+				if wantErr.Error() != gotErr.Error() {
+					t.Fatalf("refusal differs:\n  per-query: %v\n  set:       %v", wantErr, gotErr)
+				}
+				return
+			}
+
+			if gotResult.Rcode != wantResult.Rcode {
+				t.Fatalf("rcode %d, want %d", gotResult.Rcode, wantResult.Rcode)
+			}
+			if len(gotResult.Proof) != len(wantResult.Proof) {
+				t.Fatalf("proof has %d records, want %d", len(gotResult.Proof), len(wantResult.Proof))
+			}
+			for i := range wantResult.Proof {
+				if gotResult.Proof[i] != wantResult.Proof[i] {
+					t.Fatalf("proof[%d] is not the same record instance", i)
+				}
+			}
+		})
+	}
+
+	if _, err := EvaluateAggressiveNSECSet(
+		dns.Question{Name: "b.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}, nil,
+	); err == nil {
+		t.Fatal("a nil set was accepted")
+	}
+}
+
+// TestEvaluateAggressiveNSECSetAllocations pins the point of the set: the
+// per-query cost is canonicalizing the question, not rebuilding the table.
+func TestEvaluateAggressiveNSECSetAllocations(t *testing.T) {
+	const zone = "example.com."
+	records := []*dns.NSEC{
+		nsecRecord("example.com.", "a.example.com.", dns.TypeSOA, dns.TypeNS, dns.TypeRRSIG, dns.TypeNSEC),
+		nsecRecord("a.example.com.", "c.example.com.", dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC),
+		nsecRecord("c.example.com.", "example.com.", dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC),
+	}
+	prepared := make([]PreparedNSEC, 0, len(records))
+	for _, rr := range records {
+		p, err := PrepareAggressiveNSEC(rr)
+		if err != nil {
+			t.Fatal(err)
+		}
+		prepared = append(prepared, p)
+	}
+	set, err := NewAggressiveNSECSet(prepared, zone)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	q := dns.Question{Name: "b.example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	fromPrepared := testing.AllocsPerRun(200, func() {
+		if _, err := EvaluateAggressiveNSECPrepared(q, zone, prepared); err != nil {
+			t.Fatal(err)
+		}
+	})
+	fromSet := testing.AllocsPerRun(200, func() {
+		if _, err := EvaluateAggressiveNSECSet(q, set); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if fromSet >= fromPrepared {
+		t.Fatalf("set evaluation allocates %.0f, per-query path %.0f; "+
+			"the stored validation is not actually being reused", fromSet, fromPrepared)
+	}
+	t.Logf("allocations per evaluation: prepared=%.0f set=%.0f", fromPrepared, fromSet)
+}


### PR DESCRIPTION
One residual from the load-test allocation profile (43.3GB cumulative over 28.9M queries; NXDOMAIN-heavy mix). **Scope note:** the pooled byte-path body commit was removed after review caught a real ownership bug — the base responseWriter retains the written body for lazy post-write `Msg()`, so a pool release at WriteWire-return corrupts across requests. Pooling returns in a follow-up with the lease held until chain reset.

## Aggressive NSEC set validated once at publish

`aggressiveNSECEntriesFromPrepared` was the **single largest allocator in the process — 4.61GB, 10.6% of all allocated bytes** — because every negative answer served through the denial-proof cache rebuilt the zone's entry table just to re-run set-level checks (class homogeneity, signer containment, interval conflicts) that are static properties of the published set. Large zones (root: ~70+ NSEC entries) made each rebuild ~6KB. Its sibling `denialProofSelectedEntries` built two maps per query for the same reason (**1.91GB, 4.4%**).

- `AggressiveNSECSet` carries the validation outcome from snapshot publish; a lookup that finds nothing expired evaluates the stored table directly. An expired subset or a never-validated set takes the old per-query path unchanged.
- The record→entry selection index is built with the snapshot (only when the set validated); the duplicate filter scans the handful it selected instead of allocating a set.
- **Parity pinned test-by-test**: construction-time refusals are asserted to be the same refusals the per-query path produces; the one route difference (class, checked against the query at evaluation) reaches the same verdict and is tested as such. Existing prepared-vs-records equivalence corpus reused.

Reviewer-measured: 32-record NSEC lookup **7400 → 696 B/op, 22 → 12 allocs/op**.

Full suite with `-race` green, lint clean.