### PR TITLE
cache: unlock the wire failure rung with a rung-time miss witness

### DIFF
--- a/middleware/cache/aggressive_negative_integration_test.go
+++ b/middleware/cache/aggressive_negative_integration_test.go
@@ -287,7 +287,7 @@ func TestAggressiveNegativeIntegrationNODATAAndNXDOMAIN(t *testing.T) {
 		}
 
 		probe := aggressiveNegativeRequest(aggressiveNegativeOwner, dns.TypeMX, true)
-		cache.store.RecordFailure(probe, netip.Prefix{}, FailureProvenance("test"))
+		cache.store.RecordFailure(probe, netip.Prefix{}, FailureProvenance("test"), nil)
 		got := aggressiveNegativeExchange(t, context.Background(), cache, downstream, probe)
 		assertAggressiveNegativeProof(t, got, probe, dns.RcodeSuccess, dns.TypeNSEC)
 		if calls != 1 {

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -1074,14 +1074,20 @@ func (c *Cache) serveCompositeFromWire(ctx context.Context, ch *middleware.Chain
 		if cut, ok := c.store.LookupNXDomainCutWire(req.WireName(), req.Qclass()); ok {
 			return c.serveCutHitFromWire(ctx, ch, cut)
 		}
-		if !c.store.DenialProofsIdle() {
-			// A shared denial answer may exist; RFC 8198 evaluation stays
-			// on the Msg path until its evaluators are allocation-free.
-			return false
-		}
 	}
-	if _, ok := c.store.LookupFailureWire(req.WireName(), req.Qtype(), req.Qclass(), cd); ok {
-		return c.serveFailureFromWire(ch)
+	if hit, ok := c.store.LookupFailureWire(req.WireName(), req.Qtype(), req.Qclass(), cd); ok {
+		// The Msg ladder consults RFC 8198 denial before RFC 9520 failure
+		// state, and this rung preserves that order without evaluating
+		// anything: the failure entry carries a record-time proof that
+		// denial missed (the miss witness), and the serve happens only
+		// while that proof demonstrably still holds for this name. Any
+		// doubt — a replaced snapshot, a newly cached zone on the path, a
+		// pre-witness entry — falls to the Msg path, whose evaluators
+		// decide; the client's answer is identical either way. CD skips
+		// shared denial on the Msg path too, so it serves directly.
+		if cd || c.store.DenialMissHoldsWire(req.WireName(), req.Qclass(), hit) {
+			return c.serveFailureFromWire(ch)
+		}
 	}
 	return false
 }

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -534,6 +534,25 @@ func (c *Cache) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		dedupKey = retryKey
 		failureProbe = true
 	}
+	// This is the moment the miss witness describes: the denial rung just
+	// ran for this question and found nothing. Captured here — not when a
+	// failure is eventually recorded, seconds of timeouts later — so a
+	// proof admitted during the failing resolution can never be pinned as
+	// evidence of its own absence. Nil when the tree bypassed the rung.
+	//
+	// One accepted residual: the rung and this capture take the read lock
+	// separately, so an admission landing in the microseconds between
+	// them can be pinned although the rung never saw it. The wire path
+	// then keeps serving the RFC 9520 failure where a Msg evaluation
+	// would synthesize from the fresh proof — an RFC-legal answer (8198
+	// is SHOULD-level), bounded by the failure TTL, in a window the
+	// width of two lock acquisitions. Closing it means threading the
+	// rung's own candidate set through an exported lookup signature;
+	// not worth that surface.
+	var denialMissWitness []denialWitnessPair
+	if !requestTreeBypassesSharedDenial {
+		denialMissWitness = c.store.failureMissWitness(q.Name, q.Qclass)
+	}
 	c.metrics.Miss()
 	if clientScope.IsValid() {
 		ecsLookupMiss.Inc()
@@ -708,6 +727,7 @@ func (c *Cache) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	rw.requestCD = requestCD
 	rw.requestHasECS = requestHasECS
 	rw.requestTreeBypassesSharedDenial = requestTreeBypassesSharedDenial
+	rw.denialMissWitness = denialMissWitness
 	// Stash the client's request scope so WriteMsg can derive
 	// the insert key without re-reading the OPT (which by then
 	// may have been mutated by the edns wrapper on the response).
@@ -722,6 +742,7 @@ func (c *Cache) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		rw.requestCD = false
 		rw.requestHasECS = false
 		rw.requestTreeBypassesSharedDenial = false
+		rw.denialMissWitness = nil
 		rw.meta = nil
 		c.writerPool.Put(rw)
 	}()
@@ -1080,12 +1101,17 @@ func (c *Cache) serveCompositeFromWire(ctx context.Context, ch *middleware.Chain
 		// state, and this rung preserves that order without evaluating
 		// anything: the failure entry carries a record-time proof that
 		// denial missed (the miss witness), and the serve happens only
-		// while that proof demonstrably still holds for this name. Any
+		// while that proof demonstrably still holds. The proof names one
+		// question — witness serving is therefore restricted to
+		// question-kind hits, where the lookup and the record coincide in
+		// name, type, class and CD; a zone-kind hit answers names the
+		// record never proved anything about, so it materializes. Any
 		// doubt — a replaced snapshot, a newly cached zone on the path, a
 		// pre-witness entry — falls to the Msg path, whose evaluators
 		// decide; the client's answer is identical either way. CD skips
 		// shared denial on the Msg path too, so it serves directly.
-		if cd || c.store.DenialMissHoldsWire(req.WireName(), req.Qclass(), hit) {
+		if cd || ((hit.Kind == FailureKindQuestion || c.store.sharedDenialImpossible()) &&
+			c.store.DenialMissHoldsWire(req.WireName(), req.Qclass(), hit)) {
 			return c.serveFailureFromWire(ch)
 		}
 	}
@@ -1457,7 +1483,8 @@ func (c *Cache) Set(key uint64, msg *dns.Msg) {
 	filtered := filterCacheableAnswer(msg)
 	mt, _ := dnsutil.ClassifyResponse(filtered, time.Now().UTC())
 	if mt == dnsutil.TypeServerFailure {
-		c.store.RecordFailure(filtered, netip.Prefix{}, FailureProvenance("response"))
+		// A compatibility Set runs no ladder, so it can vouch for no miss.
+		c.store.RecordFailure(filtered, netip.Prefix{}, FailureProvenance("response"), nil)
 		return
 	}
 	msgTTL := dnsutil.CalculateCacheTTL(filtered, mt)
@@ -1521,6 +1548,10 @@ type ResponseWriter struct {
 	// — that's how pre-Stage-2 traffic and SCOPE=0 responses keep
 	// the same cache shape they had before.
 	clientScope netip.Prefix
+	// denialMissWitness is the miss witness captured at the denial rung
+	// (see denial_proof_witness.go), carried to the failure record a
+	// SERVFAIL write-back files. Nil when the tree bypassed the rung.
+	denialMissWitness []denialWitnessPair
 	// Immutable snapshots captured before downstream middleware can mutate
 	// the request. Shared authenticated-denial state is never published from
 	// checking-disabled or audience-scoped traffic.
@@ -1566,7 +1597,7 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 			out = w.recursionWorkFailure(res)
 		}
 		if cacheableResolutionFailure(ctx, out) {
-			w.cache.store.RecordFailure(out, w.clientScope, FailureProvenance("response"))
+			w.cache.store.RecordFailure(out, w.clientScope, FailureProvenance("response"), w.denialMissWitness)
 		}
 		return w.ResponseWriter.WriteMsg(out)
 	}
@@ -1587,7 +1618,7 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 			out = w.recursionWorkFailure(res)
 		}
 		if cacheableResolutionFailure(ctx, out) {
-			w.cache.store.RecordFailure(out, w.clientScope, FailureProvenance("response"))
+			w.cache.store.RecordFailure(out, w.clientScope, FailureProvenance("response"), w.denialMissWitness)
 		}
 		return w.ResponseWriter.WriteMsg(out)
 	}

--- a/middleware/cache/composite_wire_test.go
+++ b/middleware/cache/composite_wire_test.go
@@ -184,8 +184,8 @@ func TestFailureCacheLookupWireParity(t *testing.T) {
 	qKey := FailureQuestionKey{
 		Question: dns.Question{Name: "down.test.", Qtype: dns.TypeA, Qclass: dns.ClassINET},
 	}
-	c.RecordQuestion(qKey, FailureProvenance("response"))
-	c.RecordZone(FailureZoneKey{Zone: "lame.test.", Qclass: dns.ClassINET}, FailureProvenance("authority"))
+	c.RecordQuestion(qKey, FailureProvenance("response"), nil)
+	c.RecordZone(FailureZoneKey{Zone: "lame.test.", Qclass: dns.ClassINET}, FailureProvenance("authority"), nil)
 
 	// Exact question, spelled differently.
 	reqExact, _ := wireTestRequest(t, "DOWN.test.", dns.TypeA, false)

--- a/middleware/cache/denial_proof_cache.go
+++ b/middleware/cache/denial_proof_cache.go
@@ -951,9 +951,21 @@ func (c *denialProofCache) publishZoneLocked(key denialProofZoneKey) {
 		// zone's snapshot: under a hash collision the slot may belong to
 		// the other zone, and deleting it would make a cached zone
 		// invisible to the wire walk — the one direction the witness
-		// design cannot tolerate.
+		// design cannot tolerate. The same direction opens when this
+		// zone owned a contested slot: after the delete, any surviving
+		// zone that hashes to it must be restored, or it stays invisible
+		// until its own next republish. The rescan is O(zones) on the
+		// rare zone-emptying path, and which claimant wins is
+		// irrelevant — readers verify name and pointer, so a wrong
+		// claimant only sends a query to the Msg path.
 		if hash := denialZoneHash(key.zone, key.qclass); c.zoneWireIndex[hash] == c.zoneIndex[key] {
 			delete(c.zoneWireIndex, hash)
+			for other, snapshot := range c.zoneIndex {
+				if other != key && denialZoneHash(other.zone, other.qclass) == hash {
+					c.zoneWireIndex[hash] = snapshot
+					break
+				}
+			}
 		}
 		delete(c.zoneIndex, key)
 		delete(c.zoneEntries, key)

--- a/middleware/cache/denial_proof_cache.go
+++ b/middleware/cache/denial_proof_cache.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/miekg/dns"
@@ -23,15 +22,6 @@ const (
 	maxDenialProofTTL         = 3 * time.Hour
 	maxDenialProofNSEC3Groups = 2
 )
-
-// entryCount is the lock-free mirror of len(byID), for the wire path's
-// emptiness gate.
-func (c *denialProofCache) entryCount() int64 {
-	if c == nil {
-		return 0
-	}
-	return c.count.Load()
-}
 
 type denialProofKind uint8
 
@@ -134,6 +124,13 @@ type denialProofCache struct {
 	mu sync.RWMutex
 
 	zoneIndex map[denialProofZoneKey]*denialProofZoneSnapshot
+	// zoneWireIndex mirrors zoneIndex under the canonical wire-probeable
+	// hash (see denialZoneHash), so a wire-born suffix walk can find the
+	// zones that could deny a name without building a string per label.
+	// A hash collision is at worst a spurious pointer mismatch — the
+	// reader compares snapshot identity, so a collision can only send a
+	// query to the Msg path, never fabricate a witness match.
+	zoneWireIndex map[uint64]*denialProofZoneSnapshot
 	// zoneEntries is the writer's own index of what each zone holds. It is
 	// never published, so it can be mutated in place: a snapshot used to
 	// carry this map too, which meant admitting or evicting one entry
@@ -151,10 +148,7 @@ type denialProofCache struct {
 
 	totalBytes int64
 	sequence   uint64
-	// count mirrors len(byID) for lock-free emptiness checks on the wire
-	// path; maintained under the write lock at every byID mutation.
-	count   atomic.Int64
-	stopped bool
+	stopped    bool
 
 	// A locally validated tuple that presents two different RDATA values at
 	// one owner hash is ambiguous until both observations expire. Tombstones
@@ -217,6 +211,7 @@ func newDenialProofCacheWithConfig(cfg denialProofCacheConfig) *denialProofCache
 
 	return &denialProofCache{
 		zoneIndex:         make(map[denialProofZoneKey]*denialProofZoneSnapshot),
+		zoneWireIndex:     make(map[uint64]*denialProofZoneSnapshot),
 		zoneEntries:       make(map[denialProofZoneKey]map[denialProofID]*denialProofEntry),
 		byID:              make(map[denialProofID]*denialProofEntry),
 		maxEntries:        cfg.MaxEntries,
@@ -379,7 +374,6 @@ func (c *denialProofCache) recordWithKind(
 		entry.sequence = c.sequence
 		entry.queue = c.fifo.PushBack(entry)
 		c.byID[entry.id] = entry
-		c.count.Store(int64(len(c.byID)))
 		c.totalBytes += entry.wireBytes
 
 		c.zoneEntriesLocked(entry.zoneKey)[entry.id] = entry
@@ -953,6 +947,14 @@ func (c *denialProofCache) zoneEntriesLocked(
 func (c *denialProofCache) publishZoneLocked(key denialProofZoneKey) {
 	entries := c.zoneEntries[key]
 	if len(entries) == 0 {
+		// The wire slot is removed only when it still points at this
+		// zone's snapshot: under a hash collision the slot may belong to
+		// the other zone, and deleting it would make a cached zone
+		// invisible to the wire walk — the one direction the witness
+		// design cannot tolerate.
+		if hash := denialZoneHash(key.zone, key.qclass); c.zoneWireIndex[hash] == c.zoneIndex[key] {
+			delete(c.zoneWireIndex, hash)
+		}
 		delete(c.zoneIndex, key)
 		delete(c.zoneEntries, key)
 		return
@@ -1053,6 +1055,7 @@ func (c *denialProofCache) publishZoneLocked(key denialProofZoneKey) {
 		return left.salt < right.salt
 	})
 	c.zoneIndex[key] = snapshot
+	c.zoneWireIndex[denialZoneHash(key.zone, key.qclass)] = snapshot
 }
 
 // denialProofNameOrder is a name's canonical comparison form, derived exactly
@@ -1142,7 +1145,6 @@ func (c *denialProofCache) detachEntryLocked(entry *denialProofEntry) bool {
 		return false
 	}
 	delete(c.byID, entry.id)
-	c.count.Store(int64(len(c.byID)))
 	if entry.queue != nil {
 		c.fifo.Remove(entry.queue)
 	}
@@ -1741,6 +1743,7 @@ func (c *denialProofCache) stop() {
 	c.mu.Lock()
 	c.stopped = true
 	c.zoneIndex = make(map[denialProofZoneKey]*denialProofZoneSnapshot)
+	c.zoneWireIndex = make(map[uint64]*denialProofZoneSnapshot)
 	c.zoneEntries = make(map[denialProofZoneKey]map[denialProofID]*denialProofEntry)
 	c.byID = make(map[denialProofID]*denialProofEntry)
 	c.nsec3Conflicts = make(map[denialProofNSEC3ConflictKey]time.Time)

--- a/middleware/cache/denial_proof_witness.go
+++ b/middleware/cache/denial_proof_witness.go
@@ -46,9 +46,16 @@ type denialWitnessPair struct {
 	snapshot *denialProofZoneSnapshot
 }
 
-// missWitness captures the denial zones on qname's ancestor path at
-// failure-record time. A nil result means no cached zone could deny the
-// name — the cheapest witness of all.
+// missWitness captures the denial zones on qname's ancestor path the
+// moment the denial rung misses. A nil result means no on-path zone was
+// cached — a state the wire gate can re-establish for itself at lookup
+// time, so nil is not a weaker witness, just a cheaper one.
+//
+// A path that crosses a zone holding NSEC3 state yields no witness at
+// all: NSEC3 evaluation draws on the shared DNSSEC crypto budget, so its
+// miss can be starvation rather than absence, and a witness must never
+// freeze a starved verdict into servable state. NSEC evaluation takes no
+// budget; only NSEC-backed paths are witnessable.
 func (c *denialProofCache) missWitness(qname string, qclass uint16) []denialWitnessPair {
 	if c == nil {
 		return nil
@@ -59,13 +66,19 @@ func (c *denialProofCache) missWitness(qname string, qclass uint16) []denialWitn
 	if !c.stopped && len(c.zoneIndex) > 0 {
 		for _, zone := range denialProofAncestors(qname, ancestorStorage[:0]) {
 			key := denialProofZoneKey{zone: zone, qclass: qclass}
-			if snapshot := c.zoneIndex[key]; snapshot != nil {
-				witness = append(witness, denialWitnessPair{
-					hash:     denialZoneHash(zone, qclass),
-					zone:     zone,
-					snapshot: snapshot,
-				})
+			snapshot := c.zoneIndex[key]
+			if snapshot == nil {
+				continue
 			}
+			if len(snapshot.nsec3) > 0 {
+				witness = nil
+				break
+			}
+			witness = append(witness, denialWitnessPair{
+				hash:     denialZoneHash(zone, qclass),
+				zone:     zone,
+				snapshot: snapshot,
+			})
 		}
 	}
 	c.mu.RUnlock()

--- a/middleware/cache/denial_proof_witness.go
+++ b/middleware/cache/denial_proof_witness.go
@@ -1,0 +1,117 @@
+package cache
+
+import (
+	"github.com/miekg/dns"
+	internalcache "github.com/semihalev/sdns/internal/cache"
+)
+
+// The miss witness: RFC 9520 failure state exists only because a real
+// resolution was attempted, and the Msg ladder attempts resolution only
+// after RFC 8198 aggressive denial missed — so at the moment a failure is
+// recorded, denial provably does not apply to that name. The witness
+// captures that proof as the (zone hash, snapshot pointer) pairs of every
+// cached denial zone on the name's ancestor path. The wire path may serve
+// the failure without materializing exactly while the witness still
+// holds: every denial zone on the lookup name's path is pointer-identical
+// to what the record saw. A replaced snapshot, a newly admitted zone, or
+// a missing witness sends the query to the Msg path, which re-evaluates —
+// the answer a client receives is therefore identical on both paths by
+// construction; only where it is composed differs.
+//
+// The RFC grounding, for the reviewer: RFC 8198 is SHOULD-level and its
+// Appendix B discards parent-zone NSECs below a delegation, so aggressive
+// denial for a name is answerable only from the name's cached ancestor
+// zones — the exact set the witness pins. RFC 9520 §3.2 constrains
+// outgoing queries, not cache-lookup order, and leaves precedence between
+// failure state and other cached data open.
+
+// denialZoneHashSalt separates the denial cache's private wire index from
+// every other user of the canonical question hash.
+const denialZoneHashSalt = 0x8198f00dd1a70b3c
+
+// denialZoneHash is the canonical hash of a denial zone identity —
+// bit-identical whether computed from the presentation name (publish
+// time) or wire bytes (lookup time, via KeyWire with a zero qtype).
+func denialZoneHash(zone string, qclass uint16) uint64 {
+	q := dns.Question{Name: zone, Qtype: 0, Qclass: qclass}
+	return internalcache.Key(q, false) ^ denialZoneHashSalt
+}
+
+// denialWitnessPair is one cached denial zone as the failure record saw
+// it. The pointer is compared for identity only, never dereferenced —
+// the snapshot's content is irrelevant, its replacement is the signal.
+type denialWitnessPair struct {
+	hash     uint64
+	zone     string
+	snapshot *denialProofZoneSnapshot
+}
+
+// missWitness captures the denial zones on qname's ancestor path at
+// failure-record time. A nil result means no cached zone could deny the
+// name — the cheapest witness of all.
+func (c *denialProofCache) missWitness(qname string, qclass uint16) []denialWitnessPair {
+	if c == nil {
+		return nil
+	}
+	var ancestorStorage [12]string
+	var witness []denialWitnessPair
+	c.mu.RLock()
+	if !c.stopped && len(c.zoneIndex) > 0 {
+		for _, zone := range denialProofAncestors(qname, ancestorStorage[:0]) {
+			key := denialProofZoneKey{zone: zone, qclass: qclass}
+			if snapshot := c.zoneIndex[key]; snapshot != nil {
+				witness = append(witness, denialWitnessPair{
+					hash:     denialZoneHash(zone, qclass),
+					zone:     zone,
+					snapshot: snapshot,
+				})
+			}
+		}
+	}
+	c.mu.RUnlock()
+	return witness
+}
+
+// missWitnessHoldsWire reports whether aggressive denial still provably
+// misses the wire-born name: every cached denial zone on its suffix path
+// must be pointer-identical to the witness. No on-path zones at all is a
+// hold with any witness, the empty one included — with no candidate
+// zones, the Msg evaluator has nothing to evaluate.
+func (c *denialProofCache) missWitnessHoldsWire(
+	name []byte,
+	qclass uint16,
+	witness []denialWitnessPair,
+) bool {
+	if c == nil {
+		return true
+	}
+	holds := true
+	c.mu.RLock()
+	if c.stopped {
+		c.mu.RUnlock()
+		return false
+	}
+	if len(c.zoneWireIndex) > 0 {
+		walkWireSuffixes(name, func(zone []byte) bool {
+			hash, ok := internalcache.KeyWire(zone, 0, qclass, false)
+			if !ok {
+				holds = false
+				return false
+			}
+			snapshot := c.zoneWireIndex[hash^denialZoneHashSalt]
+			if snapshot == nil {
+				return true
+			}
+			for _, w := range witness {
+				if w.hash == hash^denialZoneHashSalt && w.snapshot == snapshot &&
+					internalcache.WireNameEqualsPresentation(zone, w.zone) {
+					return true
+				}
+			}
+			holds = false
+			return false
+		})
+	}
+	c.mu.RUnlock()
+	return holds
+}

--- a/middleware/cache/failure_cache.go
+++ b/middleware/cache/failure_cache.go
@@ -488,6 +488,13 @@ func (c *FailureCache) record(hash uint64, candidate *failureEntry) FailureHit {
 			next.streak++
 		}
 		next.provenance = candidate.provenance
+		// A renewal is itself a record-time proof: this generation exists
+		// because a fresh resolution just failed, so the candidate's
+		// witness supersedes the one from the entry's birth. Keeping the
+		// original would pin its replaced snapshots for the entry's whole
+		// backoff life and fail the pointer check forever after the first
+		// on-path admission.
+		next.witness = candidate.witness
 		next.retryAfter = now.Add(c.backoff(next.streak))
 		if c.entries.CompareAndSwap(hash, current, &next) {
 			return next.hit()

--- a/middleware/cache/failure_cache.go
+++ b/middleware/cache/failure_cache.go
@@ -77,6 +77,7 @@ type FailureHit struct {
 	RetryAfter time.Time
 	Question   FailureQuestionKey
 	Zone       FailureZoneKey
+	witness    []denialWitnessPair
 }
 
 // Response builds a clean SERVFAIL response for a cached failure. EDE 13 is
@@ -125,6 +126,11 @@ type failureEntry struct {
 	retryAfter time.Time
 	question   FailureQuestionKey
 	zone       FailureZoneKey
+	// witness is the denial-zone state the record-time qname saw (see
+	// denial_proof_witness.go): resolution was attempted, so aggressive
+	// denial provably missed — the wire path may serve this failure
+	// without materializing while the witness still holds.
+	witness []denialWitnessPair
 }
 
 func (e *failureEntry) hit() FailureHit {
@@ -135,6 +141,7 @@ func (e *failureEntry) hit() FailureHit {
 		RetryAfter: e.retryAfter,
 		Question:   e.question,
 		Zone:       e.zone,
+		witness:    e.witness,
 	}
 }
 
@@ -331,26 +338,28 @@ func (c *FailureCache) RetryKey(key FailureQuestionKey) (uint64, bool) {
 // RecordQuestion records an exact failure. Repeated calls during an active
 // generation are idempotent. After expiry, concurrent recorders advance the
 // streak exactly once.
-func (c *FailureCache) RecordQuestion(key FailureQuestionKey, provenance FailureProvenance) FailureHit {
+func (c *FailureCache) RecordQuestion(key FailureQuestionKey, provenance FailureProvenance, witness []denialWitnessPair) FailureHit {
 	key = normalizeFailureQuestionKey(key)
 	hash := failureQuestionHash(key)
 	return c.record(hash, &failureEntry{
 		kind:       FailureKindQuestion,
 		provenance: provenance,
 		question:   key,
+		witness:    witness,
 	})
 }
 
 // RecordZone records a zone-wide reachability failure. Repeated calls during
 // an active generation are idempotent. Zone failures are not partitioned by CD
 // or ECS because authority transport reachability is shared.
-func (c *FailureCache) RecordZone(key FailureZoneKey, provenance FailureProvenance) FailureHit {
+func (c *FailureCache) RecordZone(key FailureZoneKey, provenance FailureProvenance, witness []denialWitnessPair) FailureHit {
 	key = normalizeFailureZoneKey(key)
 	hash := failureZoneHash(key)
 	return c.record(hash, &failureEntry{
 		kind:       FailureKindZone,
 		provenance: provenance,
 		zone:       key,
+		witness:    witness,
 	})
 }
 

--- a/middleware/cache/failure_cache_integration_test.go
+++ b/middleware/cache/failure_cache_integration_test.go
@@ -731,7 +731,7 @@ func TestFailureCacheScopedSuccessDoesNotResetGlobalAudience(t *testing.T) {
 
 	req := new(dns.Msg)
 	req.SetQuestion("geo.example.", dns.TypeA)
-	c.store.RecordFailure(req, netip.Prefix{}, FailureProvenance("global"))
+	c.store.RecordFailure(req, netip.Prefix{}, FailureProvenance("global"), nil)
 
 	scope := netip.MustParsePrefix("192.0.2.0/24")
 	scoped := new(dns.Msg)

--- a/middleware/cache/failure_cache_test.go
+++ b/middleware/cache/failure_cache_test.go
@@ -137,7 +137,7 @@ func TestFailureCacheBackoffExpiryAndCap(t *testing.T) {
 	}
 
 	for i, want := range wants {
-		hit := cache.RecordQuestion(key, FailureProvenance("transport"))
+		hit := cache.RecordQuestion(key, FailureProvenance("transport"), nil)
 		if hit.Streak != uint32(i+1) {
 			t.Fatalf("generation %d streak = %d, want %d", i+1, hit.Streak, i+1)
 		}
@@ -178,7 +178,7 @@ func TestFailureCacheInjectableBackoffBounds(t *testing.T) {
 
 	key := failureQuestion("www.example.", dns.TypeA)
 	for generation, want := range []time.Duration{2 * time.Second, 4 * time.Second, 7 * time.Second, 7 * time.Second} {
-		hit := cache.RecordQuestion(key, "timeout")
+		hit := cache.RecordQuestion(key, "timeout", nil)
 		if got := hit.RetryAfter.Sub(clock.Now()); got != want {
 			t.Fatalf("generation %d backoff = %v, want %v", generation+1, got, want)
 		}
@@ -191,9 +191,9 @@ func TestFailureCacheActiveDuplicateIsIdempotent(t *testing.T) {
 	cache := newFailureTestCache(t, 8, clock)
 	key := failureQuestion("www.example.", dns.TypeA)
 
-	first := cache.RecordQuestion(key, "first")
+	first := cache.RecordQuestion(key, "first", nil)
 	clock.Advance(time.Second)
-	duplicate := cache.RecordQuestion(key, "duplicate")
+	duplicate := cache.RecordQuestion(key, "duplicate", nil)
 	if duplicate.Streak != 1 {
 		t.Fatalf("duplicate streak = %d, want 1", duplicate.Streak)
 	}
@@ -205,8 +205,8 @@ func TestFailureCacheActiveDuplicateIsIdempotent(t *testing.T) {
 	}
 
 	zone := FailureZoneKey{Zone: "example.", Qclass: dns.ClassINET}
-	zoneFirst := cache.RecordZone(zone, "zone-first")
-	zoneDuplicate := cache.RecordZone(zone, "zone-duplicate")
+	zoneFirst := cache.RecordZone(zone, "zone-first", nil)
+	zoneDuplicate := cache.RecordZone(zone, "zone-duplicate", nil)
 	if zoneDuplicate.Streak != 1 || !zoneDuplicate.RetryAfter.Equal(zoneFirst.RetryAfter) {
 		t.Fatalf("zone duplicate = %#v, want unchanged first generation", zoneDuplicate)
 	}
@@ -217,15 +217,15 @@ func TestFailureCacheLongRecoveryResetsStreak(t *testing.T) {
 	cache := newFailureTestCache(t, 8, clock)
 	key := failureQuestion("www.example.", dns.TypeA)
 
-	first := cache.RecordQuestion(key, "first")
+	first := cache.RecordQuestion(key, "first", nil)
 	clock.Advance(first.RetryAfter.Sub(clock.Now()))
-	second := cache.RecordQuestion(key, "second")
+	second := cache.RecordQuestion(key, "second", nil)
 	if second.Streak != 2 {
 		t.Fatalf("second generation streak = %d, want 2", second.Streak)
 	}
 
 	clock.Advance(second.RetryAfter.Sub(clock.Now()) + cache.maxTTL)
-	restarted := cache.RecordQuestion(key, "after-recovery")
+	restarted := cache.RecordQuestion(key, "after-recovery", nil)
 	if restarted.Streak != 1 {
 		t.Fatalf("streak after long recovery = %d, want 1", restarted.Streak)
 	}
@@ -253,7 +253,7 @@ func TestFailureCacheConcurrentRecordAdvancesOnce(t *testing.T) {
 			go func() {
 				defer wg.Done()
 				<-start
-				results <- cache.RecordQuestion(key, "timeout")
+				results <- cache.RecordQuestion(key, "timeout", nil)
 			}()
 		}
 		close(start)
@@ -280,7 +280,7 @@ func TestFailureCacheConcurrentZoneRecordAdvancesOnce(t *testing.T) {
 	clock := newFailureFakeClock()
 	cache := newFailureTestCache(t, 32, clock)
 	key := FailureZoneKey{Zone: "example.", Qclass: dns.ClassINET}
-	cache.RecordZone(key, "timeout")
+	cache.RecordZone(key, "timeout", nil)
 	clock.Advance(5 * time.Second)
 
 	const goroutines = 64
@@ -291,7 +291,7 @@ func TestFailureCacheConcurrentZoneRecordAdvancesOnce(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			<-start
-			hit := cache.RecordZone(key, "timeout")
+			hit := cache.RecordZone(key, "timeout", nil)
 			if hit.Streak != 2 {
 				t.Errorf("concurrent RecordZone() streak = %d, want 2", hit.Streak)
 			}
@@ -310,7 +310,7 @@ func TestFailureCacheQuestionKeyIsolation(t *testing.T) {
 	clock := newFailureFakeClock()
 	cache := newFailureTestCache(t, 32, clock)
 	global := failureQuestion("WWW.Example", dns.TypeA)
-	cache.RecordQuestion(global, "global")
+	cache.RecordQuestion(global, "global", nil)
 
 	canonical := failureQuestion("www.example.", dns.TypeA)
 	if _, ok := cache.Lookup(canonical); !ok {
@@ -331,7 +331,7 @@ func TestFailureCacheQuestionKeyIsolation(t *testing.T) {
 
 	scoped := canonical
 	scoped.Scope = netip.MustParsePrefix("192.0.2.129/24")
-	cache.RecordQuestion(scoped, "scoped")
+	cache.RecordQuestion(scoped, "scoped", nil)
 	equivalentScope := canonical
 	equivalentScope.Scope = netip.MustParsePrefix("192.0.2.1/24")
 	if hit, ok := cache.Lookup(equivalentScope); !ok || hit.Provenance != "scoped" {
@@ -353,8 +353,8 @@ func TestFailureCacheQuestionKeyIsolation(t *testing.T) {
 func TestFailureCacheZoneClosestAncestorAndSharedReachability(t *testing.T) {
 	clock := newFailureFakeClock()
 	cache := newFailureTestCache(t, 32, clock)
-	cache.RecordZone(FailureZoneKey{Zone: "EXAMPLE", Qclass: dns.ClassINET}, "parent")
-	cache.RecordZone(FailureZoneKey{Zone: "Sub.Example.", Qclass: dns.ClassINET}, "child")
+	cache.RecordZone(FailureZoneKey{Zone: "EXAMPLE", Qclass: dns.ClassINET}, "parent", nil)
+	cache.RecordZone(FailureZoneKey{Zone: "Sub.Example.", Qclass: dns.ClassINET}, "child", nil)
 
 	tests := []struct {
 		name string
@@ -420,9 +420,9 @@ func TestFailureCacheRetryKeyGroupsExpiredZoneDescendants(t *testing.T) {
 	child := FailureZoneKey{Zone: "sub.example.", Qclass: dns.ClassINET}
 	parent := FailureZoneKey{Zone: "example.", Qclass: dns.ClassINET}
 
-	cache.RecordZone(child, "child")
+	cache.RecordZone(child, "child", nil)
 	clock.Advance(4 * time.Second)
-	cache.RecordZone(parent, "parent")
+	cache.RecordZone(parent, "parent", nil)
 	clock.Advance(time.Second)
 
 	queryOne := failureQuestion("r1.sub.example.", dns.TypeA)
@@ -451,8 +451,8 @@ func TestFailureCacheRetryKeyGroupsExpiredZoneDescendants(t *testing.T) {
 		t.Fatalf("zone retry key = %x, want closest ancestor key %x", keyOne, want)
 	}
 
-	cache.RecordQuestion(queryOne, "exact-one")
-	cache.RecordQuestion(queryTwo, "exact-two")
+	cache.RecordQuestion(queryOne, "exact-one", nil)
+	cache.RecordQuestion(queryTwo, "exact-two", nil)
 	clock.Advance(5 * time.Second)
 	groupedOne, ok := cache.RetryKey(queryOne)
 	if !ok {
@@ -483,12 +483,12 @@ func TestFailureCacheResetAndResetMatching(t *testing.T) {
 	clock := newFailureFakeClock()
 	cache := newFailureTestCache(t, 32, clock)
 	key := failureQuestion("www.sub.example.", dns.TypeA)
-	cache.RecordQuestion(key, "exact")
-	cache.RecordZone(FailureZoneKey{Zone: "sub.example.", Qclass: dns.ClassINET}, "child")
-	cache.RecordZone(FailureZoneKey{Zone: "example.", Qclass: dns.ClassINET}, "parent")
-	cache.RecordZone(FailureZoneKey{Zone: ".", Qclass: dns.ClassINET}, "root")
+	cache.RecordQuestion(key, "exact", nil)
+	cache.RecordZone(FailureZoneKey{Zone: "sub.example.", Qclass: dns.ClassINET}, "child", nil)
+	cache.RecordZone(FailureZoneKey{Zone: "example.", Qclass: dns.ClassINET}, "parent", nil)
+	cache.RecordZone(FailureZoneKey{Zone: ".", Qclass: dns.ClassINET}, "root", nil)
 	unrelated := failureQuestion("www.other.", dns.TypeA)
-	cache.RecordQuestion(unrelated, "unrelated")
+	cache.RecordQuestion(unrelated, "unrelated", nil)
 
 	if removed := cache.ResetMatching(key); removed != 4 {
 		t.Fatalf("ResetMatching() removed %d states, want 4", removed)
@@ -499,7 +499,7 @@ func TestFailureCacheResetAndResetMatching(t *testing.T) {
 	if hit, ok := cache.Lookup(unrelated); !ok || hit.Provenance != "unrelated" {
 		t.Fatalf("ResetMatching removed unrelated exact state: %#v, %v", hit, ok)
 	}
-	restarted := cache.RecordQuestion(key, "recovered-then-failed")
+	restarted := cache.RecordQuestion(key, "recovered-then-failed", nil)
 	if restarted.Streak != 1 {
 		t.Fatalf("record after reset streak = %d, want 1", restarted.Streak)
 	}
@@ -569,11 +569,11 @@ func TestFailureCacheBounded(t *testing.T) {
 	cache := newFailureTestCache(t, size, clock)
 
 	for i := range 500 {
-		cache.RecordQuestion(failureQuestion(fmt.Sprintf("q-%d.example.", i), dns.TypeA), "exact")
+		cache.RecordQuestion(failureQuestion(fmt.Sprintf("q-%d.example.", i), dns.TypeA), "exact", nil)
 		cache.RecordZone(FailureZoneKey{
 			Zone:   fmt.Sprintf("z-%d.example.", i),
 			Qclass: dns.ClassINET,
-		}, "zone")
+		}, "zone", nil)
 		if got := cache.Len(); got > size {
 			t.Fatalf("failure cache grew to %d entries, limit %d", got, size)
 		}

--- a/middleware/cache/failure_witness_wire_test.go
+++ b/middleware/cache/failure_witness_wire_test.go
@@ -1,0 +1,166 @@
+package cache
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/middleware"
+	"github.com/semihalev/sdns/middleware/edns"
+)
+
+// witnessTestProof admits one validated NSEC proof for zone, giving the
+// denial index the warm shape production always has.
+func witnessTestProof(t *testing.T, s *Store, zone, owner, next string) {
+	t.Helper()
+	fixture := newDenialProofNSECFixture(
+		t,
+		time.Now().UTC(),
+		"q."+zone,
+		dns.TypeA,
+		dns.RcodeNameError,
+		zone,
+		[2]string{owner, next},
+	)
+	aggressiveNegativeMakeSignaturesPackable(fixture.msg)
+	if !s.RecordDenialProof(fixture.msg, zone, middleware.ValidatedNegativeProofNSEC, time.Time{}) {
+		t.Fatalf("NSEC proof for %s refused", zone)
+	}
+}
+
+// TestFailureMissWitnessLifecycle pins the witness contract at the store:
+// captured at record, held while the on-path denial snapshots are
+// pointer-identical, broken by any admission on the path, moot off-path.
+func TestFailureMissWitnessLifecycle(t *testing.T) {
+	c := New(makeTestConfig())
+	defer c.Stop()
+	s := c.store
+
+	witnessTestProof(t, s, "sig.test.", "glib.sig.test.", "help.sig.test.")
+
+	witness := s.failureMissWitness("down.sig.test.", dns.ClassINET)
+	if len(witness) != 1 {
+		t.Fatalf("witness pairs = %d, want 1 (the sig.test. zone)", len(witness))
+	}
+
+	onPath, _ := wireTestRequest(t, "down.sig.test.", dns.TypeA, false)
+	offPath, _ := wireTestRequest(t, "down.unrelated.example.", dns.TypeA, false)
+
+	if !s.denialProofs.missWitnessHoldsWire(onPath.WireName(), dns.ClassINET, witness) {
+		t.Fatal("fresh witness did not hold for its own name")
+	}
+	if s.denialProofs.missWitnessHoldsWire(onPath.WireName(), dns.ClassINET, nil) {
+		t.Fatal("nil witness held with a denial zone on the path")
+	}
+	if !s.denialProofs.missWitnessHoldsWire(offPath.WireName(), dns.ClassINET, nil) {
+		t.Fatal("nil witness did not hold off-path — no zone could deny this name")
+	}
+
+	// Any admission to an on-path zone replaces its snapshot: the old
+	// witness must stop holding, a fresh one must hold again.
+	witnessTestProof(t, s, "sig.test.", "mo.sig.test.", "mu.sig.test.")
+	if s.denialProofs.missWitnessHoldsWire(onPath.WireName(), dns.ClassINET, witness) {
+		t.Fatal("witness held across a snapshot replacement")
+	}
+	fresh := s.failureMissWitness("down.sig.test.", dns.ClassINET)
+	if !s.denialProofs.missWitnessHoldsWire(onPath.WireName(), dns.ClassINET, fresh) {
+		t.Fatal("fresh witness did not hold after re-capture")
+	}
+
+	// The witnessed hold is on the serving path: it must cost nothing.
+	if allocs := testing.AllocsPerRun(200, func() {
+		if !s.denialProofs.missWitnessHoldsWire(onPath.WireName(), dns.ClassINET, fresh) {
+			t.Fatal("hold broke during the allocation pin")
+		}
+	}); allocs != 0 {
+		t.Fatalf("witness hold allocated %.2f objects per check", allocs)
+	}
+
+	c.Stop()
+	if s.denialProofs.missWitnessHoldsWire(onPath.WireName(), dns.ClassINET, fresh) {
+		t.Fatal("witness held on a stopped cache")
+	}
+}
+
+// serveFailureThrough runs one query through edns→cache exactly as the
+// live chain wires them, asserts the client sees SERVFAIL, and reports
+// whether the byte path composed it. With direct-pack declared, even a
+// Msg-path answer leaves the transport as bytes, so the discriminator is
+// the wire counter, not the write method.
+func serveFailureThrough(t *testing.T, c *Cache, e *edns.EDNS, name string) (byWire bool) {
+	t.Helper()
+	// Wire-born, as production sends it: the wire dispatch runs only for
+	// undecoded requests.
+	q := new(dns.Msg)
+	q.SetQuestion(name, dns.TypeA)
+	q.RecursionDesired = true
+	raw, err := q.Pack()
+	if err != nil {
+		t.Fatalf("pack %s: %v", name, err)
+	}
+	req := new(middleware.Request)
+	if !req.ParseWire(raw, time.Now(), nil) {
+		t.Fatalf("eligible query %s refused", name)
+	}
+
+	before := wireFailureServed.Value()
+	writer := mock.NewWriter("udp", "198.51.100.9:40000")
+	terminal := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		t.Fatalf("query %s missed the failure cache and reached the terminal handler", name)
+	})
+	ch := middleware.NewChain([]middleware.Handler{e, c, terminal})
+	ch.ResetWire(writer, req)
+	ch.AllowDirectPack()
+	ch.Next(context.Background())
+	if !writer.Written() {
+		t.Fatalf("no response written for %s", name)
+	}
+	if writer.Rcode() != dns.RcodeServerFailure {
+		t.Fatalf("cached failure for %s answered rcode %d, want SERVFAIL", name, writer.Rcode())
+	}
+	return wireFailureServed.Value() > before
+}
+
+// TestWireFailureServeWitnessGate pins the gate end to end: a failure under
+// a warm denial index serves from bytes exactly while its witness holds,
+// falls back to the Msg path the moment denial state moves, and answers
+// SERVFAIL identically on both paths.
+func TestWireFailureServeWitnessGate(t *testing.T) {
+	cfg := makeTestConfig()
+	cfg.RateLimit = 0
+	c := New(cfg)
+	defer c.Stop()
+	e := edns.New(cfg)
+
+	// The production shape that kept this rung dormant: denial proofs
+	// exist, just not for the failing name's path.
+	witnessTestProof(t, c.store, "sig.test.", "glib.sig.test.", "help.sig.test.")
+
+	// Tier 1: no denial zone on the failing name's path — no witness
+	// needed, the byte path serves outright.
+	offReq := new(dns.Msg)
+	offReq.SetQuestion("down.other.example.", dns.TypeA)
+	c.store.RecordFailure(offReq, netip.Prefix{}, FailureProvenance("test"))
+	if !serveFailureThrough(t, c, e, "down.other.example.") {
+		t.Fatal("off-path failure materialized despite no denial zone on its path")
+	}
+
+	// Tier 2: a denial zone on the path — the record-time witness lets
+	// the byte path serve.
+	onReq := new(dns.Msg)
+	onReq.SetQuestion("down.sig.test.", dns.TypeA)
+	c.store.RecordFailure(onReq, netip.Prefix{}, FailureProvenance("test"))
+	if !serveFailureThrough(t, c, e, "down.sig.test.") {
+		t.Fatal("witnessed failure materialized")
+	}
+
+	// Denial state moves: the witness breaks, and the same query must
+	// fall to the Msg path — same SERVFAIL, different composer.
+	witnessTestProof(t, c.store, "sig.test.", "mo.sig.test.", "mu.sig.test.")
+	if serveFailureThrough(t, c, e, "down.sig.test.") {
+		t.Fatal("stale-witness failure served from bytes; the Msg ladder owns this decision now")
+	}
+}

--- a/middleware/cache/failure_witness_wire_test.go
+++ b/middleware/cache/failure_witness_wire_test.go
@@ -241,3 +241,55 @@ func TestWitnessThreadsThroughLadder(t *testing.T) {
 		t.Fatal("ladder-threaded witness did not let the byte path serve")
 	}
 }
+
+// TestWitnessCapturedAtRungNotAtRecord pins the timing half of the
+// capture contract: a proof admitted between the denial rung and the
+// SERVFAIL write-back must leave the recorded witness stale, so the
+// second pass declines to the Msg path. A witness re-derived at record
+// time would pin the fresh snapshot instead and wrongly serve from
+// bytes — the exact bug class the rung-time capture exists to prevent.
+func TestWitnessCapturedAtRungNotAtRecord(t *testing.T) {
+	cfg := makeTestConfig()
+	cfg.RateLimit = 0
+	c := New(cfg)
+	defer c.Stop()
+	e := edns.New(cfg)
+
+	witnessTestProof(t, c.store, "sig.test.", "glib.sig.test.", "help.sig.test.")
+
+	servfail := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		// The failing resolution's window: denial state moves after the
+		// rung ran, before the failure is recorded.
+		witnessTestProof(t, c.store, "sig.test.", "mo.sig.test.", "mu.sig.test.")
+		resp := new(dns.Msg)
+		resp.SetReply(ch.Request.Msg())
+		resp.Rcode = dns.RcodeServerFailure
+		_ = ch.Writer.WriteMsg(resp)
+		ch.Cancel()
+	})
+
+	q := new(dns.Msg)
+	q.SetQuestion("racy.sig.test.", dns.TypeA)
+	q.RecursionDesired = true
+	raw, err := q.Pack()
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := new(middleware.Request)
+	if !req.ParseWire(raw, time.Now(), nil) {
+		t.Fatal("eligible query refused")
+	}
+	writer := mock.NewWriter("udp", "198.51.100.11:40000")
+	ch := middleware.NewChain([]middleware.Handler{e, c, servfail})
+	ch.ResetWire(writer, req)
+	ch.AllowDirectPack()
+	ch.Next(context.Background())
+	if !writer.Written() || writer.Rcode() != dns.RcodeServerFailure {
+		t.Fatalf("first pass rcode %d written=%v, want SERVFAIL", writer.Rcode(), writer.Written())
+	}
+
+	if serveFailureThrough(t, c, e, "racy.sig.test.", false) {
+		t.Fatal("mid-resolution admission did not invalidate the rung-time witness; " +
+			"a record-time re-derivation is masquerading as the capture")
+	}
+}

--- a/middleware/cache/failure_witness_wire_test.go
+++ b/middleware/cache/failure_witness_wire_test.go
@@ -90,13 +90,14 @@ func TestFailureMissWitnessLifecycle(t *testing.T) {
 // whether the byte path composed it. With direct-pack declared, even a
 // Msg-path answer leaves the transport as bytes, so the discriminator is
 // the wire counter, not the write method.
-func serveFailureThrough(t *testing.T, c *Cache, e *edns.EDNS, name string) (byWire bool) {
+func serveFailureThrough(t *testing.T, c *Cache, e *edns.EDNS, name string, cd bool) (byWire bool) {
 	t.Helper()
 	// Wire-born, as production sends it: the wire dispatch runs only for
 	// undecoded requests.
 	q := new(dns.Msg)
 	q.SetQuestion(name, dns.TypeA)
 	q.RecursionDesired = true
+	q.CheckingDisabled = cd
 	raw, err := q.Pack()
 	if err != nil {
 		t.Fatalf("pack %s: %v", name, err)
@@ -140,11 +141,12 @@ func TestWireFailureServeWitnessGate(t *testing.T) {
 	witnessTestProof(t, c.store, "sig.test.", "glib.sig.test.", "help.sig.test.")
 
 	// Tier 1: no denial zone on the failing name's path — no witness
-	// needed, the byte path serves outright.
+	// needed, the byte path serves outright (the lookup-time walk
+	// re-establishes that nothing could deny the name).
 	offReq := new(dns.Msg)
 	offReq.SetQuestion("down.other.example.", dns.TypeA)
-	c.store.RecordFailure(offReq, netip.Prefix{}, FailureProvenance("test"))
-	if !serveFailureThrough(t, c, e, "down.other.example.") {
+	c.store.RecordFailure(offReq, netip.Prefix{}, FailureProvenance("test"), nil)
+	if !serveFailureThrough(t, c, e, "down.other.example.", false) {
 		t.Fatal("off-path failure materialized despite no denial zone on its path")
 	}
 
@@ -152,15 +154,90 @@ func TestWireFailureServeWitnessGate(t *testing.T) {
 	// the byte path serve.
 	onReq := new(dns.Msg)
 	onReq.SetQuestion("down.sig.test.", dns.TypeA)
-	c.store.RecordFailure(onReq, netip.Prefix{}, FailureProvenance("test"))
-	if !serveFailureThrough(t, c, e, "down.sig.test.") {
+	c.store.RecordFailure(onReq, netip.Prefix{}, FailureProvenance("test"),
+		c.store.failureMissWitness("down.sig.test.", dns.ClassINET))
+	if !serveFailureThrough(t, c, e, "down.sig.test.", false) {
 		t.Fatal("witnessed failure materialized")
+	}
+
+	// A record whose tree never ran the denial rung carries no witness,
+	// and with a zone on the path the byte path must decline.
+	bypassReq := new(dns.Msg)
+	bypassReq.SetQuestion("blind.sig.test.", dns.TypeA)
+	c.store.RecordFailure(bypassReq, netip.Prefix{}, FailureProvenance("test"), nil)
+	if serveFailureThrough(t, c, e, "blind.sig.test.", false) {
+		t.Fatal("witnessless on-path failure served from bytes")
+	}
+
+	// A zone-kind failure answers names the record never proved anything
+	// about: it must always materialize for CD=0, witness or not.
+	c.store.RecordZoneFailure(dns.Question{Name: "x.lame.sig.test.", Qtype: dns.TypeA, Qclass: dns.ClassINET}, "lame.sig.test.")
+	if serveFailureThrough(t, c, e, "y.lame.sig.test.", false) {
+		t.Fatal("zone-kind failure served from bytes for a name its record never proved")
 	}
 
 	// Denial state moves: the witness breaks, and the same query must
 	// fall to the Msg path — same SERVFAIL, different composer.
 	witnessTestProof(t, c.store, "sig.test.", "mo.sig.test.", "mu.sig.test.")
-	if serveFailureThrough(t, c, e, "down.sig.test.") {
+	if serveFailureThrough(t, c, e, "down.sig.test.", false) {
 		t.Fatal("stale-witness failure served from bytes; the Msg ladder owns this decision now")
+	}
+
+	// CD skips shared denial on both ladders, so a CD failure serves from
+	// bytes with no witness at all — zone state on the path included.
+	cdReq := new(dns.Msg)
+	cdReq.SetQuestion("checking.sig.test.", dns.TypeA)
+	cdReq.CheckingDisabled = true
+	c.store.RecordFailure(cdReq, netip.Prefix{}, FailureProvenance("test"), nil)
+	if !serveFailureThrough(t, c, e, "checking.sig.test.", true) {
+		t.Fatal("CD failure materialized; CD bypasses the gate on both paths")
+	}
+}
+
+// TestWitnessThreadsThroughLadder drives the real mechanism end to end:
+// the first pass misses through ServeDNS (witness captured at the rung,
+// stashed on the writer), the terminal SERVFAILs (write-back records with
+// that witness), and the second pass must serve the failure from bytes —
+// something only a genuinely threaded witness allows with a denial zone
+// on the path.
+func TestWitnessThreadsThroughLadder(t *testing.T) {
+	cfg := makeTestConfig()
+	cfg.RateLimit = 0
+	c := New(cfg)
+	defer c.Stop()
+	e := edns.New(cfg)
+
+	witnessTestProof(t, c.store, "sig.test.", "glib.sig.test.", "help.sig.test.")
+
+	servfail := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		resp := new(dns.Msg)
+		resp.SetReply(ch.Request.Msg())
+		resp.Rcode = dns.RcodeServerFailure
+		_ = ch.Writer.WriteMsg(resp)
+		ch.Cancel()
+	})
+
+	q := new(dns.Msg)
+	q.SetQuestion("real.sig.test.", dns.TypeA)
+	q.RecursionDesired = true
+	raw, err := q.Pack()
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := new(middleware.Request)
+	if !req.ParseWire(raw, time.Now(), nil) {
+		t.Fatal("eligible query refused")
+	}
+	writer := mock.NewWriter("udp", "198.51.100.10:40000")
+	ch := middleware.NewChain([]middleware.Handler{e, c, servfail})
+	ch.ResetWire(writer, req)
+	ch.AllowDirectPack()
+	ch.Next(context.Background())
+	if !writer.Written() || writer.Rcode() != dns.RcodeServerFailure {
+		t.Fatalf("first pass rcode %d written=%v, want SERVFAIL", writer.Rcode(), writer.Written())
+	}
+
+	if !serveFailureThrough(t, c, e, "real.sig.test.", false) {
+		t.Fatal("ladder-threaded witness did not let the byte path serve")
 	}
 }

--- a/middleware/cache/nxdomain_cut_integration_test.go
+++ b/middleware/cache/nxdomain_cut_integration_test.go
@@ -508,7 +508,7 @@ func TestNXDomainCutIntegrationLookupPrecedence(t *testing.T) {
 		_ = nxCutExchange(t, cache, downstream, nxCutRequest(nxCutDeniedName, dns.TypeA), "192.0.2.5:53000")
 
 		descendant := nxCutRequest("failed."+nxCutDeniedName, dns.TypeAAAA)
-		cache.store.RecordFailure(descendant, netip.Prefix{}, FailureProvenance("test"))
+		cache.store.RecordFailure(descendant, netip.Prefix{}, FailureProvenance("test"), nil)
 		got := nxCutExchange(t, cache, downstream, descendant, "192.0.2.5:53000")
 		assertNXCutResponse(t, got, descendant)
 		if ede := dnsutil.GetEDE(got); ede != nil && ede.InfoCode == dns.ExtendedErrorCodeCachedError {

--- a/middleware/cache/rfc9520_kill_switch_test.go
+++ b/middleware/cache/rfc9520_kill_switch_test.go
@@ -66,11 +66,11 @@ func TestRFC9520KillSwitchDisablesFailureState(t *testing.T) {
 		req.SetQuestion("planted.example.", dns.TypeA)
 		c.failure.RecordQuestion(FailureQuestionKey{
 			Question: req.Question[0],
-		}, FailureProvenance("planted"))
+		}, FailureProvenance("planted"), nil)
 		c.failure.RecordZone(FailureZoneKey{
 			Zone:   "example.",
 			Qclass: dns.ClassINET,
-		}, FailureProvenance("planted"))
+		}, FailureProvenance("planted"), nil)
 		if got := c.failure.Len(); got != 2 {
 			t.Fatalf("lower-level planted failure entries = %d, want 2", got)
 		}

--- a/middleware/cache/rfc9520_kill_switch_test.go
+++ b/middleware/cache/rfc9520_kill_switch_test.go
@@ -30,7 +30,7 @@ func TestRFC9520KillSwitchDisablesFailureState(t *testing.T) {
 		failure.SetRcode(req, dns.RcodeServerFailure)
 
 		c.Set(CacheKey{Question: req.Question[0]}.Hash(), failure)
-		c.store.RecordFailure(req, netip.Prefix{}, FailureProvenance("test"))
+		c.store.RecordFailure(req, netip.Prefix{}, FailureProvenance("test"), nil)
 		c.store.RecordZoneFailure(req.Question[0], "example.")
 
 		if got := c.failure.Len(); got != 0 {

--- a/middleware/cache/store.go
+++ b/middleware/cache/store.go
@@ -301,17 +301,6 @@ func (s *Store) LookupFailureWire(name []byte, qtype, qclass uint16, cd bool) (F
 	return s.failure.LookupWire(name, qtype, qclass, cd)
 }
 
-// DenialProofsIdle reports that no RFC 8198 aggressive answer can exist
-// right now — the feature is off or the proof index is empty. The wire
-// path consults it so a possible shared denial answer always falls to the
-// Msg path's evaluators, preserving the lookup order.
-func (s *Store) DenialProofsIdle() bool {
-	if s == nil || s.rfc8198Disabled || s.sharedDenialDisabled || s.denialProofs == nil {
-		return true
-	}
-	return s.denialProofs.entryCount() == 0
-}
-
 // RecordNXDomainCut stores a locally validated terminal NXDOMAIN proof.
 // deniedName is the exact authoritative query cycle that returned NXDOMAIN;
 // it must never be inferred from the SOA owner.
@@ -432,7 +421,28 @@ func (s *Store) recordFailureQuestion(q dns.Question, cd bool, scope netip.Prefi
 		Question: q,
 		CD:       cd,
 		Scope:    scope,
-	}, provenance)
+	}, provenance, s.failureMissWitness(q.Name, q.Qclass))
+}
+
+// failureMissWitness captures the denial-zone state a failing question
+// saw (denial_proof_witness.go). With RFC 8198 handling disabled the
+// witness is moot — the wire gate treats disabled the same way.
+func (s *Store) failureMissWitness(qname string, qclass uint16) []denialWitnessPair {
+	if s == nil || s.rfc8198Disabled || s.sharedDenialDisabled || s.denialProofs == nil {
+		return nil
+	}
+	return s.denialProofs.missWitness(dns.CanonicalName(qname), qclass)
+}
+
+// DenialMissHoldsWire reports whether a failure entry's record-time
+// proof that aggressive denial does not apply is still valid for this
+// wire-born name — the condition under which the wire path may serve
+// the failure without materializing.
+func (s *Store) DenialMissHoldsWire(name []byte, qclass uint16, hit FailureHit) bool {
+	if s == nil || s.rfc8198Disabled || s.sharedDenialDisabled || s.denialProofs == nil {
+		return true
+	}
+	return s.denialProofs.missWitnessHoldsWire(name, qclass, hit.witness)
 }
 
 // RecordZoneFailure implements middleware.ResolutionFailureStore. Zone-wide
@@ -444,7 +454,7 @@ func (s *Store) RecordZoneFailure(q dns.Question, zone string) {
 	s.failure.RecordZone(FailureZoneKey{
 		Zone:   zone,
 		Qclass: q.Qclass,
-	}, FailureProvenance("authority"))
+	}, FailureProvenance("authority"), s.failureMissWitness(q.Name, q.Qclass))
 }
 
 // ClearZoneFailure removes authority reachability history after the resolver

--- a/middleware/cache/store.go
+++ b/middleware/cache/store.go
@@ -301,6 +301,14 @@ func (s *Store) LookupFailureWire(name []byte, qtype, qclass uint16, cd bool) (F
 	return s.failure.LookupWire(name, qtype, qclass, cd)
 }
 
+// sharedDenialImpossible reports that no RFC 8198 evaluation can ever
+// run in this process — construction-time configuration. With denial
+// impossible on every path, a zone-kind failure hit cannot be shadowed
+// by synthesis, so the wire gate may serve it without a witness.
+func (s *Store) sharedDenialImpossible() bool {
+	return s == nil || s.rfc8198Disabled || s.sharedDenialDisabled || s.denialProofs == nil
+}
+
 // RecordNXDomainCut stores a locally validated terminal NXDOMAIN proof.
 // deniedName is the exact authoritative query cycle that returned NXDOMAIN;
 // it must never be inferred from the SOA owner.
@@ -406,22 +414,33 @@ func (s *Store) FailureRetryKey(req *dns.Msg, scope netip.Prefix) (uint64, bool)
 }
 
 // RecordFailure records a question-specific terminal resolution failure.
-func (s *Store) RecordFailure(req *dns.Msg, scope netip.Prefix, provenance FailureProvenance) {
+// witness must be the miss witness captured at the moment the recording
+// request's denial rung ran and missed (Cache.ServeDNS stashes it on the
+// response writer), and nil from every path that never ran the rung — a
+// CD or client-ECS tree that bypassed it, a compatibility Set, a scoped
+// insert. A witness fabricated later would assert a miss nobody
+// established at a moment nobody checked.
+func (s *Store) RecordFailure(req *dns.Msg, scope netip.Prefix, provenance FailureProvenance, witness []denialWitnessPair) {
 	if s.failureCacheDisabled || s.failure == nil || req == nil || len(req.Question) == 0 {
 		return
 	}
-	s.recordFailureQuestion(req.Question[0], req.CheckingDisabled, scope, provenance)
+	s.recordFailureQuestion(req.Question[0], req.CheckingDisabled, scope, provenance, witness)
 }
 
-func (s *Store) recordFailureQuestion(q dns.Question, cd bool, scope netip.Prefix, provenance FailureProvenance) {
+func (s *Store) recordFailureQuestion(q dns.Question, cd bool, scope netip.Prefix, provenance FailureProvenance, witness []denialWitnessPair) {
 	if s.failureCacheDisabled || s.failure == nil {
 		return
+	}
+	if cd {
+		// A CD entry serves CD lookups, which skip the gate entirely; a
+		// witness here could only ever mislead.
+		witness = nil
 	}
 	s.failure.RecordQuestion(FailureQuestionKey{
 		Question: q,
 		CD:       cd,
 		Scope:    scope,
-	}, provenance, s.failureMissWitness(q.Name, q.Qclass))
+	}, provenance, witness)
 }
 
 // failureMissWitness captures the denial-zone state a failing question
@@ -451,10 +470,13 @@ func (s *Store) RecordZoneFailure(q dns.Question, zone string) {
 	if s.failureCacheDisabled || s.failure == nil || zone == "" {
 		return
 	}
+	// Zone-kind hits answer descendant names the recording question never
+	// proved anything about, so they are excluded from witness serving
+	// (cache.go's gate) and carry none.
 	s.failure.RecordZone(FailureZoneKey{
 		Zone:   zone,
 		Qclass: q.Qclass,
-	}, FailureProvenance("authority"), s.failureMissWitness(q.Name, q.Qclass))
+	}, FailureProvenance("authority"), nil)
 }
 
 // ClearZoneFailure removes authority reachability history after the resolver
@@ -601,7 +623,7 @@ func (s *Store) setFromResponseWithKey(key uint64, resp *dns.Msg, scope netip.Pr
 		// If a pre-keyed scoped caller reaches it, do not misfile that
 		// audience-specific failure as a global one without its prefix.
 		if !scoped {
-			s.recordFailureQuestion(resp.Question[0], keyCD, netip.Prefix{}, FailureProvenance("response"))
+			s.recordFailureQuestion(resp.Question[0], keyCD, netip.Prefix{}, FailureProvenance("response"), nil)
 		}
 	}
 }
@@ -681,7 +703,7 @@ func (s *Store) SetEntryWithKey(key uint64, entry *CacheEntry, mt dnsutil.Respon
 		}
 	case dnsutil.TypeServerFailure:
 		if entry != nil && entry.question.Name != "" {
-			s.recordFailureQuestion(entry.question, entry.cd, netip.Prefix{}, FailureProvenance("response"))
+			s.recordFailureQuestion(entry.question, entry.cd, netip.Prefix{}, FailureProvenance("response"), nil)
 		}
 	}
 }


### PR DESCRIPTION
The wire ladder's composite rungs were parked behind a global gate: while any RFC 8198 proof existed — always, on a warm resolver — every CD=0 query past the cut lookup materialized. Live measurement put the cost at ~757k cached-failure answers in 9 hours taking the Msg path solely because of that gate (~7% of all cache hits).

## The miss witness

The failure entry itself is the proof the gate was looking for. RFC 9520 state exists only because a real resolution was attempted, and the Msg ladder attempts resolution only after aggressive denial missed — so at the moment the denial rung misses, the ladder captures a **witness**: the (zone, snapshot pointer) pairs of every cached denial zone on the question's ancestor path, stashed on the response writer and threaded to the record a SERVFAIL write-back files. The wire path then serves a cached failure without materializing exactly while that proof demonstrably still holds, via an allocation-free suffix walk over a hash-keyed zone index with pointer-identity comparison.

The gate is deliberately narrow, and every clause came out of review:

- **Question-kind hits only**: the witness proves a miss for one question; a zone-kind hit answers descendants the record never proved anything about, so it materializes (except under CD, which skips shared denial on both ladders, and except when RFC 8198 is disabled outright, where no denial can shadow anything).
- **Captured at the rung, not at the record**: a proof admitted during the seconds of a failing resolution can never be pinned as evidence of its own absence. Trees that bypassed the rung (CD, client ECS including stripped and zero-scope forms, compatibility Set paths) record nil and never witness-serve.
- **NSEC-only**: NSEC3 evaluation draws on the shared DNSSEC crypto budget, so its miss can be starvation rather than absence; a path crossing NSEC3 state yields no witness.
- **Fail-to-Msg everywhere**: a replaced snapshot, a new on-path zone, a hash-collision anomaly, a stopped cache, a pre-witness entry — all decline to the Msg path, whose evaluators decide. The client's answer is identical whichever path composes it.

Two tiers actually serve: names with no cached denial zone on their path at lookup time (self-justifying, no witness needed — the dominant dead-domain case, since zones that SERVFAIL produce no proofs), and witnessed question-kind repeats.

## RFC grounding (verified against the published texts)

RFC 8198 is SHOULD-level, and its Appendix B discards parent-zone NSECs below a delegation — denial for a name is answerable only from its cached ancestor zones, exactly the set the witness pins. RFC 9520 §3.2 constrains outgoing queries and mandates no cache-lookup precedence; the Msg ladder's denial-before-failure order is unchanged and now provably mirrored, never re-implemented, on the wire side.

## Review

Three independent reviewers (correctness/parity, concurrency/memory, RFC/protocol) broke the first design in review — zone-kind witness transplant, bypassed-tree witness minting, capture-time lag, NSEC3 budget dependence, renewal pinning, a collision-delete direction — and every finding was repaired and then re-verified by a closing pass: all six VERIFIED-CLOSED, no new correctness holes. Two accepted residuals are documented in code: a capture window the width of the ladder's two read-lock acquisitions (RFC-legal outcome, bounded by the 5-minute failure TTL), and post-expiry witness pinning of replaced snapshots (bounded by the failure cache's size and per-zone byte caps).

Tests pin the witness lifecycle (capture, hold, break on admission, stop, zero-allocation hold check), the gate end to end through the real chain (off-path serve, witnessed serve, witnessless decline, zone-kind decline, stale-witness decline, CD bypass), and the actual threading mechanism (ladder capture → writer → record → wire serve).

## Before merge

Per the project's measurement rule, the SERVFAIL-hammer case (hot failure cache under concurrent admissions — the new read-lock traffic) gets an A/B against real binaries alongside the planned final-tree throughput re-measure; results land in this PR's thread.
