### PR TITLE
tests: retire the testify dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/quic-go/quic-go v0.61.0
 	github.com/semihalev/zlog/v2 v2.0.8
 	github.com/spf13/cobra v1.10.2
-	github.com/stretchr/testify v1.11.1
 	golang.org/x/sync v0.22.0
 	golang.org/x/sys v0.47.0
 	golang.org/x/time v0.15.0
@@ -65,7 +64,6 @@ require (
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260414162039-ec9c827d403f // indirect
 	k8s.io/utils v0.0.0-20260319190234-28399d86e0b5 // indirect

--- a/internal/authority/cache_test.go
+++ b/internal/authority/cache_test.go
@@ -1,12 +1,12 @@
 package authority
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/internal/cache"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_Cache(t *testing.T) {
@@ -22,29 +22,43 @@ func Test_Cache(t *testing.T) {
 	servers := &Servers{List: []*Server{a}}
 
 	_, err := nscache.Get(key)
-	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "cache not found")
+	if err == nil {
+		t.Errorf("expected an error, got nil")
+	}
+	if !reflect.DeepEqual(err.Error(), "cache not found") {
+		t.Errorf("'cache not found' = %v, want %v", "cache not found", err.Error())
+	}
 
 	nscache.Set(key, nil, servers, time.Hour)
 
 	_, err = nscache.Get(key)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	nscache.now = func() time.Time {
 		return time.Now().Add(30 * time.Minute)
 	}
 	_, err = nscache.Get(key)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	nscache.now = func() time.Time {
 		return time.Now().Add(2 * time.Hour)
 	}
 	_, err = nscache.Get(key)
-	assert.Error(t, err)
-	assert.Equal(t, err.Error(), "cache expired")
+	if err == nil {
+		t.Errorf("expected an error, got nil")
+	}
+	if !reflect.DeepEqual(err.Error(), "cache expired") {
+		t.Errorf("'cache expired' = %v, want %v", "cache expired", err.Error())
+	}
 
 	_, err = nscache.Get(key)
-	assert.Error(t, err)
+	if err == nil {
+		t.Errorf("expected an error, got nil")
+	}
 
 	nscache.Remove(key)
 }

--- a/internal/authority/server_test.go
+++ b/internal/authority/server_test.go
@@ -5,11 +5,11 @@ import (
 	"math/rand"
 	"net"
 	"net/netip"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 	"unsafe"
-
-	"github.com/stretchr/testify/assert"
 )
 
 // serverWithoutCanonical is Server as it stood before it recorded whether its
@@ -56,14 +56,24 @@ func Test_TrySort(t *testing.T) {
 		}
 	}
 
-	assert.Equal(t, int64(1), s.List[0].Count)
+	if !reflect.DeepEqual(int64(1), s.List[0].Count) {
+		t.Errorf("s.List[0].Count = %v, want %v", s.List[0].Count, int64(1))
+	}
 }
 
 func Test_VersionString(t *testing.T) {
-	assert.Equal(t, "IPv4", IPv4.String())
-	assert.Equal(t, "IPv6", IPv6.String())
-	assert.Equal(t, "Unknown", IPVersion(0).String())
-	assert.Equal(t, "Unknown", IPVersion(99).String())
+	if !reflect.DeepEqual("IPv4", IPv4.String()) {
+		t.Errorf("IPv4.String() = %v, want %v", IPv4.String(), "IPv4")
+	}
+	if !reflect.DeepEqual("IPv6", IPv6.String()) {
+		t.Errorf("IPv6.String() = %v, want %v", IPv6.String(), "IPv6")
+	}
+	if !reflect.DeepEqual("Unknown", IPVersion(0).String()) {
+		t.Errorf("IPVersion(0).String() = %v, want %v", IPVersion(0).String(), "Unknown")
+	}
+	if !reflect.DeepEqual("Unknown", IPVersion(99).String()) {
+		t.Errorf("IPVersion(99).String() = %v, want %v", IPVersion(99).String(), "Unknown")
+	}
 }
 
 // Test_Servers_FingerprintInvalidation pins the contract that
@@ -74,10 +84,14 @@ func Test_Servers_FingerprintInvalidation(t *testing.T) {
 	s := &Servers{}
 	s.List = append(s.List, NewServer("1.1.1.1:53", IPv4))
 	first := s.Fingerprint()
-	assert.NotZero(t, first)
+	if first == 0 {
+		t.Error("first is zero")
+	}
 
 	// Same state → same fingerprint.
-	assert.Equal(t, first, s.Fingerprint())
+	if !reflect.DeepEqual(first, s.Fingerprint()) {
+		t.Errorf("s.Fingerprint() = %v, want %v", s.Fingerprint(), first)
+	}
 
 	// Mutate and invalidate; new fingerprint must differ.
 	s.Lock()
@@ -85,7 +99,9 @@ func Test_Servers_FingerprintInvalidation(t *testing.T) {
 	s.InvalidateFingerprint()
 	s.Unlock()
 	second := s.Fingerprint()
-	assert.NotEqual(t, first, second)
+	if reflect.DeepEqual(first, second) {
+		t.Errorf("second = %v, want a different value", second)
+	}
 }
 
 // Test_Servers_FingerprintMutationRace simulates the interleaving
@@ -115,28 +131,40 @@ func Test_Servers_FingerprintMutationRace(t *testing.T) {
 	}
 
 	got := s.Fingerprint()
-	assert.NotEqual(t, staleFP, got, "stale fingerprint must not be served after mutation")
+	if reflect.DeepEqual(staleFP, got) {
+		t.Errorf("%s: got = %v, want a different value", "stale fingerprint must not be served after mutation", got)
+	}
 }
 
 func Test_ServerString(t *testing.T) {
 	// Test UNKNOWN health (Rtt <= 0)
 	s := NewServer("1.2.3.4:53", IPv4)
 	str := s.String()
-	assert.Contains(t, str, "IPv4")
-	assert.Contains(t, str, "1.2.3.4:53")
-	assert.Contains(t, str, "UNKNOWN")
+	if !strings.Contains(str, "IPv4") {
+		t.Errorf("%q does not contain %q", str, "IPv4")
+	}
+	if !strings.Contains(str, "1.2.3.4:53") {
+		t.Errorf("%q does not contain %q", str, "1.2.3.4:53")
+	}
+	if !strings.Contains(str, "UNKNOWN") {
+		t.Errorf("%q does not contain %q", str, "UNKNOWN")
+	}
 
 	// Test GOOD health (0 < Rtt < 1 second)
 	s.Rtt = int64(100 * time.Millisecond)
 	s.Count = 1
 	str = s.String()
-	assert.Contains(t, str, "GOOD")
+	if !strings.Contains(str, "GOOD") {
+		t.Errorf("%q does not contain %q", str, "GOOD")
+	}
 
 	// Test POOR health (Rtt >= 1 second)
 	s.Rtt = int64(2 * time.Second)
 	s.Count = 1
 	str = s.String()
-	assert.Contains(t, str, "POOR")
+	if !strings.Contains(str, "POOR") {
+		t.Errorf("%q does not contain %q", str, "POOR")
+	}
 }
 
 // TestNewServerCanonicalizes directly pins the canonical Addr contract every

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -3,12 +3,10 @@ package cache
 
 import (
 	"fmt"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCacheAddAndGet(t *testing.T) {
@@ -16,35 +14,51 @@ func TestCacheAddAndGet(t *testing.T) {
 	c.Add(1, 1)
 
 	value, found := c.Get(1)
-	require.True(t, found, "Failed to find inserted record")
-	assert.Equal(t, 1, value)
+	if !(found) {
+		t.Fatalf("%s: found is false", "Failed to find inserted record")
+	}
+	if !reflect.DeepEqual(1, value) {
+		t.Errorf("value = %v, want %v", value, 1)
+	}
 }
 
 func TestCacheLen(t *testing.T) {
 	c := New(4)
 
 	c.Add(1, 1)
-	assert.Equal(t, 1, c.Len(), "Cache should have 1 item")
+	if !reflect.DeepEqual(1, c.Len()) {
+		t.Errorf("%s: c.Len() = %v, want %v", "Cache should have 1 item", c.Len(), 1)
+	}
 
 	// Adding same key shouldn't increase size
 	c.Add(1, 1)
-	assert.Equal(t, 1, c.Len(), "Cache should still have 1 item")
+	if !reflect.DeepEqual(1, c.Len()) {
+		t.Errorf("%s: c.Len() = %v, want %v", "Cache should still have 1 item", c.Len(), 1)
+	}
 
 	c.Add(2, 2)
-	assert.Equal(t, 2, c.Len(), "Cache should have 2 items")
+	if !reflect.DeepEqual(2, c.Len()) {
+		t.Errorf("%s: c.Len() = %v, want %v", "Cache should have 2 items", c.Len(), 2)
+	}
 }
 
 func TestCacheRemove(t *testing.T) {
 	c := New(4)
 
 	c.Add(1, 1)
-	assert.Equal(t, 1, c.Len(), "Cache should have 1 item")
+	if !reflect.DeepEqual(1, c.Len()) {
+		t.Errorf("%s: c.Len() = %v, want %v", "Cache should have 1 item", c.Len(), 1)
+	}
 
 	c.Remove(1)
-	assert.Equal(t, 0, c.Len(), "Cache should be empty after removal")
+	if !reflect.DeepEqual(0, c.Len()) {
+		t.Errorf("%s: c.Len() = %v, want %v", "Cache should be empty after removal", c.Len(), 0)
+	}
 
 	_, found := c.Get(1)
-	assert.False(t, found, "Item should not be found after removal")
+	if found {
+		t.Errorf("%s: found is true", "Item should not be found after removal")
+	}
 }
 
 func TestCacheConditionalReplaceAndDelete(t *testing.T) {
@@ -89,13 +103,17 @@ func TestCacheLRUEviction(t *testing.T) {
 
 	c.Add(1, "one")
 	c.Add(2, "two")
-	assert.LessOrEqual(t, c.Len(), 2)
+	if c.Len() > 2 {
+		t.Errorf("c.Len() = %v, want <= %v", c.Len(), 2)
+	}
 
 	// Adding third item should trigger eviction
 	c.Add(3, "three")
 
 	// RadicalCache may clear entire segments, so we just verify size limit
-	assert.LessOrEqual(t, c.Len(), 3, "Cache should not grow unbounded")
+	if c.Len() > 3 {
+		t.Errorf("%s: c.Len() = %v, want <= %v", "Cache should not grow unbounded", c.Len(), 3)
+	}
 }
 
 func TestCacheLRUBehavior(t *testing.T) {
@@ -115,7 +133,9 @@ func TestCacheLRUBehavior(t *testing.T) {
 	c.Add(4, "four")
 
 	// Should have at most 4 items (allows slight overshoot for performance)
-	assert.LessOrEqual(t, c.Len(), 4, "Cache should maintain reasonable bounds")
+	if c.Len() > 4 {
+		t.Errorf("%s: c.Len() = %v, want <= %v", "Cache should maintain reasonable bounds", c.Len(), 4)
+	}
 }
 
 func TestCacheConcurrency(t *testing.T) {
@@ -147,7 +167,9 @@ func TestCacheConcurrency(t *testing.T) {
 
 	// Verify cache still functions correctly
 	// Allow up to 10% overshoot for concurrent operations with 256 segments
-	assert.LessOrEqual(t, c.Len(), 1100, "Cache should not exceed capacity by more than 10%")
+	if c.Len() > 1100 {
+		t.Errorf("%s: c.Len() = %v, want <= %v", "Cache should not exceed capacity by more than 10%", c.Len(), 1100)
+	}
 }
 
 func TestCacheRemoveConcurrency(t *testing.T) {
@@ -157,7 +179,7 @@ func TestCacheRemoveConcurrency(t *testing.T) {
 
 	// Pre-populate cache
 	for i := 0; i < numGoroutines*keysPerGoroutine; i++ {
-		c.Add(uint64(i), i) //nolint:gosec // G115 - test loop //nolint:gosec // G115 - test loop
+		c.Add(uint64(i), i) //nolint:gosec // G115 - test loop
 	}
 
 	var wg sync.WaitGroup
@@ -176,7 +198,9 @@ func TestCacheRemoveConcurrency(t *testing.T) {
 
 	wg.Wait()
 
-	assert.Equal(t, 0, c.Len(), "All items should be removed")
+	if !reflect.DeepEqual(0, c.Len()) {
+		t.Errorf("%s: c.Len() = %v, want %v", "All items should be removed", c.Len(), 0)
+	}
 }
 
 func TestCacheZeroCapacity(t *testing.T) {
@@ -184,10 +208,14 @@ func TestCacheZeroCapacity(t *testing.T) {
 
 	// Zero capacity becomes 1 (minimum)
 	c.Add(1, "one")
-	assert.LessOrEqual(t, c.Len(), 1)
+	if c.Len() > 1 {
+		t.Errorf("c.Len() = %v, want <= %v", c.Len(), 1)
+	}
 
 	_, found := c.Get(1)
-	assert.True(t, found, "Should find item in minimum capacity cache")
+	if !(found) {
+		t.Errorf("%s: found is false", "Should find item in minimum capacity cache")
+	}
 }
 
 func TestCacheUpdateExisting(t *testing.T) {
@@ -195,17 +223,27 @@ func TestCacheUpdateExisting(t *testing.T) {
 
 	c.Add(1, "original")
 	val, found := c.Get(1)
-	require.True(t, found)
-	assert.Equal(t, "original", val)
+	if !(found) {
+		t.Fatalf("found is false")
+	}
+	if !reflect.DeepEqual("original", val) {
+		t.Errorf("val = %v, want %v", val, "original")
+	}
 
 	// Update with new value
 	c.Add(1, "updated")
 	val, found = c.Get(1)
-	require.True(t, found)
-	assert.Equal(t, "updated", val)
+	if !(found) {
+		t.Fatalf("found is false")
+	}
+	if !reflect.DeepEqual("updated", val) {
+		t.Errorf("val = %v, want %v", val, "updated")
+	}
 
 	// Size should remain 1
-	assert.Equal(t, 1, c.Len())
+	if !reflect.DeepEqual(1, c.Len()) {
+		t.Errorf("c.Len() = %v, want %v", c.Len(), 1)
+	}
 }
 
 func TestCacheCapacity(t *testing.T) {
@@ -217,21 +255,27 @@ func TestCacheCapacity(t *testing.T) {
 	}
 
 	// Verify size
-	assert.Equal(t, 50, c.Len())
+	if !reflect.DeepEqual(50, c.Len()) {
+		t.Errorf("c.Len() = %v, want %v", c.Len(), 50)
+	}
 
 	// Add more items up to capacity
 	for i := 50; i < 100; i++ {
 		c.Add(uint64(i), i) //nolint:gosec // G115 - test loop
 	}
 
-	assert.Equal(t, 100, c.Len())
+	if !reflect.DeepEqual(100, c.Len()) {
+		t.Errorf("c.Len() = %v, want %v", c.Len(), 100)
+	}
 
 	// Adding more should maintain capacity
 	for i := 100; i < 150; i++ {
 		c.Add(uint64(i), i) //nolint:gosec // G115 - test loop
 	}
 
-	assert.LessOrEqual(t, c.Len(), 100, "Cache should not exceed capacity")
+	if c.Len() > 100 {
+		t.Errorf("%s: c.Len() = %v, want <= %v", "Cache should not exceed capacity", c.Len(), 100)
+	}
 }
 
 // Benchmarks.
@@ -279,7 +323,7 @@ func BenchmarkCacheMixed(b *testing.B) {
 		i := 0
 		for pb.Next() {
 			if i%2 == 0 {
-				c.Get(uint64(i % 10000)) //nolint:gosec // G115 - test loop //nolint:gosec // G115 - test loop
+				c.Get(uint64(i % 10000)) //nolint:gosec // G115 - test loop
 			} else {
 				c.Add(uint64(i), i) //nolint:gosec // G115 - test loop
 			}
@@ -309,7 +353,9 @@ func TestCacheMemoryUsage(t *testing.T) {
 	}
 
 	t.Logf("Found %d items out of 100 checked", found)
-	assert.Greater(t, found, 0, "Should find some cached items")
+	if found <= 0 {
+		t.Errorf("%s: found = %v, want > %v", "Should find some cached items", found, 0)
+	}
 }
 
 func TestCacheTTL(t *testing.T) {
@@ -330,19 +376,29 @@ func TestCacheTTL(t *testing.T) {
 
 	// Should find immediately
 	val, found := c.Get(1)
-	require.True(t, found)
+	if !(found) {
+		t.Fatalf("found is false")
+	}
 	tv := val.(timedValue)
-	assert.Equal(t, "test", tv.value)
-	assert.False(t, time.Now().After(tv.expiry))
+	if !reflect.DeepEqual("test", tv.value) {
+		t.Errorf("tv.value = %v, want %v", tv.value, "test")
+	}
+	if time.Now().After(tv.expiry) {
+		t.Errorf("time.Now().After(tv.expiry) is true")
+	}
 
 	// Wait for expiry
 	time.Sleep(1100 * time.Millisecond)
 
 	// Can still get from cache, but caller should check expiry
 	val, found = c.Get(1)
-	require.True(t, found)
+	if !(found) {
+		t.Fatalf("found is false")
+	}
 	tv = val.(timedValue)
-	assert.True(t, time.Now().After(tv.expiry), "Item should be expired")
+	if !(time.Now().After(tv.expiry)) {
+		t.Errorf("%s: time.Now().After(tv.expiry) is false", "Item should be expired")
+	}
 }
 
 func TestCacheStop(t *testing.T) {
@@ -356,8 +412,12 @@ func TestCacheStop(t *testing.T) {
 
 	// Cache should still work after Stop (no-op)
 	val, found := c.Get(1)
-	assert.True(t, found)
-	assert.Equal(t, "one", val)
+	if !(found) {
+		t.Errorf("found is false")
+	}
+	if !reflect.DeepEqual("one", val) {
+		t.Errorf("val = %v, want %v", val, "one")
+	}
 }
 
 func TestCacheNewSizeBranches(t *testing.T) {
@@ -377,13 +437,19 @@ func TestCacheNewSizeBranches(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := New(tt.size)
-			assert.NotNil(t, c)
+			if c == nil {
+				t.Fatalf("c is nil")
+			}
 
 			// Add and verify
 			c.Add(1, "test")
 			val, found := c.Get(1)
-			assert.True(t, found)
-			assert.Equal(t, "test", val)
+			if !(found) {
+				t.Errorf("found is false")
+			}
+			if !reflect.DeepEqual("test", val) {
+				t.Errorf("val = %v, want %v", val, "test")
+			}
 		})
 	}
 }

--- a/internal/cache/key_test.go
+++ b/internal/cache/key_test.go
@@ -3,11 +3,11 @@ package cache
 import (
 	"fmt"
 	"net/netip"
+	"reflect"
 	"sync"
 	"testing"
 
 	"github.com/miekg/dns"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestKey(t *testing.T) {
@@ -68,11 +68,15 @@ func TestKey(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := Key(tt.question, tt.cd...)
-			assert.Equal(t, tt.want, got)
+			if !reflect.DeepEqual(tt.want, got) {
+				t.Errorf("got = %v, want %v", got, tt.want)
+			}
 
 			// Verify consistency
 			got2 := Key(tt.question, tt.cd...)
-			assert.Equal(t, got, got2, "Key should be consistent")
+			if !reflect.DeepEqual(got, got2) {
+				t.Errorf("%s: got2 = %v, want %v", "Key should be consistent", got2, got)
+			}
 		})
 	}
 }
@@ -213,7 +217,9 @@ func TestKeyLongDomainNames(t *testing.T) {
 	key1 := Key(q)
 	key2 := Key(q)
 
-	assert.Equal(t, key1, key2, "Keys for long domain names should be consistent")
+	if !reflect.DeepEqual(key1, key2) {
+		t.Errorf("%s: key2 = %v, want %v", "Keys for long domain names should be consistent", key2, key1)
+	}
 
 	// Test with mixed case
 	q2 := dns.Question{
@@ -223,7 +229,9 @@ func TestKeyLongDomainNames(t *testing.T) {
 	}
 
 	key3 := Key(q2)
-	assert.Equal(t, key1, key3, "Case should be normalized for long names")
+	if !reflect.DeepEqual(key1, key3) {
+		t.Errorf("%s: key3 = %v, want %v", "Case should be normalized for long names", key3, key1)
+	}
 }
 
 // Benchmarks
@@ -339,7 +347,9 @@ func TestKeyString(t *testing.T) {
 			// KeyString should produce consistent results
 			key1 := KeyString(tt.qname, tt.qtype, tt.qclass, tt.cd)
 			key2 := KeyString(tt.qname, tt.qtype, tt.qclass, tt.cd)
-			assert.Equal(t, key1, key2, "KeyString should be consistent")
+			if !reflect.DeepEqual(key1, key2) {
+				t.Errorf("%s: key2 = %v, want %v", "KeyString should be consistent", key2, key1)
+			}
 
 			// KeyString should match Key for equivalent queries
 			q := dns.Question{
@@ -348,7 +358,9 @@ func TestKeyString(t *testing.T) {
 				Qclass: tt.qclass,
 			}
 			keyFromQuestion := Key(q, tt.cd)
-			assert.Equal(t, keyFromQuestion, key1, "KeyString should match Key")
+			if !reflect.DeepEqual(keyFromQuestion, key1) {
+				t.Errorf("%s: key1 = %v, want %v", "KeyString should match Key", key1, keyFromQuestion)
+			}
 		})
 	}
 }
@@ -391,7 +403,9 @@ func TestKeySimple(t *testing.T) {
 			// KeySimple should produce same result as Key
 			keySimple := KeySimple(tt.question, tt.cd...)
 			keyPooled := Key(tt.question, tt.cd...)
-			assert.Equal(t, keyPooled, keySimple, "KeySimple should match Key")
+			if !reflect.DeepEqual(keyPooled, keySimple) {
+				t.Errorf("%s: keySimple = %v, want %v", "KeySimple should match Key", keySimple, keyPooled)
+			}
 		})
 	}
 }
@@ -413,9 +427,13 @@ func TestKeyVeryLongDomainName(t *testing.T) {
 	// Should not panic and should be consistent
 	key1 := Key(q)
 	key2 := Key(q)
-	assert.Equal(t, key1, key2)
+	if !reflect.DeepEqual(key1, key2) {
+		t.Errorf("key2 = %v, want %v", key2, key1)
+	}
 
 	// KeyString should also handle it
 	key3 := KeyString(longName, dns.TypeA, dns.ClassINET, false)
-	assert.Equal(t, key1, key3)
+	if !reflect.DeepEqual(key1, key3) {
+		t.Errorf("key3 = %v, want %v", key3, key1)
+	}
 }

--- a/internal/cache/segment_uint64_map_test.go
+++ b/internal/cache/segment_uint64_map_test.go
@@ -1,9 +1,9 @@
 package cache
 
 import (
+	"reflect"
+	"slices"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestSegmentUInt64MapPutIfNotExists(t *testing.T) {
@@ -11,21 +11,39 @@ func TestSegmentUInt64MapPutIfNotExists(t *testing.T) {
 
 	// First insert should succeed
 	val, inserted := m.PutIfNotExists(1, "first")
-	assert.True(t, inserted)
-	assert.Equal(t, "first", val)
-	assert.Equal(t, int64(1), m.Len())
+	if !(inserted) {
+		t.Errorf("inserted is false")
+	}
+	if !reflect.DeepEqual("first", val) {
+		t.Errorf("val = %v, want %v", val, "first")
+	}
+	if !reflect.DeepEqual(int64(1), m.Len()) {
+		t.Errorf("m.Len() = %v, want %v", m.Len(), int64(1))
+	}
 
 	// Second insert with same key should fail
 	val, inserted = m.PutIfNotExists(1, "second")
-	assert.False(t, inserted)
-	assert.Equal(t, "first", val) // Should return existing value
-	assert.Equal(t, int64(1), m.Len())
+	if inserted {
+		t.Errorf("inserted is true")
+	}
+	if !reflect.DeepEqual("first", val) {
+		t.Errorf("val = %v, want %v", val, "first")
+	} // Should return existing value
+	if !reflect.DeepEqual(int64(1), m.Len()) {
+		t.Errorf("m.Len() = %v, want %v", m.Len(), int64(1))
+	}
 
 	// Insert different key should succeed
 	val, inserted = m.PutIfNotExists(2, "another")
-	assert.True(t, inserted)
-	assert.Equal(t, "another", val)
-	assert.Equal(t, int64(2), m.Len())
+	if !(inserted) {
+		t.Errorf("inserted is false")
+	}
+	if !reflect.DeepEqual("another", val) {
+		t.Errorf("val = %v, want %v", val, "another")
+	}
+	if !reflect.DeepEqual(int64(2), m.Len()) {
+		t.Errorf("m.Len() = %v, want %v", m.Len(), int64(2))
+	}
 }
 
 func TestSegmentUInt64MapAll(t *testing.T) {
@@ -42,10 +60,18 @@ func TestSegmentUInt64MapAll(t *testing.T) {
 		collected[k] = v
 	}
 
-	assert.Len(t, collected, 3)
-	assert.Equal(t, 100, collected[1])
-	assert.Equal(t, 200, collected[2])
-	assert.Equal(t, 300, collected[3])
+	if len(collected) != 3 {
+		t.Errorf("len(collected) = %d, want %d", len(collected), 3)
+	}
+	if !reflect.DeepEqual(100, collected[1]) {
+		t.Errorf("collected[1] = %v, want %v", collected[1], 100)
+	}
+	if !reflect.DeepEqual(200, collected[2]) {
+		t.Errorf("collected[2] = %v, want %v", collected[2], 200)
+	}
+	if !reflect.DeepEqual(300, collected[3]) {
+		t.Errorf("collected[3] = %v, want %v", collected[3], 300)
+	}
 }
 
 func TestSegmentUInt64MapKeys(t *testing.T) {
@@ -61,10 +87,14 @@ func TestSegmentUInt64MapKeys(t *testing.T) {
 		keys = append(keys, k)
 	}
 
-	assert.Len(t, keys, 3)
-	assert.Contains(t, keys, uint64(10))
-	assert.Contains(t, keys, uint64(20))
-	assert.Contains(t, keys, uint64(30))
+	if len(keys) != 3 {
+		t.Errorf("len(keys) = %d, want %d", len(keys), 3)
+	}
+	for _, want := range []uint64{10, 20, 30} {
+		if !slices.Contains(keys, want) {
+			t.Errorf("keys %v do not contain %d", keys, want)
+		}
+	}
 }
 
 func TestSegmentUInt64MapValues(t *testing.T) {
@@ -80,10 +110,14 @@ func TestSegmentUInt64MapValues(t *testing.T) {
 		values = append(values, v)
 	}
 
-	assert.Len(t, values, 3)
-	assert.Contains(t, values, "one")
-	assert.Contains(t, values, "two")
-	assert.Contains(t, values, "three")
+	if len(values) != 3 {
+		t.Errorf("len(values) = %d, want %d", len(values), 3)
+	}
+	for _, want := range []string{"one", "two", "three"} {
+		if !slices.Contains(values, want) {
+			t.Errorf("values %v do not contain %q", values, want)
+		}
+	}
 }
 
 func TestSegmentUInt64MapClear(t *testing.T) {
@@ -93,20 +127,30 @@ func TestSegmentUInt64MapClear(t *testing.T) {
 	m.Set(1, 100)
 	m.Set(2, 200)
 	m.Set(3, 300)
-	assert.Equal(t, int64(3), m.Len())
+	if !reflect.DeepEqual(int64(3), m.Len()) {
+		t.Errorf("m.Len() = %v, want %v", m.Len(), int64(3))
+	}
 
 	// Clear the map
 	m.Clear()
 
-	assert.Equal(t, int64(0), m.Len())
+	if !reflect.DeepEqual(int64(0), m.Len()) {
+		t.Errorf("m.Len() = %v, want %v", m.Len(), int64(0))
+	}
 
 	// Verify keys are gone
 	_, found := m.Get(1)
-	assert.False(t, found)
+	if found {
+		t.Errorf("found is true")
+	}
 	_, found = m.Get(2)
-	assert.False(t, found)
+	if found {
+		t.Errorf("found is true")
+	}
 	_, found = m.Get(3)
-	assert.False(t, found)
+	if found {
+		t.Errorf("found is true")
+	}
 }
 
 func TestSegmentUInt64MapStop(t *testing.T) {
@@ -119,8 +163,12 @@ func TestSegmentUInt64MapStop(t *testing.T) {
 
 	// Map should still work after Stop
 	val, found := m.Get(1)
-	assert.True(t, found)
-	assert.Equal(t, 100, val)
+	if !(found) {
+		t.Errorf("found is false")
+	}
+	if !reflect.DeepEqual(100, val) {
+		t.Errorf("val = %v, want %v", val, 100)
+	}
 }
 
 func TestSegmentUInt64MapForEachEarlyExit(t *testing.T) {
@@ -138,21 +186,29 @@ func TestSegmentUInt64MapForEachEarlyExit(t *testing.T) {
 		return count < 5 // Stop after 5 iterations
 	})
 
-	assert.Equal(t, 5, count)
+	if !reflect.DeepEqual(5, count) {
+		t.Errorf("count = %v, want %v", count, 5)
+	}
 }
 
 func TestSegmentUInt64MapSegmentPowerBounds(t *testing.T) {
 	// Test minimum segment power (should be clamped to 4)
 	m1 := NewSegmentUInt64Map[int](1, 100)
-	assert.Equal(t, 16, m1.SegmentCount()) // 2^4 = 16
+	if !reflect.DeepEqual(16, m1.SegmentCount()) {
+		t.Errorf("m1.SegmentCount() = %v, want %v", m1.SegmentCount(), 16)
+	} // 2^4 = 16
 
 	// Test maximum segment power (should be clamped to 8)
 	m2 := NewSegmentUInt64Map[int](10, 100)
-	assert.Equal(t, 256, m2.SegmentCount()) // 2^8 = 256
+	if !reflect.DeepEqual(256, m2.SegmentCount()) {
+		t.Errorf("m2.SegmentCount() = %v, want %v", m2.SegmentCount(), 256)
+	} // 2^8 = 256
 
 	// Test valid segment power
 	m3 := NewSegmentUInt64Map[int](6, 100)
-	assert.Equal(t, 64, m3.SegmentCount()) // 2^6 = 64
+	if !reflect.DeepEqual(64, m3.SegmentCount()) {
+		t.Errorf("m3.SegmentCount() = %v, want %v", m3.SegmentCount(), 64)
+	} // 2^6 = 64
 }
 
 func TestSegmentUInt64MapClearSegmentOutOfBounds(t *testing.T) {
@@ -166,6 +222,10 @@ func TestSegmentUInt64MapClearSegmentOutOfBounds(t *testing.T) {
 
 	// Original value should still exist
 	val, found := m.Get(1)
-	assert.True(t, found)
-	assert.Equal(t, 100, val)
+	if !(found) {
+		t.Errorf("found is false")
+	}
+	if !reflect.DeepEqual(100, val) {
+		t.Errorf("val = %v, want %v", val, 100)
+	}
 }

--- a/internal/cache/uint64_unsafe_map_test.go
+++ b/internal/cache/uint64_unsafe_map_test.go
@@ -1,9 +1,9 @@
 package cache
 
 import (
+	"reflect"
+	"slices"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestUInt64MapPutIfNotExists(t *testing.T) {
@@ -11,21 +11,39 @@ func TestUInt64MapPutIfNotExists(t *testing.T) {
 
 	// First insert should succeed
 	val, inserted := m.PutIfNotExists(1, "first")
-	assert.True(t, inserted)
-	assert.Equal(t, "first", val)
-	assert.Equal(t, 1, m.Len())
+	if !(inserted) {
+		t.Errorf("inserted is false")
+	}
+	if !reflect.DeepEqual("first", val) {
+		t.Errorf("val = %v, want %v", val, "first")
+	}
+	if !reflect.DeepEqual(1, m.Len()) {
+		t.Errorf("m.Len() = %v, want %v", m.Len(), 1)
+	}
 
 	// Second insert with same key should fail
 	val, inserted = m.PutIfNotExists(1, "second")
-	assert.False(t, inserted)
-	assert.Equal(t, "first", val) // Should return existing value
-	assert.Equal(t, 1, m.Len())
+	if inserted {
+		t.Errorf("inserted is true")
+	}
+	if !reflect.DeepEqual("first", val) {
+		t.Errorf("val = %v, want %v", val, "first")
+	} // Should return existing value
+	if !reflect.DeepEqual(1, m.Len()) {
+		t.Errorf("m.Len() = %v, want %v", m.Len(), 1)
+	}
 
 	// Insert different key should succeed
 	val, inserted = m.PutIfNotExists(2, "another")
-	assert.True(t, inserted)
-	assert.Equal(t, "another", val)
-	assert.Equal(t, 2, m.Len())
+	if !(inserted) {
+		t.Errorf("inserted is false")
+	}
+	if !reflect.DeepEqual("another", val) {
+		t.Errorf("val = %v, want %v", val, "another")
+	}
+	if !reflect.DeepEqual(2, m.Len()) {
+		t.Errorf("m.Len() = %v, want %v", m.Len(), 2)
+	}
 }
 
 func TestUInt64MapPutIfNotExistsZeroKey(t *testing.T) {
@@ -33,13 +51,21 @@ func TestUInt64MapPutIfNotExistsZeroKey(t *testing.T) {
 
 	// Zero key first insert
 	val, inserted := m.PutIfNotExists(0, "zero")
-	assert.True(t, inserted)
-	assert.Equal(t, "zero", val)
+	if !(inserted) {
+		t.Errorf("inserted is false")
+	}
+	if !reflect.DeepEqual("zero", val) {
+		t.Errorf("val = %v, want %v", val, "zero")
+	}
 
 	// Zero key second insert should fail
 	val, inserted = m.PutIfNotExists(0, "another")
-	assert.False(t, inserted)
-	assert.Equal(t, "zero", val)
+	if inserted {
+		t.Errorf("inserted is true")
+	}
+	if !reflect.DeepEqual("zero", val) {
+		t.Errorf("val = %v, want %v", val, "zero")
+	}
 }
 
 func TestUInt64MapPutIfNotExistsWithCollisions(t *testing.T) {
@@ -48,15 +74,23 @@ func TestUInt64MapPutIfNotExistsWithCollisions(t *testing.T) {
 	// Add many items to force collisions
 	for i := 1; i <= 20; i++ {
 		val, inserted := m.PutIfNotExists(uint64(i), i*10) //nolint:gosec // G115 - test values are small
-		assert.True(t, inserted)
-		assert.Equal(t, i*10, val)
+		if !(inserted) {
+			t.Errorf("inserted is false")
+		}
+		if !reflect.DeepEqual(i*10, val) {
+			t.Errorf("val = %v, want %v", val, i*10)
+		}
 	}
 
 	// Try to insert existing keys
 	for i := 1; i <= 20; i++ {
 		val, inserted := m.PutIfNotExists(uint64(i), i*100) //nolint:gosec // G115 - test values are small
-		assert.False(t, inserted)
-		assert.Equal(t, i*10, val) // Original value
+		if inserted {
+			t.Errorf("inserted is true")
+		}
+		if !reflect.DeepEqual(i*10, val) {
+			t.Errorf("val = %v, want %v", val, i*10)
+		} // Original value
 	}
 }
 
@@ -74,11 +108,21 @@ func TestUInt64MapAll(t *testing.T) {
 		collected[k] = v
 	}
 
-	assert.Len(t, collected, 4)
-	assert.Equal(t, 100, collected[1])
-	assert.Equal(t, 200, collected[2])
-	assert.Equal(t, 300, collected[3])
-	assert.Equal(t, 999, collected[0])
+	if len(collected) != 4 {
+		t.Errorf("len(collected) = %d, want %d", len(collected), 4)
+	}
+	if !reflect.DeepEqual(100, collected[1]) {
+		t.Errorf("collected[1] = %v, want %v", collected[1], 100)
+	}
+	if !reflect.DeepEqual(200, collected[2]) {
+		t.Errorf("collected[2] = %v, want %v", collected[2], 200)
+	}
+	if !reflect.DeepEqual(300, collected[3]) {
+		t.Errorf("collected[3] = %v, want %v", collected[3], 300)
+	}
+	if !reflect.DeepEqual(999, collected[0]) {
+		t.Errorf("collected[0] = %v, want %v", collected[0], 999)
+	}
 }
 
 func TestUInt64MapAllNilMap(t *testing.T) {
@@ -89,7 +133,9 @@ func TestUInt64MapAllNilMap(t *testing.T) {
 	for range m.All() {
 		count++
 	}
-	assert.Equal(t, 0, count)
+	if !reflect.DeepEqual(0, count) {
+		t.Errorf("count = %v, want %v", count, 0)
+	}
 }
 
 func TestUInt64MapKeys(t *testing.T) {
@@ -106,11 +152,14 @@ func TestUInt64MapKeys(t *testing.T) {
 		keys = append(keys, k)
 	}
 
-	assert.Len(t, keys, 4)
-	assert.Contains(t, keys, uint64(0))
-	assert.Contains(t, keys, uint64(10))
-	assert.Contains(t, keys, uint64(20))
-	assert.Contains(t, keys, uint64(30))
+	if len(keys) != 4 {
+		t.Errorf("len(keys) = %d, want %d", len(keys), 4)
+	}
+	for _, want := range []uint64{0, 10, 20, 30} {
+		if !slices.Contains(keys, want) {
+			t.Errorf("keys %v do not contain %d", keys, want)
+		}
+	}
 }
 
 func TestUInt64MapKeysNilMap(t *testing.T) {
@@ -121,7 +170,9 @@ func TestUInt64MapKeysNilMap(t *testing.T) {
 	for range m.Keys() {
 		count++
 	}
-	assert.Equal(t, 0, count)
+	if !reflect.DeepEqual(0, count) {
+		t.Errorf("count = %v, want %v", count, 0)
+	}
 }
 
 func TestUInt64MapKeysEarlyExit(t *testing.T) {
@@ -139,7 +190,9 @@ func TestUInt64MapKeysEarlyExit(t *testing.T) {
 			break
 		}
 	}
-	assert.Equal(t, 3, count)
+	if !reflect.DeepEqual(3, count) {
+		t.Errorf("count = %v, want %v", count, 3)
+	}
 }
 
 func TestUInt64MapValues(t *testing.T) {
@@ -156,11 +209,14 @@ func TestUInt64MapValues(t *testing.T) {
 		values = append(values, v)
 	}
 
-	assert.Len(t, values, 4)
-	assert.Contains(t, values, "zero")
-	assert.Contains(t, values, "one")
-	assert.Contains(t, values, "two")
-	assert.Contains(t, values, "three")
+	if len(values) != 4 {
+		t.Errorf("len(values) = %d, want %d", len(values), 4)
+	}
+	for _, want := range []string{"zero", "one", "two", "three"} {
+		if !slices.Contains(values, want) {
+			t.Errorf("values %v do not contain %q", values, want)
+		}
+	}
 }
 
 func TestUInt64MapValuesNilMap(t *testing.T) {
@@ -171,7 +227,9 @@ func TestUInt64MapValuesNilMap(t *testing.T) {
 	for range m.Values() {
 		count++
 	}
-	assert.Equal(t, 0, count)
+	if !reflect.DeepEqual(0, count) {
+		t.Errorf("count = %v, want %v", count, 0)
+	}
 }
 
 func TestUInt64MapValuesEarlyExit(t *testing.T) {
@@ -190,7 +248,9 @@ func TestUInt64MapValuesEarlyExit(t *testing.T) {
 			break
 		}
 	}
-	assert.Equal(t, 3, count)
+	if !reflect.DeepEqual(3, count) {
+		t.Errorf("count = %v, want %v", count, 3)
+	}
 }
 
 func TestUInt64MapHasWithCollisions(t *testing.T) {
@@ -203,30 +263,46 @@ func TestUInt64MapHasWithCollisions(t *testing.T) {
 
 	// Test Has for existing keys
 	for i := uint64(1); i <= 20; i++ {
-		assert.True(t, m.Has(i))
+		if !(m.Has(i)) {
+			t.Errorf("m.Has(i) is false")
+		}
 	}
 
 	// Test Has for non-existing keys
-	assert.False(t, m.Has(100))
-	assert.False(t, m.Has(200))
+	if m.Has(100) {
+		t.Errorf("m.Has(100) is true")
+	}
+	if m.Has(200) {
+		t.Errorf("m.Has(200) is true")
+	}
 }
 
 func TestUInt64MapHasZeroKey(t *testing.T) {
 	m := NewUInt64Map[int](16)
 
-	assert.False(t, m.Has(0))
+	if m.Has(0) {
+		t.Errorf("m.Has(0) is true")
+	}
 
 	m.Put(0, 100)
-	assert.True(t, m.Has(0))
+	if !(m.Has(0)) {
+		t.Errorf("m.Has(0) is false")
+	}
 
 	m.Del(0)
-	assert.False(t, m.Has(0))
+	if m.Has(0) {
+		t.Errorf("m.Has(0) is true")
+	}
 }
 
 func TestUInt64MapHasNilMap(t *testing.T) {
 	var m *UInt64Map[int]
-	assert.False(t, m.Has(1))
-	assert.False(t, m.Has(0))
+	if m.Has(1) {
+		t.Errorf("m.Has(1) is true")
+	}
+	if m.Has(0) {
+		t.Errorf("m.Has(0) is true")
+	}
 }
 
 func TestUInt64MapForEachEarlyExit(t *testing.T) {
@@ -243,7 +319,9 @@ func TestUInt64MapForEachEarlyExit(t *testing.T) {
 		return count < 5
 	})
 
-	assert.Equal(t, 5, count)
+	if !reflect.DeepEqual(5, count) {
+		t.Errorf("count = %v, want %v", count, 5)
+	}
 }
 
 func TestUInt64MapForEachWithZeroKey(t *testing.T) {
@@ -260,8 +338,12 @@ func TestUInt64MapForEachWithZeroKey(t *testing.T) {
 		return true
 	})
 
-	assert.Len(t, keys, 3)
-	assert.Contains(t, keys, uint64(0))
+	if len(keys) != 3 {
+		t.Errorf("len(keys) = %d, want %d", len(keys), 3)
+	}
+	if !slices.Contains(keys, uint64(0)) {
+		t.Errorf("keys %v do not contain 0", keys)
+	}
 }
 
 func TestUInt64MapForEachNilMap(t *testing.T) {
@@ -273,7 +355,9 @@ func TestUInt64MapForEachNilMap(t *testing.T) {
 		count++
 		return true
 	})
-	assert.Equal(t, 0, count)
+	if !reflect.DeepEqual(0, count) {
+		t.Errorf("count = %v, want %v", count, 0)
+	}
 }
 
 func TestUInt64MapClearNilMap(t *testing.T) {
@@ -285,27 +369,41 @@ func TestUInt64MapClearNilMap(t *testing.T) {
 
 func TestUInt64MapLenNilMap(t *testing.T) {
 	var m *UInt64Map[int]
-	assert.Equal(t, 0, m.Len())
+	if !reflect.DeepEqual(0, m.Len()) {
+		t.Errorf("m.Len() = %v, want %v", m.Len(), 0)
+	}
 }
 
 func TestUInt64MapGetNilMap(t *testing.T) {
 	var m *UInt64Map[int]
 
 	val, found := m.Get(1)
-	assert.False(t, found)
-	assert.Equal(t, 0, val)
+	if found {
+		t.Errorf("found is true")
+	}
+	if !reflect.DeepEqual(0, val) {
+		t.Errorf("val = %v, want %v", val, 0)
+	}
 
 	val, found = m.Get(0)
-	assert.False(t, found)
-	assert.Equal(t, 0, val)
+	if found {
+		t.Errorf("found is true")
+	}
+	if !reflect.DeepEqual(0, val) {
+		t.Errorf("val = %v, want %v", val, 0)
+	}
 }
 
 func TestUInt64MapDelNilMap(t *testing.T) {
 	var m *UInt64Map[int]
 
 	// Should not panic and return false
-	assert.False(t, m.Del(1))
-	assert.False(t, m.Del(0))
+	if m.Del(1) {
+		t.Errorf("m.Del(1) is true")
+	}
+	if m.Del(0) {
+		t.Errorf("m.Del(0) is true")
+	}
 }
 
 func TestUInt64MapGrow(t *testing.T) {
@@ -319,11 +417,17 @@ func TestUInt64MapGrow(t *testing.T) {
 	// Verify all items are still accessible
 	for i := 1; i <= 100; i++ {
 		val, found := m.Get(uint64(i)) //nolint:gosec // G115 - test values are small
-		assert.True(t, found)
-		assert.Equal(t, i*10, val)
+		if !(found) {
+			t.Errorf("found is false")
+		}
+		if !reflect.DeepEqual(i*10, val) {
+			t.Errorf("val = %v, want %v", val, i*10)
+		}
 	}
 
-	assert.Equal(t, 100, m.Len())
+	if !reflect.DeepEqual(100, m.Len()) {
+		t.Errorf("m.Len() = %v, want %v", m.Len(), 100)
+	}
 }
 
 func TestUInt64MapGrowWithZeroKey(t *testing.T) {
@@ -339,6 +443,10 @@ func TestUInt64MapGrowWithZeroKey(t *testing.T) {
 
 	// Zero key should still be accessible
 	val, found := m.Get(0)
-	assert.True(t, found)
-	assert.Equal(t, 999, val)
+	if !(found) {
+		t.Errorf("found is false")
+	}
+	if !reflect.DeepEqual(999, val) {
+		t.Errorf("val = %v, want %v", val, 999)
+	}
 }

--- a/internal/dnsutil/cache_ttl_test.go
+++ b/internal/dnsutil/cache_ttl_test.go
@@ -1,11 +1,11 @@
 package dnsutil
 
 import (
+	"math"
 	"testing"
 	"time"
 
 	"github.com/miekg/dns"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCalculateCacheTTLWithRRSIG(t *testing.T) {
@@ -154,8 +154,9 @@ func TestCalculateCacheTTLWithRRSIG(t *testing.T) {
 
 			// Allow small time difference due to execution time
 			delta := time.Second
-			assert.InDelta(t, tt.expectedTTL.Seconds(), ttl.Seconds(), delta.Seconds(),
-				"TTL should be approximately %v but got %v", tt.expectedTTL, ttl)
+			if math.Abs(ttl.Seconds()-tt.expectedTTL.Seconds()) > delta.Seconds() {
+				t.Errorf("TTL should be approximately %v but got %v", tt.expectedTTL, ttl)
+			}
 		})
 	}
 }
@@ -206,8 +207,9 @@ func TestGetRRSIGTTL(t *testing.T) {
 
 			// Allow small time difference due to execution time
 			delta := time.Second
-			assert.InDelta(t, tt.expectedTTL.Seconds(), ttl.Seconds(), delta.Seconds(),
-				"TTL should be approximately %v but got %v", tt.expectedTTL, ttl)
+			if math.Abs(ttl.Seconds()-tt.expectedTTL.Seconds()) > delta.Seconds() {
+				t.Errorf("TTL should be approximately %v but got %v", tt.expectedTTL, ttl)
+			}
 		})
 	}
 }

--- a/internal/dnsutil/ede_test.go
+++ b/internal/dnsutil/ede_test.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/miekg/dns"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestSetRcodeWithEDE(t *testing.T) {
@@ -33,16 +33,32 @@ func TestSetRcodeWithEDE(t *testing.T) {
 			edeCode: dns.ExtendedErrorCodeDNSSECIndeterminate,
 			edeText: "DNSSEC validation failure",
 			expected: func(t *testing.T, msg *dns.Msg) {
-				assert.Equal(t, dns.RcodeServerFailure, msg.Rcode)
-				assert.Len(t, msg.Extra, 1)
+				if !reflect.DeepEqual(dns.RcodeServerFailure, msg.Rcode) {
+					t.Errorf("msg.Rcode = %v, want %v", msg.Rcode, dns.RcodeServerFailure)
+				}
+				if len(msg.Extra) != 1 {
+					t.Errorf("len(msg.Extra) = %d, want %d", len(msg.Extra), 1)
+				}
 				opt, ok := msg.Extra[0].(*dns.OPT)
-				assert.True(t, ok)
-				assert.True(t, opt.Do())
-				assert.Len(t, opt.Option, 1)
+				if !(ok) {
+					t.Errorf("ok is false")
+				}
+				if !(opt.Do()) {
+					t.Errorf("opt.Do() is false")
+				}
+				if len(opt.Option) != 1 {
+					t.Errorf("len(opt.Option) = %d, want %d", len(opt.Option), 1)
+				}
 				ede, ok := opt.Option[0].(*dns.EDNS0_EDE)
-				assert.True(t, ok)
-				assert.Equal(t, dns.ExtendedErrorCodeDNSSECIndeterminate, ede.InfoCode)
-				assert.Equal(t, "DNSSEC validation failure", ede.ExtraText)
+				if !(ok) {
+					t.Errorf("ok is false")
+				}
+				if !reflect.DeepEqual(dns.ExtendedErrorCodeDNSSECIndeterminate, ede.InfoCode) {
+					t.Errorf("ede.InfoCode = %v, want %v", ede.InfoCode, dns.ExtendedErrorCodeDNSSECIndeterminate)
+				}
+				if !reflect.DeepEqual("DNSSEC validation failure", ede.ExtraText) {
+					t.Errorf("ede.ExtraText = %v, want %v", ede.ExtraText, "DNSSEC validation failure")
+				}
 			},
 		},
 		{
@@ -58,11 +74,19 @@ func TestSetRcodeWithEDE(t *testing.T) {
 			edeCode: dns.ExtendedErrorCodeNetworkError,
 			edeText: "Network unreachable",
 			expected: func(t *testing.T, msg *dns.Msg) {
-				assert.Equal(t, dns.RcodeServerFailure, msg.Rcode)
+				if !reflect.DeepEqual(dns.RcodeServerFailure, msg.Rcode) {
+					t.Errorf("msg.Rcode = %v, want %v", msg.Rcode, dns.RcodeServerFailure)
+				}
 				opt := msg.IsEdns0()
-				assert.NotNil(t, opt)
-				assert.False(t, opt.Do())
-				assert.Len(t, opt.Option, 1) // EDE is added for SERVFAIL
+				if opt == nil {
+					t.Fatalf("opt is nil")
+				}
+				if opt.Do() {
+					t.Errorf("opt.Do() is true")
+				}
+				if len(opt.Option) != 1 {
+					t.Errorf("len(opt.Option) = %d, want %d", len(opt.Option), 1)
+				} // EDE is added for SERVFAIL
 			},
 		},
 		{
@@ -78,11 +102,19 @@ func TestSetRcodeWithEDE(t *testing.T) {
 			edeCode: dns.ExtendedErrorCodeCachedError,
 			edeText: "Cached negative response",
 			expected: func(t *testing.T, msg *dns.Msg) {
-				assert.Equal(t, dns.RcodeNameError, msg.Rcode)
+				if !reflect.DeepEqual(dns.RcodeNameError, msg.Rcode) {
+					t.Errorf("msg.Rcode = %v, want %v", msg.Rcode, dns.RcodeNameError)
+				}
 				opt := msg.IsEdns0()
-				assert.NotNil(t, opt)
-				assert.True(t, opt.Do())
-				assert.Len(t, opt.Option, 0) // No EDE for non-SERVFAIL
+				if opt == nil {
+					t.Fatalf("opt is nil")
+				}
+				if !(opt.Do()) {
+					t.Errorf("opt.Do() is false")
+				}
+				if len(opt.Option) != 0 {
+					t.Errorf("len(opt.Option) = %d, want %d", len(opt.Option), 0)
+				} // No EDE for non-SERVFAIL
 			},
 		},
 		{
@@ -98,15 +130,29 @@ func TestSetRcodeWithEDE(t *testing.T) {
 			edeCode: dns.ExtendedErrorCodeOther,
 			edeText: "",
 			expected: func(t *testing.T, msg *dns.Msg) {
-				assert.Equal(t, dns.RcodeServerFailure, msg.Rcode)
-				assert.Len(t, msg.Extra, 1)
+				if !reflect.DeepEqual(dns.RcodeServerFailure, msg.Rcode) {
+					t.Errorf("msg.Rcode = %v, want %v", msg.Rcode, dns.RcodeServerFailure)
+				}
+				if len(msg.Extra) != 1 {
+					t.Errorf("len(msg.Extra) = %d, want %d", len(msg.Extra), 1)
+				}
 				opt, ok := msg.Extra[0].(*dns.OPT)
-				assert.True(t, ok)
-				assert.Len(t, opt.Option, 1)
+				if !(ok) {
+					t.Errorf("ok is false")
+				}
+				if len(opt.Option) != 1 {
+					t.Errorf("len(opt.Option) = %d, want %d", len(opt.Option), 1)
+				}
 				ede, ok := opt.Option[0].(*dns.EDNS0_EDE)
-				assert.True(t, ok)
-				assert.Equal(t, dns.ExtendedErrorCodeOther, ede.InfoCode)
-				assert.Equal(t, "", ede.ExtraText)
+				if !(ok) {
+					t.Errorf("ok is false")
+				}
+				if !reflect.DeepEqual(dns.ExtendedErrorCodeOther, ede.InfoCode) {
+					t.Errorf("ede.InfoCode = %v, want %v", ede.InfoCode, dns.ExtendedErrorCodeOther)
+				}
+				if !reflect.DeepEqual("", ede.ExtraText) {
+					t.Errorf("ede.ExtraText = %v, want %v", ede.ExtraText, "")
+				}
 			},
 		},
 		{
@@ -121,11 +167,19 @@ func TestSetRcodeWithEDE(t *testing.T) {
 			edeCode: dns.ExtendedErrorCodeNoReachableAuthority,
 			edeText: "All nameservers unreachable",
 			expected: func(t *testing.T, msg *dns.Msg) {
-				assert.Equal(t, dns.RcodeServerFailure, msg.Rcode)
-				assert.Len(t, msg.Extra, 1)
+				if !reflect.DeepEqual(dns.RcodeServerFailure, msg.Rcode) {
+					t.Errorf("msg.Rcode = %v, want %v", msg.Rcode, dns.RcodeServerFailure)
+				}
+				if len(msg.Extra) != 1 {
+					t.Errorf("len(msg.Extra) = %d, want %d", len(msg.Extra), 1)
+				}
 				opt, ok := msg.Extra[0].(*dns.OPT)
-				assert.True(t, ok)
-				assert.Len(t, opt.Option, 1)
+				if !(ok) {
+					t.Errorf("ok is false")
+				}
+				if len(opt.Option) != 1 {
+					t.Errorf("len(opt.Option) = %d, want %d", len(opt.Option), 1)
+				}
 			},
 		},
 	}
@@ -192,8 +246,12 @@ func TestErrorToEDE(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			code, text := ErrorToEDE(tt.err)
-			assert.Equal(t, tt.expectedCode, code)
-			assert.Equal(t, tt.expectedText, text)
+			if !reflect.DeepEqual(tt.expectedCode, code) {
+				t.Errorf("code = %v, want %v", code, tt.expectedCode)
+			}
+			if !reflect.DeepEqual(tt.expectedText, text) {
+				t.Errorf("text = %v, want %v", text, tt.expectedText)
+			}
 		})
 	}
 }
@@ -285,11 +343,19 @@ func TestGetEDE(t *testing.T) {
 			ede := GetEDE(tt.msg)
 
 			if tt.expectNil {
-				assert.Nil(t, ede)
+				if ede != nil {
+					t.Errorf("ede = %v, want nil", ede)
+				}
 			} else {
-				assert.NotNil(t, ede)
-				assert.Equal(t, tt.expectedCode, ede.InfoCode)
-				assert.Equal(t, tt.expectedText, ede.ExtraText)
+				if ede == nil {
+					t.Fatalf("ede is nil")
+				}
+				if !reflect.DeepEqual(tt.expectedCode, ede.InfoCode) {
+					t.Errorf("ede.InfoCode = %v, want %v", ede.InfoCode, tt.expectedCode)
+				}
+				if !reflect.DeepEqual(tt.expectedText, ede.ExtraText) {
+					t.Errorf("ede.ExtraText = %v, want %v", ede.ExtraText, tt.expectedText)
+				}
 			}
 		})
 	}
@@ -334,11 +400,17 @@ func TestSetEDE(t *testing.T) {
 
 			ede := GetEDE(tt.msg)
 			if tt.expectEDE {
-				assert.NotNil(t, ede)
-				assert.Equal(t, tt.code, ede.InfoCode)
-				assert.Equal(t, tt.text, ede.ExtraText)
-			} else {
-				assert.Nil(t, ede)
+				if ede == nil {
+					t.Fatalf("ede is nil")
+				}
+				if !reflect.DeepEqual(tt.code, ede.InfoCode) {
+					t.Errorf("ede.InfoCode = %v, want %v", ede.InfoCode, tt.code)
+				}
+				if !reflect.DeepEqual(tt.text, ede.ExtraText) {
+					t.Errorf("ede.ExtraText = %v, want %v", ede.ExtraText, tt.text)
+				}
+			} else if ede != nil {
+				t.Errorf("ede = %v, want nil", ede)
 			}
 		})
 	}

--- a/internal/dnsutil/helpers_test.go
+++ b/internal/dnsutil/helpers_test.go
@@ -3,12 +3,12 @@ package dnsutil
 import (
 	"net"
 	"net/netip"
+	"reflect"
 	"testing"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/internal/ecs"
 	"github.com/semihalev/sdns/internal/mock"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestSetEdns0(t *testing.T) {
@@ -154,15 +154,27 @@ func TestSetEdns0(t *testing.T) {
 			// matching the pre-7871 contract this test was written for.
 			opt, size, cookie, nsid, origDo := SetEdns0(tt.req, nil, netip.Addr{})
 
-			assert.NotNil(t, opt)
-			assert.Equal(t, tt.expectedSize, size)
-			assert.Equal(t, tt.expectedCookie, cookie)
-			assert.Equal(t, tt.expectedNsid, nsid)
-			assert.Equal(t, tt.expectedOrigDo, origDo)
+			if opt == nil {
+				t.Fatalf("opt is nil")
+			}
+			if !reflect.DeepEqual(tt.expectedSize, size) {
+				t.Errorf("size = %v, want %v", size, tt.expectedSize)
+			}
+			if !reflect.DeepEqual(tt.expectedCookie, cookie) {
+				t.Errorf("cookie = %v, want %v", cookie, tt.expectedCookie)
+			}
+			if !reflect.DeepEqual(tt.expectedNsid, nsid) {
+				t.Errorf("nsid = %v, want %v", nsid, tt.expectedNsid)
+			}
+			if !reflect.DeepEqual(tt.expectedOrigDo, origDo) {
+				t.Errorf("origDo = %v, want %v", origDo, tt.expectedOrigDo)
+			}
 
 			// Verify OPT record is now in request
 			reqOpt := tt.req.IsEdns0()
-			assert.NotNil(t, reqOpt)
+			if reqOpt == nil {
+				t.Fatalf("reqOpt is nil")
+			}
 		})
 	}
 }
@@ -305,16 +317,24 @@ func TestGenerateServerCookie(t *testing.T) {
 			result := GenerateServerCookie(tt.secret, tt.remoteip, tt.cookie)
 
 			// Cookie should start with the original cookie
-			assert.True(t, len(result) > len(tt.cookie))
-			assert.Equal(t, tt.cookie, result[:len(tt.cookie)])
+			if len(result) <= len(tt.cookie) {
+				t.Errorf("len(result) = %d, want > %d", len(result), len(tt.cookie))
+			}
+			if !reflect.DeepEqual(tt.cookie, result[:len(tt.cookie)]) {
+				t.Errorf("result[:len(tt.cookie)] = %v, want %v", result[:len(tt.cookie)], tt.cookie)
+			}
 
 			// Generate same cookie with same parameters should be identical
 			result2 := GenerateServerCookie(tt.secret, tt.remoteip, tt.cookie)
-			assert.Equal(t, result, result2)
+			if !reflect.DeepEqual(result, result2) {
+				t.Errorf("result2 = %v, want %v", result2, result)
+			}
 
 			// Different parameters should produce different results
 			result3 := GenerateServerCookie(tt.secret+"x", tt.remoteip, tt.cookie)
-			assert.NotEqual(t, result, result3)
+			if reflect.DeepEqual(result, result3) {
+				t.Errorf("result3 = %v, want a different value", result3)
+			}
 		})
 	}
 }
@@ -364,9 +384,13 @@ func TestClearOPT(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := ClearOPT(tt.msg)
 
-			assert.Equal(t, tt.expectedExtra, len(result.Extra))
+			if !reflect.DeepEqual(tt.expectedExtra, len(result.Extra)) {
+				t.Errorf("len(result.Extra) = %v, want %v", len(result.Extra), tt.expectedExtra)
+			}
 			// Verify no OPT records remain
-			assert.Nil(t, result.IsEdns0())
+			if result.IsEdns0() != nil {
+				t.Errorf("result.IsEdns0() = %v, want nil", result.IsEdns0())
+			}
 		})
 	}
 }
@@ -472,8 +496,12 @@ func TestClearDNSSEC(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			result := ClearDNSSEC(tt.msg)
 
-			assert.Equal(t, tt.expectedAnswer, len(result.Answer))
-			assert.Equal(t, tt.expectedNs, len(result.Ns))
+			if !reflect.DeepEqual(tt.expectedAnswer, len(result.Answer)) {
+				t.Errorf("len(result.Answer) = %v, want %v", len(result.Answer), tt.expectedAnswer)
+			}
+			if !reflect.DeepEqual(tt.expectedNs, len(result.Ns)) {
+				t.Errorf("len(result.Ns) = %v, want %v", len(result.Ns), tt.expectedNs)
+			}
 		})
 	}
 }
@@ -487,15 +515,29 @@ func TestNotSupported(t *testing.T) {
 	w := mock.NewWriter("tcp", "127.0.0.1:0")
 
 	err := NotSupported(w, req)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	msg := w.Msg()
-	assert.NotNil(t, msg)
-	assert.Equal(t, dns.RcodeNotImplemented, msg.Rcode)
-	assert.Equal(t, req.Id, msg.Id)
-	assert.True(t, msg.Response)
-	assert.True(t, msg.RecursionDesired)
-	assert.True(t, msg.AuthenticatedData)
+	if msg == nil {
+		t.Fatalf("msg is nil")
+	}
+	if !reflect.DeepEqual(dns.RcodeNotImplemented, msg.Rcode) {
+		t.Errorf("msg.Rcode = %v, want %v", msg.Rcode, dns.RcodeNotImplemented)
+	}
+	if !reflect.DeepEqual(req.Id, msg.Id) {
+		t.Errorf("msg.Id = %v, want %v", msg.Id, req.Id)
+	}
+	if !(msg.Response) {
+		t.Errorf("msg.Response is false")
+	}
+	if !(msg.RecursionDesired) {
+		t.Errorf("msg.RecursionDesired is false")
+	}
+	if !(msg.AuthenticatedData) {
+		t.Errorf("msg.AuthenticatedData is false")
+	}
 }
 
 func TestSetRcode(t *testing.T) {
@@ -541,14 +583,24 @@ func TestSetRcode(t *testing.T) {
 
 			msg := SetRcode(req, tt.rcode, tt.do)
 
-			assert.Equal(t, tt.expectedRc, msg.Rcode)
-			assert.True(t, msg.RecursionAvailable)
-			assert.True(t, msg.RecursionDesired)
+			if !reflect.DeepEqual(tt.expectedRc, msg.Rcode) {
+				t.Errorf("msg.Rcode = %v, want %v", msg.Rcode, tt.expectedRc)
+			}
+			if !(msg.RecursionAvailable) {
+				t.Errorf("msg.RecursionAvailable is false")
+			}
+			if !(msg.RecursionDesired) {
+				t.Errorf("msg.RecursionDesired is false")
+			}
 
 			opt := msg.IsEdns0()
 			if tt.expectedEdns {
-				assert.NotNil(t, opt)
-				assert.Equal(t, tt.expectedDo, opt.Do())
+				if opt == nil {
+					t.Fatalf("opt is nil")
+				}
+				if !reflect.DeepEqual(tt.expectedDo, opt.Do()) {
+					t.Errorf("opt.Do() = %v, want %v", opt.Do(), tt.expectedDo)
+				}
 			}
 		})
 	}

--- a/internal/dnsutil/ptr_test.go
+++ b/internal/dnsutil/ptr_test.go
@@ -1,9 +1,8 @@
 package dnsutil
 
 import (
+	"reflect"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestIPFromReverseName(t *testing.T) {
@@ -57,7 +56,9 @@ func TestIPFromReverseName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := IPFromReverseName(tt.input)
-			assert.Equal(t, tt.expected, result)
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("result = %v, want %v", result, tt.expected)
+			}
 		})
 	}
 }
@@ -98,7 +99,9 @@ func TestCheckReverseName(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := CheckReverseName(tt.input)
-			assert.Equal(t, tt.expected, result)
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("result = %v, want %v", result, tt.expected)
+			}
 		})
 	}
 }
@@ -139,7 +142,9 @@ func TestParseIPv4PTR(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := parseIPv4PTR(tt.input)
-			assert.Equal(t, tt.expected, result)
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("result = %v, want %v", result, tt.expected)
+			}
 		})
 	}
 }
@@ -175,7 +180,9 @@ func TestParseIPv6PTR(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := parseIPv6PTR(tt.input)
-			assert.Equal(t, tt.expected, result)
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("result = %v, want %v", result, tt.expected)
+			}
 		})
 	}
 }

--- a/internal/dnsutil/response_test.go
+++ b/internal/dnsutil/response_test.go
@@ -1,11 +1,11 @@
 package dnsutil
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/miekg/dns"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestClassifyResponse(t *testing.T) {
@@ -215,11 +215,17 @@ func TestClassifyResponse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			respType, opt := ClassifyResponse(tt.msg, now)
 
-			assert.Equal(t, tt.expectedType, respType)
+			if !reflect.DeepEqual(tt.expectedType, respType) {
+				t.Errorf("respType = %v, want %v", respType, tt.expectedType)
+			}
 			if tt.hasOpt {
-				assert.NotNil(t, opt)
+				if opt == nil {
+					t.Fatalf("opt is nil")
+				}
 			} else {
-				assert.Nil(t, opt)
+				if opt != nil {
+					t.Errorf("opt = %v, want nil", opt)
+				}
 			}
 		})
 	}
@@ -282,7 +288,9 @@ func TestIsDelegation(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := isDelegation(tt.msg)
-			assert.Equal(t, tt.expected, result)
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("result = %v, want %v", result, tt.expected)
+			}
 		})
 	}
 }
@@ -333,7 +341,9 @@ func TestHasSOA(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := hasSOA(tt.msg)
-			assert.Equal(t, tt.expected, result)
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("result = %v, want %v", result, tt.expected)
+			}
 		})
 	}
 }
@@ -429,7 +439,9 @@ func TestHasExpiredSignatures(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := hasExpiredSignatures(tt.msg, now)
-			assert.Equal(t, tt.expected, result)
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("result = %v, want %v", result, tt.expected)
+			}
 		})
 	}
 }
@@ -480,7 +492,9 @@ func TestShouldCache(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := shouldCache(tt.msg)
-			assert.Equal(t, tt.expected, result)
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("result = %v, want %v", result, tt.expected)
+			}
 		})
 	}
 }

--- a/internal/mock/writer_test.go
+++ b/internal/mock/writer_test.go
@@ -1,10 +1,10 @@
 package mock
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/miekg/dns"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_Writer(t *testing.T) {
@@ -14,29 +14,63 @@ func Test_Writer(t *testing.T) {
 	m.SetQuestion("example.com.", dns.TypeA)
 	err := mw.WriteMsg(m)
 
-	assert.NoError(t, err)
-	assert.True(t, mw.Written())
-	assert.Equal(t, mw.Rcode(), dns.RcodeSuccess)
-	assert.NotNil(t, mw.Msg())
-	assert.Equal(t, mw.LocalAddr().String(), "127.0.0.1:53")
-	assert.Equal(t, mw.RemoteAddr().String(), "127.0.0.1:0")
-	assert.Nil(t, mw.Close())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !(mw.Written()) {
+		t.Errorf("mw.Written() is false")
+	}
+	if !reflect.DeepEqual(mw.Rcode(), dns.RcodeSuccess) {
+		t.Errorf("dns.RcodeSuccess = %v, want %v", dns.RcodeSuccess, mw.Rcode())
+	}
+	if mw.Msg() == nil {
+		t.Fatalf("mw.Msg() is nil")
+	}
+	if !reflect.DeepEqual(mw.LocalAddr().String(), "127.0.0.1:53") {
+		t.Errorf("'127.0.0.1:53' = %v, want %v", "127.0.0.1:53", mw.LocalAddr().String())
+	}
+	if !reflect.DeepEqual(mw.RemoteAddr().String(), "127.0.0.1:0") {
+		t.Errorf("'127.0.0.1:0' = %v, want %v", "127.0.0.1:0", mw.RemoteAddr().String())
+	}
+	if mw.Close() != nil {
+		t.Errorf("mw.Close() = %v, want nil", mw.Close())
+	}
 
 	mw = NewWriter("tcp", "127.0.0.255:0")
-	assert.False(t, mw.Written())
-	assert.Equal(t, mw.Rcode(), dns.RcodeServerFailure)
+	if mw.Written() {
+		t.Errorf("mw.Written() is true")
+	}
+	if !reflect.DeepEqual(mw.Rcode(), dns.RcodeServerFailure) {
+		t.Errorf("dns.RcodeServerFailure = %v, want %v", dns.RcodeServerFailure, mw.Rcode())
+	}
 
-	assert.Equal(t, "tcp", mw.Proto())
-	assert.Equal(t, "127.0.0.255", mw.RemoteIP().String())
+	if !reflect.DeepEqual("tcp", mw.Proto()) {
+		t.Errorf("mw.Proto() = %v, want %v", mw.Proto(), "tcp")
+	}
+	if !reflect.DeepEqual("127.0.0.255", mw.RemoteIP().String()) {
+		t.Errorf("mw.RemoteIP().String() = %v, want %v", mw.RemoteIP().String(), "127.0.0.255")
+	}
 
 	_, err = mw.Write([]byte{})
-	assert.Error(t, err)
+	if err == nil {
+		t.Errorf("expected an error, got nil")
+	}
 
 	data, err := m.Pack()
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 	_, err = mw.Write(data)
-	assert.NoError(t, err)
-	assert.True(t, mw.Written())
-	assert.Equal(t, mw.Rcode(), dns.RcodeSuccess)
-	assert.True(t, mw.Internal())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !(mw.Written()) {
+		t.Errorf("mw.Written() is false")
+	}
+	if !reflect.DeepEqual(mw.Rcode(), dns.RcodeSuccess) {
+		t.Errorf("dns.RcodeSuccess = %v, want %v", dns.RcodeSuccess, mw.Rcode())
+	}
+	if !(mw.Internal()) {
+		t.Errorf("mw.Internal() is false")
+	}
 }

--- a/internal/waitgroup/waitgroup_test.go
+++ b/internal/waitgroup/waitgroup_test.go
@@ -2,6 +2,8 @@ package waitgroup
 
 import (
 	"context"
+	"errors"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -9,8 +11,6 @@ import (
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/internal/cache"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_WaitGroupWait(t *testing.T) {
@@ -24,12 +24,16 @@ func Test_WaitGroupWait(t *testing.T) {
 	wg.Add(key)
 
 	count := wg.Get(key)
-	assert.Equal(t, 1, count)
+	if !reflect.DeepEqual(1, count) {
+		t.Errorf("count = %v, want %v", count, 1)
+	}
 
 	key2 := cache.Key(dns.Question{Name: "none.", Qtype: dns.TypeA, Qclass: dns.ClassINET})
 
 	count = wg.Get(key2)
-	assert.Equal(t, 0, count)
+	if !reflect.DeepEqual(0, count) {
+		t.Errorf("count = %v, want %v", count, 0)
+	}
 
 	wg.Wait(key2)
 
@@ -61,7 +65,9 @@ func Test_WaitGroupWait(t *testing.T) {
 	mu.RLock()
 	defer mu.RUnlock()
 	for _, w := range workers {
-		assert.Equal(t, *w, "stopped")
+		if !reflect.DeepEqual(*w, "stopped") {
+			t.Errorf("'stopped' = %v, want %v", "stopped", *w)
+		}
 	}
 }
 
@@ -77,7 +83,9 @@ func Test_JoinLeaderWakesFollowers(t *testing.T) {
 
 	// Leader.
 	wait := wg.Join(key)
-	require.Nil(t, wait, "first Join must return nil (leader)")
+	if wait != nil {
+		t.Fatalf("%s: wait = %v, want nil", "first Join must return nil (leader)", wait)
+	}
 
 	// Followers.
 	const followers = 3
@@ -86,7 +94,13 @@ func Test_JoinLeaderWakesFollowers(t *testing.T) {
 	for range followers {
 		go func() {
 			w := wg.Join(key)
-			require.NotNil(t, w, "subsequent Join must return a channel (follower)")
+			if w == nil {
+				// Errorf, not Fatalf: FailNow must not run off the test
+				// goroutine, and the collector below still needs its done.
+				t.Errorf("subsequent Join must return a channel (follower)")
+				done <- struct{}{}
+				return
+			}
 			<-w
 			woken.Add(1)
 			done <- struct{}{}
@@ -96,7 +110,9 @@ func Test_JoinLeaderWakesFollowers(t *testing.T) {
 	// Give followers time to block on the channel before the leader
 	// calls Done — that's the case the regression would mishandle.
 	time.Sleep(50 * time.Millisecond)
-	assert.Equal(t, int32(0), woken.Load(), "followers must wait for leader's Done")
+	if !reflect.DeepEqual(int32(0), woken.Load()) {
+		t.Errorf("%s: woken.Load() = %v, want %v", "followers must wait for leader's Done", woken.Load(), int32(0))
+	}
 
 	// Leader finishes. All followers should wake well before the
 	// 5s wait timeout would expire.
@@ -110,7 +126,9 @@ func Test_JoinLeaderWakesFollowers(t *testing.T) {
 			t.Fatalf("follower still blocked %v after leader Done", time.Since(start))
 		}
 	}
-	assert.Equal(t, int32(followers), woken.Load())
+	if !reflect.DeepEqual(int32(followers), woken.Load()) {
+		t.Errorf("woken.Load() = %v, want %v", woken.Load(), int32(followers))
+	}
 }
 
 func Test_RegroupPinsLateFollowersToOneNextGeneration(t *testing.T) {
@@ -118,15 +136,23 @@ func Test_RegroupPinsLateFollowersToOneNextGeneration(t *testing.T) {
 	key := cache.Key(dns.Question{Name: "regroup.test.", Qtype: dns.TypeA, Qclass: dns.ClassINET})
 
 	first, leader := wg.JoinGeneration(key)
-	require.True(t, leader)
+	if !(leader) {
+		t.Fatalf("leader is false")
+	}
 	follower, leader := wg.JoinGeneration(key)
-	require.False(t, leader)
-	require.Same(t, first, follower)
+	if leader {
+		t.Fatalf("leader is true")
+	}
+	if first != follower {
+		t.Fatalf("%p and %p are not the same pointer", first, follower)
+	}
 	wg.DoneGeneration(key, first)
 	<-first.Done()
 
 	second, leader := wg.Regroup(key, first)
-	require.True(t, leader)
+	if !(leader) {
+		t.Fatalf("leader is false")
+	}
 	wg.DoneGeneration(key, second)
 	<-second.Done()
 
@@ -134,8 +160,12 @@ func Test_RegroupPinsLateFollowersToOneNextGeneration(t *testing.T) {
 	// first cohort must still observe that exact token instead of becoming a
 	// third leader.
 	late, leader := wg.Regroup(key, follower)
-	require.False(t, leader)
-	require.Same(t, second, late)
+	if leader {
+		t.Fatalf("leader is true")
+	}
+	if second != late {
+		t.Fatalf("%p and %p are not the same pointer", second, late)
+	}
 }
 
 func Test_DoneGenerationCannotDeleteNewerRegroup(t *testing.T) {
@@ -143,19 +173,27 @@ func Test_DoneGenerationCannotDeleteNewerRegroup(t *testing.T) {
 	key := cache.Key(dns.Question{Name: "stale.test.", Qtype: dns.TypeA, Qclass: dns.ClassINET})
 
 	first, leader := wg.JoinGeneration(key)
-	require.True(t, leader)
+	if !(leader) {
+		t.Fatalf("leader is false")
+	}
 	wg.DoneGeneration(key, first)
 	<-first.Done()
 
 	second, leader := wg.Regroup(key, first)
-	require.True(t, leader)
+	if !(leader) {
+		t.Fatalf("leader is false")
+	}
 
 	// The abandoned first leader finally returns. Its token-specific Done
 	// must not erase the current second generation.
 	wg.DoneGeneration(key, first)
 	current, leader := wg.JoinGeneration(key)
-	require.False(t, leader)
-	require.Same(t, second, current)
+	if leader {
+		t.Fatalf("leader is true")
+	}
+	if second != current {
+		t.Fatalf("%p and %p are not the same pointer", second, current)
+	}
 
 	wg.DoneGeneration(key, second)
 }
@@ -165,21 +203,37 @@ func Test_TimedOutGenerationRemainsTombstoneUntilLeaderDone(t *testing.T) {
 	key := cache.Key(dns.Question{Name: "timeout.test.", Qtype: dns.TypeA, Qclass: dns.ClassINET})
 
 	first, leader := wg.JoinGeneration(key)
-	require.True(t, leader)
+	if !(leader) {
+		t.Fatalf("leader is false")
+	}
 	<-first.Done()
-	require.ErrorIs(t, first.Err(), context.DeadlineExceeded)
+	if !errors.Is(first.Err(), context.DeadlineExceeded) {
+		t.Fatalf("error = %v, want %v", first.Err(), context.DeadlineExceeded)
+	}
 
 	regrouped, leader := wg.Regroup(key, first)
-	require.False(t, leader)
-	require.Same(t, first, regrouped)
+	if leader {
+		t.Fatalf("leader is true")
+	}
+	if first != regrouped {
+		t.Fatalf("%p and %p are not the same pointer", first, regrouped)
+	}
 	current, leader := wg.JoinGeneration(key)
-	require.False(t, leader)
-	require.Same(t, first, current)
+	if leader {
+		t.Fatalf("leader is true")
+	}
+	if first != current {
+		t.Fatalf("%p and %p are not the same pointer", first, current)
+	}
 
 	wg.DoneGeneration(key, first)
 	next, leader := wg.JoinGeneration(key)
-	require.True(t, leader)
-	require.NotSame(t, first, next)
+	if !(leader) {
+		t.Fatalf("leader is false")
+	}
+	if first == next {
+		t.Fatalf("%p is the same pointer", first)
+	}
 	wg.DoneGeneration(key, next)
 }
 
@@ -188,7 +242,9 @@ func Test_ConcurrentRegroupElectsOneSharedLeader(t *testing.T) {
 	key := cache.Key(dns.Question{Name: "concurrent.test.", Qtype: dns.TypeA, Qclass: dns.ClassINET})
 
 	first, leader := wg.JoinGeneration(key)
-	require.True(t, leader)
+	if !(leader) {
+		t.Fatalf("leader is false")
+	}
 	wg.DoneGeneration(key, first)
 	<-first.Done()
 
@@ -219,11 +275,13 @@ func Test_ConcurrentRegroupElectsOneSharedLeader(t *testing.T) {
 		}
 		if next == nil {
 			next = got.generation
-		} else {
-			require.Same(t, next, got.generation)
+		} else if next != got.generation {
+			t.Fatalf("%p and %p are not the same pointer", next, got.generation)
 		}
 	}
-	require.Equal(t, 1, leaders)
+	if !reflect.DeepEqual(1, leaders) {
+		t.Fatalf("leaders = %v, want %v", leaders, 1)
+	}
 	wg.DoneGeneration(key, next)
 }
 
@@ -232,7 +290,9 @@ func Test_JoinAndRegroupRaceAdoptsOneGeneration(t *testing.T) {
 		wg := New(5 * time.Second)
 		key := cache.Key(dns.Question{Name: "adopt.test.", Qtype: dns.TypeA, Qclass: dns.ClassINET})
 		first, leader := wg.JoinGeneration(key)
-		require.True(t, leader)
+		if !(leader) {
+			t.Fatalf("leader is false")
+		}
 		wg.DoneGeneration(key, first)
 		<-first.Done()
 
@@ -256,8 +316,12 @@ func Test_JoinAndRegroupRaceAdoptsOneGeneration(t *testing.T) {
 
 		a := <-results
 		b := <-results
-		require.Same(t, a.generation, b.generation)
-		require.NotEqual(t, a.leader, b.leader)
+		if a.generation != b.generation {
+			t.Fatalf("%p and %p are not the same pointer", a.generation, b.generation)
+		}
+		if reflect.DeepEqual(a.leader, b.leader) {
+			t.Fatalf("b.leader = %v, want a different value", b.leader)
+		}
 		wg.DoneGeneration(key, a.generation)
 	}
 }

--- a/middleware/accesslist/accesslist_test.go
+++ b/middleware/accesslist/accesslist_test.go
@@ -2,13 +2,13 @@ package accesslist
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/semihalev/sdns/config"
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/zlog/v2"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_AccesslistDefaults(t *testing.T) {
@@ -42,7 +42,9 @@ func Test_Accesslist(t *testing.T) {
 	middleware.Setup(cfg)
 
 	a := middleware.Get("accesslist").(*List)
-	assert.Equal(t, "accesslist", a.Name())
+	if !reflect.DeepEqual("accesslist", a.Name()) {
+		t.Errorf("a.Name() = %v, want %v", a.Name(), "accesslist")
+	}
 
 	ch := middleware.NewChain([]middleware.Handler{})
 

--- a/middleware/accesslog/accesslog_test.go
+++ b/middleware/accesslog/accesslog_test.go
@@ -3,6 +3,7 @@ package accesslog
 import (
 	"context"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/miekg/dns"
@@ -10,7 +11,6 @@ import (
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/zlog/v2"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_accesslog(t *testing.T) {
@@ -27,8 +27,12 @@ func Test_accesslog(t *testing.T) {
 	middleware.Setup(cfg)
 	a := middleware.Get("accesslog").(*Log)
 
-	assert.Equal(t, "accesslog", a.Name())
-	assert.NotNil(t, a.logFile)
+	if !reflect.DeepEqual("accesslog", a.Name()) {
+		t.Errorf("a.Name() = %v, want %v", a.Name(), "accesslog")
+	}
+	if a.logFile == nil {
+		t.Fatalf("a.logFile is nil")
+	}
 
 	ch := middleware.NewChain([]middleware.Handler{a})
 
@@ -46,16 +50,24 @@ func Test_accesslog(t *testing.T) {
 
 	a.ServeDNS(context.Background(), ch)
 
-	assert.Equal(t, dns.RcodeServerFailure, mw.Msg().Rcode)
+	if !reflect.DeepEqual(dns.RcodeServerFailure, mw.Msg().Rcode) {
+		t.Errorf("mw.Msg().Rcode = %v, want %v", mw.Msg().Rcode, dns.RcodeServerFailure)
+	}
 
 	resp.CheckingDisabled = true
 	a.ServeDNS(context.Background(), ch)
 
-	assert.True(t, resp.CheckingDisabled)
+	if !(resp.CheckingDisabled) {
+		t.Errorf("resp.CheckingDisabled is false")
+	}
 
-	assert.NoError(t, a.logFile.Close())
+	if err := a.logFile.Close(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	a.ServeDNS(context.Background(), ch)
 
-	assert.NoError(t, os.Remove(cfg.AccessLog))
+	if err := os.Remove(cfg.AccessLog); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 }

--- a/middleware/as112/as112_test.go
+++ b/middleware/as112/as112_test.go
@@ -2,6 +2,7 @@ package as112
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/miekg/dns"
@@ -9,7 +10,6 @@ import (
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/zlog/v2"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_AS112(t *testing.T) {
@@ -29,7 +29,9 @@ func Test_AS112(t *testing.T) {
 
 	a := middleware.Get("as112").(*AS112)
 
-	assert.Equal(t, "as112", a.Name())
+	if !reflect.DeepEqual("as112", a.Name()) {
+		t.Errorf("a.Name() = %v, want %v", a.Name(), "as112")
+	}
 
 	ch := middleware.NewChain([]middleware.Handler{})
 
@@ -41,67 +43,97 @@ func Test_AS112(t *testing.T) {
 	ch.Writer = mw
 
 	a.ServeDNS(context.Background(), ch)
-	assert.Equal(t, true, len(mw.Msg().Answer) > 0)
-	assert.Equal(t, dns.RcodeSuccess, mw.Rcode())
+	if !reflect.DeepEqual(true, len(mw.Msg().Answer) > 0) {
+		t.Errorf("len(mw.Msg().Answer) > 0 = %v, want %v", len(mw.Msg().Answer) > 0, true)
+	}
+	if !reflect.DeepEqual(dns.RcodeSuccess, mw.Rcode()) {
+		t.Errorf("mw.Rcode() = %v, want %v", mw.Rcode(), dns.RcodeSuccess)
+	}
 
 	req.SetQuestion("10.in-addr.arpa.", dns.TypeNS)
 
 	mw = mock.NewWriter("udp", "127.0.0.1:0")
 	ch.Writer = mw
 	a.ServeDNS(context.Background(), ch)
-	assert.Equal(t, true, len(mw.Msg().Answer) > 0)
-	assert.Equal(t, dns.RcodeSuccess, mw.Rcode())
+	if !reflect.DeepEqual(true, len(mw.Msg().Answer) > 0) {
+		t.Errorf("len(mw.Msg().Answer) > 0 = %v, want %v", len(mw.Msg().Answer) > 0, true)
+	}
+	if !reflect.DeepEqual(dns.RcodeSuccess, mw.Rcode()) {
+		t.Errorf("mw.Rcode() = %v, want %v", mw.Rcode(), dns.RcodeSuccess)
+	}
 
 	req.SetQuestion("10.in-addr.arpa.", dns.TypeSOA)
 
 	mw = mock.NewWriter("udp", "127.0.0.1:0")
 	ch.Writer = mw
 	a.ServeDNS(context.Background(), ch)
-	assert.Equal(t, true, len(mw.Msg().Answer) > 0)
-	assert.Equal(t, dns.RcodeSuccess, mw.Rcode())
+	if !reflect.DeepEqual(true, len(mw.Msg().Answer) > 0) {
+		t.Errorf("len(mw.Msg().Answer) > 0 = %v, want %v", len(mw.Msg().Answer) > 0, true)
+	}
+	if !reflect.DeepEqual(dns.RcodeSuccess, mw.Rcode()) {
+		t.Errorf("mw.Rcode() = %v, want %v", mw.Rcode(), dns.RcodeSuccess)
+	}
 
 	req.SetQuestion("10.in-addr.arpa.", dns.TypeDS)
 
 	mw = mock.NewWriter("udp", "127.0.0.1:0")
 	ch.Writer = mw
 	a.ServeDNS(context.Background(), ch)
-	assert.False(t, mw.Written())
+	if mw.Written() {
+		t.Errorf("mw.Written() is true")
+	}
 
 	req.SetQuestion("20.in-addr.arpa.", dns.TypeNS)
 
 	mw = mock.NewWriter("udp", "127.0.0.1:0")
 	ch.Writer = mw
 	a.ServeDNS(context.Background(), ch)
-	assert.False(t, mw.Written())
+	if mw.Written() {
+		t.Errorf("mw.Written() is true")
+	}
 
 	req.SetQuestion("example.com.", dns.TypeNS)
 
 	mw = mock.NewWriter("udp", "127.0.0.1:0")
 	ch.Writer = mw
 	a.ServeDNS(context.Background(), ch)
-	assert.False(t, mw.Written())
+	if mw.Written() {
+		t.Errorf("mw.Written() is true")
+	}
 
 	req.SetQuestion("10.10.in-addr.arpa.", dns.TypeSOA)
 
 	mw = mock.NewWriter("udp", "127.0.0.1:0")
 	ch.Writer = mw
 	a.ServeDNS(context.Background(), ch)
-	assert.Equal(t, true, len(mw.Msg().Ns) > 0)
-	assert.Equal(t, dns.RcodeNameError, mw.Rcode())
+	if !reflect.DeepEqual(true, len(mw.Msg().Ns) > 0) {
+		t.Errorf("len(mw.Msg().Ns) > 0 = %v, want %v", len(mw.Msg().Ns) > 0, true)
+	}
+	if !reflect.DeepEqual(dns.RcodeNameError, mw.Rcode()) {
+		t.Errorf("mw.Rcode() = %v, want %v", mw.Rcode(), dns.RcodeNameError)
+	}
 
 	req.SetQuestion("10.10.in-addr.arpa.", dns.TypeA)
 
 	mw = mock.NewWriter("udp", "127.0.0.1:0")
 	ch.Writer = mw
 	a.ServeDNS(context.Background(), ch)
-	assert.Equal(t, true, len(mw.Msg().Ns) > 0)
-	assert.Equal(t, dns.RcodeNameError, mw.Rcode())
+	if !reflect.DeepEqual(true, len(mw.Msg().Ns) > 0) {
+		t.Errorf("len(mw.Msg().Ns) > 0 = %v, want %v", len(mw.Msg().Ns) > 0, true)
+	}
+	if !reflect.DeepEqual(dns.RcodeNameError, mw.Rcode()) {
+		t.Errorf("mw.Rcode() = %v, want %v", mw.Rcode(), dns.RcodeNameError)
+	}
 
 	req.SetQuestion("10.10.in-addr.arpa.", dns.TypeNS)
 
 	mw = mock.NewWriter("udp", "127.0.0.1:0")
 	ch.Writer = mw
 	a.ServeDNS(context.Background(), ch)
-	assert.Equal(t, true, len(mw.Msg().Ns) > 0)
-	assert.Equal(t, dns.RcodeNameError, mw.Rcode())
+	if !reflect.DeepEqual(true, len(mw.Msg().Ns) > 0) {
+		t.Errorf("len(mw.Msg().Ns) > 0 = %v, want %v", len(mw.Msg().Ns) > 0, true)
+	}
+	if !reflect.DeepEqual(dns.RcodeNameError, mw.Rcode()) {
+		t.Errorf("mw.Rcode() = %v, want %v", mw.Rcode(), dns.RcodeNameError)
+	}
 }

--- a/middleware/autowire_test.go
+++ b/middleware/autowire_test.go
@@ -2,12 +2,12 @@ package middleware
 
 import (
 	"context"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/config"
-	"github.com/stretchr/testify/assert"
 )
 
 // providerHandler implements Handler + StoreProvider (+ optional
@@ -95,13 +95,23 @@ func TestAutoWire_FullWiring(t *testing.T) {
 	// metrics is ClientOnly → must be missing from both sub-pipelines.
 	pipe := GlobalPipeline()
 	sub := pipe.SubPipeline("metrics")
-	assert.Nil(t, sub.Get("metrics"))
+	if sub.Get("metrics") != nil {
+		t.Errorf("sub.Get('metrics') = %v, want nil", sub.Get("metrics"))
+	}
 
 	// Setter got all three wiring calls.
-	assert.NotNil(t, setter.gotQ, "SetQueryer not called")
-	assert.NotNil(t, setter.gotPQ, "SetPrefetchQueryer not called")
-	assert.Equal(t, Store(st), setter.gotStr, "SetStore received wrong store")
-	assert.Equal(t, DNSSECCryptoLimiter(limiter), setter.gotLim, "crypto limiter was not shared")
+	if setter.gotQ == nil {
+		t.Errorf("%s: setter.gotQ is nil", "SetQueryer not called")
+	}
+	if setter.gotPQ == nil {
+		t.Errorf("%s: setter.gotPQ is nil", "SetPrefetchQueryer not called")
+	}
+	if !reflect.DeepEqual(Store(st), setter.gotStr) {
+		t.Errorf("%s: setter.gotStr = %v, want %v", "SetStore received wrong store", setter.gotStr, Store(st))
+	}
+	if !reflect.DeepEqual(DNSSECCryptoLimiter(limiter), setter.gotLim) {
+		t.Errorf("%s: setter.gotLim = %v, want %v", "crypto limiter was not shared", setter.gotLim, DNSSECCryptoLimiter(limiter))
+	}
 }
 
 // TestAutoWire_MultipleProviders covers the first-wins branch plus
@@ -121,7 +131,9 @@ func TestAutoWire_MultipleProviders(t *testing.T) {
 	Setup(&config.Config{})
 
 	// First-wins: setter's store must be from the first provider.
-	assert.Equal(t, first.store, setter.gotStr)
+	if !reflect.DeepEqual(first.store, setter.gotStr) {
+		t.Errorf("setter.gotStr = %v, want %v", setter.gotStr, first.store)
+	}
 }
 
 func TestAutoWire_TypedNilCryptoProviderDoesNotMaskUsableProvider(t *testing.T) {
@@ -140,7 +152,9 @@ func TestAutoWire_TypedNilCryptoProviderDoesNotMaskUsableProvider(t *testing.T) 
 
 	Setup(&config.Config{})
 
-	assert.Equal(t, DNSSECCryptoLimiter(usable), setter.gotLim)
+	if !reflect.DeepEqual(DNSSECCryptoLimiter(usable), setter.gotLim) {
+		t.Errorf("setter.gotLim = %v, want %v", setter.gotLim, DNSSECCryptoLimiter(usable))
+	}
 }
 
 // TestAutoWire_SetterWithoutProvider covers the
@@ -155,10 +169,16 @@ func TestAutoWire_SetterWithoutProvider(t *testing.T) {
 
 	Setup(&config.Config{})
 
-	assert.Nil(t, setter.gotStr, "SetStore must not be called without a StoreProvider")
+	if setter.gotStr != nil {
+		t.Errorf("%s: setter.gotStr = %v, want nil", "SetStore must not be called without a StoreProvider", setter.gotStr)
+	}
 	// But queryer setters still fire.
-	assert.NotNil(t, setter.gotQ)
-	assert.NotNil(t, setter.gotPQ)
+	if setter.gotQ == nil {
+		t.Fatalf("setter.gotQ is nil")
+	}
+	if setter.gotPQ == nil {
+		t.Fatalf("setter.gotPQ is nil")
+	}
 }
 
 // TestPutChain_NilSafe covers the early-return path on nil

--- a/middleware/blocklist/blocklist_test.go
+++ b/middleware/blocklist/blocklist_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -13,7 +14,6 @@ import (
 	"github.com/semihalev/sdns/config"
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/semihalev/sdns/middleware"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_BlockList(t *testing.T) {
@@ -37,7 +37,9 @@ func Test_BlockList(t *testing.T) {
 
 	blocklist := middleware.Get("blocklist").(*BlockList)
 
-	assert.Equal(t, "blocklist", blocklist.Name())
+	if !reflect.DeepEqual("blocklist", blocklist.Name()) {
+		t.Errorf("blocklist.Name() = %v, want %v", blocklist.Name(), "blocklist")
+	}
 	blocklist.Set(testDomain)
 
 	ch := middleware.NewChain([]middleware.Handler{})
@@ -50,33 +52,49 @@ func Test_BlockList(t *testing.T) {
 	ch.Writer = mw
 
 	blocklist.ServeDNS(context.Background(), ch)
-	assert.Equal(t, true, len(mw.Msg().Answer) > 0)
+	if !reflect.DeepEqual(true, len(mw.Msg().Answer) > 0) {
+		t.Errorf("len(mw.Msg().Answer) > 0 = %v, want %v", len(mw.Msg().Answer) > 0, true)
+	}
 
 	req.SetQuestion("test.com.", dns.TypeAAAA)
 	ch.Request = middleware.NewRequest(req)
 
 	blocklist.ServeDNS(context.Background(), ch)
-	assert.Equal(t, true, len(mw.Msg().Answer) > 0)
+	if !reflect.DeepEqual(true, len(mw.Msg().Answer) > 0) {
+		t.Errorf("len(mw.Msg().Answer) > 0 = %v, want %v", len(mw.Msg().Answer) > 0, true)
+	}
 
 	req.SetQuestion("test.com.", dns.TypeNS)
 	ch.Request = middleware.NewRequest(req)
 
 	blocklist.ServeDNS(context.Background(), ch)
-	assert.Equal(t, true, len(mw.Msg().Ns) > 0)
+	if !reflect.DeepEqual(true, len(mw.Msg().Ns) > 0) {
+		t.Errorf("len(mw.Msg().Ns) > 0 = %v, want %v", len(mw.Msg().Ns) > 0, true)
+	}
 
 	mw = mock.NewWriter("udp", "127.0.0.1:0")
 	ch.Writer = mw
 	req.SetQuestion("test2.com.", dns.TypeA)
 	blocklist.ServeDNS(context.Background(), ch)
-	assert.Nil(t, mw.Msg())
+	if mw.Msg() != nil {
+		t.Errorf("mw.Msg() = %v, want nil", mw.Msg())
+	}
 
-	assert.Equal(t, blocklist.Exists(testDomain), true)
-	assert.Equal(t, blocklist.Exists(strings.ToUpper(testDomain)), true)
+	if !reflect.DeepEqual(blocklist.Exists(testDomain), true) {
+		t.Errorf("true = %v, want %v", true, blocklist.Exists(testDomain))
+	}
+	if !reflect.DeepEqual(blocklist.Exists(strings.ToUpper(testDomain)), true) {
+		t.Errorf("true = %v, want %v", true, blocklist.Exists(strings.ToUpper(testDomain)))
+	}
 
 	_, err := blocklist.Get(testDomain)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
-	assert.Equal(t, blocklist.Length(), 1)
+	if !reflect.DeepEqual(blocklist.Length(), 1) {
+		t.Errorf("1 = %v, want %v", 1, blocklist.Length())
+	}
 
 	if exists := blocklist.Exists(fmt.Sprintf("%sfuzz", testDomain)); exists {
 		t.Error("fuzz existed in block blocklist")
@@ -87,10 +105,14 @@ func Test_BlockList(t *testing.T) {
 	}
 
 	blocklist.Remove(testDomain)
-	assert.Equal(t, blocklist.Exists(testDomain), false)
+	if !reflect.DeepEqual(blocklist.Exists(testDomain), false) {
+		t.Errorf("false = %v, want %v", false, blocklist.Exists(testDomain))
+	}
 
 	_, err = blocklist.Get(testDomain)
-	assert.Error(t, err)
+	if err == nil {
+		t.Errorf("expected an error, got nil")
+	}
 
 	blocklist.Set(testDomain)
 }
@@ -107,30 +129,56 @@ func Test_BlockList_Wildcard(t *testing.T) {
 	blocklist.Set("*.blocked.com.")
 
 	// These should all be blocked
-	assert.True(t, blocklist.Exists("subdomain.blocked.com."))
-	assert.True(t, blocklist.Exists("deep.subdomain.blocked.com."))
-	assert.True(t, blocklist.Exists("very.deep.subdomain.blocked.com."))
+	if !(blocklist.Exists("subdomain.blocked.com.")) {
+		t.Errorf("blocklist.Exists('subdomain.blocked.com.') is false")
+	}
+	if !(blocklist.Exists("deep.subdomain.blocked.com.")) {
+		t.Errorf("blocklist.Exists('deep.subdomain.blocked.com.') is false")
+	}
+	if !(blocklist.Exists("very.deep.subdomain.blocked.com.")) {
+		t.Errorf("blocklist.Exists('very.deep.subdomain.blocked.com.') is false")
+	}
 
 	// The base domain should not be blocked (only subdomains)
-	assert.False(t, blocklist.Exists("blocked.com."))
+	if blocklist.Exists("blocked.com.") {
+		t.Errorf("blocklist.Exists('blocked.com.') is true")
+	}
 
 	// Other domains should not be blocked
-	assert.False(t, blocklist.Exists("notblocked.com."))
-	assert.False(t, blocklist.Exists("subdomain.notblocked.com."))
+	if blocklist.Exists("notblocked.com.") {
+		t.Errorf("blocklist.Exists('notblocked.com.') is true")
+	}
+	if blocklist.Exists("subdomain.notblocked.com.") {
+		t.Errorf("blocklist.Exists('subdomain.notblocked.com.') is true")
+	}
 
 	// A bare domain blocks the name itself and every subdomain
 	// (matches Pi-hole/AdGuard/dnsmasq; see issue #478).
 	blocklist.Set("exact.com.")
-	assert.True(t, blocklist.Exists("exact.com."))
-	assert.True(t, blocklist.Exists("subdomain.exact.com."))
-	assert.True(t, blocklist.Exists("deep.subdomain.exact.com."))
+	if !(blocklist.Exists("exact.com.")) {
+		t.Errorf("blocklist.Exists('exact.com.') is false")
+	}
+	if !(blocklist.Exists("subdomain.exact.com.")) {
+		t.Errorf("blocklist.Exists('subdomain.exact.com.') is false")
+	}
+	if !(blocklist.Exists("deep.subdomain.exact.com.")) {
+		t.Errorf("blocklist.Exists('deep.subdomain.exact.com.') is false")
+	}
 
 	// Test multiple wildcard levels
 	blocklist.Set("*.subdomain.multi.com.")
-	assert.True(t, blocklist.Exists("test.subdomain.multi.com."))
-	assert.True(t, blocklist.Exists("deep.test.subdomain.multi.com."))
-	assert.False(t, blocklist.Exists("subdomain.multi.com."))
-	assert.False(t, blocklist.Exists("multi.com."))
+	if !(blocklist.Exists("test.subdomain.multi.com.")) {
+		t.Errorf("blocklist.Exists('test.subdomain.multi.com.') is false")
+	}
+	if !(blocklist.Exists("deep.test.subdomain.multi.com.")) {
+		t.Errorf("blocklist.Exists('deep.test.subdomain.multi.com.') is false")
+	}
+	if blocklist.Exists("subdomain.multi.com.") {
+		t.Errorf("blocklist.Exists('subdomain.multi.com.') is true")
+	}
+	if blocklist.Exists("multi.com.") {
+		t.Errorf("blocklist.Exists('multi.com.') is true")
+	}
 
 	// Test with ServeDNS
 	ch := middleware.NewChain([]middleware.Handler{})
@@ -142,19 +190,29 @@ func Test_BlockList_Wildcard(t *testing.T) {
 	ch.Writer = mw
 
 	blocklist.ServeDNS(context.Background(), ch)
-	assert.NotNil(t, mw.Msg())
-	assert.Equal(t, true, len(mw.Msg().Answer) > 0)
+	if mw.Msg() == nil {
+		t.Fatalf("mw.Msg() is nil")
+	}
+	if !reflect.DeepEqual(true, len(mw.Msg().Answer) > 0) {
+		t.Errorf("len(mw.Msg().Answer) > 0 = %v, want %v", len(mw.Msg().Answer) > 0, true)
+	}
 
 	// Test non-blocked domain
 	mw = mock.NewWriter("udp", "127.0.0.1:0")
 	ch.Writer = mw
 	req.SetQuestion("allowed.com.", dns.TypeA)
 	blocklist.ServeDNS(context.Background(), ch)
-	assert.Nil(t, mw.Msg())
+	if mw.Msg() != nil {
+		t.Errorf("mw.Msg() = %v, want nil", mw.Msg())
+	}
 
 	// Test case insensitivity
-	assert.True(t, blocklist.Exists("TEST.BLOCKED.COM."))
-	assert.True(t, blocklist.Exists("Test.Blocked.Com."))
+	if !(blocklist.Exists("TEST.BLOCKED.COM.")) {
+		t.Errorf("blocklist.Exists('TEST.BLOCKED.COM.') is false")
+	}
+	if !(blocklist.Exists("Test.Blocked.Com.")) {
+		t.Errorf("blocklist.Exists('Test.Blocked.Com.') is false")
+	}
 }
 
 // Test_BlockList_Issue478 loads a plain-domain list (hagezi
@@ -163,12 +221,18 @@ func Test_BlockList_Wildcard(t *testing.T) {
 // actually query — are blocked, not just the apex.
 func Test_BlockList_Issue478(t *testing.T) {
 	dir := filepath.Join(os.TempDir(), "sdns_temp_issue478")
-	assert.NoError(t, os.RemoveAll(dir))
-	assert.NoError(t, os.MkdirAll(dir, 0750))
+	if err := os.RemoveAll(dir); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := os.MkdirAll(dir, 0750); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 	defer func() { _ = os.RemoveAll(dir) }()
 
 	onlyDomains := "# Syntax: Domains (without subdomains)\nmiui.net\nkuyun.com\n"
-	assert.NoError(t, os.WriteFile(filepath.Join(dir, "xiaomi-onlydomains.txt"), []byte(onlyDomains), 0600))
+	if err := os.WriteFile(filepath.Join(dir, "xiaomi-onlydomains.txt"), []byte(onlyDomains), 0600); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	cfg := new(config.Config)
 	cfg.Nullroute = "0.0.0.0"
@@ -178,17 +242,31 @@ func Test_BlockList_Issue478(t *testing.T) {
 	blocklist := New(cfg)
 
 	// Apex names are blocked.
-	assert.True(t, blocklist.Exists("miui.net."))
-	assert.True(t, blocklist.Exists("kuyun.com."))
+	if !(blocklist.Exists("miui.net.")) {
+		t.Errorf("blocklist.Exists('miui.net.') is false")
+	}
+	if !(blocklist.Exists("kuyun.com.")) {
+		t.Errorf("blocklist.Exists('kuyun.com.') is false")
+	}
 
 	// Subdomains are blocked too — the actual fix for #478.
-	assert.True(t, blocklist.Exists("tracking.miui.net."))
-	assert.True(t, blocklist.Exists("api.kuyun.com."))
-	assert.True(t, blocklist.Exists("a.b.kuyun.com."))
+	if !(blocklist.Exists("tracking.miui.net.")) {
+		t.Errorf("blocklist.Exists('tracking.miui.net.') is false")
+	}
+	if !(blocklist.Exists("api.kuyun.com.")) {
+		t.Errorf("blocklist.Exists('api.kuyun.com.') is false")
+	}
+	if !(blocklist.Exists("a.b.kuyun.com.")) {
+		t.Errorf("blocklist.Exists('a.b.kuyun.com.') is false")
+	}
 
 	// Unrelated names and sibling apexes stay unblocked.
-	assert.False(t, blocklist.Exists("notblocked.com."))
-	assert.False(t, blocklist.Exists("miui.net.evil.com."))
+	if blocklist.Exists("notblocked.com.") {
+		t.Errorf("blocklist.Exists('notblocked.com.') is true")
+	}
+	if blocklist.Exists("miui.net.evil.com.") {
+		t.Errorf("blocklist.Exists('miui.net.evil.com.') is true")
+	}
 }
 
 func Test_BlockList_FastPath(t *testing.T) {
@@ -210,13 +288,17 @@ func Test_BlockList_FastPath(t *testing.T) {
 
 	// With empty blocklist, ServeDNS should call Next and not write any response
 	blocklist.ServeDNS(context.Background(), ch)
-	assert.Nil(t, mw.Msg(), "No response should be written for empty blocklist")
+	if mw.Msg() != nil {
+		t.Errorf("%s: mw.Msg() = %v, want nil", "No response should be written for empty blocklist", mw.Msg())
+	}
 
 	// Now add an entry and verify it blocks
 	blocklist.Set("blocked.com.")
 	req.SetQuestion("blocked.com.", dns.TypeA)
 	blocklist.ServeDNS(context.Background(), ch)
-	assert.NotNil(t, mw.Msg(), "Response should be written for blocked domain")
+	if mw.Msg() == nil {
+		t.Errorf("%s: mw.Msg() is nil", "Response should be written for blocked domain")
+	}
 }
 
 func Test_BlockList_Remove(t *testing.T) {
@@ -229,15 +311,25 @@ func Test_BlockList_Remove(t *testing.T) {
 
 	// Test removing a wildcard entry
 	blocklist.Set("*.wildcard.com.")
-	assert.True(t, blocklist.Exists("sub.wildcard.com."))
-	assert.True(t, blocklist.Remove("*.wildcard.com."))
-	assert.False(t, blocklist.Exists("sub.wildcard.com."))
+	if !(blocklist.Exists("sub.wildcard.com.")) {
+		t.Errorf("blocklist.Exists('sub.wildcard.com.') is false")
+	}
+	if !(blocklist.Remove("*.wildcard.com.")) {
+		t.Errorf("blocklist.Remove('*.wildcard.com.') is false")
+	}
+	if blocklist.Exists("sub.wildcard.com.") {
+		t.Errorf("blocklist.Exists('sub.wildcard.com.') is true")
+	}
 
 	// Test removing a non-existent entry
-	assert.False(t, blocklist.Remove("nonexistent.com."))
+	if blocklist.Remove("nonexistent.com.") {
+		t.Errorf("blocklist.Remove('nonexistent.com.') is true")
+	}
 
 	// Test removing a non-existent wildcard
-	assert.False(t, blocklist.Remove("*.nonexistent.com."))
+	if blocklist.Remove("*.nonexistent.com.") {
+		t.Errorf("blocklist.Remove('*.nonexistent.com.') is true")
+	}
 }
 
 func Test_BlockList_Batch(t *testing.T) {
@@ -260,26 +352,46 @@ func Test_BlockList_Batch(t *testing.T) {
 	// reach the map; setLocked returns true for each. The count is
 	// "calls that took effect" rather than "unique keys", which is
 	// fine for the API caller — they get what they asked for.
-	assert.Equal(t, 4, added)
-	assert.True(t, bl.Exists("a.example."))
-	assert.True(t, bl.Exists("sub.evil.com."))
-	assert.Equal(t, 3, bl.Length()) // map dedups: a.example, b.example, evil.com.
+	if !reflect.DeepEqual(4, added) {
+		t.Errorf("added = %v, want %v", added, 4)
+	}
+	if !(bl.Exists("a.example.")) {
+		t.Errorf("bl.Exists('a.example.') is false")
+	}
+	if !(bl.Exists("sub.evil.com.")) {
+		t.Errorf("bl.Exists('sub.evil.com.') is false")
+	}
+	if !reflect.DeepEqual(3, bl.Length()) {
+		t.Errorf("bl.Length() = %v, want %v", bl.Length(), 3)
+	} // map dedups: a.example, b.example, evil.com.
 
 	// Whitelist takes precedence: a key on the whitelist contributes
 	// 0 to the added count.
 	bl.w[dns.CanonicalName("safe.example.")] = true
 	added = bl.SetBatch([]string{"safe.example.", "next.example."})
-	assert.Equal(t, 1, added)
+	if !reflect.DeepEqual(1, added) {
+		t.Errorf("added = %v, want %v", added, 1)
+	}
 
 	// Empty batch is a no-op (no I/O, no count).
-	assert.Equal(t, 0, bl.SetBatch(nil))
-	assert.Equal(t, 0, bl.RemoveBatch(nil))
+	if !reflect.DeepEqual(0, bl.SetBatch(nil)) {
+		t.Errorf("bl.SetBatch(nil) = %v, want %v", bl.SetBatch(nil), 0)
+	}
+	if !reflect.DeepEqual(0, bl.RemoveBatch(nil)) {
+		t.Errorf("bl.RemoveBatch(nil) = %v, want %v", bl.RemoveBatch(nil), 0)
+	}
 
 	// Bulk remove.
 	removed := bl.RemoveBatch([]string{"a.example.", "*.evil.com.", "missing.example."})
-	assert.Equal(t, 2, removed)
-	assert.False(t, bl.Exists("a.example."))
-	assert.False(t, bl.Exists("sub.evil.com."))
+	if !reflect.DeepEqual(2, removed) {
+		t.Errorf("removed = %v, want %v", removed, 2)
+	}
+	if bl.Exists("a.example.") {
+		t.Errorf("bl.Exists('a.example.') is true")
+	}
+	if bl.Exists("sub.evil.com.") {
+		t.Errorf("bl.Exists('sub.evil.com.') is true")
+	}
 }
 
 // Test_BlockList_NoStallDuringSave proves the property the GitHub
@@ -334,23 +446,37 @@ func Test_BlockList_WhitelistHierarchy(t *testing.T) {
 	b := New(cfg)
 
 	b.Set("*.example.com.")
-	assert.True(t, b.Exists("sub.example.com."), "subdomain blocked before whitelist")
+	if !(b.Exists("sub.example.com.")) {
+		t.Errorf("%s: b.Exists('sub.example.com.') is false", "subdomain blocked before whitelist")
+	}
 
 	// Whitelist the parent — subtree is now exempt.
 	b.w[dns.CanonicalName("example.com.")] = true
-	assert.False(t, b.Exists("sub.example.com."), "parent whitelist must exempt subdomain")
-	assert.False(t, b.Exists("deep.sub.example.com."), "parent whitelist must exempt deep subdomain")
-	assert.False(t, b.Exists("example.com."), "whitelisted name itself exempt")
+	if b.Exists("sub.example.com.") {
+		t.Errorf("%s: b.Exists('sub.example.com.') is true", "parent whitelist must exempt subdomain")
+	}
+	if b.Exists("deep.sub.example.com.") {
+		t.Errorf("%s: b.Exists('deep.sub.example.com.') is true", "parent whitelist must exempt deep subdomain")
+	}
+	if b.Exists("example.com.") {
+		t.Errorf("%s: b.Exists('example.com.') is true", "whitelisted name itself exempt")
+	}
 
 	// A different blocked subtree is unaffected by the whitelist.
 	b.Set("*.other.com.")
-	assert.True(t, b.Exists("x.other.com."), "unrelated subtree still blocked")
+	if !(b.Exists("x.other.com.")) {
+		t.Errorf("%s: b.Exists('x.other.com.') is false", "unrelated subtree still blocked")
+	}
 
 	// Set must refuse a block the whitelist hierarchically shadows, rather
 	// than persist a block that can never take effect (Exists exempts it
 	// anyway). Symmetric with the hierarchical Exists whitelist match.
-	assert.False(t, b.Set("sub.example.com."), "Set must refuse a hierarchically-whitelisted name")
-	assert.False(t, b.Exists("sub.example.com."), "shadowed name stays exempt")
+	if b.Set("sub.example.com.") {
+		t.Errorf("%s: b.Set('sub.example.com.') is true", "Set must refuse a hierarchically-whitelisted name")
+	}
+	if b.Exists("sub.example.com.") {
+		t.Errorf("%s: b.Exists('sub.example.com.') is true", "shadowed name stays exempt")
+	}
 }
 
 // Test_BlockList_PersistOrdering pins the ordering guarantee of the
@@ -381,7 +507,9 @@ func Test_BlockList_PersistOrdering(t *testing.T) {
 	high := bl.snapshotLocked() // newer version
 	bl.mu.Unlock()
 
-	assert.Greater(t, high.version, low.version, "later snapshot must carry a higher version")
+	if high.version <= low.version {
+		t.Errorf("%s: high.version = %v, want > %v", "later snapshot must carry a higher version", high.version, low.version)
+	}
 
 	// Persist out of order: newer first, then the stale older one
 	// races in behind it.
@@ -389,11 +517,16 @@ func Test_BlockList_PersistOrdering(t *testing.T) {
 	bl.persist(low)
 
 	data, err := os.ReadFile(filepath.Join(cfg.BlockListDir, "local"))
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 	got := string(data)
-	assert.Contains(t, got, "a.example.")
-	assert.Contains(t, got, "b.example.",
-		"stale snapshot overwrote newer on-disk state: persist rolled backwards")
+	if !strings.Contains(got, "a.example.") {
+		t.Errorf("%q does not contain %q", got, "a.example.")
+	}
+	if !strings.Contains(got, "b.example.") {
+		t.Errorf("%s: %q does not contain %q", "stale snapshot overwrote newer on-disk state: persist rolled backwards", got, "b.example.")
+	}
 
 	// A brand-new, newer snapshot still writes normally.
 	bl.mu.Lock()
@@ -403,8 +536,12 @@ func Test_BlockList_PersistOrdering(t *testing.T) {
 	bl.persist(next)
 
 	data, err = os.ReadFile(filepath.Join(cfg.BlockListDir, "local"))
-	assert.NoError(t, err)
-	assert.Contains(t, string(data), "c.example.", "a newer snapshot must still persist")
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(data), "c.example.") {
+		t.Errorf("%s: %q does not contain %q", "a newer snapshot must still persist", string(data), "c.example.")
+	}
 }
 
 // Test_BlockList_EntriesGauge pins dns_blocklist_entries to the live map
@@ -433,17 +570,24 @@ func Test_BlockList_EntriesGauge(t *testing.T) {
 		return float64((*fn)())
 	}
 
-	assert.Equal(t, float64(0), read(), "a fresh blocklist reports zero entries")
+	if !reflect.DeepEqual(float64(0), read()) {
+		t.Errorf("%s: read() = %v, want %v", "a fresh blocklist reports zero entries", read(), float64(0))
+	}
 
 	bl.Set("one.example.")
 	bl.Set("two.example.")
 	bl.Set("*.three.example.")
-	assert.Equal(t, float64(3), read(),
-		"gauge must count exact names plus wildcard suffixes")
-	assert.Equal(t, float64(bl.Length()), read(), "gauge must track Length()")
+	if !reflect.DeepEqual(float64(3), read()) {
+		t.Errorf("%s: read() = %v, want %v", "gauge must count exact names plus wildcard suffixes", read(), float64(3))
+	}
+	if !reflect.DeepEqual(float64(bl.Length()), read()) {
+		t.Errorf("%s: read() = %v, want %v", "gauge must track Length()", read(), float64(bl.Length()))
+	}
 
 	bl.Remove("one.example.")
-	assert.Equal(t, float64(2), read(), "gauge must follow removals, not just adds")
+	if !reflect.DeepEqual(float64(2), read()) {
+		t.Errorf("%s: read() = %v, want %v", "gauge must follow removals, not just adds", read(), float64(2))
+	}
 
 	// A second instance takes over the published accessor, mirroring what
 	// happens when the middleware is rebuilt; the gauge must follow the
@@ -458,5 +602,7 @@ func Test_BlockList_EntriesGauge(t *testing.T) {
 	}
 	bl2 := New(cfg2)
 	bl2.Set("only.example.")
-	assert.Equal(t, float64(1), read(), "gauge must follow the newest instance")
+	if !reflect.DeepEqual(float64(1), read()) {
+		t.Errorf("%s: read() = %v, want %v", "gauge must follow the newest instance", read(), float64(1))
+	}
 }

--- a/middleware/cache/ad_bit_test.go
+++ b/middleware/cache/ad_bit_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCacheADBitHandling(t *testing.T) {
@@ -33,8 +32,12 @@ func TestCacheADBitHandling(t *testing.T) {
 	req1.CheckingDisabled = false
 
 	resp1 := entry.ToMsg(req1)
-	assert.NotNil(t, resp1)
-	assert.True(t, resp1.AuthenticatedData, "AD bit should be preserved when CD=0")
+	if resp1 == nil {
+		t.Fatalf("resp1 is nil")
+	}
+	if !(resp1.AuthenticatedData) {
+		t.Errorf("%s: resp1.AuthenticatedData is false", "AD bit should be preserved when CD=0")
+	}
 
 	// Test 2: Request with CD=1 should clear AD bit
 	req2 := new(dns.Msg)
@@ -42,11 +45,17 @@ func TestCacheADBitHandling(t *testing.T) {
 	req2.CheckingDisabled = true
 
 	resp2 := entry.ToMsg(req2)
-	assert.NotNil(t, resp2)
-	assert.False(t, resp2.AuthenticatedData, "AD bit should be cleared when CD=1")
+	if resp2 == nil {
+		t.Fatalf("resp2 is nil")
+	}
+	if resp2.AuthenticatedData {
+		t.Errorf("%s: resp2.AuthenticatedData is true", "AD bit should be cleared when CD=1")
+	}
 
 	// Verify original entry is not modified
-	assert.True(t, msg.AuthenticatedData, "Original message should not be modified")
+	if !(msg.AuthenticatedData) {
+		t.Errorf("%s: msg.AuthenticatedData is false", "Original message should not be modified")
+	}
 }
 
 func TestCacheEntryWithoutAD(t *testing.T) {
@@ -75,8 +84,11 @@ func TestCacheEntryWithoutAD(t *testing.T) {
 		req.CheckingDisabled = cd
 
 		resp := entry.ToMsg(req)
-		assert.NotNil(t, resp)
-		assert.False(t, resp.AuthenticatedData,
-			"AD bit should remain false when original had AD=0")
+		if resp == nil {
+			t.Fatalf("resp is nil")
+		}
+		if resp.AuthenticatedData {
+			t.Errorf("%s: resp.AuthenticatedData is true", "AD bit should remain false when original had AD=0")
+		}
 	}
 }

--- a/middleware/cache/cache_coverage_test.go
+++ b/middleware/cache/cache_coverage_test.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
@@ -10,7 +11,6 @@ import (
 	"github.com/semihalev/sdns/config"
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/semihalev/sdns/middleware"
-	"github.com/stretchr/testify/assert"
 )
 
 // Test_Cache_Stats tests the Stats method.
@@ -54,17 +54,22 @@ func Test_Cache_Stats(t *testing.T) {
 	// Get stats
 	stats := c.Stats()
 
-	assert.NotNil(t, stats)
-	assert.Contains(t, stats, "hits")
-	assert.Contains(t, stats, "misses")
-	assert.Contains(t, stats, "evictions")
-	assert.Contains(t, stats, "prefetches")
-	assert.Contains(t, stats, "positive_size")
-	assert.Contains(t, stats, "negative_size")
-	assert.Contains(t, stats, "hit_rate")
+	if stats == nil {
+		t.Fatalf("stats is nil")
+	}
+	if _, ok := stats["hits"]; !ok {
+		t.Errorf("stats %v missing %q", stats, "hits")
+	}
+	for _, key := range []string{"misses", "evictions", "prefetches", "positive_size", "negative_size", "hit_rate"} {
+		if _, ok := stats[key]; !ok {
+			t.Errorf("stats %v missing %q", stats, key)
+		}
+	}
 
 	// Check positive size
-	assert.Equal(t, 1, stats["positive_size"])
+	if !reflect.DeepEqual(1, stats["positive_size"]) {
+		t.Errorf("stats['positive_size'] = %v, want %v", stats["positive_size"], 1)
+	}
 }
 
 // Test_Cache_Metrics_All tests all metric methods.
@@ -82,10 +87,18 @@ func Test_Cache_Metrics_All(t *testing.T) {
 
 	hits, misses, evictions, prefetches := m.Stats()
 
-	assert.Equal(t, int64(2), hits)
-	assert.Equal(t, int64(1), misses)
-	assert.Equal(t, int64(3), evictions)
-	assert.Equal(t, int64(1), prefetches)
+	if !reflect.DeepEqual(int64(2), hits) {
+		t.Errorf("hits = %v, want %v", hits, int64(2))
+	}
+	if !reflect.DeepEqual(int64(1), misses) {
+		t.Errorf("misses = %v, want %v", misses, int64(1))
+	}
+	if !reflect.DeepEqual(int64(3), evictions) {
+		t.Errorf("evictions = %v, want %v", evictions, int64(3))
+	}
+	if !reflect.DeepEqual(int64(1), prefetches) {
+		t.Errorf("prefetches = %v, want %v", prefetches, int64(1))
+	}
 }
 
 // Test_Cache_Len tests Len methods.
@@ -96,8 +109,12 @@ func Test_Cache_Len(t *testing.T) {
 	nc := NewNegativeCache(100, time.Minute, time.Hour, metrics)
 
 	// Initially empty
-	assert.Equal(t, 0, pc.Len())
-	assert.Equal(t, 0, nc.Len())
+	if !reflect.DeepEqual(0, pc.Len()) {
+		t.Errorf("pc.Len() = %v, want %v", pc.Len(), 0)
+	}
+	if !reflect.DeepEqual(0, nc.Len()) {
+		t.Errorf("nc.Len() = %v, want %v", nc.Len(), 0)
+	}
 
 	// Add entries
 	req := new(dns.Msg)
@@ -108,8 +125,12 @@ func Test_Cache_Len(t *testing.T) {
 	pc.Set(key, entry)
 	nc.Set(key, entry)
 
-	assert.Equal(t, 1, pc.Len())
-	assert.Equal(t, 1, nc.Len())
+	if !reflect.DeepEqual(1, pc.Len()) {
+		t.Errorf("pc.Len() = %v, want %v", pc.Len(), 1)
+	}
+	if !reflect.DeepEqual(1, nc.Len()) {
+		t.Errorf("nc.Len() = %v, want %v", nc.Len(), 1)
+	}
 }
 
 // Test_Cache_InvalidQueries tests handling of invalid queries.
@@ -131,7 +152,9 @@ func Test_Cache_InvalidQueries(t *testing.T) {
 	c.ServeDNS(context.Background(), ch)
 
 	// Should cancel the request
-	assert.False(t, mw.Written())
+	if mw.Written() {
+		t.Errorf("mw.Written() is true")
+	}
 
 	// Test with invalid query type
 	req2 := new(dns.Msg)
@@ -144,7 +167,9 @@ func Test_Cache_InvalidQueries(t *testing.T) {
 	c.ServeDNS(context.Background(), ch2)
 
 	// Should cancel the request
-	assert.False(t, mw2.Written())
+	if mw2.Written() {
+		t.Errorf("mw2.Written() is true")
+	}
 }
 
 // Test_TTL_Manager tests TTL calculation edge cases.
@@ -152,13 +177,19 @@ func Test_TTL_Manager(t *testing.T) {
 	ttl := NewTTLManager(time.Minute, time.Hour)
 
 	// Test below minimum
-	assert.Equal(t, time.Minute, ttl.Calculate(30*time.Second))
+	if !reflect.DeepEqual(time.Minute, ttl.Calculate(30*time.Second)) {
+		t.Errorf("ttl.Calculate(30*time.Second) = %v, want %v", ttl.Calculate(30*time.Second), time.Minute)
+	}
 
 	// Test above maximum
-	assert.Equal(t, time.Hour, ttl.Calculate(2*time.Hour))
+	if !reflect.DeepEqual(time.Hour, ttl.Calculate(2*time.Hour)) {
+		t.Errorf("ttl.Calculate(2*time.Hour) = %v, want %v", ttl.Calculate(2*time.Hour), time.Hour)
+	}
 
 	// Test within range
-	assert.Equal(t, 30*time.Minute, ttl.Calculate(30*time.Minute))
+	if !reflect.DeepEqual(30*time.Minute, ttl.Calculate(30*time.Minute)) {
+		t.Errorf("ttl.Calculate(30*time.Minute) = %v, want %v", ttl.Calculate(30*time.Minute), 30*time.Minute)
+	}
 }
 
 // Test_Cache_Entry_Edge_Cases tests CacheEntry edge cases.
@@ -170,17 +201,27 @@ func Test_Cache_Entry_Edge_Cases(t *testing.T) {
 	entry := NewCacheEntry(req, 1*time.Millisecond, 0)
 	time.Sleep(2 * time.Millisecond)
 
-	assert.True(t, entry.IsExpired())
-	assert.Equal(t, 0, entry.TTL())
-	assert.Nil(t, entry.ToMsg(req))
+	if !(entry.IsExpired()) {
+		t.Errorf("entry.IsExpired() is false")
+	}
+	if !reflect.DeepEqual(0, entry.TTL()) {
+		t.Errorf("entry.TTL() = %v, want %v", entry.TTL(), 0)
+	}
+	if entry.ToMsg(req) != nil {
+		t.Errorf("entry.ToMsg(req) = %v, want nil", entry.ToMsg(req))
+	}
 
 	// Test ShouldPrefetch with threshold 0
 	entry2 := NewCacheEntry(req, time.Hour, 0)
-	assert.False(t, entry2.ShouldPrefetch(0))
+	if entry2.ShouldPrefetch(0) {
+		t.Errorf("entry2.ShouldPrefetch(0) is true")
+	}
 
 	// Test ShouldPrefetch when already prefetching
 	entry2.prefetch.Store(true)
-	assert.False(t, entry2.ShouldPrefetch(50))
+	if entry2.ShouldPrefetch(50) {
+		t.Errorf("entry2.ShouldPrefetch(50) is true")
+	}
 }
 
 // Test_Prefetch_Queue_Full tests prefetch queue when full.
@@ -198,13 +239,17 @@ func Test_Prefetch_Queue_Full(t *testing.T) {
 
 	// Add first request - should succeed
 	added := queue.Add(PrefetchRequest{Request: req, Key: 1})
-	assert.True(t, added)
+	if !(added) {
+		t.Errorf("added is false")
+	}
 
 	// Add second request immediately - queue should be full
 	req2 := new(dns.Msg)
 	req2.SetQuestion("test2.com.", dns.TypeA)
 	added = queue.Add(PrefetchRequest{Request: req2, Key: 2})
-	assert.False(t, added)
+	if added {
+		t.Errorf("added is true")
+	}
 }
 
 // Test_Release_Msg_Large tests ReleaseMsg with large message.
@@ -251,7 +296,9 @@ func Test_Handle_Special_Query_DebugNS(t *testing.T) {
 
 	c.ServeDNS(context.Background(), ch)
 
-	assert.True(t, called)
+	if !(called) {
+		t.Errorf("called is false")
+	}
 }
 
 // Test_WriteMsg_Truncated tests WriteMsg with truncated response.
@@ -271,7 +318,9 @@ func Test_WriteMsg_Truncated(t *testing.T) {
 	res.Truncated = true
 
 	err := w.WriteMsg(res)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	// Empty question should pass through
 	res2 := new(dns.Msg)
@@ -279,7 +328,9 @@ func Test_WriteMsg_Truncated(t *testing.T) {
 	res2.Question = []dns.Question{}
 
 	err = w.WriteMsg(res2)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 }
 
 // Test_Negative_Cache_Eviction tests negative cache with eviction.
@@ -297,7 +348,9 @@ func Test_Negative_Cache_Eviction(t *testing.T) {
 
 	// Some entries should have been evicted
 	// The exact number depends on the cache implementation
-	assert.LessOrEqual(t, nc.Len(), 10)
+	if nc.Len() > 10 {
+		t.Errorf("nc.Len() = %v, want <= %v", nc.Len(), 10)
+	}
 }
 
 // Test_Config_Edge_Cases tests configuration edge cases.
@@ -312,8 +365,12 @@ func Test_Config_Edge_Cases(t *testing.T) {
 	c := New(cfg)
 	defer c.Stop()
 
-	assert.NotNil(t, c)
-	assert.Equal(t, 10, c.config.Prefetch)
+	if c == nil {
+		t.Fatalf("c is nil")
+	}
+	if !reflect.DeepEqual(10, c.config.Prefetch) {
+		t.Errorf("c.config.Prefetch = %v, want %v", c.config.Prefetch, 10)
+	}
 
 	// Test with prefetch > 90
 	cfg2 := &config.Config{
@@ -326,5 +383,7 @@ func Test_Config_Edge_Cases(t *testing.T) {
 	defer c2.Stop()
 
 	// Should trigger validation warning but continue
-	assert.NotNil(t, c2)
+	if c2 == nil {
+		t.Fatalf("c2 is nil")
+	}
 }

--- a/middleware/cache/cache_ecs_test.go
+++ b/middleware/cache/cache_ecs_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"net/netip"
 	"os"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -14,8 +15,6 @@ import (
 	internalcache "github.com/semihalev/sdns/internal/cache"
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/semihalev/sdns/middleware"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // makeECSTestConfig builds a config with ECS enabled at /24 IPv4
@@ -148,7 +147,9 @@ func sendAndExpect(t *testing.T, c *Cache, h middleware.Handler, req *dns.Msg, c
 	ch := middleware.NewChain([]middleware.Handler{c, h})
 	ch.Reset(mw, req)
 	ch.Next(context.Background())
-	require.True(t, mw.Written(), "writer was not written")
+	if !(mw.Written()) {
+		t.Fatalf("%s: mw.Written() is false", "writer was not written")
+	}
 	return mw.Msg()
 }
 
@@ -168,8 +169,12 @@ func TestECSCache_NoCrossContamination(t *testing.T) {
 	// First: client A in 203.0.113.0/24 gets 10.20.30.40 (cached
 	// under scope 203.0.113.0/24).
 	respA := sendAndExpect(t, c, h, reqWithECS("cdn.example.", 1, 24, "203.0.113.0"), "203.0.113.5")
-	assert.Equal(t, "10.20.30.40", answerA(respA), "client A first lookup")
-	require.Equal(t, 1, h.Calls(), "upstream called once for client A")
+	if !reflect.DeepEqual("10.20.30.40", answerA(respA)) {
+		t.Errorf("%s: answerA(respA) = %v, want %v", "client A first lookup", answerA(respA), "10.20.30.40")
+	}
+	if !reflect.DeepEqual(1, h.Calls()) {
+		t.Fatalf("%s: h.Calls() = %v, want %v", "upstream called once for client A", h.Calls(), 1)
+	}
 
 	// Authority now answers a different address for the next miss.
 	h.aRecord = "10.20.30.99"
@@ -178,14 +183,22 @@ func TestECSCache_NoCrossContamination(t *testing.T) {
 	// cached answer (#417 regression). The cache miss falls through
 	// to the upstream which serves the new audience-B answer.
 	respB := sendAndExpect(t, c, h, reqWithECS("cdn.example.", 1, 24, "198.51.100.0"), "198.51.100.5")
-	assert.Equal(t, "10.20.30.99", answerA(respB), "client B must NOT inherit client A's cached answer")
-	require.Equal(t, 2, h.Calls(), "upstream called once for client B (no cache cross-contamination)")
+	if !reflect.DeepEqual("10.20.30.99", answerA(respB)) {
+		t.Errorf("%s: answerA(respB) = %v, want %v", "client B must NOT inherit client A's cached answer", answerA(respB), "10.20.30.99")
+	}
+	if !reflect.DeepEqual(2, h.Calls()) {
+		t.Fatalf("%s: h.Calls() = %v, want %v", "upstream called once for client B (no cache cross-contamination)", h.Calls(), 2)
+	}
 
 	// Third: client A again. Must hit the cache (no third upstream
 	// call), still serving 10.20.30.40.
 	respA2 := sendAndExpect(t, c, h, reqWithECS("cdn.example.", 1, 24, "203.0.113.0"), "203.0.113.5")
-	assert.Equal(t, "10.20.30.40", answerA(respA2), "client A second lookup hits scoped cache")
-	assert.Equal(t, 2, h.Calls(), "no extra upstream call for client A's cache hit")
+	if !reflect.DeepEqual("10.20.30.40", answerA(respA2)) {
+		t.Errorf("%s: answerA(respA2) = %v, want %v", "client A second lookup hits scoped cache", answerA(respA2), "10.20.30.40")
+	}
+	if !reflect.DeepEqual(2, h.Calls()) {
+		t.Errorf("%s: h.Calls() = %v, want %v", "no extra upstream call for client A's cache hit", h.Calls(), 2)
+	}
 }
 
 // TestECSCache_SharedKeyOnGlobalScope verifies that a SCOPE=0
@@ -203,15 +216,23 @@ func TestECSCache_SharedKeyOnGlobalScope(t *testing.T) {
 	// ECS client populates the cache under the shared key (because
 	// the response had SCOPE=0).
 	respECS := sendAndExpect(t, c, h, reqWithECS("global.example.", 1, 24, "203.0.113.0"), "203.0.113.5")
-	assert.Equal(t, "10.0.0.1", answerA(respECS))
-	require.Equal(t, 1, h.Calls())
+	if !reflect.DeepEqual("10.0.0.1", answerA(respECS)) {
+		t.Errorf("answerA(respECS) = %v, want %v", answerA(respECS), "10.0.0.1")
+	}
+	if !reflect.DeepEqual(1, h.Calls()) {
+		t.Fatalf("h.Calls() = %v, want %v", h.Calls(), 1)
+	}
 
 	// Plain (non-ECS) client must hit the same entry.
 	plain := new(dns.Msg)
 	plain.SetQuestion("global.example.", dns.TypeA)
 	respPlain := sendAndExpect(t, c, h, plain, "10.0.0.2")
-	assert.Equal(t, "10.0.0.1", answerA(respPlain), "non-ECS client must hit the SCOPE=0 shared entry")
-	assert.Equal(t, 1, h.Calls(), "no extra upstream — shared-key hit")
+	if !reflect.DeepEqual("10.0.0.1", answerA(respPlain)) {
+		t.Errorf("%s: answerA(respPlain) = %v, want %v", "non-ECS client must hit the SCOPE=0 shared entry", answerA(respPlain), "10.0.0.1")
+	}
+	if !reflect.DeepEqual(1, h.Calls()) {
+		t.Errorf("%s: h.Calls() = %v, want %v", "no extra upstream — shared-key hit", h.Calls(), 1)
+	}
 }
 
 // TestECSCache_PreStage2EntriesStillHit pins migration safety: a
@@ -236,8 +257,12 @@ func TestECSCache_PreStage2EntriesStillHit(t *testing.T) {
 	// Plain client lookup hits without an upstream call.
 	h := &echoHandler{aRecord: "should-not-be-used", scopeBits: 0}
 	resp := sendAndExpect(t, c, h, req, "10.0.0.7")
-	assert.Equal(t, "192.0.2.50", answerA(resp))
-	assert.Equal(t, 0, h.Calls(), "pre-Stage-2 entry must hit without upstream")
+	if !reflect.DeepEqual("192.0.2.50", answerA(resp)) {
+		t.Errorf("answerA(resp) = %v, want %v", answerA(resp), "192.0.2.50")
+	}
+	if !reflect.DeepEqual(0, h.Calls()) {
+		t.Errorf("%s: h.Calls() = %v, want %v", "pre-Stage-2 entry must hit without upstream", h.Calls(), 0)
+	}
 }
 
 // TestECSCache_SupernetHit covers the longest-prefix-match fallback:
@@ -257,7 +282,9 @@ func TestECSCache_SupernetHit(t *testing.T) {
 	req := new(dns.Msg)
 	req.SetQuestion("super.example.", dns.TypeA)
 	scope, err := netip.ParsePrefix("203.0.112.0/22")
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	key := CacheKey{Question: req.Question[0], CD: false, Scope: scope}.Hash()
 	c.store.SetFromResponseScoped(key, reply(req, "10.1.1.1", 22), scope, time.Time{}, 0)
 
@@ -266,8 +293,12 @@ func TestECSCache_SupernetHit(t *testing.T) {
 	// /22 (hit).
 	h := &echoHandler{aRecord: "should-not-be-used", scopeBits: 0}
 	resp := sendAndExpect(t, c, h, reqWithECS("super.example.", 1, 24, "203.0.113.0"), "203.0.113.42")
-	assert.Equal(t, "10.1.1.1", answerA(resp))
-	assert.Equal(t, 0, h.Calls(), "supernet probe must hit without upstream")
+	if !reflect.DeepEqual("10.1.1.1", answerA(resp)) {
+		t.Errorf("answerA(resp) = %v, want %v", answerA(resp), "10.1.1.1")
+	}
+	if !reflect.DeepEqual(0, h.Calls()) {
+		t.Errorf("%s: h.Calls() = %v, want %v", "supernet probe must hit without upstream", h.Calls(), 0)
+	}
 }
 
 // TestECSCache_PolicyOffBypassesEverything: even an ECS-laden
@@ -286,13 +317,21 @@ func TestECSCache_PolicyOffBypassesEverything(t *testing.T) {
 	// see the same cached answer — because policy is off and the
 	// cache keys both under the shared key.
 	respA := sendAndExpect(t, c, h, reqWithECS("nopolicy.example.", 1, 24, "203.0.113.0"), "203.0.113.5")
-	assert.Equal(t, "10.10.10.10", answerA(respA))
-	require.Equal(t, 1, h.Calls())
+	if !reflect.DeepEqual("10.10.10.10", answerA(respA)) {
+		t.Errorf("answerA(respA) = %v, want %v", answerA(respA), "10.10.10.10")
+	}
+	if !reflect.DeepEqual(1, h.Calls()) {
+		t.Fatalf("h.Calls() = %v, want %v", h.Calls(), 1)
+	}
 
 	h.aRecord = "10.10.10.99" // never observed because cache hits
 	respB := sendAndExpect(t, c, h, reqWithECS("nopolicy.example.", 1, 24, "198.51.100.0"), "198.51.100.5")
-	assert.Equal(t, "10.10.10.10", answerA(respB), "policy off → client B sees client A's cached answer (today's behaviour)")
-	assert.Equal(t, 1, h.Calls(), "policy off → no extra upstream call")
+	if !reflect.DeepEqual("10.10.10.10", answerA(respB)) {
+		t.Errorf("%s: answerA(respB) = %v, want %v", "policy off → client B sees client A's cached answer (today's behaviour)", answerA(respB), "10.10.10.10")
+	}
+	if !reflect.DeepEqual(1, h.Calls()) {
+		t.Errorf("%s: h.Calls() = %v, want %v", "policy off → no extra upstream call", h.Calls(), 1)
+	}
 }
 
 // TestECSCache_ScopedEntryNotPrefetched: a scoped entry's
@@ -380,8 +419,12 @@ func TestECSCache_BroaderScopeOnNormalClientHits(t *testing.T) {
 	respA := sendAndExpect(t, c, h,
 		reqWithECS("broad-scope.example.", 1, 24, "203.0.112.0"),
 		"203.0.112.5")
-	assert.Equal(t, "10.1.2.3", answerA(respA))
-	require.Equal(t, 1, h.Calls())
+	if !reflect.DeepEqual("10.1.2.3", answerA(respA)) {
+		t.Errorf("answerA(respA) = %v, want %v", answerA(respA), "10.1.2.3")
+	}
+	if !reflect.DeepEqual(1, h.Calls()) {
+		t.Fatalf("h.Calls() = %v, want %v", h.Calls(), 1)
+	}
 
 	// Second /24 query from the same client must HIT — same source
 	// prefix, the stored /20 entry covers it.
@@ -389,19 +432,24 @@ func TestECSCache_BroaderScopeOnNormalClientHits(t *testing.T) {
 	respB := sendAndExpect(t, c, h,
 		reqWithECS("broad-scope.example.", 1, 24, "203.0.112.0"),
 		"203.0.112.5")
-	assert.Equal(t, "10.1.2.3", answerA(respB),
-		"second /24 query missed the /20 entry the first query inserted")
-	assert.Equal(t, 1, h.Calls(),
-		"second /24 query went upstream instead of hitting the broader cached entry")
+	if !reflect.DeepEqual("10.1.2.3", answerA(respB)) {
+		t.Errorf("%s: answerA(respB) = %v, want %v", "second /24 query missed the /20 entry the first query inserted", answerA(respB), "10.1.2.3")
+	}
+	if !reflect.DeepEqual(1, h.Calls()) {
+		t.Errorf("%s: h.Calls() = %v, want %v", "second /24 query went upstream instead of hitting the broader cached entry", h.Calls(), 1)
+	}
 
 	// A different /24 *within* the same /20 must also hit — that's
 	// the whole point of caching at a broader SCOPE.
 	respC := sendAndExpect(t, c, h,
 		reqWithECS("broad-scope.example.", 1, 24, "203.0.113.0"),
 		"203.0.113.42")
-	assert.Equal(t, "10.1.2.3", answerA(respC),
-		"sibling /24 within the same /20 missed the broader entry")
-	assert.Equal(t, 1, h.Calls(), "sibling /24 went upstream needlessly")
+	if !reflect.DeepEqual("10.1.2.3", answerA(respC)) {
+		t.Errorf("%s: answerA(respC) = %v, want %v", "sibling /24 within the same /20 missed the broader entry", answerA(respC), "10.1.2.3")
+	}
+	if !reflect.DeepEqual(1, h.Calls()) {
+		t.Errorf("%s: h.Calls() = %v, want %v", "sibling /24 went upstream needlessly", h.Calls(), 1)
+	}
 }
 
 // TestECSCache_BroaderThanMinClientScopeHits pins the fourth-round
@@ -429,14 +477,22 @@ func TestECSCache_BroaderThanMinClientScopeHits(t *testing.T) {
 	// First request inserts the /20 entry.
 	req := reqWithECS("broad.example.", 1, 20, "203.0.96.0")
 	respA := sendAndExpect(t, c, h, req, "203.0.96.5")
-	assert.Equal(t, "10.20.30.40", answerA(respA))
-	require.Equal(t, 1, h.Calls())
+	if !reflect.DeepEqual("10.20.30.40", answerA(respA)) {
+		t.Errorf("answerA(respA) = %v, want %v", answerA(respA), "10.20.30.40")
+	}
+	if !reflect.DeepEqual(1, h.Calls()) {
+		t.Fatalf("h.Calls() = %v, want %v", h.Calls(), 1)
+	}
 
 	// Second request from the same /20 must HIT the cache.
 	h.aRecord = "should-not-be-used"
 	respB := sendAndExpect(t, c, h, reqWithECS("broad.example.", 1, 20, "203.0.96.0"), "203.0.96.5")
-	assert.Equal(t, "10.20.30.40", answerA(respB), "second /20 query missed the /20 entry just inserted")
-	assert.Equal(t, 1, h.Calls(), "second /20 query went upstream instead of hitting the cache")
+	if !reflect.DeepEqual("10.20.30.40", answerA(respB)) {
+		t.Errorf("%s: answerA(respB) = %v, want %v", "second /20 query missed the /20 entry just inserted", answerA(respB), "10.20.30.40")
+	}
+	if !reflect.DeepEqual(1, h.Calls()) {
+		t.Errorf("%s: h.Calls() = %v, want %v", "second /20 query went upstream instead of hitting the cache", h.Calls(), 1)
+	}
 }
 
 // TestECSCache_LookupsMetricCountsOnlyECSPaths pins the sixth-round
@@ -528,14 +584,17 @@ func TestECSCache_BuildPolicyFailClosed(t *testing.T) {
 	plain := new(dns.Msg)
 	plain.SetQuestion("disabled-policy.example.", dns.TypeA)
 	resp := sendAndExpect(t, c, h, plain, "10.0.0.7")
-	assert.Equal(t, "10.0.0.1", answerA(resp))
+	if !reflect.DeepEqual("10.0.0.1", answerA(resp)) {
+		t.Errorf("answerA(resp) = %v, want %v", answerA(resp), "10.0.0.1")
+	}
 
 	// And an ECS-bearing request goes through the shared-key path
 	// because requestScope short-circuits on c.ecsPolicy == nil.
 	ecs := reqWithECS("disabled-policy.example.", 1, 24, "203.0.113.0")
 	resp2 := sendAndExpect(t, c, h, ecs, "203.0.113.5")
-	assert.Equal(t, "10.0.0.1", answerA(resp2),
-		"ECS request with disabled policy must hit the shared-key entry")
+	if !reflect.DeepEqual("10.0.0.1", answerA(resp2)) {
+		t.Errorf("%s: answerA(resp2) = %v, want %v", "ECS request with disabled policy must hit the shared-key entry", answerA(resp2), "10.0.0.1")
+	}
 }
 
 // TestECSCache_RequestScopeMalformedReturnsZero covers the
@@ -623,8 +682,9 @@ func TestECSCache_PurgeIsCaseInsensitive(t *testing.T) {
 	scope := netip.MustParsePrefix("203.0.113.0/24")
 	key := CacheKey{Question: req.Question[0], CD: false, Scope: scope}.Hash()
 	c.store.SetFromResponseScoped(key, reply(req, "10.0.0.1", 24), scope, time.Time{}, 0)
-	require.Truef(t, func() bool { _, ok := c.store.LookupByKey(key); return ok }(),
-		"seed did not land in cache")
+	if !(func() bool { _, ok := c.store.LookupByKey(key); return ok }()) {
+		t.Fatalf("%s: func() bool { _, ok := c.store.LookupByKey(key); return ok }() is false", "seed did not land in cache")
+	}
 
 	// Operator purges via the canonical lowercase FQDN.
 	c.store.Purge(dns.Question{
@@ -670,7 +730,9 @@ func TestECSCache_CacheLimitTTLCapsScopedWrites(t *testing.T) {
 	c.store.SetFromResponseScoped(key, resp, scope, time.Time{}, 0)
 
 	entry, ok := c.store.LookupByKey(key)
-	require.True(t, ok, "scoped seed did not land in cache")
+	if !(ok) {
+		t.Fatalf("%s: ok is false", "scoped seed did not land in cache")
+	}
 	if entry.ttl > cfg.ECS.CacheLimitTTL.Duration {
 		t.Errorf("scoped TTL %s exceeded cache_limit_ttl cap %s",
 			entry.ttl, cfg.ECS.CacheLimitTTL.Duration)
@@ -681,7 +743,9 @@ func TestECSCache_CacheLimitTTLCapsScopedWrites(t *testing.T) {
 	plainKey := CacheKey{Question: req.Question[0], CD: false}.Hash()
 	c.store.SetFromResponseWithKey(plainKey, resp, time.Time{}, 0)
 	plain, ok := c.store.LookupByKey(plainKey)
-	require.True(t, ok)
+	if !(ok) {
+		t.Fatalf("ok is false")
+	}
 	if plain.ttl <= cfg.ECS.CacheLimitTTL.Duration {
 		t.Errorf("unscoped TTL %s was capped at %s (should not be)",
 			plain.ttl, cfg.ECS.CacheLimitTTL.Duration)

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -16,8 +17,6 @@ import (
 	"github.com/semihalev/sdns/internal/cache"
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/semihalev/sdns/middleware"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func makeRR(data string) dns.RR {
@@ -54,11 +53,21 @@ func TestNew(t *testing.T) {
 	c := New(cfg)
 	defer c.Stop()
 
-	require.NotNil(t, c)
-	assert.Equal(t, "cache", c.Name())
-	assert.NotNil(t, c.positive)
-	assert.NotNil(t, c.negative)
-	assert.Equal(t, cfg.CacheSize, c.config.Size)
+	if c == nil {
+		t.Fatalf("c is nil")
+	}
+	if !reflect.DeepEqual("cache", c.Name()) {
+		t.Errorf("c.Name() = %v, want %v", c.Name(), "cache")
+	}
+	if c.positive == nil {
+		t.Fatalf("c.positive is nil")
+	}
+	if c.negative == nil {
+		t.Fatalf("c.negative is nil")
+	}
+	if !reflect.DeepEqual(cfg.CacheSize, c.config.Size) {
+		t.Errorf("c.config.Size = %v, want %v", c.config.Size, cfg.CacheSize)
+	}
 
 	// Clean up
 	os.RemoveAll(cfg.Directory) //nolint:gosec // G104 - test cleanup
@@ -109,8 +118,12 @@ func TestCachePurge(t *testing.T) {
 	ch.Reset(mw, req)
 
 	c.ServeDNS(context.Background(), ch)
-	assert.True(t, mw.Written())
-	assert.Len(t, mw.Msg().Extra, 1)
+	if !(mw.Written()) {
+		t.Errorf("mw.Written() is false")
+	}
+	if len(mw.Msg().Extra) != 1 {
+		t.Errorf("len(mw.Msg().Extra) = %d, want %d", len(mw.Msg().Extra), 1)
+	}
 }
 
 func TestPositiveCache(t *testing.T) {
@@ -133,7 +146,9 @@ func TestPositiveCache(t *testing.T) {
 
 	// Check cache is empty initially
 	entry := c.checkCache(key)
-	assert.Nil(t, entry)
+	if entry != nil {
+		t.Errorf("entry = %v, want nil", entry)
+	}
 
 	// Create and cache a positive response
 	msg := new(dns.Msg)
@@ -144,16 +159,24 @@ func TestPositiveCache(t *testing.T) {
 
 	// Verify it's in cache
 	entry = c.checkCache(key)
-	require.NotNil(t, entry)
+	if entry == nil {
+		t.Fatalf("entry is nil")
+	}
 
 	// Serve from cache
 	ch.Reset(mw, req)
 	c.ServeDNS(context.Background(), ch)
-	assert.True(t, mw.Written())
+	if !(mw.Written()) {
+		t.Errorf("mw.Written() is false")
+	}
 
 	resp := mw.Msg()
-	require.Len(t, resp.Answer, 1)
-	assert.Equal(t, "test.com.", resp.Answer[0].Header().Name)
+	if len(resp.Answer) != 1 {
+		t.Fatalf("len(resp.Answer) = %d, want %d", len(resp.Answer), 1)
+	}
+	if !reflect.DeepEqual("test.com.", resp.Answer[0].Header().Name) {
+		t.Errorf("resp.Answer[0].Header().Name = %v, want %v", resp.Answer[0].Header().Name, "test.com.")
+	}
 }
 
 func TestNegativeCache(t *testing.T) {
@@ -183,12 +206,18 @@ func TestNegativeCache(t *testing.T) {
 
 	// Verify it's in cache (NXDOMAIN goes to positive cache)
 	entry := c.checkCache(key)
-	require.NotNil(t, entry)
+	if entry == nil {
+		t.Fatalf("entry is nil")
+	}
 
 	// NXDOMAIN responses are stored in positive cache with ttl from SOA
 	posEntry, found := c.positive.Get(key)
-	assert.True(t, found)
-	assert.NotNil(t, posEntry)
+	if !(found) {
+		t.Errorf("found is false")
+	}
+	if posEntry == nil {
+		t.Fatalf("posEntry is nil")
+	}
 }
 
 func TestCacheTTL(t *testing.T) {
@@ -215,7 +244,9 @@ func TestCacheTTL(t *testing.T) {
 
 	// Should be in cache immediately
 	entry := c.checkCache(key)
-	require.NotNil(t, entry)
+	if entry == nil {
+		t.Fatalf("entry is nil")
+	}
 
 	// Age the entry past its TTL rather than waiting it out: expiry is
 	// derived from stored+ttl, so moving stored back is exactly equivalent
@@ -225,7 +256,9 @@ func TestCacheTTL(t *testing.T) {
 
 	// Should be expired
 	entry = c.checkCache(key)
-	assert.Nil(t, entry)
+	if entry != nil {
+		t.Errorf("entry = %v, want nil", entry)
+	}
 }
 
 func TestCacheDNSSEC(t *testing.T) {
@@ -252,11 +285,15 @@ func TestCacheDNSSEC(t *testing.T) {
 	// Query without CD bit should not find it
 	keyNoCD := cache.Key(q, false)
 	entry := c.checkCache(keyNoCD)
-	assert.Nil(t, entry)
+	if entry != nil {
+		t.Errorf("entry = %v, want nil", entry)
+	}
 
 	// Query with CD bit should find it
 	entry = c.checkCache(key)
-	assert.NotNil(t, entry)
+	if entry == nil {
+		t.Fatalf("entry is nil")
+	}
 }
 
 func TestCachePrefetch(t *testing.T) {
@@ -269,7 +306,9 @@ func TestCachePrefetch(t *testing.T) {
 
 	// Just verify prefetch is configured
 	if cfg.Prefetch > 0 {
-		assert.NotNil(t, c.prefetchQueue)
+		if c.prefetchQueue == nil {
+			t.Fatalf("c.prefetchQueue is nil")
+		}
 	}
 
 	// Test basic caching without waiting for prefetch
@@ -285,7 +324,9 @@ func TestCachePrefetch(t *testing.T) {
 
 	// Verify it's cached
 	entry := c.checkCache(key)
-	assert.NotNil(t, entry)
+	if entry == nil {
+		t.Fatalf("entry is nil")
+	}
 }
 
 func TestCacheConcurrency(t *testing.T) {
@@ -339,7 +380,9 @@ func TestCacheConcurrency(t *testing.T) {
 
 	// Verify cache has some entries
 	stats := c.Stats()
-	assert.Contains(t, stats, "positive_size")
+	if _, ok := stats["positive_size"]; !ok {
+		t.Errorf("stats %v missing %q", stats, "positive_size")
+	}
 }
 
 func TestCacheMetrics(t *testing.T) {
@@ -376,10 +419,11 @@ func TestCacheMetrics(t *testing.T) {
 
 	stats := c.Stats()
 
-	assert.Contains(t, stats, "positive_size")
-	assert.Contains(t, stats, "negative_size")
-	assert.Contains(t, stats, "hits")
-	assert.Contains(t, stats, "misses")
+	for _, key := range []string{"positive_size", "negative_size", "hits", "misses"} {
+		if _, ok := stats[key]; !ok {
+			t.Errorf("stats %v missing %q", stats, key)
+		}
+	}
 }
 
 func TestCacheInvalidation(t *testing.T) {
@@ -402,7 +446,9 @@ func TestCacheInvalidation(t *testing.T) {
 
 	// Verify it's cached
 	entry := c.checkCache(key)
-	require.NotNil(t, entry)
+	if entry == nil {
+		t.Fatalf("entry is nil")
+	}
 
 	// Clear cache by creating new instances. checkCache reads through
 	// c.store, so the swap has to update both the direct fields and
@@ -413,7 +459,9 @@ func TestCacheInvalidation(t *testing.T) {
 
 	// Should be gone
 	entry = c.checkCache(key)
-	assert.Nil(t, entry)
+	if entry != nil {
+		t.Errorf("entry = %v, want nil", entry)
+	}
 }
 
 func TestCacheEDNS(t *testing.T) {
@@ -429,7 +477,9 @@ func TestCacheEDNS(t *testing.T) {
 	req.SetEdns0(4096, false)
 
 	opt := req.IsEdns0()
-	require.NotNil(t, opt)
+	if opt == nil {
+		t.Fatalf("opt is nil")
+	}
 
 	msg := new(dns.Msg)
 	msg.SetReply(req)
@@ -448,11 +498,19 @@ func TestCacheEDNS(t *testing.T) {
 	ch.Reset(mw, req2)
 
 	c.ServeDNS(context.Background(), ch)
-	assert.True(t, mw.Written())
+	if !(mw.Written()) {
+		t.Errorf("mw.Written() is false")
+	}
 
 	// Response should be valid
 	resp := mw.Msg()
-	require.NotNil(t, resp)
-	assert.Len(t, resp.Answer, 1)
-	assert.Equal(t, "edns.com.", resp.Answer[0].Header().Name)
+	if resp == nil {
+		t.Fatalf("resp is nil")
+	}
+	if len(resp.Answer) != 1 {
+		t.Errorf("len(resp.Answer) = %d, want %d", len(resp.Answer), 1)
+	}
+	if !reflect.DeepEqual("edns.com.", resp.Answer[0].Header().Name) {
+		t.Errorf("resp.Answer[0].Header().Name = %v, want %v", resp.Answer[0].Header().Name, "edns.com.")
+	}
 }

--- a/middleware/cache/ede_test.go
+++ b/middleware/cache/ede_test.go
@@ -2,11 +2,11 @@ package cache
 
 import (
 	"net"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/miekg/dns"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestEDEPreservationInCache(t *testing.T) {
@@ -34,9 +34,15 @@ func TestEDEPreservationInCache(t *testing.T) {
 	entry := NewCacheEntry(msg, 30*time.Second, 0)
 
 	// Verify EDE was preserved
-	assert.NotNil(t, entry.ede)
-	assert.Equal(t, dns.ExtendedErrorCodeDNSBogus, entry.ede.InfoCode)
-	assert.Equal(t, "DNSSEC validation failed", entry.ede.ExtraText)
+	if entry.ede == nil {
+		t.Fatalf("entry.ede is nil")
+	}
+	if !reflect.DeepEqual(dns.ExtendedErrorCodeDNSBogus, entry.ede.InfoCode) {
+		t.Errorf("entry.ede.InfoCode = %v, want %v", entry.ede.InfoCode, dns.ExtendedErrorCodeDNSBogus)
+	}
+	if !reflect.DeepEqual("DNSSEC validation failed", entry.ede.ExtraText) {
+		t.Errorf("entry.ede.ExtraText = %v, want %v", entry.ede.ExtraText, "DNSSEC validation failed")
+	}
 
 	// Create a request
 	req := new(dns.Msg)
@@ -45,11 +51,15 @@ func TestEDEPreservationInCache(t *testing.T) {
 
 	// Get response from cache
 	resp := entry.ToMsg(req)
-	assert.NotNil(t, resp)
+	if resp == nil {
+		t.Fatalf("resp is nil")
+	}
 
 	// Verify EDE is present in response
 	opt2 := resp.IsEdns0()
-	assert.NotNil(t, opt2)
+	if opt2 == nil {
+		t.Fatalf("opt2 is nil")
+	}
 
 	var foundEDE *dns.EDNS0_EDE
 	for _, option := range opt2.Option {
@@ -59,9 +69,15 @@ func TestEDEPreservationInCache(t *testing.T) {
 		}
 	}
 
-	assert.NotNil(t, foundEDE)
-	assert.Equal(t, dns.ExtendedErrorCodeDNSBogus, foundEDE.InfoCode)
-	assert.Equal(t, "DNSSEC validation failed", foundEDE.ExtraText)
+	if foundEDE == nil {
+		t.Fatalf("foundEDE is nil")
+	}
+	if !reflect.DeepEqual(dns.ExtendedErrorCodeDNSBogus, foundEDE.InfoCode) {
+		t.Errorf("foundEDE.InfoCode = %v, want %v", foundEDE.InfoCode, dns.ExtendedErrorCodeDNSBogus)
+	}
+	if !reflect.DeepEqual("DNSSEC validation failed", foundEDE.ExtraText) {
+		t.Errorf("foundEDE.ExtraText = %v, want %v", foundEDE.ExtraText, "DNSSEC validation failed")
+	}
 }
 
 func TestEDENotAddedForSuccessResponses(t *testing.T) {
@@ -86,7 +102,9 @@ func TestEDENotAddedForSuccessResponses(t *testing.T) {
 	entry := NewCacheEntry(msg, 30*time.Second, 0)
 
 	// Verify no EDE was preserved (success responses don't have EDE)
-	assert.Nil(t, entry.ede)
+	if entry.ede != nil {
+		t.Errorf("entry.ede = %v, want nil", entry.ede)
+	}
 
 	// Create a request
 	req := new(dns.Msg)
@@ -95,15 +113,21 @@ func TestEDENotAddedForSuccessResponses(t *testing.T) {
 
 	// Get response from cache
 	resp := entry.ToMsg(req)
-	assert.NotNil(t, resp)
-	assert.Equal(t, dns.RcodeSuccess, resp.Rcode)
+	if resp == nil {
+		t.Fatalf("resp is nil")
+	}
+	if !reflect.DeepEqual(dns.RcodeSuccess, resp.Rcode) {
+		t.Errorf("resp.Rcode = %v, want %v", resp.Rcode, dns.RcodeSuccess)
+	}
 
 	// Verify no EDE is added
 	opt := resp.IsEdns0()
 	if opt != nil {
 		for _, option := range opt.Option {
 			_, isEDE := option.(*dns.EDNS0_EDE)
-			assert.False(t, isEDE, "EDE should not be present in success responses")
+			if isEDE {
+				t.Errorf("%s: isEDE is true", "EDE should not be present in success responses")
+			}
 		}
 	}
 }

--- a/middleware/cache/negative_cache_test.go
+++ b/middleware/cache/negative_cache_test.go
@@ -2,12 +2,12 @@ package cache
 
 import (
 	"net/netip"
+	"reflect"
 	"testing"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/config"
 	"github.com/semihalev/sdns/internal/dnsutil"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestResolutionFailuresUseDedicatedCache(t *testing.T) {
@@ -92,9 +92,15 @@ func TestResolutionFailureRcodeClassification(t *testing.T) {
 			req.SetQuestion(msg.Question[0].Name, msg.Question[0].Qtype)
 			_, inFailure := c.store.LookupFailure(req, netip.Prefix{})
 
-			assert.False(t, inLegacyNegative, "legacy negative cache must remain empty")
-			assert.Equal(t, tt.wantFailure, inFailure)
-			assert.Equal(t, !tt.wantFailure, inPositive)
+			if inLegacyNegative {
+				t.Errorf("%s: inLegacyNegative is true", "legacy negative cache must remain empty")
+			}
+			if !reflect.DeepEqual(tt.wantFailure, inFailure) {
+				t.Errorf("inFailure = %v, want %v", inFailure, tt.wantFailure)
+			}
+			if !reflect.DeepEqual(!tt.wantFailure, inPositive) {
+				t.Errorf("inPositive = %v, want %v", inPositive, !tt.wantFailure)
+			}
 		})
 	}
 }

--- a/middleware/cache/prefetch_fix_test.go
+++ b/middleware/cache/prefetch_fix_test.go
@@ -1,12 +1,12 @@
 package cache
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/config"
-	"github.com/stretchr/testify/assert"
 )
 
 // Test_Prefetch_Stores_Response tests that prefetch actually stores responses in cache.
@@ -47,7 +47,9 @@ func Test_Prefetch_Stores_Response(t *testing.T) {
 
 	// Verify entry is in cache
 	retrieved := c.checkCache(cacheKey)
-	assert.NotNil(t, retrieved)
+	if retrieved == nil {
+		t.Fatalf("retrieved is nil")
+	}
 
 	// Test that prefetch request has the cache reference
 	if c.prefetchQueue != nil {
@@ -58,8 +60,12 @@ func Test_Prefetch_Stores_Response(t *testing.T) {
 		}
 
 		// Verify the cache reference is set
-		assert.NotNil(t, req.Cache)
-		assert.Equal(t, c, req.Cache)
+		if req.Cache == nil {
+			t.Fatalf("req.Cache is nil")
+		}
+		if !reflect.DeepEqual(c, req.Cache) {
+			t.Errorf("req.Cache = %v, want %v", req.Cache, c)
+		}
 
 		// In real execution, processPrefetch:
 		//   1. Calls req.Cache.prefetchExchange(ctx, req.Request)

--- a/middleware/cache/types_test.go
+++ b/middleware/cache/types_test.go
@@ -1,12 +1,11 @@
 package cache
 
 import (
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/miekg/dns"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestEDEPreservation(t *testing.T) {
@@ -42,16 +41,28 @@ func TestEDEPreservation(t *testing.T) {
 				return m
 			}(),
 			expected: func(t *testing.T, original, restored *dns.Msg) {
-				assert.Equal(t, dns.RcodeServerFailure, restored.Rcode)
+				if !reflect.DeepEqual(dns.RcodeServerFailure, restored.Rcode) {
+					t.Errorf("restored.Rcode = %v, want %v", restored.Rcode, dns.RcodeServerFailure)
+				}
 
 				opt := restored.IsEdns0()
-				require.NotNil(t, opt)
-				require.Len(t, opt.Option, 1)
+				if opt == nil {
+					t.Fatalf("opt is nil")
+				}
+				if len(opt.Option) != 1 {
+					t.Fatalf("len(opt.Option) = %d, want %d", len(opt.Option), 1)
+				}
 
 				ede, ok := opt.Option[0].(*dns.EDNS0_EDE)
-				require.True(t, ok)
-				assert.Equal(t, dns.ExtendedErrorCodeNetworkError, ede.InfoCode)
-				assert.Equal(t, "Network unreachable", ede.ExtraText)
+				if !(ok) {
+					t.Fatalf("ok is false")
+				}
+				if !reflect.DeepEqual(dns.ExtendedErrorCodeNetworkError, ede.InfoCode) {
+					t.Errorf("ede.InfoCode = %v, want %v", ede.InfoCode, dns.ExtendedErrorCodeNetworkError)
+				}
+				if !reflect.DeepEqual("Network unreachable", ede.ExtraText) {
+					t.Errorf("ede.ExtraText = %v, want %v", ede.ExtraText, "Network unreachable")
+				}
 			},
 		},
 		{
@@ -80,16 +91,28 @@ func TestEDEPreservation(t *testing.T) {
 				return m
 			}(),
 			expected: func(t *testing.T, original, restored *dns.Msg) {
-				assert.Equal(t, dns.RcodeNameError, restored.Rcode)
+				if !reflect.DeepEqual(dns.RcodeNameError, restored.Rcode) {
+					t.Errorf("restored.Rcode = %v, want %v", restored.Rcode, dns.RcodeNameError)
+				}
 
 				opt := restored.IsEdns0()
-				require.NotNil(t, opt)
-				require.Len(t, opt.Option, 1)
+				if opt == nil {
+					t.Fatalf("opt is nil")
+				}
+				if len(opt.Option) != 1 {
+					t.Fatalf("len(opt.Option) = %d, want %d", len(opt.Option), 1)
+				}
 
 				ede, ok := opt.Option[0].(*dns.EDNS0_EDE)
-				require.True(t, ok)
-				assert.Equal(t, dns.ExtendedErrorCodeStaleNXDOMAINAnswer, ede.InfoCode)
-				assert.Equal(t, "Stale NXDOMAIN response", ede.ExtraText)
+				if !(ok) {
+					t.Fatalf("ok is false")
+				}
+				if !reflect.DeepEqual(dns.ExtendedErrorCodeStaleNXDOMAINAnswer, ede.InfoCode) {
+					t.Errorf("ede.InfoCode = %v, want %v", ede.InfoCode, dns.ExtendedErrorCodeStaleNXDOMAINAnswer)
+				}
+				if !reflect.DeepEqual("Stale NXDOMAIN response", ede.ExtraText) {
+					t.Errorf("ede.ExtraText = %v, want %v", ede.ExtraText, "Stale NXDOMAIN response")
+				}
 			},
 		},
 		{
@@ -129,17 +152,31 @@ func TestEDEPreservation(t *testing.T) {
 				return m
 			}(),
 			expected: func(t *testing.T, original, restored *dns.Msg) {
-				assert.Equal(t, dns.RcodeSuccess, restored.Rcode)
-				assert.Len(t, restored.Answer, 1)
+				if !reflect.DeepEqual(dns.RcodeSuccess, restored.Rcode) {
+					t.Errorf("restored.Rcode = %v, want %v", restored.Rcode, dns.RcodeSuccess)
+				}
+				if len(restored.Answer) != 1 {
+					t.Errorf("len(restored.Answer) = %d, want %d", len(restored.Answer), 1)
+				}
 
 				opt := restored.IsEdns0()
-				require.NotNil(t, opt)
-				require.Len(t, opt.Option, 1)
+				if opt == nil {
+					t.Fatalf("opt is nil")
+				}
+				if len(opt.Option) != 1 {
+					t.Fatalf("len(opt.Option) = %d, want %d", len(opt.Option), 1)
+				}
 
 				ede, ok := opt.Option[0].(*dns.EDNS0_EDE)
-				require.True(t, ok)
-				assert.Equal(t, dns.ExtendedErrorCodeStaleAnswer, ede.InfoCode)
-				assert.Equal(t, "Stale data served", ede.ExtraText)
+				if !(ok) {
+					t.Fatalf("ok is false")
+				}
+				if !reflect.DeepEqual(dns.ExtendedErrorCodeStaleAnswer, ede.InfoCode) {
+					t.Errorf("ede.InfoCode = %v, want %v", ede.InfoCode, dns.ExtendedErrorCodeStaleAnswer)
+				}
+				if !reflect.DeepEqual("Stale data served", ede.ExtraText) {
+					t.Errorf("ede.ExtraText = %v, want %v", ede.ExtraText, "Stale data served")
+				}
 			},
 		},
 		{
@@ -174,16 +211,26 @@ func TestEDEPreservation(t *testing.T) {
 				return m
 			}(),
 			expected: func(t *testing.T, original, restored *dns.Msg) {
-				assert.Equal(t, dns.RcodeServerFailure, restored.Rcode)
+				if !reflect.DeepEqual(dns.RcodeServerFailure, restored.Rcode) {
+					t.Errorf("restored.Rcode = %v, want %v", restored.Rcode, dns.RcodeServerFailure)
+				}
 
 				opt := restored.IsEdns0()
-				require.NotNil(t, opt)
+				if opt == nil {
+					t.Fatalf("opt is nil")
+				}
 				// Should only preserve the first EDE
-				require.Len(t, opt.Option, 1)
+				if len(opt.Option) != 1 {
+					t.Fatalf("len(opt.Option) = %d, want %d", len(opt.Option), 1)
+				}
 
 				ede, ok := opt.Option[0].(*dns.EDNS0_EDE)
-				require.True(t, ok)
-				assert.Equal(t, dns.ExtendedErrorCodeDNSSECIndeterminate, ede.InfoCode)
+				if !(ok) {
+					t.Fatalf("ok is false")
+				}
+				if !reflect.DeepEqual(dns.ExtendedErrorCodeDNSSECIndeterminate, ede.InfoCode) {
+					t.Errorf("ede.InfoCode = %v, want %v", ede.InfoCode, dns.ExtendedErrorCodeDNSSECIndeterminate)
+				}
 			},
 		},
 		{
@@ -212,9 +259,13 @@ func TestEDEPreservation(t *testing.T) {
 				return m
 			}(),
 			expected: func(t *testing.T, original, restored *dns.Msg) {
-				assert.Equal(t, dns.RcodeServerFailure, restored.Rcode)
+				if !reflect.DeepEqual(dns.RcodeServerFailure, restored.Rcode) {
+					t.Errorf("restored.Rcode = %v, want %v", restored.Rcode, dns.RcodeServerFailure)
+				}
 				// No EDE should be added if request doesn't have EDNS
-				assert.Nil(t, restored.IsEdns0())
+				if restored.IsEdns0() != nil {
+					t.Errorf("restored.IsEdns0() = %v, want nil", restored.IsEdns0())
+				}
 			},
 		},
 		{
@@ -243,16 +294,28 @@ func TestEDEPreservation(t *testing.T) {
 				return m
 			}(),
 			expected: func(t *testing.T, original, restored *dns.Msg) {
-				assert.Equal(t, dns.RcodeServerFailure, restored.Rcode)
+				if !reflect.DeepEqual(dns.RcodeServerFailure, restored.Rcode) {
+					t.Errorf("restored.Rcode = %v, want %v", restored.Rcode, dns.RcodeServerFailure)
+				}
 
 				opt := restored.IsEdns0()
-				require.NotNil(t, opt)
-				require.Len(t, opt.Option, 1)
+				if opt == nil {
+					t.Fatalf("opt is nil")
+				}
+				if len(opt.Option) != 1 {
+					t.Fatalf("len(opt.Option) = %d, want %d", len(opt.Option), 1)
+				}
 
 				ede, ok := opt.Option[0].(*dns.EDNS0_EDE)
-				require.True(t, ok)
-				assert.Equal(t, dns.ExtendedErrorCodeOther, ede.InfoCode)
-				assert.Equal(t, "", ede.ExtraText)
+				if !(ok) {
+					t.Fatalf("ok is false")
+				}
+				if !reflect.DeepEqual(dns.ExtendedErrorCodeOther, ede.InfoCode) {
+					t.Errorf("ede.InfoCode = %v, want %v", ede.InfoCode, dns.ExtendedErrorCodeOther)
+				}
+				if !reflect.DeepEqual("", ede.ExtraText) {
+					t.Errorf("ede.ExtraText = %v, want %v", ede.ExtraText, "")
+				}
 			},
 		},
 		{
@@ -291,16 +354,26 @@ func TestEDEPreservation(t *testing.T) {
 				return m
 			}(),
 			expected: func(t *testing.T, original, restored *dns.Msg) {
-				assert.Equal(t, dns.RcodeServerFailure, restored.Rcode)
+				if !reflect.DeepEqual(dns.RcodeServerFailure, restored.Rcode) {
+					t.Errorf("restored.Rcode = %v, want %v", restored.Rcode, dns.RcodeServerFailure)
+				}
 
 				opt := restored.IsEdns0()
-				require.NotNil(t, opt)
+				if opt == nil {
+					t.Fatalf("opt is nil")
+				}
 				// Should only have EDE, not the cookie
-				require.Len(t, opt.Option, 1)
+				if len(opt.Option) != 1 {
+					t.Fatalf("len(opt.Option) = %d, want %d", len(opt.Option), 1)
+				}
 
 				ede, ok := opt.Option[0].(*dns.EDNS0_EDE)
-				require.True(t, ok)
-				assert.Equal(t, dns.ExtendedErrorCodeNetworkError, ede.InfoCode)
+				if !(ok) {
+					t.Fatalf("ok is false")
+				}
+				if !reflect.DeepEqual(dns.ExtendedErrorCodeNetworkError, ede.InfoCode) {
+					t.Errorf("ede.InfoCode = %v, want %v", ede.InfoCode, dns.ExtendedErrorCodeNetworkError)
+				}
 			},
 		},
 	}
@@ -309,11 +382,15 @@ func TestEDEPreservation(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Create cache entry
 			entry := NewCacheEntry(tt.msg, 300*time.Second, 0)
-			require.NotNil(t, entry)
+			if entry == nil {
+				t.Fatalf("entry is nil")
+			}
 
 			// Convert back to message
 			restored := entry.ToMsg(tt.req)
-			require.NotNil(t, restored)
+			if restored == nil {
+				t.Fatalf("restored is nil")
+			}
 
 			// Verify expectations
 			tt.expected(t, tt.msg, restored)
@@ -336,8 +413,12 @@ func TestCacheEntryWithoutEDE(t *testing.T) {
 	})
 
 	entry := NewCacheEntry(msg, 300*time.Second, 0)
-	require.NotNil(t, entry)
-	assert.Nil(t, entry.ede)
+	if entry == nil {
+		t.Fatalf("entry is nil")
+	}
+	if entry.ede != nil {
+		t.Errorf("entry.ede = %v, want nil", entry.ede)
+	}
 
 	// Restore with EDNS request
 	req := new(dns.Msg)
@@ -345,7 +426,13 @@ func TestCacheEntryWithoutEDE(t *testing.T) {
 	req.SetEdns0(512, true)
 
 	restored := entry.ToMsg(req)
-	require.NotNil(t, restored)
-	assert.Len(t, restored.Answer, 1)
-	assert.Nil(t, restored.IsEdns0()) // No OPT should be added
+	if restored == nil {
+		t.Fatalf("restored is nil")
+	}
+	if len(restored.Answer) != 1 {
+		t.Errorf("len(restored.Answer) = %d, want %d", len(restored.Answer), 1)
+	}
+	if restored.IsEdns0() != nil {
+		t.Errorf("restored.IsEdns0() = %v, want nil", restored.IsEdns0())
+	} // No OPT should be added
 }

--- a/middleware/chain_test.go
+++ b/middleware/chain_test.go
@@ -3,6 +3,7 @@ package middleware
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -10,7 +11,6 @@ import (
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/internal/contextutil"
 	"github.com/semihalev/sdns/internal/mock"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestWithResponseMetaKeepsBaseContextIsolated(t *testing.T) {
@@ -463,40 +463,72 @@ func Test_Chain(t *testing.T) {
 
 	req.Rcode = dns.RcodeSuccess
 	err := ch.Writer.WriteMsg(req)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	data, err := req.Pack()
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
-	assert.Equal(t, true, ch.Writer.Written())
-	assert.Equal(t, dns.RcodeSuccess, ch.Writer.Rcode())
+	if !reflect.DeepEqual(true, ch.Writer.Written()) {
+		t.Errorf("ch.Writer.Written() = %v, want %v", ch.Writer.Written(), true)
+	}
+	if !reflect.DeepEqual(dns.RcodeSuccess, ch.Writer.Rcode()) {
+		t.Errorf("ch.Writer.Rcode() = %v, want %v", ch.Writer.Rcode(), dns.RcodeSuccess)
+	}
 
 	_, err = ch.Writer.Write(data)
-	assert.Equal(t, errAlreadyWritten, err)
+	if !reflect.DeepEqual(errAlreadyWritten, err) {
+		t.Errorf("err = %v, want %v", err, errAlreadyWritten)
+	}
 
 	ch.Reset(mock.NewWriter("tcp", "127.0.0.1:0"), req)
 	size, err := ch.Writer.Write(data)
-	assert.NoError(t, err)
-	assert.Equal(t, len(data), size)
-	assert.NotNil(t, ch.Writer.Msg())
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual(len(data), size) {
+		t.Errorf("size = %v, want %v", size, len(data))
+	}
+	if ch.Writer.Msg() == nil {
+		t.Fatalf("ch.Writer.Msg() is nil")
+	}
 
 	err = ch.Writer.WriteMsg(req)
-	assert.Equal(t, errAlreadyWritten, err)
+	if !reflect.DeepEqual(errAlreadyWritten, err) {
+		t.Errorf("err = %v, want %v", err, errAlreadyWritten)
+	}
 
 	ch.Reset(mock.NewWriter("tcp", "127.0.0.1:0"), req)
 	_, err = ch.Writer.Write([]byte{})
-	assert.Error(t, err)
+	if err == nil {
+		t.Errorf("expected an error, got nil")
+	}
 
-	assert.Equal(t, "tcp", ch.Writer.Proto())
-	assert.Equal(t, "127.0.0.1", ch.Writer.RemoteIP().String())
+	if !reflect.DeepEqual("tcp", ch.Writer.Proto()) {
+		t.Errorf("ch.Writer.Proto() = %v, want %v", ch.Writer.Proto(), "tcp")
+	}
+	if !reflect.DeepEqual("127.0.0.1", ch.Writer.RemoteIP().String()) {
+		t.Errorf("ch.Writer.RemoteIP().String() = %v, want %v", ch.Writer.RemoteIP().String(), "127.0.0.1")
+	}
 
 	ch.Cancel()
-	assert.Equal(t, 0, ch.count)
+	if !reflect.DeepEqual(0, ch.count) {
+		t.Errorf("ch.count = %v, want %v", ch.count, 0)
+	}
 
 	ch.Reset(mock.NewWriter("tcp", "127.0.0.1:0"), req)
 
 	ch.CancelWithRcode(dns.RcodeServerFailure, true)
-	assert.True(t, ch.Writer.Written())
-	assert.Equal(t, dns.RcodeServerFailure, ch.Writer.Rcode())
-	assert.Equal(t, 0, ch.count)
+	if !(ch.Writer.Written()) {
+		t.Errorf("ch.Writer.Written() is false")
+	}
+	if !reflect.DeepEqual(dns.RcodeServerFailure, ch.Writer.Rcode()) {
+		t.Errorf("ch.Writer.Rcode() = %v, want %v", ch.Writer.Rcode(), dns.RcodeServerFailure)
+	}
+	if !reflect.DeepEqual(0, ch.count) {
+		t.Errorf("ch.count = %v, want %v", ch.count, 0)
+	}
 }

--- a/middleware/chaos/chaos_test.go
+++ b/middleware/chaos/chaos_test.go
@@ -12,8 +12,6 @@ import (
 	"github.com/semihalev/sdns/config"
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/semihalev/sdns/middleware"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // testConfig creates a config with the given version for testing.
@@ -35,14 +33,30 @@ func TestNew(t *testing.T) {
 	cfg := testConfig(true, "1.5.0")
 
 	c := New(cfg)
-	require.NotNil(t, c)
-	assert.True(t, c.enabled)
-	assert.Equal(t, "1.5.0", c.version)
-	assert.NotEmpty(t, c.identity)
-	assert.NotEmpty(t, c.platform)
-	assert.NotEmpty(t, c.fingerprint)
-	assert.Equal(t, 16, len(c.fingerprint)) // SHA256 truncated to 16 chars
-	assert.Equal(t, "chaos", c.Name())
+	if c == nil {
+		t.Fatalf("c is nil")
+	}
+	if !(c.enabled) {
+		t.Errorf("c.enabled is false")
+	}
+	if !reflect.DeepEqual("1.5.0", c.version) {
+		t.Errorf("c.version = %v, want %v", c.version, "1.5.0")
+	}
+	if len(c.identity) == 0 {
+		t.Errorf("c.identity is empty")
+	}
+	if len(c.platform) == 0 {
+		t.Errorf("c.platform is empty")
+	}
+	if len(c.fingerprint) == 0 {
+		t.Errorf("c.fingerprint is empty")
+	}
+	if !reflect.DeepEqual(16, len(c.fingerprint)) {
+		t.Errorf("len(c.fingerprint) = %v, want %v", len(c.fingerprint), 16)
+	} // SHA256 truncated to 16 chars
+	if !reflect.DeepEqual("chaos", c.Name()) {
+		t.Errorf("c.Name() = %v, want %v", c.Name(), "chaos")
+	}
 }
 
 func TestServeDNS_NotEnabled(t *testing.T) {
@@ -59,7 +73,9 @@ func TestServeDNS_NotEnabled(t *testing.T) {
 	ch.Reset(w, req)
 
 	c.ServeDNS(context.Background(), ch)
-	assert.False(t, w.Written())
+	if w.Written() {
+		t.Errorf("w.Written() is true")
+	}
 }
 
 func TestServeDNS_NonChaosClass(t *testing.T) {
@@ -76,7 +92,9 @@ func TestServeDNS_NonChaosClass(t *testing.T) {
 	ch.Reset(w, req)
 
 	c.ServeDNS(context.Background(), ch)
-	assert.False(t, w.Written())
+	if w.Written() {
+		t.Errorf("w.Written() is true")
+	}
 }
 
 func TestServeDNS_NonTXTType(t *testing.T) {
@@ -93,7 +111,9 @@ func TestServeDNS_NonTXTType(t *testing.T) {
 	ch.Reset(w, req)
 
 	c.ServeDNS(context.Background(), ch)
-	assert.False(t, w.Written())
+	if w.Written() {
+		t.Errorf("w.Written() is true")
+	}
 }
 
 func TestServeDNS_Version(t *testing.T) {
@@ -114,18 +134,34 @@ func TestServeDNS_Version(t *testing.T) {
 			ch.Reset(w, req)
 
 			c.ServeDNS(context.Background(), ch)
-			require.True(t, w.Written())
+			if !(w.Written()) {
+				t.Fatalf("w.Written() is false")
+			}
 
 			resp := w.Msg()
-			require.Len(t, resp.Answer, 1)
+			if len(resp.Answer) != 1 {
+				t.Fatalf("len(resp.Answer) = %d, want %d", len(resp.Answer), 1)
+			}
 
 			txt := resp.Answer[0].(*dns.TXT)
-			assert.Equal(t, qname, txt.Header().Name)
-			assert.Equal(t, uint16(dns.ClassCHAOS), txt.Header().Class)
-			assert.Equal(t, uint32(0), txt.Header().Ttl)
-			assert.Len(t, txt.Txt, 1)
-			assert.Equal(t, "SDNS v1.5.0", txt.Txt[0])
-			assert.True(t, resp.Authoritative)
+			if !reflect.DeepEqual(qname, txt.Header().Name) {
+				t.Errorf("txt.Header().Name = %v, want %v", txt.Header().Name, qname)
+			}
+			if !reflect.DeepEqual(uint16(dns.ClassCHAOS), txt.Header().Class) {
+				t.Errorf("txt.Header().Class = %v, want %v", txt.Header().Class, uint16(dns.ClassCHAOS))
+			}
+			if !reflect.DeepEqual(uint32(0), txt.Header().Ttl) {
+				t.Errorf("txt.Header().Ttl = %v, want %v", txt.Header().Ttl, uint32(0))
+			}
+			if len(txt.Txt) != 1 {
+				t.Errorf("len(txt.Txt) = %d, want %d", len(txt.Txt), 1)
+			}
+			if !reflect.DeepEqual("SDNS v1.5.0", txt.Txt[0]) {
+				t.Errorf("txt.Txt[0] = %v, want %v", txt.Txt[0], "SDNS v1.5.0")
+			}
+			if !(resp.Authoritative) {
+				t.Errorf("resp.Authoritative is false")
+			}
 		})
 	}
 }
@@ -148,15 +184,25 @@ func TestServeDNS_Identity(t *testing.T) {
 			ch.Reset(w, req)
 
 			c.ServeDNS(context.Background(), ch)
-			require.True(t, w.Written())
+			if !(w.Written()) {
+				t.Fatalf("w.Written() is false")
+			}
 
 			resp := w.Msg()
-			require.Len(t, resp.Answer, 1)
+			if len(resp.Answer) != 1 {
+				t.Fatalf("len(resp.Answer) = %d, want %d", len(resp.Answer), 1)
+			}
 
 			txt := resp.Answer[0].(*dns.TXT)
-			assert.Equal(t, qname, txt.Header().Name)
-			assert.Len(t, txt.Txt, 1)
-			assert.NotEmpty(t, txt.Txt[0])
+			if !reflect.DeepEqual(qname, txt.Header().Name) {
+				t.Errorf("txt.Header().Name = %v, want %v", txt.Header().Name, qname)
+			}
+			if len(txt.Txt) != 1 {
+				t.Errorf("len(txt.Txt) = %d, want %d", len(txt.Txt), 1)
+			}
+			if len(txt.Txt[0]) == 0 {
+				t.Errorf("txt.Txt[0] is empty")
+			}
 		})
 	}
 }
@@ -180,19 +226,35 @@ func TestServeDNS_Uptime(t *testing.T) {
 			ch.Reset(w, req)
 
 			c.ServeDNS(context.Background(), ch)
-			require.True(t, w.Written())
+			if !(w.Written()) {
+				t.Fatalf("w.Written() is false")
+			}
 
 			resp := w.Msg()
-			require.Len(t, resp.Answer, 1)
+			if len(resp.Answer) != 1 {
+				t.Fatalf("len(resp.Answer) = %d, want %d", len(resp.Answer), 1)
+			}
 
 			txt := resp.Answer[0].(*dns.TXT)
-			assert.Equal(t, qname, txt.Header().Name)
-			assert.Len(t, txt.Txt, 1)
+			if !reflect.DeepEqual(qname, txt.Header().Name) {
+				t.Errorf("txt.Header().Name = %v, want %v", txt.Header().Name, qname)
+			}
+			if len(txt.Txt) != 1 {
+				t.Errorf("len(txt.Txt) = %d, want %d", len(txt.Txt), 1)
+			}
 			// Should contain days, hours, minutes, seconds format
-			assert.Contains(t, txt.Txt[0], "d")
-			assert.Contains(t, txt.Txt[0], "h")
-			assert.Contains(t, txt.Txt[0], "m")
-			assert.Contains(t, txt.Txt[0], "s")
+			if !strings.Contains(txt.Txt[0], "d") {
+				t.Errorf("%q does not contain %q", txt.Txt[0], "d")
+			}
+			if !strings.Contains(txt.Txt[0], "h") {
+				t.Errorf("%q does not contain %q", txt.Txt[0], "h")
+			}
+			if !strings.Contains(txt.Txt[0], "m") {
+				t.Errorf("%q does not contain %q", txt.Txt[0], "m")
+			}
+			if !strings.Contains(txt.Txt[0], "s") {
+				t.Errorf("%q does not contain %q", txt.Txt[0], "s")
+			}
 		})
 	}
 }
@@ -215,16 +277,26 @@ func TestServeDNS_Platform(t *testing.T) {
 			ch.Reset(w, req)
 
 			c.ServeDNS(context.Background(), ch)
-			require.True(t, w.Written())
+			if !(w.Written()) {
+				t.Fatalf("w.Written() is false")
+			}
 
 			resp := w.Msg()
-			require.Len(t, resp.Answer, 1)
+			if len(resp.Answer) != 1 {
+				t.Fatalf("len(resp.Answer) = %d, want %d", len(resp.Answer), 1)
+			}
 
 			txt := resp.Answer[0].(*dns.TXT)
-			assert.Equal(t, qname, txt.Header().Name)
-			assert.Len(t, txt.Txt, 1)
+			if !reflect.DeepEqual(qname, txt.Header().Name) {
+				t.Errorf("txt.Header().Name = %v, want %v", txt.Header().Name, qname)
+			}
+			if len(txt.Txt) != 1 {
+				t.Errorf("len(txt.Txt) = %d, want %d", len(txt.Txt), 1)
+			}
 			// Should contain OS/ARCH format
-			assert.Contains(t, txt.Txt[0], "/")
+			if !strings.Contains(txt.Txt[0], "/") {
+				t.Errorf("%q does not contain %q", txt.Txt[0], "/")
+			}
 		})
 	}
 }
@@ -247,15 +319,25 @@ func TestServeDNS_Fingerprint(t *testing.T) {
 			ch.Reset(w, req)
 
 			c.ServeDNS(context.Background(), ch)
-			require.True(t, w.Written())
+			if !(w.Written()) {
+				t.Fatalf("w.Written() is false")
+			}
 
 			resp := w.Msg()
-			require.Len(t, resp.Answer, 1)
+			if len(resp.Answer) != 1 {
+				t.Fatalf("len(resp.Answer) = %d, want %d", len(resp.Answer), 1)
+			}
 
 			txt := resp.Answer[0].(*dns.TXT)
-			assert.Equal(t, qname, txt.Header().Name)
-			assert.Len(t, txt.Txt, 1)
-			assert.Equal(t, 16, len(txt.Txt[0]))
+			if !reflect.DeepEqual(qname, txt.Header().Name) {
+				t.Errorf("txt.Header().Name = %v, want %v", txt.Header().Name, qname)
+			}
+			if len(txt.Txt) != 1 {
+				t.Errorf("len(txt.Txt) = %d, want %d", len(txt.Txt), 1)
+			}
+			if !reflect.DeepEqual(16, len(txt.Txt[0])) {
+				t.Errorf("len(txt.Txt[0]) = %v, want %v", len(txt.Txt[0]), 16)
+			}
 		})
 	}
 }
@@ -278,17 +360,29 @@ func TestServeDNS_Stats(t *testing.T) {
 			ch.Reset(w, req)
 
 			c.ServeDNS(context.Background(), ch)
-			require.True(t, w.Written())
+			if !(w.Written()) {
+				t.Fatalf("w.Written() is false")
+			}
 
 			resp := w.Msg()
-			require.Len(t, resp.Answer, 1)
+			if len(resp.Answer) != 1 {
+				t.Fatalf("len(resp.Answer) = %d, want %d", len(resp.Answer), 1)
+			}
 
 			txt := resp.Answer[0].(*dns.TXT)
-			assert.Equal(t, qname, txt.Header().Name)
-			assert.Len(t, txt.Txt, 1)
+			if !reflect.DeepEqual(qname, txt.Header().Name) {
+				t.Errorf("txt.Header().Name = %v, want %v", txt.Header().Name, qname)
+			}
+			if len(txt.Txt) != 1 {
+				t.Errorf("len(txt.Txt) = %d, want %d", len(txt.Txt), 1)
+			}
 			// Should contain queries and uptime
-			assert.Contains(t, txt.Txt[0], "queries:")
-			assert.Contains(t, txt.Txt[0], "uptime:")
+			if !strings.Contains(txt.Txt[0], "queries:") {
+				t.Errorf("%q does not contain %q", txt.Txt[0], "queries:")
+			}
+			if !strings.Contains(txt.Txt[0], "uptime:") {
+				t.Errorf("%q does not contain %q", txt.Txt[0], "uptime:")
+			}
 		})
 	}
 }
@@ -307,7 +401,9 @@ func TestServeDNS_UnknownQuery(t *testing.T) {
 	ch.Reset(w, req)
 
 	c.ServeDNS(context.Background(), ch)
-	assert.False(t, w.Written())
+	if w.Written() {
+		t.Errorf("w.Written() is true")
+	}
 }
 
 func TestServeDNS_EmptyQuestion(t *testing.T) {
@@ -323,7 +419,9 @@ func TestServeDNS_EmptyQuestion(t *testing.T) {
 	ch.Reset(w, req)
 
 	c.ServeDNS(context.Background(), ch)
-	assert.False(t, w.Written())
+	if w.Written() {
+		t.Errorf("w.Written() is true")
+	}
 }
 
 func TestQueryCounting(t *testing.T) {
@@ -359,7 +457,9 @@ func TestQueryCounting(t *testing.T) {
 	count := c.queryCount
 	c.mu.RUnlock()
 
-	assert.Equal(t, uint64(queries), count) //nolint:gosec // G115 - test value, queries is small
+	if !reflect.DeepEqual(uint64(queries), count) {
+		t.Errorf("count = %v, want %v", count, uint64(queries))
+	} //nolint:gosec // G115 - test value, queries is small
 }
 
 func TestUptimeFormatting(t *testing.T) {
@@ -392,18 +492,30 @@ func TestUptimeFormatting(t *testing.T) {
 			ch.Reset(w, req)
 
 			c.ServeDNS(context.Background(), ch)
-			require.True(t, w.Written())
+			if !(w.Written()) {
+				t.Fatalf("w.Written() is false")
+			}
 
 			resp := w.Msg()
-			require.Len(t, resp.Answer, 1)
+			if len(resp.Answer) != 1 {
+				t.Fatalf("len(resp.Answer) = %d, want %d", len(resp.Answer), 1)
+			}
 
 			txt := resp.Answer[0].(*dns.TXT)
 			// Check that the format matches expected pattern
 			uptimeStr := txt.Txt[0]
-			assert.True(t, strings.HasSuffix(uptimeStr, "s"))
-			assert.Contains(t, uptimeStr, "d")
-			assert.Contains(t, uptimeStr, "h")
-			assert.Contains(t, uptimeStr, "m")
+			if !(strings.HasSuffix(uptimeStr, "s")) {
+				t.Errorf("strings.HasSuffix(uptimeStr, 's') is false")
+			}
+			if !strings.Contains(uptimeStr, "d") {
+				t.Errorf("%q does not contain %q", uptimeStr, "d")
+			}
+			if !strings.Contains(uptimeStr, "h") {
+				t.Errorf("%q does not contain %q", uptimeStr, "h")
+			}
+			if !strings.Contains(uptimeStr, "m") {
+				t.Errorf("%q does not contain %q", uptimeStr, "m")
+			}
 		})
 	}
 }

--- a/middleware/dns64/coverage_test.go
+++ b/middleware/dns64/coverage_test.go
@@ -4,19 +4,21 @@ import (
 	"context"
 	"errors"
 	"net"
+	"reflect"
 	"testing"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/config"
 	"github.com/semihalev/sdns/middleware"
-	"github.com/stretchr/testify/assert"
 )
 
 // TestName pins the registered middleware name so the gen.go entry
 // can't drift away from what the package reports.
 func TestName(t *testing.T) {
 	d := New(baseConfig())
-	assert.Equal(t, "dns64", d.Name())
+	if !reflect.DeepEqual("dns64", d.Name()) {
+		t.Errorf("d.Name() = %v, want %v", d.Name(), "dns64")
+	}
 }
 
 // TestSetQueryer covers the trivial setter used by middleware.Setup
@@ -46,7 +48,9 @@ func TestClassifyQueryErr(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, classifyQueryErr(tc.err))
+			if !reflect.DeepEqual(tc.want, classifyQueryErr(tc.err)) {
+				t.Errorf("classifyQueryErr(tc.err) = %v, want %v", classifyQueryErr(tc.err), tc.want)
+			}
 		})
 	}
 }
@@ -71,17 +75,37 @@ func TestCompileConfig_BadEntriesSkipped(t *testing.T) {
 	if c == nil {
 		t.Fatalf("compileConfig returned nil despite usable prefixes")
 	}
-	if assert.Len(t, c.prefixes, 2, "both valid prefixes are kept (well-known + operator)") {
-		assert.True(t, c.prefixes[0].net.IP.Equal(net.ParseIP("64:ff9b::")), "well-known appears first as configured")
-		assert.True(t, c.prefixes[0].wellKnown)
-		assert.True(t, c.prefixes[1].net.IP.Equal(net.ParseIP("2001:db8::")))
-		assert.False(t, c.prefixes[1].wellKnown)
+	if len(c.prefixes) != 2 {
+		t.Errorf("%s: len(c.prefixes) = %d, want %d", "both valid prefixes are kept (well-known + operator)", len(c.prefixes), 2)
+	} else {
+		if !(c.prefixes[0].net.IP.Equal(net.ParseIP("64:ff9b::"))) {
+			t.Errorf("%s: c.prefixes[0].net.IP.Equal(net.ParseIP('64:ff9b::')) is false", "well-known appears first as configured")
+		}
+		if !(c.prefixes[0].wellKnown) {
+			t.Errorf("c.prefixes[0].wellKnown is false")
+		}
+		if !(c.prefixes[1].net.IP.Equal(net.ParseIP("2001:db8::"))) {
+			t.Errorf("c.prefixes[1].net.IP.Equal(net.ParseIP('2001:db8::')) is false")
+		}
+		if c.prefixes[1].wellKnown {
+			t.Errorf("c.prefixes[1].wellKnown is true")
+		}
 	}
-	assert.True(t, c.hasWellKnown())
-	assert.Len(t, c.clientNetworks, 1, "bad CIDR dropped, good one kept")
-	assert.Len(t, c.excludeZones, 1, "empty zone entry dropped, good one kept and FQDN'd")
-	assert.Equal(t, "example.org.", c.excludeZones[0])
-	assert.Len(t, c.excludeAv4, 1, "bad and IPv6 exclude entries dropped")
+	if !(c.hasWellKnown()) {
+		t.Errorf("c.hasWellKnown() is false")
+	}
+	if len(c.clientNetworks) != 1 {
+		t.Errorf("%s: len(c.clientNetworks) = %d, want %d", "bad CIDR dropped, good one kept", len(c.clientNetworks), 1)
+	}
+	if len(c.excludeZones) != 1 {
+		t.Errorf("%s: len(c.excludeZones) = %d, want %d", "empty zone entry dropped, good one kept and FQDN'd", len(c.excludeZones), 1)
+	}
+	if !reflect.DeepEqual("example.org.", c.excludeZones[0]) {
+		t.Errorf("c.excludeZones[0] = %v, want %v", c.excludeZones[0], "example.org.")
+	}
+	if len(c.excludeAv4) != 1 {
+		t.Errorf("%s: len(c.excludeAv4) = %d, want %d", "bad and IPv6 exclude entries dropped", len(c.excludeAv4), 1)
+	}
 }
 
 // TestCompileConfig_NoUsablePrefixFallsBackToWellKnown pins
@@ -98,9 +122,15 @@ func TestCompileConfig_NoUsablePrefixFallsBackToWellKnown(t *testing.T) {
 	if c == nil {
 		t.Fatalf("compileConfig must default to well-known prefix, not return nil")
 	}
-	if assert.Len(t, c.prefixes, 1) {
-		assert.True(t, c.prefixes[0].wellKnown)
-		assert.True(t, c.prefixes[0].net.IP.Equal(net.ParseIP("64:ff9b::")))
+	if len(c.prefixes) != 1 {
+		t.Errorf("len(c.prefixes) = %d, want %d", len(c.prefixes), 1)
+	} else {
+		if !(c.prefixes[0].wellKnown) {
+			t.Errorf("c.prefixes[0].wellKnown is false")
+		}
+		if !(c.prefixes[0].net.IP.Equal(net.ParseIP("64:ff9b::"))) {
+			t.Errorf("c.prefixes[0].net.IP.Equal(net.ParseIP('64:ff9b::')) is false")
+		}
 	}
 }
 
@@ -129,7 +159,9 @@ func TestCompileConfig_DefaultExcludeAUnderWKP(t *testing.T) {
 	if c == nil {
 		t.Fatalf("compileConfig should not disable")
 	}
-	assert.NotEmpty(t, c.excludeAv4, "WKP + nil exclude list must apply runtime default")
+	if len(c.excludeAv4) == 0 {
+		t.Errorf("%s: c.excludeAv4 is empty", "WKP + nil exclude list must apply runtime default")
+	}
 	// Spot-check a couple of representative entries.
 	covers := func(ip string) bool {
 		for _, n := range c.excludeAv4 {
@@ -139,10 +171,18 @@ func TestCompileConfig_DefaultExcludeAUnderWKP(t *testing.T) {
 		}
 		return false
 	}
-	assert.True(t, covers("10.0.0.1"), "RFC 1918 must be excluded by default")
-	assert.True(t, covers("127.0.0.1"), "loopback must be excluded by default")
-	assert.True(t, covers("169.254.1.1"), "link-local must be excluded by default")
-	assert.True(t, covers("192.88.99.1"), "deprecated 6to4 anycast (RFC 7526) must be excluded")
+	if !(covers("10.0.0.1")) {
+		t.Errorf("%s: covers('10.0.0.1') is false", "RFC 1918 must be excluded by default")
+	}
+	if !(covers("127.0.0.1")) {
+		t.Errorf("%s: covers('127.0.0.1') is false", "loopback must be excluded by default")
+	}
+	if !(covers("169.254.1.1")) {
+		t.Errorf("%s: covers('169.254.1.1') is false", "link-local must be excluded by default")
+	}
+	if !(covers("192.88.99.1")) {
+		t.Errorf("%s: covers('192.88.99.1') is false", "deprecated 6to4 anycast (RFC 7526) must be excluded")
+	}
 }
 
 // TestCompileConfig_ExplicitEmptyExcludeAOptsOut confirms an
@@ -158,7 +198,9 @@ func TestCompileConfig_ExplicitEmptyExcludeAOptsOut(t *testing.T) {
 	if c == nil {
 		t.Fatalf("compileConfig should not disable")
 	}
-	assert.Empty(t, c.excludeAv4, "explicit [] must opt out of the runtime default")
+	if len(c.excludeAv4) != 0 {
+		t.Errorf("%s: c.excludeAv4 not empty: %v", "explicit [] must opt out of the runtime default", c.excludeAv4)
+	}
 }
 
 // TestCompileConfig_AcceptsIPv4MappedExcludeAAAA pins the fix
@@ -175,8 +217,10 @@ func TestCompileConfig_AcceptsIPv4MappedExcludeAAAA(t *testing.T) {
 	if c == nil {
 		t.Fatalf("compileConfig should not disable; ::ffff:0:0/96 is a valid IPv6 prefix")
 	}
-	if assert.Len(t, c.excludeAAAA, 1, "explicit ::ffff:0:0/96 must be retained") {
-		assert.True(t, c.excludeAAAA[0].IP.Equal(net.ParseIP("::ffff:0:0")))
+	if len(c.excludeAAAA) != 1 {
+		t.Errorf("%s: len(c.excludeAAAA) = %d, want %d", "explicit ::ffff:0:0/96 must be retained", len(c.excludeAAAA), 1)
+	} else if !(c.excludeAAAA[0].IP.Equal(net.ParseIP("::ffff:0:0"))) {
+		t.Errorf("c.excludeAAAA[0].IP.Equal(net.ParseIP('::ffff:0:0')) is false")
 	}
 }
 
@@ -193,8 +237,12 @@ func TestCompileConfig_OperatorPrefixSkipsExcludeA(t *testing.T) {
 	if c == nil {
 		t.Fatalf("expected non-nil compiled config")
 	}
-	assert.False(t, c.hasWellKnown(), "no well-known prefix configured")
-	assert.Empty(t, c.excludeAv4, "operator-only prefix list must not retain the exclude-A list")
+	if c.hasWellKnown() {
+		t.Errorf("%s: c.hasWellKnown() is true", "no well-known prefix configured")
+	}
+	if len(c.excludeAv4) != 0 {
+		t.Errorf("%s: c.excludeAv4 not empty: %v", "operator-only prefix list must not retain the exclude-A list", c.excludeAv4)
+	}
 }
 
 // TestClientEligible_NilIP covers the explicit nil-IP guard, which
@@ -204,7 +252,9 @@ func TestClientEligible_NilIP(t *testing.T) {
 	c := &compiled{
 		clientNetworks: []*net.IPNet{parseCIDR(t, "10.0.0.0/8")},
 	}
-	assert.False(t, c.clientEligible(nil))
+	if c.clientEligible(nil) {
+		t.Errorf("c.clientEligible(nil) is true")
+	}
 }
 
 // TestZoneExcluded covers exact-match, label-boundary suffix
@@ -212,14 +262,26 @@ func TestClientEligible_NilIP(t *testing.T) {
 // circuit.
 func TestZoneExcluded(t *testing.T) {
 	c := &compiled{excludeZones: []string{"example.org."}}
-	assert.True(t, c.zoneExcluded("example.org."), "exact match should be excluded")
-	assert.True(t, c.zoneExcluded("host.example.org."), "label-boundary suffix should be excluded")
-	assert.True(t, c.zoneExcluded("a.b.example.org."), "deeper label-boundary suffix should be excluded")
-	assert.False(t, c.zoneExcluded("badexample.org."), "label-fragment match must NOT trigger exclusion")
-	assert.False(t, c.zoneExcluded("other.example.com."))
+	if !(c.zoneExcluded("example.org.")) {
+		t.Errorf("%s: c.zoneExcluded('example.org.') is false", "exact match should be excluded")
+	}
+	if !(c.zoneExcluded("host.example.org.")) {
+		t.Errorf("%s: c.zoneExcluded('host.example.org.') is false", "label-boundary suffix should be excluded")
+	}
+	if !(c.zoneExcluded("a.b.example.org.")) {
+		t.Errorf("%s: c.zoneExcluded('a.b.example.org.') is false", "deeper label-boundary suffix should be excluded")
+	}
+	if c.zoneExcluded("badexample.org.") {
+		t.Errorf("%s: c.zoneExcluded('badexample.org.') is true", "label-fragment match must NOT trigger exclusion")
+	}
+	if c.zoneExcluded("other.example.com.") {
+		t.Errorf("c.zoneExcluded('other.example.com.') is true")
+	}
 
 	empty := &compiled{}
-	assert.False(t, empty.zoneExcluded("anything."))
+	if empty.zoneExcluded("anything.") {
+		t.Errorf("empty.zoneExcluded('anything.') is true")
+	}
 }
 
 // TestWriteMsg_Truncated_PassThrough pins the truncated-response
@@ -234,7 +296,9 @@ func TestWriteMsg_Truncated_PassThrough(t *testing.T) {
 
 	d.ServeDNS(context.Background(), ch)
 	resp := mw.Msg()
-	assert.True(t, resp.Truncated, "truncated reply must pass through untouched")
+	if !(resp.Truncated) {
+		t.Errorf("%s: resp.Truncated is false", "truncated reply must pass through untouched")
+	}
 }
 
 // TestWriteMsg_ServFail_AResponseIsBasis covers RFC 6147 §5.1.6:
@@ -262,12 +326,22 @@ func TestWriteMsg_ServFail_AResponseIsBasis(t *testing.T) {
 	d.ServeDNS(context.Background(), ch)
 
 	resp := mw.Msg()
-	assert.Equal(t, dns.RcodeSuccess, resp.Rcode, "A NOERROR-NODATA must replace AAAA SERVFAIL per RFC 6147 §5.1.6")
-	assert.Empty(t, resp.Answer, "no answer records for an empty A response")
-	assert.Equal(t, dns.TypeAAAA, resp.Question[0].Qtype, "client must see its original AAAA question")
-	if assert.Len(t, resp.Ns, 1, "SOA from A response carried into Authority section") {
+	if !reflect.DeepEqual(dns.RcodeSuccess, resp.Rcode) {
+		t.Errorf("%s: resp.Rcode = %v, want %v", "A NOERROR-NODATA must replace AAAA SERVFAIL per RFC 6147 §5.1.6", resp.Rcode, dns.RcodeSuccess)
+	}
+	if len(resp.Answer) != 0 {
+		t.Errorf("%s: resp.Answer not empty: %v", "no answer records for an empty A response", resp.Answer)
+	}
+	if !reflect.DeepEqual(dns.TypeAAAA, resp.Question[0].Qtype) {
+		t.Errorf("%s: resp.Question[0].Qtype = %v, want %v", "client must see its original AAAA question", resp.Question[0].Qtype, dns.TypeAAAA)
+	}
+	if len(resp.Ns) != 1 {
+		t.Errorf("%s: len(resp.Ns) = %d, want %d", "SOA from A response carried into Authority section", len(resp.Ns), 1)
+	} else {
 		_, ok := resp.Ns[0].(*dns.SOA)
-		assert.True(t, ok)
+		if !(ok) {
+			t.Errorf("ok is false")
+		}
 	}
 }
 
@@ -282,7 +356,9 @@ func TestSynthesise_QueryerNotWired(t *testing.T) {
 	d.ServeDNS(context.Background(), ch)
 
 	resp := mw.Msg()
-	assert.Equal(t, dns.RcodeSuccess, resp.Rcode, "original NODATA preserved")
+	if !reflect.DeepEqual(dns.RcodeSuccess, resp.Rcode) {
+		t.Errorf("%s: resp.Rcode = %v, want %v", "original NODATA preserved", resp.Rcode, dns.RcodeSuccess)
+	}
 	for _, rr := range resp.Answer {
 		if rr.Header().Rrtype == dns.TypeAAAA {
 			t.Fatalf("no Queryer wired → no synthesis")

--- a/middleware/dns64/dns64_test.go
+++ b/middleware/dns64/dns64_test.go
@@ -3,7 +3,9 @@ package dns64
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
+	"reflect"
 	"testing"
 
 	"github.com/miekg/dns"
@@ -12,7 +14,6 @@ import (
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/semihalev/sdns/middleware"
 	cachemw "github.com/semihalev/sdns/middleware/cache"
-	"github.com/stretchr/testify/assert"
 )
 
 // stubQueryer is a fixed-response Queryer used to drive the
@@ -86,15 +87,23 @@ func makeChain(t *testing.T, d *DNS64, downstream middleware.Handler, clientAddr
 
 func assertRecursionWorkLimitEDE(t *testing.T, resp *dns.Msg) {
 	t.Helper()
-	if !assert.NotNil(t, resp, "work-limit path must produce a response") {
+	if resp == nil {
+		t.Errorf("%s: resp is nil", "work-limit path must produce a response")
 		return
 	}
-	assert.Equal(t, dns.RcodeServerFailure, resp.Rcode)
+	if !reflect.DeepEqual(dns.RcodeServerFailure, resp.Rcode) {
+		t.Errorf("resp.Rcode = %v, want %v", resp.Rcode, dns.RcodeServerFailure)
+	}
 	ede := dnsutil.GetEDE(resp)
-	if assert.NotNil(t, ede, "work-limit SERVFAIL must carry an EDE") {
-		assert.Equal(t, middleware.RecursionWorkEDECode, ede.InfoCode)
-		assert.Equal(t, "Recursion work budget exceeded", ede.ExtraText,
-			"EDE text is a stable wire-visible contract")
+	if ede == nil {
+		t.Errorf("%s: ede is nil", "work-limit SERVFAIL must carry an EDE")
+	} else {
+		if !reflect.DeepEqual(middleware.RecursionWorkEDECode, ede.InfoCode) {
+			t.Errorf("ede.InfoCode = %v, want %v", ede.InfoCode, middleware.RecursionWorkEDECode)
+		}
+		if !reflect.DeepEqual("Recursion work budget exceeded", ede.ExtraText) {
+			t.Errorf("%s: ede.ExtraText = %v, want %v", "EDE text is a stable wire-visible contract", ede.ExtraText, "Recursion work budget exceeded")
+		}
 	}
 }
 
@@ -178,10 +187,14 @@ func TestServeDNS_NonAAAA_FallsThrough(t *testing.T) {
 	d.queryer = &stubQueryer{} // should not be invoked
 
 	d.ServeDNS(context.Background(), ch)
-	assert.True(t, mw.Written())
+	if !(mw.Written()) {
+		t.Errorf("mw.Written() is false")
+	}
 	resp := mw.Msg()
-	if assert.NotNil(t, resp) {
-		assert.Equal(t, dns.TypeA, resp.Answer[0].Header().Rrtype)
+	if resp == nil {
+		t.Fatalf("resp is nil")
+	} else if !reflect.DeepEqual(dns.TypeA, resp.Answer[0].Header().Rrtype) {
+		t.Errorf("resp.Answer[0].Header().Rrtype = %v, want %v", resp.Answer[0].Header().Rrtype, dns.TypeA)
 	}
 }
 
@@ -201,13 +214,19 @@ func TestServeDNS_PassThrough_NonEmptyAAAA(t *testing.T) {
 	ch, mw := makeChain(t, d, downstream, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
 	d.ServeDNS(context.Background(), ch)
 
-	assert.True(t, mw.Written())
+	if !(mw.Written()) {
+		t.Errorf("mw.Written() is false")
+	}
 	if q.last != nil {
 		t.Fatalf("non-empty AAAA must not trigger an A lookup; queryer was called with %+v", q.last)
 	}
 	resp := mw.Msg()
-	assert.Len(t, resp.Answer, 1)
-	assert.Equal(t, "2001:db8::1", resp.Answer[0].(*dns.AAAA).AAAA.String())
+	if len(resp.Answer) != 1 {
+		t.Errorf("len(resp.Answer) = %d, want %d", len(resp.Answer), 1)
+	}
+	if !reflect.DeepEqual("2001:db8::1", resp.Answer[0].(*dns.AAAA).AAAA.String()) {
+		t.Errorf("resp.Answer[0].(*dns.AAAA).AAAA.String() = %v, want %v", resp.Answer[0].(*dns.AAAA).AAAA.String(), "2001:db8::1")
+	}
 }
 
 func TestServeDNS_Internal_NoSynth(t *testing.T) {
@@ -222,10 +241,14 @@ func TestServeDNS_Internal_NoSynth(t *testing.T) {
 	ch.Reset(mw, req)
 
 	d.ServeDNS(context.Background(), ch)
-	assert.True(t, mw.Written())
+	if !(mw.Written()) {
+		t.Errorf("mw.Written() is false")
+	}
 	resp := mw.Msg()
 	// Pass-through: original NODATA is preserved, no AAAA in answer.
-	assert.Equal(t, dns.RcodeSuccess, resp.Rcode)
+	if !reflect.DeepEqual(dns.RcodeSuccess, resp.Rcode) {
+		t.Errorf("resp.Rcode = %v, want %v", resp.Rcode, dns.RcodeSuccess)
+	}
 	for _, rr := range resp.Answer {
 		if rr.Header().Rrtype == dns.TypeAAAA {
 			t.Fatalf("internal query must not be synthesised, but got AAAA %s", rr)
@@ -247,7 +270,9 @@ func TestServeDNS_CDBit_NoSynth(t *testing.T) {
 	ch.Reset(mw, req)
 
 	d.ServeDNS(context.Background(), ch)
-	assert.True(t, mw.Written())
+	if !(mw.Written()) {
+		t.Errorf("mw.Written() is false")
+	}
 	if q.last != nil {
 		t.Fatalf("CD=1 must not trigger A lookup")
 	}
@@ -262,7 +287,9 @@ func TestServeDNS_ClientOutsideNetworks_NoSynth(t *testing.T) {
 
 	ch, mw := makeChain(t, d, &stubAnswerer{msg: noDataMsg("foo.example.org.", 300)}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
 	d.ServeDNS(context.Background(), ch)
-	assert.True(t, mw.Written())
+	if !(mw.Written()) {
+		t.Errorf("mw.Written() is false")
+	}
 	if q.last != nil {
 		t.Fatalf("client outside client_networks must not trigger A lookup")
 	}
@@ -289,17 +316,31 @@ func TestSynthesise_NODATA_HasA(t *testing.T) {
 	ch, mw := makeChain(t, d, &stubAnswerer{msg: noDataMsg("foo.example.org.", 300)}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
 	d.ServeDNS(context.Background(), ch)
 
-	assert.True(t, mw.Written())
+	if !(mw.Written()) {
+		t.Errorf("mw.Written() is false")
+	}
 	resp := mw.Msg()
-	assert.Equal(t, dns.RcodeSuccess, resp.Rcode)
-	if assert.Len(t, resp.Answer, 1) {
+	if !reflect.DeepEqual(dns.RcodeSuccess, resp.Rcode) {
+		t.Errorf("resp.Rcode = %v, want %v", resp.Rcode, dns.RcodeSuccess)
+	}
+	if len(resp.Answer) != 1 {
+		t.Errorf("len(resp.Answer) = %d, want %d", len(resp.Answer), 1)
+	} else {
 		aaaa, ok := resp.Answer[0].(*dns.AAAA)
-		if assert.True(t, ok) {
-			assert.Equal(t, "64:ff9b::c000:221", aaaa.AAAA.String())
+		if !(ok) {
+			t.Errorf("ok is false")
+		} else {
+			if !reflect.DeepEqual("64:ff9b::c000:221", aaaa.AAAA.String()) {
+				t.Errorf("aaaa.AAAA.String() = %v, want %v", aaaa.AAAA.String(), "64:ff9b::c000:221")
+			}
 			// SOA-min (300) is lower than A TTL (600), so the
 			// synth TTL is clamped to 300.
-			assert.Equal(t, uint32(300), aaaa.Hdr.Ttl)
-			assert.Equal(t, "foo.example.org.", aaaa.Hdr.Name)
+			if !reflect.DeepEqual(uint32(300), aaaa.Hdr.Ttl) {
+				t.Errorf("aaaa.Hdr.Ttl = %v, want %v", aaaa.Hdr.Ttl, uint32(300))
+			}
+			if !reflect.DeepEqual("foo.example.org.", aaaa.Hdr.Name) {
+				t.Errorf("aaaa.Hdr.Name = %v, want %v", aaaa.Hdr.Name, "foo.example.org.")
+			}
 		}
 	}
 }
@@ -318,7 +359,9 @@ func TestNXDOMAIN_PassesThrough(t *testing.T) {
 	d.ServeDNS(context.Background(), ch)
 
 	resp := mw.Msg()
-	assert.Equal(t, dns.RcodeNameError, resp.Rcode, "NXDOMAIN must pass through unchanged per RFC 6147 §5.1.2")
+	if !reflect.DeepEqual(dns.RcodeNameError, resp.Rcode) {
+		t.Errorf("%s: resp.Rcode = %v, want %v", "NXDOMAIN must pass through unchanged per RFC 6147 §5.1.2", resp.Rcode, dns.RcodeNameError)
+	}
 	if q.last != nil {
 		t.Fatalf("NXDOMAIN must not trigger an A-record lookup; queryer was called")
 	}
@@ -342,10 +385,16 @@ func TestServFail_TriggersSynthesis(t *testing.T) {
 	d.ServeDNS(context.Background(), ch)
 
 	resp := mw.Msg()
-	assert.Equal(t, dns.RcodeSuccess, resp.Rcode)
-	if assert.Len(t, resp.Answer, 1) {
+	if !reflect.DeepEqual(dns.RcodeSuccess, resp.Rcode) {
+		t.Errorf("resp.Rcode = %v, want %v", resp.Rcode, dns.RcodeSuccess)
+	}
+	if len(resp.Answer) != 1 {
+		t.Errorf("len(resp.Answer) = %d, want %d", len(resp.Answer), 1)
+	} else {
 		aaaa := resp.Answer[0].(*dns.AAAA)
-		assert.Equal(t, "64:ff9b::c000:221", aaaa.AAAA.String())
+		if !reflect.DeepEqual("64:ff9b::c000:221", aaaa.AAAA.String()) {
+			t.Errorf("aaaa.AAAA.String() = %v, want %v", aaaa.AAAA.String(), "64:ff9b::c000:221")
+		}
 	}
 }
 
@@ -402,11 +451,19 @@ func TestUpstreamPolicyEDEInShadowStillSynthesises(t *testing.T) {
 				t.Fatal("upstream policy EDE suppressed the DNS64 A lookup in shadow mode")
 			}
 			resp := mw.Msg()
-			if assert.Equal(t, dns.RcodeSuccess, resp.Rcode) && assert.Len(t, resp.Answer, 1) {
-				aaaa, ok := resp.Answer[0].(*dns.AAAA)
-				if assert.True(t, ok) {
-					assert.Equal(t, "64:ff9b::c000:221", aaaa.AAAA.String())
-				}
+			if !reflect.DeepEqual(dns.RcodeSuccess, resp.Rcode) {
+				t.Errorf("resp.Rcode = %v, want %v", resp.Rcode, dns.RcodeSuccess)
+				return
+			}
+			if len(resp.Answer) != 1 {
+				t.Errorf("len(resp.Answer) = %d, want %d", len(resp.Answer), 1)
+				return
+			}
+			aaaa, ok := resp.Answer[0].(*dns.AAAA)
+			if !(ok) {
+				t.Errorf("ok is false")
+			} else if !reflect.DeepEqual("64:ff9b::c000:221", aaaa.AAAA.String()) {
+				t.Errorf("aaaa.AAAA.String() = %v, want %v", aaaa.AAAA.String(), "64:ff9b::c000:221")
 			}
 		})
 	}
@@ -421,7 +478,9 @@ func TestSynthesise_QueryerError_FallsBack(t *testing.T) {
 
 	resp := mw.Msg()
 	// Original NODATA preserved.
-	assert.Equal(t, dns.RcodeSuccess, resp.Rcode)
+	if !reflect.DeepEqual(dns.RcodeSuccess, resp.Rcode) {
+		t.Errorf("resp.Rcode = %v, want %v", resp.Rcode, dns.RcodeSuccess)
+	}
 	for _, rr := range resp.Answer {
 		if rr.Header().Rrtype == dns.TypeAAAA {
 			t.Fatalf("queryer error must not produce synthesised AAAA")
@@ -484,8 +543,10 @@ func TestSynthesise_RecursionWorkLimitReturnsPolicyEDE(t *testing.T) {
 	d.ServeDNS(context.Background(), ch)
 
 	assertRecursionWorkLimitEDE(t, mw.Msg())
-	if assert.NotNil(t, queryer.last, "secondary A query must be attempted") {
-		assert.Equal(t, dns.TypeA, queryer.last.Question[0].Qtype)
+	if queryer.last == nil {
+		t.Errorf("%s: queryer.last is nil", "secondary A query must be attempted")
+	} else if !reflect.DeepEqual(dns.TypeA, queryer.last.Question[0].Qtype) {
+		t.Errorf("queryer.last.Question[0].Qtype = %v, want %v", queryer.last.Question[0].Qtype, dns.TypeA)
 	}
 }
 
@@ -499,11 +560,15 @@ func TestSynthesise_AD_AddsEDE(t *testing.T) {
 
 	d.ServeDNS(context.Background(), ch)
 	resp := mw.Msg()
-	assert.False(t, resp.AuthenticatedData, "synthesised reply must clear AD")
+	if resp.AuthenticatedData {
+		t.Errorf("%s: resp.AuthenticatedData is true", "synthesised reply must clear AD")
+	}
 
 	ede := dnsutil.GetEDE(resp)
-	if assert.NotNil(t, ede, "EDE 4 should be attached when original was AD=1") {
-		assert.Equal(t, dns.ExtendedErrorCodeForgedAnswer, ede.InfoCode)
+	if ede == nil {
+		t.Errorf("%s: ede is nil", "EDE 4 should be attached when original was AD=1")
+	} else if !reflect.DeepEqual(dns.ExtendedErrorCodeForgedAnswer, ede.InfoCode) {
+		t.Errorf("ede.InfoCode = %v, want %v", ede.InfoCode, dns.ExtendedErrorCodeForgedAnswer)
 	}
 }
 
@@ -514,7 +579,9 @@ func TestSynthesise_NoAD_NoEDE(t *testing.T) {
 	ch, mw := makeChain(t, d, &stubAnswerer{msg: noDataMsg("foo.example.org.", 300)}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
 	d.ServeDNS(context.Background(), ch)
 	resp := mw.Msg()
-	assert.Nil(t, dnsutil.GetEDE(resp), "EDE must NOT be attached when original was AD=0")
+	if dnsutil.GetEDE(resp) != nil {
+		t.Errorf("%s: dnsutil.GetEDE(resp) = %v, want nil", "EDE must NOT be attached when original was AD=0", dnsutil.GetEDE(resp))
+	}
 }
 
 func TestSynthesise_PrivateA_WellKnownPrefix_AllExcluded(t *testing.T) {
@@ -525,7 +592,9 @@ func TestSynthesise_PrivateA_WellKnownPrefix_AllExcluded(t *testing.T) {
 	d.ServeDNS(context.Background(), ch)
 
 	resp := mw.Msg()
-	assert.Equal(t, dns.RcodeSuccess, resp.Rcode)
+	if !reflect.DeepEqual(dns.RcodeSuccess, resp.Rcode) {
+		t.Errorf("resp.Rcode = %v, want %v", resp.Rcode, dns.RcodeSuccess)
+	}
 	for _, rr := range resp.Answer {
 		if rr.Header().Rrtype == dns.TypeAAAA {
 			t.Fatalf("RFC 6147 §5.1.4: private A under well-known prefix must not be synthesised")
@@ -544,9 +613,13 @@ func TestSynthesise_PrivateA_OperatorPrefix_Synth(t *testing.T) {
 	d.ServeDNS(context.Background(), ch)
 
 	resp := mw.Msg()
-	if assert.Len(t, resp.Answer, 1) {
+	if len(resp.Answer) != 1 {
+		t.Errorf("len(resp.Answer) = %d, want %d", len(resp.Answer), 1)
+	} else {
 		aaaa := resp.Answer[0].(*dns.AAAA)
-		assert.Equal(t, "2001:db8:64::a00:1", aaaa.AAAA.String())
+		if !reflect.DeepEqual("2001:db8:64::a00:1", aaaa.AAAA.String()) {
+			t.Errorf("aaaa.AAAA.String() = %v, want %v", aaaa.AAAA.String(), "2001:db8:64::a00:1")
+		}
 	}
 }
 
@@ -559,7 +632,9 @@ func TestSynthesise_TTL_ATtlIsLower(t *testing.T) {
 	ch, mw := makeChain(t, d, &stubAnswerer{msg: noDataMsg("foo.example.org.", 7200)}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
 	d.ServeDNS(context.Background(), ch)
 	aaaa := mw.Msg().Answer[0].(*dns.AAAA)
-	assert.Equal(t, uint32(30), aaaa.Hdr.Ttl)
+	if !reflect.DeepEqual(uint32(30), aaaa.Hdr.Ttl) {
+		t.Errorf("aaaa.Hdr.Ttl = %v, want %v", aaaa.Hdr.Ttl, uint32(30))
+	}
 }
 
 // TestSynthesise_TTL_NegativeIsLower covers the symmetric case:
@@ -570,7 +645,9 @@ func TestSynthesise_TTL_NegativeIsLower(t *testing.T) {
 	ch, mw := makeChain(t, d, &stubAnswerer{msg: noDataMsg("foo.example.org.", 120)}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
 	d.ServeDNS(context.Background(), ch)
 	aaaa := mw.Msg().Answer[0].(*dns.AAAA)
-	assert.Equal(t, uint32(120), aaaa.Hdr.Ttl)
+	if !reflect.DeepEqual(uint32(120), aaaa.Hdr.Ttl) {
+		t.Errorf("aaaa.Hdr.Ttl = %v, want %v", aaaa.Hdr.Ttl, uint32(120))
+	}
 }
 
 // TestSynthesise_TTL_NoSOA_Caps600 pins RFC 6147 §5.1.7: when
@@ -590,7 +667,9 @@ func TestSynthesise_TTL_NoSOA_Caps600(t *testing.T) {
 	ch, mw := makeChain(t, d, &stubAnswerer{msg: noSOA}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
 	d.ServeDNS(context.Background(), ch)
 	aaaa := mw.Msg().Answer[0].(*dns.AAAA)
-	assert.Equal(t, uint32(600), aaaa.Hdr.Ttl, "no-SOA AAAA must cap synth TTL at 600 per RFC 6147 §5.1.7")
+	if !reflect.DeepEqual(uint32(600), aaaa.Hdr.Ttl) {
+		t.Errorf("%s: aaaa.Hdr.Ttl = %v, want %v", "no-SOA AAAA must cap synth TTL at 600 per RFC 6147 §5.1.7", aaaa.Hdr.Ttl, uint32(600))
+	}
 }
 
 func TestSynthesise_CnameChain(t *testing.T) {
@@ -613,13 +692,23 @@ func TestSynthesise_CnameChain(t *testing.T) {
 	d.ServeDNS(context.Background(), ch)
 
 	resp := mw.Msg()
-	if assert.Len(t, resp.Answer, 2) {
+	if len(resp.Answer) != 2 {
+		t.Errorf("len(resp.Answer) = %d, want %d", len(resp.Answer), 2)
+	} else {
 		_, isCNAME := resp.Answer[0].(*dns.CNAME)
 		aaaa, isAAAA := resp.Answer[1].(*dns.AAAA)
-		assert.True(t, isCNAME, "first answer record must be the CNAME")
-		if assert.True(t, isAAAA) {
-			assert.Equal(t, "target.example.org.", aaaa.Hdr.Name, "synthesised AAAA must be owned by the CNAME target")
-			assert.Equal(t, "64:ff9b::c000:221", aaaa.AAAA.String())
+		if !(isCNAME) {
+			t.Errorf("%s: isCNAME is false", "first answer record must be the CNAME")
+		}
+		if !(isAAAA) {
+			t.Errorf("isAAAA is false")
+		} else {
+			if !reflect.DeepEqual("target.example.org.", aaaa.Hdr.Name) {
+				t.Errorf("%s: aaaa.Hdr.Name = %v, want %v", "synthesised AAAA must be owned by the CNAME target", aaaa.Hdr.Name, "target.example.org.")
+			}
+			if !reflect.DeepEqual("64:ff9b::c000:221", aaaa.AAAA.String()) {
+				t.Errorf("aaaa.AAAA.String() = %v, want %v", aaaa.AAAA.String(), "64:ff9b::c000:221")
+			}
 		}
 	}
 }
@@ -638,7 +727,9 @@ func TestSynthesise_MultipleAs_AllSynthesised(t *testing.T) {
 			count++
 		}
 	}
-	assert.Equal(t, 2, count, "every A record should produce a synthesised AAAA")
+	if !reflect.DeepEqual(2, count) {
+		t.Errorf("%s: count = %v, want %v", "every A record should produce a synthesised AAAA", count, 2)
+	}
 }
 
 // TestSynthesise_RetainsOPT pins the behaviour that lets EDE
@@ -650,7 +741,9 @@ func TestSynthesise_RetainsOPT(t *testing.T) {
 
 	ch, mw := makeChain(t, d, &stubAnswerer{msg: noDataMsg("foo.example.org.", 300)}, "203.0.113.5:53", "foo.example.org.", dns.TypeAAAA)
 	d.ServeDNS(context.Background(), ch)
-	assert.NotNil(t, mw.Msg().IsEdns0(), "synthesised response must carry OPT")
+	if mw.Msg().IsEdns0() == nil {
+		t.Errorf("%s: mw.Msg().IsEdns0() is nil", "synthesised response must carry OPT")
+	}
 }
 
 // TestExcludedAAAA_TriggersSynthesis pins RFC 6147 §5.1.4: an
@@ -674,9 +767,13 @@ func TestExcludedAAAA_TriggersSynthesis(t *testing.T) {
 	d.ServeDNS(context.Background(), ch)
 
 	resp := mw.Msg()
-	if assert.Len(t, resp.Answer, 1) {
+	if len(resp.Answer) != 1 {
+		t.Errorf("len(resp.Answer) = %d, want %d", len(resp.Answer), 1)
+	} else {
 		aaaa := resp.Answer[0].(*dns.AAAA)
-		assert.Equal(t, "64:ff9b::c000:221", aaaa.AAAA.String(), "IPv4-mapped AAAA was excluded; synthesised AAAA used instead")
+		if !reflect.DeepEqual("64:ff9b::c000:221", aaaa.AAAA.String()) {
+			t.Errorf("%s: aaaa.AAAA.String() = %v, want %v", "IPv4-mapped AAAA was excluded; synthesised AAAA used instead", aaaa.AAAA.String(), "64:ff9b::c000:221")
+		}
 	}
 }
 
@@ -706,9 +803,13 @@ func TestExcludedAAAA_StripsButPassesThrough(t *testing.T) {
 	d.ServeDNS(context.Background(), ch)
 
 	resp := mw.Msg()
-	if assert.Len(t, resp.Answer, 1, "excluded AAAA must be stripped, routable one preserved") {
+	if len(resp.Answer) != 1 {
+		t.Errorf("%s: len(resp.Answer) = %d, want %d", "excluded AAAA must be stripped, routable one preserved", len(resp.Answer), 1)
+	} else {
 		aaaa := resp.Answer[0].(*dns.AAAA)
-		assert.Equal(t, "2001:db8::1", aaaa.AAAA.String())
+		if !reflect.DeepEqual("2001:db8::1", aaaa.AAAA.String()) {
+			t.Errorf("aaaa.AAAA.String() = %v, want %v", aaaa.AAAA.String(), "2001:db8::1")
+		}
 	}
 }
 
@@ -733,12 +834,15 @@ func TestExcludedAAAA_OptOutEmptyList(t *testing.T) {
 	d.ServeDNS(context.Background(), ch)
 
 	resp := mw.Msg()
-	if assert.Len(t, resp.Answer, 1) {
+	if len(resp.Answer) != 1 {
+		t.Errorf("len(resp.Answer) = %d, want %d", len(resp.Answer), 1)
+	} else {
 		aaaa := resp.Answer[0].(*dns.AAAA)
 		// net.IP.String prints IPv4-mapped IPv6 in dotted form, so
 		// compare via Equal against the canonical 16-byte form.
-		assert.True(t, aaaa.AAAA.Equal(net.ParseIP("::ffff:c000:221")),
-			"with filter disabled, IPv4-mapped AAAA passes through; got %s", aaaa.AAAA)
+		if !(aaaa.AAAA.Equal(net.ParseIP("::ffff:c000:221"))) {
+			t.Errorf("%s: aaaa.AAAA.Equal(net.ParseIP('::ffff:c000:221')) is false", fmt.Sprintf("with filter disabled, IPv4-mapped AAAA passes through; got %s", aaaa.AAAA))
+		}
 	}
 }
 
@@ -760,9 +864,15 @@ func TestSynthesise_ANXDOMAIN_BecomesClientResponse(t *testing.T) {
 	d.ServeDNS(context.Background(), ch)
 
 	resp := mw.Msg()
-	assert.Equal(t, dns.RcodeNameError, resp.Rcode, "client sees the A NXDOMAIN promoted to AAAA")
-	assert.Empty(t, resp.Answer)
-	assert.Equal(t, dns.TypeAAAA, resp.Question[0].Qtype)
+	if !reflect.DeepEqual(dns.RcodeNameError, resp.Rcode) {
+		t.Errorf("%s: resp.Rcode = %v, want %v", "client sees the A NXDOMAIN promoted to AAAA", resp.Rcode, dns.RcodeNameError)
+	}
+	if len(resp.Answer) != 0 {
+		t.Errorf("resp.Answer not empty: %v", resp.Answer)
+	}
+	if !reflect.DeepEqual(dns.TypeAAAA, resp.Question[0].Qtype) {
+		t.Errorf("resp.Question[0].Qtype = %v, want %v", resp.Question[0].Qtype, dns.TypeAAAA)
+	}
 }
 
 // TestSynthesise_AuthorityFromAResponse pins RFC 6147 §5.4: the
@@ -787,10 +897,14 @@ func TestSynthesise_AuthorityFromAResponse(t *testing.T) {
 	d.ServeDNS(context.Background(), ch)
 
 	resp := mw.Msg()
-	if assert.Len(t, resp.Ns, 1, "exactly one SOA from the A response") {
+	if len(resp.Ns) != 1 {
+		t.Errorf("%s: len(resp.Ns) = %d, want %d", "exactly one SOA from the A response", len(resp.Ns), 1)
+	} else {
 		soa, ok := resp.Ns[0].(*dns.SOA)
-		if assert.True(t, ok) {
-			assert.Equal(t, uint32(42), soa.Serial, "Authority SOA must come from the A response (serial 42), not original AAAA (serial 99)")
+		if !(ok) {
+			t.Errorf("ok is false")
+		} else if !reflect.DeepEqual(uint32(42), soa.Serial) {
+			t.Errorf("%s: soa.Serial = %v, want %v", "Authority SOA must come from the A response (serial 42), not original AAAA (serial 99)", soa.Serial, uint32(42))
 		}
 	}
 }
@@ -832,13 +946,17 @@ func TestDNSSECFailure_PassesThrough(t *testing.T) {
 			d.ServeDNS(context.Background(), ch)
 
 			resp := mw.Msg()
-			assert.Equal(t, dns.RcodeServerFailure, resp.Rcode, "DNSSEC failure must surface to client unchanged")
+			if !reflect.DeepEqual(dns.RcodeServerFailure, resp.Rcode) {
+				t.Errorf("%s: resp.Rcode = %v, want %v", "DNSSEC failure must surface to client unchanged", resp.Rcode, dns.RcodeServerFailure)
+			}
 			if q.last != nil {
 				t.Fatalf("DNSSEC failure must not trigger an A lookup; queryer was called")
 			}
 			ede := dnsutil.GetEDE(resp)
-			if assert.NotNil(t, ede, "EDE must reach the client") {
-				assert.Equal(t, code, ede.InfoCode)
+			if ede == nil {
+				t.Errorf("%s: ede is nil", "EDE must reach the client")
+			} else if !reflect.DeepEqual(code, ede.InfoCode) {
+				t.Errorf("ede.InfoCode = %v, want %v", ede.InfoCode, code)
 			}
 		})
 	}
@@ -860,13 +978,17 @@ func TestCachedFailure_PassesThroughWithoutALookup(t *testing.T) {
 	d.ServeDNS(context.Background(), ch)
 
 	resp := mw.Msg()
-	assert.Equal(t, dns.RcodeServerFailure, resp.Rcode)
+	if !reflect.DeepEqual(dns.RcodeServerFailure, resp.Rcode) {
+		t.Errorf("resp.Rcode = %v, want %v", resp.Rcode, dns.RcodeServerFailure)
+	}
 	if q.last != nil {
 		t.Fatal("RFC 9520 cached failure triggered a DNS64 A lookup")
 	}
 	ede := dnsutil.GetEDE(resp)
-	if assert.NotNil(t, ede) {
-		assert.Equal(t, dns.ExtendedErrorCodeCachedError, ede.InfoCode)
+	if ede == nil {
+		t.Fatalf("ede is nil")
+	} else if !reflect.DeepEqual(dns.ExtendedErrorCodeCachedError, ede.InfoCode) {
+		t.Errorf("ede.InfoCode = %v, want %v", ede.InfoCode, dns.ExtendedErrorCodeCachedError)
 	}
 }
 
@@ -1023,10 +1145,16 @@ func TestServFail_NonDNSSEC_StillSynthesises(t *testing.T) {
 	d.ServeDNS(context.Background(), ch)
 
 	resp := mw.Msg()
-	assert.Equal(t, dns.RcodeSuccess, resp.Rcode)
-	if assert.Len(t, resp.Answer, 1) {
+	if !reflect.DeepEqual(dns.RcodeSuccess, resp.Rcode) {
+		t.Errorf("resp.Rcode = %v, want %v", resp.Rcode, dns.RcodeSuccess)
+	}
+	if len(resp.Answer) != 1 {
+		t.Errorf("len(resp.Answer) = %d, want %d", len(resp.Answer), 1)
+	} else {
 		aaaa := resp.Answer[0].(*dns.AAAA)
-		assert.Equal(t, "64:ff9b::c000:221", aaaa.AAAA.String())
+		if !reflect.DeepEqual("64:ff9b::c000:221", aaaa.AAAA.String()) {
+			t.Errorf("aaaa.AAAA.String() = %v, want %v", aaaa.AAAA.String(), "64:ff9b::c000:221")
+		}
 	}
 }
 
@@ -1056,8 +1184,12 @@ func TestRD0_PassesThrough(t *testing.T) {
 
 	d.ServeDNS(context.Background(), ch)
 
-	assert.True(t, answered, "RD=0 must reach the rest of the chain")
-	assert.Equal(t, dns.RcodeServerFailure, mw.Msg().Rcode, "downstream rejection passes through verbatim")
+	if !(answered) {
+		t.Errorf("%s: answered is false", "RD=0 must reach the rest of the chain")
+	}
+	if !reflect.DeepEqual(dns.RcodeServerFailure, mw.Msg().Rcode) {
+		t.Errorf("%s: mw.Msg().Rcode = %v, want %v", "downstream rejection passes through verbatim", mw.Msg().Rcode, dns.RcodeServerFailure)
+	}
 	if q.last != nil {
 		t.Fatalf("RD=0 must not trigger an A lookup; queryer was called")
 	}
@@ -1085,14 +1217,22 @@ func TestSynthesise_AResponseAsBasis_PreservesCNAME(t *testing.T) {
 	d.ServeDNS(context.Background(), ch)
 
 	resp := mw.Msg()
-	assert.Equal(t, dns.RcodeSuccess, resp.Rcode)
-	if assert.Len(t, resp.Answer, 1, "CNAME from A response must reach the client") {
+	if !reflect.DeepEqual(dns.RcodeSuccess, resp.Rcode) {
+		t.Errorf("resp.Rcode = %v, want %v", resp.Rcode, dns.RcodeSuccess)
+	}
+	if len(resp.Answer) != 1 {
+		t.Errorf("%s: len(resp.Answer) = %d, want %d", "CNAME from A response must reach the client", len(resp.Answer), 1)
+	} else {
 		c, ok := resp.Answer[0].(*dns.CNAME)
-		if assert.True(t, ok) {
-			assert.Equal(t, "target.example.org.", c.Target)
+		if !(ok) {
+			t.Errorf("ok is false")
+		} else if !reflect.DeepEqual("target.example.org.", c.Target) {
+			t.Errorf("c.Target = %v, want %v", c.Target, "target.example.org.")
 		}
 	}
-	assert.Equal(t, dns.TypeAAAA, resp.Question[0].Qtype, "client sees its original AAAA question")
+	if !reflect.DeepEqual(dns.TypeAAAA, resp.Question[0].Qtype) {
+		t.Errorf("%s: resp.Question[0].Qtype = %v, want %v", "client sees its original AAAA question", resp.Question[0].Qtype, dns.TypeAAAA)
+	}
 }
 
 // TestSynthesise_AdditionalARecordsPassThrough pins RFC 6147
@@ -1123,9 +1263,15 @@ func TestSynthesise_AdditionalARecordsPassThrough(t *testing.T) {
 			t.Fatalf("§5.3.2: Additional section must not contain a synthesised AAAA, got %s", rr)
 		}
 	}
-	if assert.NotNil(t, found, "extra-section A must be passed through unchanged") {
-		assert.Equal(t, "198.51.100.7", found.A.String())
-		assert.Equal(t, "ns.example.org.", found.Hdr.Name)
+	if found == nil {
+		t.Errorf("%s: found is nil", "extra-section A must be passed through unchanged")
+	} else {
+		if !reflect.DeepEqual("198.51.100.7", found.A.String()) {
+			t.Errorf("found.A.String() = %v, want %v", found.A.String(), "198.51.100.7")
+		}
+		if !reflect.DeepEqual("ns.example.org.", found.Hdr.Name) {
+			t.Errorf("found.Hdr.Name = %v, want %v", found.Hdr.Name, "ns.example.org.")
+		}
 	}
 }
 
@@ -1155,8 +1301,10 @@ func TestSynthesise_AuthorityARecordsPassThrough(t *testing.T) {
 			t.Fatalf("§5.3.2: Authority section must not contain a synthesised AAAA, got %s", rr)
 		}
 	}
-	if assert.NotNil(t, foundA) {
-		assert.Equal(t, "198.51.100.42", foundA.A.String())
+	if foundA == nil {
+		t.Fatalf("foundA is nil")
+	} else if !reflect.DeepEqual("198.51.100.42", foundA.A.String()) {
+		t.Errorf("foundA.A.String() = %v, want %v", foundA.A.String(), "198.51.100.42")
 	}
 }
 
@@ -1186,9 +1334,13 @@ func TestPassThrough_FilteredAAAAClearsAD(t *testing.T) {
 	d.ServeDNS(context.Background(), ch)
 
 	resp := mw.Msg()
-	assert.False(t, resp.AuthenticatedData, "AD must clear after RRset modification")
-	if ede := dnsutil.GetEDE(resp); assert.NotNil(t, ede, "EDE 4 should be attached when AD was set on the upstream") {
-		assert.Equal(t, dns.ExtendedErrorCodeForgedAnswer, ede.InfoCode)
+	if resp.AuthenticatedData {
+		t.Errorf("%s: resp.AuthenticatedData is true", "AD must clear after RRset modification")
+	}
+	if ede := dnsutil.GetEDE(resp); ede == nil {
+		t.Errorf("%s: ede is nil", "EDE 4 should be attached when AD was set on the upstream")
+	} else if !reflect.DeepEqual(dns.ExtendedErrorCodeForgedAnswer, ede.InfoCode) {
+		t.Errorf("ede.InfoCode = %v, want %v", ede.InfoCode, dns.ExtendedErrorCodeForgedAnswer)
 	}
 }
 
@@ -1211,7 +1363,9 @@ func TestPassThrough_NoStripPreservesAD(t *testing.T) {
 	d.ServeDNS(context.Background(), ch)
 
 	resp := mw.Msg()
-	assert.True(t, resp.AuthenticatedData, "AD must survive a clean pass-through")
+	if !(resp.AuthenticatedData) {
+		t.Errorf("%s: resp.AuthenticatedData is false", "AD must survive a clean pass-through")
+	}
 }
 
 // TestSynthesise_MultiPrefix pins RFC 6147 §5.2: multiple
@@ -1227,9 +1381,15 @@ func TestSynthesise_MultiPrefix(t *testing.T) {
 	d.ServeDNS(context.Background(), ch)
 
 	resp := mw.Msg()
-	if assert.Len(t, resp.Answer, 2, "one synthesised AAAA per configured prefix") {
-		assert.Equal(t, "64:ff9b::c000:221", resp.Answer[0].(*dns.AAAA).AAAA.String())
-		assert.Equal(t, "2001:db8:64::c000:221", resp.Answer[1].(*dns.AAAA).AAAA.String())
+	if len(resp.Answer) != 2 {
+		t.Errorf("%s: len(resp.Answer) = %d, want %d", "one synthesised AAAA per configured prefix", len(resp.Answer), 2)
+	} else {
+		if !reflect.DeepEqual("64:ff9b::c000:221", resp.Answer[0].(*dns.AAAA).AAAA.String()) {
+			t.Errorf("resp.Answer[0].(*dns.AAAA).AAAA.String() = %v, want %v", resp.Answer[0].(*dns.AAAA).AAAA.String(), "64:ff9b::c000:221")
+		}
+		if !reflect.DeepEqual("2001:db8:64::c000:221", resp.Answer[1].(*dns.AAAA).AAAA.String()) {
+			t.Errorf("resp.Answer[1].(*dns.AAAA).AAAA.String() = %v, want %v", resp.Answer[1].(*dns.AAAA).AAAA.String(), "2001:db8:64::c000:221")
+		}
 	}
 }
 
@@ -1247,8 +1407,10 @@ func TestSynthesise_MultiPrefix_PerPrefixExclusion(t *testing.T) {
 	d.ServeDNS(context.Background(), ch)
 
 	resp := mw.Msg()
-	if assert.Len(t, resp.Answer, 1, "private A excluded under well-known, kept under operator prefix") {
-		assert.Equal(t, "2001:db8:64::a00:1", resp.Answer[0].(*dns.AAAA).AAAA.String())
+	if len(resp.Answer) != 1 {
+		t.Errorf("%s: len(resp.Answer) = %d, want %d", "private A excluded under well-known, kept under operator prefix", len(resp.Answer), 1)
+	} else if !reflect.DeepEqual("2001:db8:64::a00:1", resp.Answer[0].(*dns.AAAA).AAAA.String()) {
+		t.Errorf("resp.Answer[0].(*dns.AAAA).AAAA.String() = %v, want %v", resp.Answer[0].(*dns.AAAA).AAAA.String(), "2001:db8:64::a00:1")
 	}
 }
 
@@ -1275,21 +1437,36 @@ func TestPTR_TranslatesUnderWellKnown(t *testing.T) {
 	d.ServeDNS(context.Background(), ch)
 
 	resp := mw.Msg()
-	if !assert.NotNil(t, resp, "PTR translation must produce a response") {
+	if resp == nil {
+		t.Errorf("%s: resp is nil", "PTR translation must produce a response")
 		return
 	}
-	assert.Equal(t, dns.RcodeSuccess, resp.Rcode)
-	if assert.GreaterOrEqual(t, len(resp.Answer), 1) {
+	if !reflect.DeepEqual(dns.RcodeSuccess, resp.Rcode) {
+		t.Errorf("resp.Rcode = %v, want %v", resp.Rcode, dns.RcodeSuccess)
+	}
+	if len(resp.Answer) < 1 {
+		t.Errorf("len(resp.Answer) = %d, want >= %d", len(resp.Answer), 1)
+	} else {
 		cname, ok := resp.Answer[0].(*dns.CNAME)
-		if assert.True(t, ok, "first answer must be a CNAME") {
-			assert.Equal(t, qname, cname.Hdr.Name)
-			assert.Equal(t, "33.2.0.192.in-addr.arpa.", cname.Target)
+		if !(ok) {
+			t.Errorf("%s: ok is false", "first answer must be a CNAME")
+		} else {
+			if !reflect.DeepEqual(qname, cname.Hdr.Name) {
+				t.Errorf("cname.Hdr.Name = %v, want %v", cname.Hdr.Name, qname)
+			}
+			if !reflect.DeepEqual("33.2.0.192.in-addr.arpa.", cname.Target) {
+				t.Errorf("cname.Target = %v, want %v", cname.Target, "33.2.0.192.in-addr.arpa.")
+			}
 		}
 	}
-	if assert.Len(t, resp.Answer, 2, "chase result must be appended") {
+	if len(resp.Answer) != 2 {
+		t.Errorf("%s: len(resp.Answer) = %d, want %d", "chase result must be appended", len(resp.Answer), 2)
+	} else {
 		ptr, ok := resp.Answer[1].(*dns.PTR)
-		if assert.True(t, ok) {
-			assert.Equal(t, "target.example.com.", ptr.Ptr)
+		if !(ok) {
+			t.Errorf("ok is false")
+		} else if !reflect.DeepEqual("target.example.com.", ptr.Ptr) {
+			t.Errorf("ptr.Ptr = %v, want %v", ptr.Ptr, "target.example.com.")
 		}
 	}
 }
@@ -1308,9 +1485,15 @@ func TestPTR_RecursionWorkLimitReturnsPolicyEDE(t *testing.T) {
 	d.ServeDNS(context.Background(), ch)
 
 	assertRecursionWorkLimitEDE(t, mw.Msg())
-	if assert.NotNil(t, queryer.last, "secondary PTR query must be attempted") {
-		assert.Equal(t, dns.TypePTR, queryer.last.Question[0].Qtype)
-		assert.Equal(t, "33.2.0.192.in-addr.arpa.", queryer.last.Question[0].Name)
+	if queryer.last == nil {
+		t.Errorf("%s: queryer.last is nil", "secondary PTR query must be attempted")
+	} else {
+		if !reflect.DeepEqual(dns.TypePTR, queryer.last.Question[0].Qtype) {
+			t.Errorf("queryer.last.Question[0].Qtype = %v, want %v", queryer.last.Question[0].Qtype, dns.TypePTR)
+		}
+		if !reflect.DeepEqual("33.2.0.192.in-addr.arpa.", queryer.last.Question[0].Name) {
+			t.Errorf("queryer.last.Question[0].Name = %v, want %v", queryer.last.Question[0].Name, "33.2.0.192.in-addr.arpa.")
+		}
 	}
 }
 
@@ -1398,14 +1581,23 @@ func TestPTR_OrdinaryQueryerErrorKeepsCNAMEOnly(t *testing.T) {
 	d.ServeDNS(context.Background(), ch)
 
 	resp := mw.Msg()
-	if !assert.NotNil(t, resp) {
+	if resp == nil {
+		t.Fatalf("resp is nil")
 		return
 	}
-	assert.Equal(t, dns.RcodeSuccess, resp.Rcode)
-	assert.Nil(t, dnsutil.GetEDE(resp))
-	if assert.Len(t, resp.Answer, 1, "ordinary chase errors retain the CNAME-only fallback") {
+	if !reflect.DeepEqual(dns.RcodeSuccess, resp.Rcode) {
+		t.Errorf("resp.Rcode = %v, want %v", resp.Rcode, dns.RcodeSuccess)
+	}
+	if dnsutil.GetEDE(resp) != nil {
+		t.Errorf("dnsutil.GetEDE(resp) = %v, want nil", dnsutil.GetEDE(resp))
+	}
+	if len(resp.Answer) != 1 {
+		t.Errorf("%s: len(resp.Answer) = %d, want %d", "ordinary chase errors retain the CNAME-only fallback", len(resp.Answer), 1)
+	} else {
 		_, ok := resp.Answer[0].(*dns.CNAME)
-		assert.True(t, ok, "fallback answer must be the synthesised CNAME")
+		if !(ok) {
+			t.Errorf("%s: ok is false", "fallback answer must be the synthesised CNAME")
+		}
 	}
 }
 
@@ -1434,8 +1626,12 @@ func TestPTR_NoMatchFallsThrough(t *testing.T) {
 	ch, mw := makeChain(t, d, downstream, "203.0.113.5:53", qname, dns.TypePTR)
 	d.ServeDNS(context.Background(), ch)
 
-	assert.True(t, answered, "downstream must run when PTR is not under a configured Pref64")
-	assert.Equal(t, dns.RcodeNameError, mw.Msg().Rcode)
+	if !(answered) {
+		t.Errorf("%s: answered is false", "downstream must run when PTR is not under a configured Pref64")
+	}
+	if !reflect.DeepEqual(dns.RcodeNameError, mw.Msg().Rcode) {
+		t.Errorf("mw.Msg().Rcode = %v, want %v", mw.Msg().Rcode, dns.RcodeNameError)
+	}
 }
 
 // TestPTR_ExcludedV4SkipsTranslation pins RFC 6147 §5.1.4
@@ -1457,8 +1653,12 @@ func TestPTR_ExcludedV4SkipsTranslation(t *testing.T) {
 	ch, mw := makeChain(t, d, downstream, "203.0.113.5:53", qname, dns.TypePTR)
 	d.ServeDNS(context.Background(), ch)
 
-	assert.True(t, answered, "excluded-v4 PTR must fall through to the rest of the chain")
-	assert.Equal(t, dns.RcodeServerFailure, mw.Msg().Rcode)
+	if !(answered) {
+		t.Errorf("%s: answered is false", "excluded-v4 PTR must fall through to the rest of the chain")
+	}
+	if !reflect.DeepEqual(dns.RcodeServerFailure, mw.Msg().Rcode) {
+		t.Errorf("mw.Msg().Rcode = %v, want %v", mw.Msg().Rcode, dns.RcodeServerFailure)
+	}
 }
 
 // TestPTR_OperatorPrefixTranslates confirms PTR translation works
@@ -1480,9 +1680,17 @@ func TestPTR_OperatorPrefixTranslates(t *testing.T) {
 	d.ServeDNS(context.Background(), ch)
 
 	resp := mw.Msg()
-	if assert.NotNil(t, resp) && assert.Len(t, resp.Answer, 1) {
-		cname := resp.Answer[0].(*dns.CNAME)
-		assert.Equal(t, "1.0.0.10.in-addr.arpa.", cname.Target)
+	if resp == nil {
+		t.Fatalf("resp is nil")
+		return
+	}
+	if len(resp.Answer) != 1 {
+		t.Errorf("len(resp.Answer) = %d, want %d", len(resp.Answer), 1)
+		return
+	}
+	cname := resp.Answer[0].(*dns.CNAME)
+	if !reflect.DeepEqual("1.0.0.10.in-addr.arpa.", cname.Target) {
+		t.Errorf("cname.Target = %v, want %v", cname.Target, "1.0.0.10.in-addr.arpa.")
 	}
 }
 
@@ -1511,15 +1719,27 @@ func TestSynthesise_DNAMEChain(t *testing.T) {
 	d.ServeDNS(context.Background(), ch)
 
 	resp := mw.Msg()
-	if assert.Len(t, resp.Answer, 3, "DNAME + synthesised CNAME + synthesised AAAA must all be present") {
+	if len(resp.Answer) != 3 {
+		t.Errorf("%s: len(resp.Answer) = %d, want %d", "DNAME + synthesised CNAME + synthesised AAAA must all be present", len(resp.Answer), 3)
+	} else {
 		_, isDNAME := resp.Answer[0].(*dns.DNAME)
 		_, isCNAME := resp.Answer[1].(*dns.CNAME)
 		aaaa, isAAAA := resp.Answer[2].(*dns.AAAA)
-		assert.True(t, isDNAME, "first record must be the DNAME")
-		assert.True(t, isCNAME, "second record must be the synthesised CNAME")
-		if assert.True(t, isAAAA) {
-			assert.Equal(t, "alias.hosts.example.net.", aaaa.Hdr.Name, "synthesised AAAA owner must follow the chain to the A's terminal name")
-			assert.Equal(t, "64:ff9b::c000:221", aaaa.AAAA.String())
+		if !(isDNAME) {
+			t.Errorf("%s: isDNAME is false", "first record must be the DNAME")
+		}
+		if !(isCNAME) {
+			t.Errorf("%s: isCNAME is false", "second record must be the synthesised CNAME")
+		}
+		if !(isAAAA) {
+			t.Errorf("isAAAA is false")
+		} else {
+			if !reflect.DeepEqual("alias.hosts.example.net.", aaaa.Hdr.Name) {
+				t.Errorf("%s: aaaa.Hdr.Name = %v, want %v", "synthesised AAAA owner must follow the chain to the A's terminal name", aaaa.Hdr.Name, "alias.hosts.example.net.")
+			}
+			if !reflect.DeepEqual("64:ff9b::c000:221", aaaa.AAAA.String()) {
+				t.Errorf("aaaa.AAAA.String() = %v, want %v", aaaa.AAAA.String(), "64:ff9b::c000:221")
+			}
 		}
 	}
 }

--- a/middleware/edns/edns_test.go
+++ b/middleware/edns/edns_test.go
@@ -3,13 +3,13 @@ package edns
 import (
 	"context"
 	"net"
+	"reflect"
 	"testing"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/config"
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/semihalev/sdns/middleware"
-	"github.com/stretchr/testify/assert"
 )
 
 type dummy struct{}
@@ -46,7 +46,9 @@ func Test_EDNS(t *testing.T) {
 	middleware.Setup(cfg)
 
 	edns := middleware.Get("edns").(*EDNS)
-	assert.Equal(t, "edns", edns.Name())
+	if !reflect.DeepEqual("edns", edns.Name()) {
+		t.Errorf("edns.Name() = %v, want %v", edns.Name(), "edns")
+	}
 
 	ch := middleware.NewChain([]middleware.Handler{edns, &dummy{}})
 
@@ -57,9 +59,15 @@ func Test_EDNS(t *testing.T) {
 	ch.Reset(mw, req)
 	ch.Next(context.Background())
 
-	assert.True(t, ch.Writer.Written())
-	assert.Equal(t, dns.RcodeSuccess, ch.Writer.Rcode())
-	assert.Nil(t, ch.Writer.Msg().IsEdns0())
+	if !(ch.Writer.Written()) {
+		t.Errorf("ch.Writer.Written() is false")
+	}
+	if !reflect.DeepEqual(dns.RcodeSuccess, ch.Writer.Rcode()) {
+		t.Errorf("ch.Writer.Rcode() = %v, want %v", ch.Writer.Rcode(), dns.RcodeSuccess)
+	}
+	if ch.Writer.Msg().IsEdns0() != nil {
+		t.Errorf("ch.Writer.Msg().IsEdns0() = %v, want nil", ch.Writer.Msg().IsEdns0())
+	}
 
 	req.SetEdns0(4096, true)
 	opt := req.IsEdns0()
@@ -69,8 +77,12 @@ func Test_EDNS(t *testing.T) {
 	ch.Reset(mw, req)
 	ch.Next(context.Background())
 
-	assert.True(t, ch.Writer.Written())
-	assert.Equal(t, dns.RcodeBadVers, ch.Writer.Rcode())
+	if !(ch.Writer.Written()) {
+		t.Errorf("ch.Writer.Written() is false")
+	}
+	if !reflect.DeepEqual(dns.RcodeBadVers, ch.Writer.Rcode()) {
+		t.Errorf("ch.Writer.Rcode() = %v, want %v", ch.Writer.Rcode(), dns.RcodeBadVers)
+	}
 
 	opt = req.IsEdns0()
 	opt.SetVersion(0)
@@ -80,16 +92,20 @@ func Test_EDNS(t *testing.T) {
 	ch.Reset(mw, req)
 	ch.Next(context.Background())
 
-	if assert.True(t, ch.Writer.Written()) {
-		assert.False(t, ch.Writer.Msg().Truncated)
+	if !(ch.Writer.Written()) {
+		t.Errorf("ch.Writer.Written() is false")
+	} else if ch.Writer.Msg().Truncated {
+		t.Errorf("ch.Writer.Msg().Truncated is true")
 	}
 
 	mw = mock.NewWriter("udp", "127.0.0.1:0")
 	ch.Reset(mw, req)
 	ch.Next(context.Background())
 
-	if assert.True(t, ch.Writer.Written()) {
-		assert.True(t, ch.Writer.Msg().Truncated)
+	if !(ch.Writer.Written()) {
+		t.Errorf("ch.Writer.Written() is false")
+	} else if !(ch.Writer.Msg().Truncated) {
+		t.Errorf("ch.Writer.Msg().Truncated is false")
 	}
 
 	opt.Option = append(opt.Option, &dns.EDNS0_COOKIE{
@@ -193,9 +209,15 @@ func TestEDNS_ForwardsECSClampedDownstream(t *testing.T) {
 	if got == nil {
 		t.Fatal("expected ECS to be forwarded to downstream")
 	}
-	assert.Equal(t, uint8(24), got.SourceNetmask, "ceiling clamp")
-	assert.Equal(t, "203.0.113.0", got.Address.String(), "host bits zeroed")
-	assert.Equal(t, uint8(0), got.SourceScope, "outgoing SCOPE must be 0")
+	if !reflect.DeepEqual(uint8(24), got.SourceNetmask) {
+		t.Errorf("%s: got.SourceNetmask = %v, want %v", "ceiling clamp", got.SourceNetmask, uint8(24))
+	}
+	if !reflect.DeepEqual("203.0.113.0", got.Address.String()) {
+		t.Errorf("%s: got.Address.String() = %v, want %v", "host bits zeroed", got.Address.String(), "203.0.113.0")
+	}
+	if !reflect.DeepEqual(uint8(0), got.SourceScope) {
+		t.Errorf("%s: got.SourceScope = %v, want %v", "outgoing SCOPE must be 0", got.SourceScope, uint8(0))
+	}
 }
 
 // TestEDNS_ResponseDoesNotLeakForwardedECS pins the P2 fix from the
@@ -330,8 +352,12 @@ func TestEDNS_ClearsADForCheckingDisabled(t *testing.T) {
 	mw := mock.NewWriter("udp", "127.0.0.1:0")
 	ch.Reset(mw, req)
 	ch.Next(context.Background())
-	assert.True(t, mw.Written())
-	assert.False(t, mw.Msg().AuthenticatedData, "AD must be cleared for a CD=1 client")
+	if !(mw.Written()) {
+		t.Errorf("mw.Written() is false")
+	}
+	if mw.Msg().AuthenticatedData {
+		t.Errorf("%s: mw.Msg().AuthenticatedData is true", "AD must be cleared for a CD=1 client")
+	}
 
 	// Control: DO=1, CD=0 client keeps the validated AD bit.
 	req2 := new(dns.Msg)
@@ -340,5 +366,7 @@ func TestEDNS_ClearsADForCheckingDisabled(t *testing.T) {
 	mw2 := mock.NewWriter("udp", "127.0.0.1:0")
 	ch.Reset(mw2, req2)
 	ch.Next(context.Background())
-	assert.True(t, mw2.Msg().AuthenticatedData, "AD must survive for a DO=1, CD=0 client")
+	if !(mw2.Msg().AuthenticatedData) {
+		t.Errorf("%s: mw2.Msg().AuthenticatedData is false", "AD must survive for a DO=1, CD=0 client")
+	}
 }

--- a/middleware/failover/failover_test.go
+++ b/middleware/failover/failover_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"reflect"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -14,7 +15,6 @@ import (
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/zlog/v2"
-	"github.com/stretchr/testify/assert"
 )
 
 type dummy struct{}
@@ -54,7 +54,9 @@ func Test_Failover(t *testing.T) {
 	middleware.Setup(cfg)
 
 	f := middleware.Get("failover").(*Failover)
-	assert.Equal(t, "failover", f.Name())
+	if !reflect.DeepEqual("failover", f.Name()) {
+		t.Errorf("f.Name() = %v, want %v", f.Name(), "failover")
+	}
 
 	ch := middleware.NewChain([]middleware.Handler{f, &dummy{}})
 
@@ -71,21 +73,27 @@ func Test_Failover(t *testing.T) {
 	ch.Reset(mw, req)
 	ch.Next(ctx)
 
-	assert.Equal(t, dns.RcodeServerFailure, mw.Rcode())
+	if !reflect.DeepEqual(dns.RcodeServerFailure, mw.Rcode()) {
+		t.Errorf("mw.Rcode() = %v, want %v", mw.Rcode(), dns.RcodeServerFailure)
+	}
 
 	req.RecursionDesired = true
 
 	ch.Reset(mw, req)
 	ch.Next(ctx)
 
-	assert.Equal(t, mw.Rcode(), dns.RcodeSuccess)
+	if !reflect.DeepEqual(mw.Rcode(), dns.RcodeSuccess) {
+		t.Errorf("dns.RcodeSuccess = %v, want %v", dns.RcodeSuccess, mw.Rcode())
+	}
 
 	f.servers = []string{}
 
 	ch.Reset(mw, req)
 	ch.Next(ctx)
 
-	assert.Equal(t, mw.Rcode(), dns.RcodeServerFailure)
+	if !reflect.DeepEqual(mw.Rcode(), dns.RcodeServerFailure) {
+		t.Errorf("dns.RcodeServerFailure = %v, want %v", dns.RcodeServerFailure, mw.Rcode())
+	}
 
 	// A refused port rather than a black hole: the assertion is that an
 	// unusable fallback yields SERVFAIL, not that we can wait out a timeout.
@@ -94,7 +102,9 @@ func Test_Failover(t *testing.T) {
 	ch.Reset(mw, req)
 	ch.Next(ctx)
 
-	assert.Equal(t, mw.Rcode(), dns.RcodeServerFailure)
+	if !reflect.DeepEqual(mw.Rcode(), dns.RcodeServerFailure) {
+		t.Errorf("dns.RcodeServerFailure = %v, want %v", dns.RcodeServerFailure, mw.Rcode())
+	}
 }
 
 func TestFailoverRecursionWorkBoundsFallbackPool(t *testing.T) {

--- a/middleware/forwarder/forwarder_test.go
+++ b/middleware/forwarder/forwarder_test.go
@@ -11,6 +11,7 @@ import (
 	"math/big"
 	"net"
 	"net/http"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -22,7 +23,6 @@ import (
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/zlog/v2"
-	"github.com/stretchr/testify/assert"
 )
 
 func startTestDNSServer(t *testing.T, network string) (addr string, stop func()) {
@@ -129,7 +129,9 @@ func Test_Forwarder(t *testing.T) {
 	middleware.Setup(cfg)
 
 	f := middleware.Get("forwarder").(*Forwarder)
-	assert.Equal(t, "forwarder", f.Name())
+	if !reflect.DeepEqual("forwarder", f.Name()) {
+		t.Errorf("f.Name() = %v, want %v", f.Name(), "forwarder")
+	}
 	// Test TLS forwarding against a local server using a self-signed cert.
 	// In production, users should provide a validating TLS configuration.
 	f.tlsConfig = &tls.Config{InsecureSkipVerify: true} //nolint:gosec // test-only
@@ -149,21 +151,27 @@ func Test_Forwarder(t *testing.T) {
 	ch.Reset(mw, req)
 	ch.Next(ctx)
 
-	assert.Equal(t, dns.RcodeSuccess, ch.Writer.Rcode())
+	if !reflect.DeepEqual(dns.RcodeSuccess, ch.Writer.Rcode()) {
+		t.Errorf("ch.Writer.Rcode() = %v, want %v", ch.Writer.Rcode(), dns.RcodeSuccess)
+	}
 
 	req.RecursionDesired = true
 
 	ch.Reset(mw, req)
 	ch.Next(ctx)
 
-	assert.Equal(t, dns.RcodeSuccess, ch.Writer.Rcode())
+	if !reflect.DeepEqual(dns.RcodeSuccess, ch.Writer.Rcode()) {
+		t.Errorf("ch.Writer.Rcode() = %v, want %v", ch.Writer.Rcode(), dns.RcodeSuccess)
+	}
 
 	f.servers = []*server{}
 
 	ch.Reset(mw, req)
 	ch.Next(ctx)
 
-	assert.Equal(t, dns.RcodeServerFailure, ch.Writer.Rcode())
+	if !reflect.DeepEqual(dns.RcodeServerFailure, ch.Writer.Rcode()) {
+		t.Errorf("ch.Writer.Rcode() = %v, want %v", ch.Writer.Rcode(), dns.RcodeServerFailure)
+	}
 
 	srv := &server{Addr: vacantLoopbackAddr(t), Proto: "udp"}
 	f.servers = []*server{srv}
@@ -171,7 +179,9 @@ func Test_Forwarder(t *testing.T) {
 	ch.Reset(mw, req)
 	ch.Next(ctx)
 
-	assert.Equal(t, dns.RcodeServerFailure, ch.Writer.Rcode())
+	if !reflect.DeepEqual(dns.RcodeServerFailure, ch.Writer.Rcode()) {
+		t.Errorf("ch.Writer.Rcode() = %v, want %v", ch.Writer.Rcode(), dns.RcodeServerFailure)
+	}
 
 	srv = &server{Addr: tlsAddr, Proto: "tcp-tls"}
 	f.servers = []*server{srv}
@@ -179,7 +189,9 @@ func Test_Forwarder(t *testing.T) {
 	ch.Reset(mw, req)
 	ch.Next(ctx)
 
-	assert.Equal(t, dns.RcodeSuccess, ch.Writer.Rcode())
+	if !reflect.DeepEqual(dns.RcodeSuccess, ch.Writer.Rcode()) {
+		t.Errorf("ch.Writer.Rcode() = %v, want %v", ch.Writer.Rcode(), dns.RcodeSuccess)
+	}
 }
 
 // startMismatchedQuestionServer returns a UDP server that always replies with
@@ -226,7 +238,9 @@ func Test_Forwarder_RejectsMismatchedQuestion(t *testing.T) {
 	// Every upstream returns a mismatched question, so the forwarder must
 	// drop the response and report SERVFAIL rather than letting an unrelated
 	// answer through to the client (and the cache).
-	assert.Equal(t, dns.RcodeServerFailure, ch.Writer.Rcode())
+	if !reflect.DeepEqual(dns.RcodeServerFailure, ch.Writer.Rcode()) {
+		t.Errorf("ch.Writer.Rcode() = %v, want %v", ch.Writer.Rcode(), dns.RcodeServerFailure)
+	}
 }
 
 func TestForwarderResolutionAttemptGuardBoundsDuplicateEndpoints(t *testing.T) {

--- a/middleware/hostsfile/hostsfile_test.go
+++ b/middleware/hostsfile/hostsfile_test.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -16,20 +18,22 @@ import (
 	"github.com/semihalev/sdns/config"
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/semihalev/sdns/middleware"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
 	// Test with empty config
 	cfg := &config.Config{}
 	h := New(cfg)
-	assert.Nil(t, h)
+	if h != nil {
+		t.Errorf("h = %v, want nil", h)
+	}
 
 	// Test with non-existent file
 	cfg.HostsFile = "/non/existent/file"
 	h = New(cfg)
-	assert.Nil(t, h)
+	if h != nil {
+		t.Errorf("h = %v, want nil", h)
+	}
 
 	// Test with valid file
 	tmpFile := createTempHostsFile(t, "127.0.0.1 localhost")
@@ -37,10 +41,18 @@ func TestNew(t *testing.T) {
 
 	cfg.HostsFile = tmpFile
 	h = New(cfg)
-	require.NotNil(t, h)
-	assert.Equal(t, tmpFile, h.path)
-	assert.Equal(t, uint32(600), h.ttl)
-	assert.Equal(t, "hostsfile", h.Name())
+	if h == nil {
+		t.Fatalf("h is nil")
+	}
+	if !reflect.DeepEqual(tmpFile, h.path) {
+		t.Errorf("h.path = %v, want %v", h.path, tmpFile)
+	}
+	if !reflect.DeepEqual(uint32(600), h.ttl) {
+		t.Errorf("h.ttl = %v, want %v", h.ttl, uint32(600))
+	}
+	if !reflect.DeepEqual("hostsfile", h.Name()) {
+		t.Errorf("h.Name() = %v, want %v", h.Name(), "hostsfile")
+	}
 }
 
 func TestServeDNS_Basic(t *testing.T) {
@@ -59,7 +71,9 @@ func TestServeDNS_Basic(t *testing.T) {
 		path: tmpFile,
 		ttl:  300,
 	}
-	require.NoError(t, h.load())
+	if err := h.load(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	tests := []struct {
 		name     string
@@ -91,16 +105,24 @@ func TestServeDNS_Basic(t *testing.T) {
 			h.ServeDNS(context.Background(), ch)
 
 			if tt.found {
-				require.True(t, w.Written())
-				resp := w.Msg()
-				assert.Equal(t, tt.expected, len(resp.Answer))
-				if tt.expected > 0 {
-					assert.True(t, resp.Authoritative)
-					assert.True(t, resp.RecursionAvailable)
+				if !(w.Written()) {
+					t.Fatalf("w.Written() is false")
 				}
-			} else {
-				// Should pass through
-				assert.False(t, w.Written())
+				resp := w.Msg()
+				if !reflect.DeepEqual(tt.expected, len(resp.Answer)) {
+					t.Errorf("len(resp.Answer) = %v, want %v", len(resp.Answer), tt.expected)
+				}
+				if tt.expected > 0 {
+					if !(resp.Authoritative) {
+						t.Errorf("resp.Authoritative is false")
+					}
+					if !(resp.RecursionAvailable) {
+						t.Errorf("resp.RecursionAvailable is false")
+					}
+				}
+			} else if w.Written() {
+				// Should pass through unanswered.
+				t.Errorf("w.Written() is true")
 			}
 		})
 	}
@@ -117,7 +139,9 @@ func TestServeDNS_PreservesHeaderBits(t *testing.T) {
 	defer os.Remove(tmpFile)
 
 	h := &Hostsfile{path: tmpFile, ttl: 300}
-	require.NoError(t, h.load())
+	if err := h.load(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	cases := []struct {
 		name string
@@ -141,14 +165,26 @@ func TestServeDNS_PreservesHeaderBits(t *testing.T) {
 			ch.Reset(w, req)
 			h.ServeDNS(context.Background(), ch)
 
-			require.True(t, w.Written())
+			if !(w.Written()) {
+				t.Fatalf("w.Written() is false")
+			}
 			resp := w.Msg()
-			require.NotNil(t, resp)
+			if resp == nil {
+				t.Fatalf("resp is nil")
+			}
 
-			assert.Equal(t, tc.cd, resp.CheckingDisabled, "CheckingDisabled bit must round-trip")
-			assert.Equal(t, tc.rd, resp.RecursionDesired, "RecursionDesired bit must round-trip")
-			assert.True(t, resp.Response, "Response bit must be set")
-			assert.Equal(t, req.Id, resp.Id)
+			if !reflect.DeepEqual(tc.cd, resp.CheckingDisabled) {
+				t.Errorf("%s: resp.CheckingDisabled = %v, want %v", "CheckingDisabled bit must round-trip", resp.CheckingDisabled, tc.cd)
+			}
+			if !reflect.DeepEqual(tc.rd, resp.RecursionDesired) {
+				t.Errorf("%s: resp.RecursionDesired = %v, want %v", "RecursionDesired bit must round-trip", resp.RecursionDesired, tc.rd)
+			}
+			if !(resp.Response) {
+				t.Errorf("%s: resp.Response is false", "Response bit must be set")
+			}
+			if !reflect.DeepEqual(req.Id, resp.Id) {
+				t.Errorf("resp.Id = %v, want %v", resp.Id, req.Id)
+			}
 		})
 	}
 }
@@ -162,7 +198,9 @@ func TestServeDNS_EdgeCases(t *testing.T) {
 		path: tmpFile,
 		ttl:  300,
 	}
-	require.NoError(t, h.load())
+	if err := h.load(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	// Test with empty question
 	req := new(dns.Msg)
@@ -171,7 +209,9 @@ func TestServeDNS_EdgeCases(t *testing.T) {
 	ch.Reset(w, req)
 
 	h.ServeDNS(context.Background(), ch)
-	assert.False(t, w.Written())
+	if w.Written() {
+		t.Errorf("w.Written() is true")
+	}
 }
 
 func TestLookupFunctions(t *testing.T) {
@@ -190,73 +230,131 @@ func TestLookupFunctions(t *testing.T) {
 		path: tmpFile,
 		ttl:  300,
 	}
-	require.NoError(t, h.load())
+	if err := h.load(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	db := h.getDB()
 
 	// Test lookupA
 	t.Run("lookupA", func(t *testing.T) {
 		// Direct lookup
 		rrs, found := h.lookupA(db, "localhost")
-		assert.True(t, found)
-		assert.Len(t, rrs, 1)
-		assert.Equal(t, "127.0.0.1", rrs[0].(*dns.A).A.String())
+		if !(found) {
+			t.Errorf("found is false")
+		}
+		if len(rrs) != 1 {
+			t.Errorf("len(rrs) = %d, want %d", len(rrs), 1)
+		}
+		if !reflect.DeepEqual("127.0.0.1", rrs[0].(*dns.A).A.String()) {
+			t.Errorf("rrs[0].(*dns.A).A.String() = %v, want %v", rrs[0].(*dns.A).A.String(), "127.0.0.1")
+		}
 
 		// Wildcard lookup
 		rrs, found = h.lookupA(db, "test.wildcard.com")
-		assert.True(t, found)
-		assert.Len(t, rrs, 1)
-		assert.Equal(t, "10.0.0.1", rrs[0].(*dns.A).A.String())
+		if !(found) {
+			t.Errorf("found is false")
+		}
+		if len(rrs) != 1 {
+			t.Errorf("len(rrs) = %d, want %d", len(rrs), 1)
+		}
+		if !reflect.DeepEqual("10.0.0.1", rrs[0].(*dns.A).A.String()) {
+			t.Errorf("rrs[0].(*dns.A).A.String() = %v, want %v", rrs[0].(*dns.A).A.String(), "10.0.0.1")
+		}
 
 		// Not found
 		rrs, found = h.lookupA(db, "notfound.local")
-		assert.False(t, found)
-		assert.Nil(t, rrs)
+		if found {
+			t.Errorf("found is true")
+		}
+		if rrs != nil {
+			t.Errorf("rrs = %v, want nil", rrs)
+		}
 	})
 
 	// Test lookupAAAA
 	t.Run("lookupAAAA", func(t *testing.T) {
 		rrs, found := h.lookupAAAA(db, "localhost")
-		assert.True(t, found)
-		assert.Len(t, rrs, 1)
-		assert.Equal(t, "::1", rrs[0].(*dns.AAAA).AAAA.String())
+		if !(found) {
+			t.Errorf("found is false")
+		}
+		if len(rrs) != 1 {
+			t.Errorf("len(rrs) = %d, want %d", len(rrs), 1)
+		}
+		if !reflect.DeepEqual("::1", rrs[0].(*dns.AAAA).AAAA.String()) {
+			t.Errorf("rrs[0].(*dns.AAAA).AAAA.String() = %v, want %v", rrs[0].(*dns.AAAA).AAAA.String(), "::1")
+		}
 
 		rrs, found = h.lookupAAAA(db, "ipv6.host.com")
-		assert.True(t, found)
-		assert.Len(t, rrs, 1)
+		if !(found) {
+			t.Errorf("found is false")
+		}
+		if len(rrs) != 1 {
+			t.Errorf("len(rrs) = %d, want %d", len(rrs), 1)
+		}
 	})
 
 	// Test lookupPTR
 	t.Run("lookupPTR", func(t *testing.T) {
 		rrs, found := h.lookupPTR(db, "1.0.0.127.in-addr.arpa.")
-		assert.True(t, found)
-		assert.Len(t, rrs, 1)
-		assert.Equal(t, "localhost.", rrs[0].(*dns.PTR).Ptr)
+		if !(found) {
+			t.Errorf("found is false")
+		}
+		if len(rrs) != 1 {
+			t.Errorf("len(rrs) = %d, want %d", len(rrs), 1)
+		}
+		if !reflect.DeepEqual("localhost.", rrs[0].(*dns.PTR).Ptr) {
+			t.Errorf("rrs[0].(*dns.PTR).Ptr = %v, want %v", rrs[0].(*dns.PTR).Ptr, "localhost.")
+		}
 
 		// Invalid PTR
 		rrs, found = h.lookupPTR(db, "invalid.ptr")
-		assert.False(t, found)
-		assert.Nil(t, rrs)
+		if found {
+			t.Errorf("found is true")
+		}
+		if rrs != nil {
+			t.Errorf("rrs = %v, want nil", rrs)
+		}
 	})
 
 	// Test lookupCNAME
 	t.Run("lookupCNAME", func(t *testing.T) {
 		rrs, found := h.lookupCNAME(db, "local")
-		assert.True(t, found)
-		assert.Len(t, rrs, 1)
-		assert.Equal(t, "localhost.", rrs[0].(*dns.CNAME).Target)
+		if !(found) {
+			t.Errorf("found is false")
+		}
+		if len(rrs) != 1 {
+			t.Errorf("len(rrs) = %d, want %d", len(rrs), 1)
+		}
+		if !reflect.DeepEqual("localhost.", rrs[0].(*dns.CNAME).Target) {
+			t.Errorf("rrs[0].(*dns.CNAME).Target = %v, want %v", rrs[0].(*dns.CNAME).Target, "localhost.")
+		}
 
 		rrs, found = h.lookupCNAME(db, "alias2")
-		assert.True(t, found)
-		assert.Len(t, rrs, 1)
-		assert.Equal(t, "host2.local.", rrs[0].(*dns.CNAME).Target)
+		if !(found) {
+			t.Errorf("found is false")
+		}
+		if len(rrs) != 1 {
+			t.Errorf("len(rrs) = %d, want %d", len(rrs), 1)
+		}
+		if !reflect.DeepEqual("host2.local.", rrs[0].(*dns.CNAME).Target) {
+			t.Errorf("rrs[0].(*dns.CNAME).Target = %v, want %v", rrs[0].(*dns.CNAME).Target, "host2.local.")
+		}
 	})
 
 	// Test hostExists
 	t.Run("hostExists", func(t *testing.T) {
-		assert.True(t, h.hostExists(db, "localhost"))
-		assert.True(t, h.hostExists(db, "local"))             // alias
-		assert.True(t, h.hostExists(db, "test.wildcard.com")) // wildcard
-		assert.False(t, h.hostExists(db, "notfound.com"))
+		if !(h.hostExists(db, "localhost")) {
+			t.Errorf("h.hostExists(db, 'localhost') is false")
+		}
+		if !(h.hostExists(db, "local")) {
+			t.Errorf("h.hostExists(db, 'local') is false")
+		} // alias
+		if !(h.hostExists(db, "test.wildcard.com")) {
+			t.Errorf("h.hostExists(db, 'test.wildcard.com') is false")
+		} // wildcard
+		if h.hostExists(db, "notfound.com") {
+			t.Errorf("h.hostExists(db, 'notfound.com') is true")
+		}
 	})
 }
 
@@ -331,13 +429,25 @@ func TestParseLine(t *testing.T) {
 			ip, hosts, comment := parseLine(tt.line)
 
 			if tt.shouldParse {
-				require.NotNil(t, ip)
-				assert.Equal(t, tt.expectedIP, ip.String())
-				assert.Equal(t, tt.expectedHosts, hosts)
-				assert.Equal(t, tt.expectedComment, comment)
+				if ip == nil {
+					t.Fatalf("ip is nil")
+				}
+				if !reflect.DeepEqual(tt.expectedIP, ip.String()) {
+					t.Errorf("ip.String() = %v, want %v", ip.String(), tt.expectedIP)
+				}
+				if !reflect.DeepEqual(tt.expectedHosts, hosts) {
+					t.Errorf("hosts = %v, want %v", hosts, tt.expectedHosts)
+				}
+				if !reflect.DeepEqual(tt.expectedComment, comment) {
+					t.Errorf("comment = %v, want %v", comment, tt.expectedComment)
+				}
 			} else {
-				assert.Nil(t, ip)
-				assert.Nil(t, hosts)
+				if ip != nil {
+					t.Errorf("ip = %v, want nil", ip)
+				}
+				if hosts != nil {
+					t.Errorf("hosts = %v, want nil", hosts)
+				}
 			}
 		})
 	}
@@ -359,7 +469,9 @@ func TestMatchWildcard(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(fmt.Sprintf("%s matches %s", tt.pattern, tt.name), func(t *testing.T) {
-			assert.Equal(t, tt.match, matchWildcard(tt.pattern, tt.name))
+			if !reflect.DeepEqual(tt.match, matchWildcard(tt.pattern, tt.name)) {
+				t.Errorf("matchWildcard(tt.pattern, tt.name) = %v, want %v", matchWildcard(tt.pattern, tt.name), tt.match)
+			}
 		})
 	}
 }
@@ -382,20 +494,34 @@ invalid line
 	}
 
 	err := h.load()
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	db := h.getDB()
-	assert.Equal(t, int64(4), atomic.LoadInt64(&db.stats.entries)) // localhost, host1, alias1, alias2
-	assert.Equal(t, int64(1), atomic.LoadInt64(&db.stats.wildcards))
+	if !reflect.DeepEqual(int64(4), atomic.LoadInt64(&db.stats.entries)) {
+		t.Errorf("atomic.LoadInt64(&db.stats.entries) = %v, want %v", atomic.LoadInt64(&db.stats.entries), int64(4))
+	} // localhost, host1, alias1, alias2
+	if !reflect.DeepEqual(int64(1), atomic.LoadInt64(&db.stats.wildcards)) {
+		t.Errorf("atomic.LoadInt64(&db.stats.wildcards) = %v, want %v", atomic.LoadInt64(&db.stats.wildcards), int64(1))
+	}
 
 	// Check reverse mappings
-	assert.Contains(t, db.reverse["127.0.0.1"], "localhost")
-	assert.Contains(t, db.reverse["192.168.1.1"], "host1")
+	if !slices.Contains(db.reverse["127.0.0.1"], "localhost") {
+		t.Errorf("reverse[127.0.0.1] %v does not contain localhost", db.reverse["127.0.0.1"])
+	}
+	if !slices.Contains(db.reverse["192.168.1.1"], "host1") {
+		t.Errorf("reverse[192.168.1.1] %v does not contain host1", db.reverse["192.168.1.1"])
+	}
 
 	// Check aliases
 	entry := db.hosts["host1"]
-	assert.Contains(t, entry.Aliases, "alias1")
-	assert.Contains(t, entry.Aliases, "alias2")
+	if !slices.Contains(entry.Aliases, "alias1") {
+		t.Errorf("aliases %v do not contain alias1", entry.Aliases)
+	}
+	if !slices.Contains(entry.Aliases, "alias2") {
+		t.Errorf("aliases %v do not contain alias2", entry.Aliases)
+	}
 }
 
 func TestFileWatcher(t *testing.T) {
@@ -410,12 +536,18 @@ func TestFileWatcher(t *testing.T) {
 
 	cfg := &config.Config{HostsFile: tmpFile}
 	h := New(cfg)
-	require.NotNil(t, h)
-	require.NotNil(t, h.watcher)
+	if h == nil {
+		t.Fatalf("h is nil")
+	}
+	if h.watcher == nil {
+		t.Fatalf("h.watcher is nil")
+	}
 
 	// Initial state
 	db := h.getDB()
-	assert.Equal(t, int64(1), atomic.LoadInt64(&db.stats.entries))
+	if !reflect.DeepEqual(int64(1), atomic.LoadInt64(&db.stats.entries)) {
+		t.Errorf("atomic.LoadInt64(&db.stats.entries) = %v, want %v", atomic.LoadInt64(&db.stats.entries), int64(1))
+	}
 
 	// Update file
 	newContent := `
@@ -423,7 +555,9 @@ func TestFileWatcher(t *testing.T) {
 192.168.1.1 newhost
 `
 	err := os.WriteFile(tmpFile, []byte(newContent), 0644) //nolint:gosec // G306 - test file
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	// Wait for reload with timeout
 	timeout := time.After(2 * time.Second)
@@ -457,7 +591,9 @@ func TestStats(t *testing.T) {
 		path: tmpFile,
 		ttl:  300,
 	}
-	require.NoError(t, h.load())
+	if err := h.load(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	// Simulate some lookups
 	db := h.getDB()
@@ -465,11 +601,21 @@ func TestStats(t *testing.T) {
 	atomic.AddUint64(&db.stats.hits, 75)
 
 	stats := h.Stats()
-	assert.Equal(t, int64(2), stats["entries"])
-	assert.Equal(t, int64(1), stats["wildcards"])
-	assert.Equal(t, uint64(100), stats["lookups"])
-	assert.Equal(t, uint64(75), stats["hits"])
-	assert.NotEmpty(t, stats["reload_time"])
+	if !reflect.DeepEqual(int64(2), stats["entries"]) {
+		t.Errorf("stats['entries'] = %v, want %v", stats["entries"], int64(2))
+	}
+	if !reflect.DeepEqual(int64(1), stats["wildcards"]) {
+		t.Errorf("stats['wildcards'] = %v, want %v", stats["wildcards"], int64(1))
+	}
+	if !reflect.DeepEqual(uint64(100), stats["lookups"]) {
+		t.Errorf("stats['lookups'] = %v, want %v", stats["lookups"], uint64(100))
+	}
+	if !reflect.DeepEqual(uint64(75), stats["hits"]) {
+		t.Errorf("stats['hits'] = %v, want %v", stats["hits"], uint64(75))
+	}
+	if s, _ := stats["reload_time"].(string); s == "" {
+		t.Errorf("stats['reload_time'] is empty")
+	}
 }
 
 func TestConcurrentAccess(t *testing.T) {
@@ -484,7 +630,9 @@ func TestConcurrentAccess(t *testing.T) {
 		path: tmpFile,
 		ttl:  300,
 	}
-	require.NoError(t, h.load())
+	if err := h.load(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	// Concurrent lookups
 	var wg sync.WaitGroup
@@ -505,7 +653,9 @@ func TestConcurrentAccess(t *testing.T) {
 			ch.Reset(w, req)
 
 			h.ServeDNS(context.Background(), ch)
-			assert.True(t, w.Written())
+			if !(w.Written()) {
+				t.Errorf("w.Written() is false")
+			}
 		}(i)
 	}
 
@@ -515,7 +665,9 @@ func TestConcurrentAccess(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < 10; i++ {
 			err := h.load()
-			assert.NoError(t, err)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
 			time.Sleep(10 * time.Millisecond)
 		}
 	}()
@@ -526,7 +678,9 @@ func TestConcurrentAccess(t *testing.T) {
 	db := h.getDB()
 	// Since we do concurrent reloads, the DB might have been replaced
 	// Just verify we have the expected number of entries
-	assert.Equal(t, int64(2), atomic.LoadInt64(&db.stats.entries))
+	if !reflect.DeepEqual(int64(2), atomic.LoadInt64(&db.stats.entries)) {
+		t.Errorf("atomic.LoadInt64(&db.stats.entries) = %v, want %v", atomic.LoadInt64(&db.stats.entries), int64(2))
+	}
 }
 
 func TestMultipleIPs(t *testing.T) {
@@ -543,7 +697,9 @@ func TestMultipleIPs(t *testing.T) {
 		path: tmpFile,
 		ttl:  300,
 	}
-	require.NoError(t, h.load())
+	if err := h.load(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	// Test A records
 	req := new(dns.Msg)
@@ -554,10 +710,14 @@ func TestMultipleIPs(t *testing.T) {
 	ch.Reset(w, req)
 
 	h.ServeDNS(context.Background(), ch)
-	require.True(t, w.Written())
+	if !(w.Written()) {
+		t.Fatalf("w.Written() is false")
+	}
 
 	resp := w.Msg()
-	assert.Len(t, resp.Answer, 2)
+	if len(resp.Answer) != 2 {
+		t.Errorf("len(resp.Answer) = %d, want %d", len(resp.Answer), 2)
+	}
 
 	// Test AAAA records
 	req.SetQuestion("multi.local.", dns.TypeAAAA)
@@ -565,10 +725,14 @@ func TestMultipleIPs(t *testing.T) {
 	ch.Reset(w, req)
 
 	h.ServeDNS(context.Background(), ch)
-	require.True(t, w.Written())
+	if !(w.Written()) {
+		t.Fatalf("w.Written() is false")
+	}
 
 	resp = w.Msg()
-	assert.Len(t, resp.Answer, 2)
+	if len(resp.Answer) != 2 {
+		t.Errorf("len(resp.Answer) = %d, want %d", len(resp.Answer), 2)
+	}
 }
 
 // Helper function to create temporary hosts file.
@@ -582,7 +746,9 @@ func createTempHostsFile(t *testing.T, content string) string {
 	}
 
 	err := os.WriteFile(tmpFile, []byte(content), 0644) //nolint:gosec // G306 - test file
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	return tmpFile
 }

--- a/middleware/metrics/metrics_test.go
+++ b/middleware/metrics/metrics_test.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strings"
 	"sync/atomic"
 	"testing"
@@ -12,7 +13,6 @@ import (
 	"github.com/semihalev/sdns/config"
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/semihalev/sdns/middleware"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_Metrics(t *testing.T) {
@@ -21,7 +21,9 @@ func Test_Metrics(t *testing.T) {
 
 	m := middleware.Get("metrics").(*Metrics)
 
-	assert.Equal(t, "metrics", m.Name())
+	if !reflect.DeepEqual("metrics", m.Name()) {
+		t.Errorf("m.Name() = %v, want %v", m.Name(), "metrics")
+	}
 
 	ch := middleware.NewChain([]middleware.Handler{})
 
@@ -32,13 +34,19 @@ func Test_Metrics(t *testing.T) {
 	ch.Reset(mw, req)
 
 	m.ServeDNS(context.Background(), ch)
-	assert.Equal(t, dns.RcodeServerFailure, mw.Rcode())
+	if !reflect.DeepEqual(dns.RcodeServerFailure, mw.Rcode()) {
+		t.Errorf("mw.Rcode() = %v, want %v", mw.Rcode(), dns.RcodeServerFailure)
+	}
 
 	_ = ch.Writer.WriteMsg(req)
-	assert.Equal(t, true, ch.Writer.Written())
+	if !reflect.DeepEqual(true, ch.Writer.Written()) {
+		t.Errorf("ch.Writer.Written() = %v, want %v", ch.Writer.Written(), true)
+	}
 
 	m.ServeDNS(context.Background(), ch)
-	assert.Equal(t, dns.RcodeSuccess, mw.Rcode())
+	if !reflect.DeepEqual(dns.RcodeSuccess, mw.Rcode()) {
+		t.Errorf("mw.Rcode() = %v, want %v", mw.Rcode(), dns.RcodeSuccess)
+	}
 }
 
 func Test_DomainMetrics(t *testing.T) {
@@ -49,9 +57,15 @@ func Test_DomainMetrics(t *testing.T) {
 	}
 
 	m := New(cfg)
-	assert.NotNil(t, m.domainQueries)
-	assert.True(t, m.domainMetricsEnabled)
-	assert.Equal(t, 3, m.domainMetricsLimit)
+	if m.domainQueries == nil {
+		t.Fatalf("m.domainQueries is nil")
+	}
+	if !(m.domainMetricsEnabled) {
+		t.Errorf("m.domainMetricsEnabled is false")
+	}
+	if !reflect.DeepEqual(3, m.domainMetricsLimit) {
+		t.Errorf("m.domainMetricsLimit = %v, want %v", m.domainMetricsLimit, 3)
+	}
 
 	ch := middleware.NewChain([]middleware.Handler{})
 
@@ -69,7 +83,9 @@ func Test_DomainMetrics(t *testing.T) {
 	}
 
 	// Check that only 3 domains are tracked due to limit
-	assert.Equal(t, int32(3), atomic.LoadInt32(&m.domainCount))
+	if !reflect.DeepEqual(int32(3), atomic.LoadInt32(&m.domainCount)) {
+		t.Errorf("atomic.LoadInt32(&m.domainCount) = %v, want %v", atomic.LoadInt32(&m.domainCount), int32(3))
+	}
 }
 
 func Test_DomainMetrics_Disabled(t *testing.T) {
@@ -79,8 +95,12 @@ func Test_DomainMetrics_Disabled(t *testing.T) {
 	}
 
 	m := New(cfg)
-	assert.Nil(t, m.domainQueries)
-	assert.False(t, m.domainMetricsEnabled)
+	if m.domainQueries != nil {
+		t.Errorf("m.domainQueries = %v, want nil", m.domainQueries)
+	}
+	if m.domainMetricsEnabled {
+		t.Errorf("m.domainMetricsEnabled is true")
+	}
 
 	ch := middleware.NewChain([]middleware.Handler{})
 	mw := mock.NewWriter("udp", "127.0.0.1:0")
@@ -92,7 +112,9 @@ func Test_DomainMetrics_Disabled(t *testing.T) {
 	m.ServeDNS(context.Background(), ch)
 
 	// No domains should be tracked
-	assert.Equal(t, int32(0), atomic.LoadInt32(&m.domainCount))
+	if !reflect.DeepEqual(int32(0), atomic.LoadInt32(&m.domainCount)) {
+		t.Errorf("atomic.LoadInt32(&m.domainCount) = %v, want %v", atomic.LoadInt32(&m.domainCount), int32(0))
+	}
 }
 
 func Test_DomainMetrics_Unlimited(t *testing.T) {
@@ -103,8 +125,12 @@ func Test_DomainMetrics_Unlimited(t *testing.T) {
 	}
 
 	m := New(cfg)
-	assert.NotNil(t, m.domainQueries)
-	assert.Equal(t, 0, m.domainMetricsLimit)
+	if m.domainQueries == nil {
+		t.Fatalf("m.domainQueries is nil")
+	}
+	if !reflect.DeepEqual(0, m.domainMetricsLimit) {
+		t.Errorf("m.domainMetricsLimit = %v, want %v", m.domainMetricsLimit, 0)
+	}
 
 	ch := middleware.NewChain([]middleware.Handler{})
 
@@ -120,7 +146,9 @@ func Test_DomainMetrics_Unlimited(t *testing.T) {
 	}
 
 	// All domains should be tracked (unlimited)
-	assert.Equal(t, int32(10), atomic.LoadInt32(&m.domainCount))
+	if !reflect.DeepEqual(int32(10), atomic.LoadInt32(&m.domainCount)) {
+		t.Errorf("atomic.LoadInt32(&m.domainCount) = %v, want %v", atomic.LoadInt32(&m.domainCount), int32(10))
+	}
 }
 
 func Test_DomainMetrics_TopDomains(t *testing.T) {
@@ -163,11 +191,15 @@ func Test_DomainMetrics_TopDomains(t *testing.T) {
 	}
 
 	// Should have tracked first 5 domains
-	assert.Equal(t, int32(5), atomic.LoadInt32(&m.domainCount))
+	if !reflect.DeepEqual(int32(5), atomic.LoadInt32(&m.domainCount)) {
+		t.Errorf("atomic.LoadInt32(&m.domainCount) = %v, want %v", atomic.LoadInt32(&m.domainCount), int32(5))
+	}
 
 	// The unpopular domain should have triggered cleanup but still not be tracked
 	_, exists := m.domainTracker.Load(strings.ToLower(strings.TrimSuffix("unpopular.com.", ".")))
-	assert.False(t, exists)
+	if exists {
+		t.Errorf("exists is true")
+	}
 }
 
 func Test_DomainMetrics_EvictionAfterCleanup(t *testing.T) {
@@ -195,7 +227,9 @@ func Test_DomainMetrics_EvictionAfterCleanup(t *testing.T) {
 	}
 
 	// Should have 3 domains
-	assert.Equal(t, int32(3), atomic.LoadInt32(&m.domainCount))
+	if !reflect.DeepEqual(int32(3), atomic.LoadInt32(&m.domainCount)) {
+		t.Errorf("atomic.LoadInt32(&m.domainCount) = %v, want %v", atomic.LoadInt32(&m.domainCount), int32(3))
+	}
 
 	// Try to add a new domain when at limit - it should not be tracked
 	mw := mock.NewWriter("udp", "127.0.0.1:0")
@@ -206,17 +240,23 @@ func Test_DomainMetrics_EvictionAfterCleanup(t *testing.T) {
 	m.ServeDNS(context.Background(), ch)
 
 	// Should still have 3 domains (limit enforced)
-	assert.Equal(t, int32(3), atomic.LoadInt32(&m.domainCount))
+	if !reflect.DeepEqual(int32(3), atomic.LoadInt32(&m.domainCount)) {
+		t.Errorf("atomic.LoadInt32(&m.domainCount) = %v, want %v", atomic.LoadInt32(&m.domainCount), int32(3))
+	}
 
 	// The new domain should not be tracked
 	_, exists := m.domainTracker.Load(strings.ToLower(strings.TrimSuffix("newdomain.com.", ".")))
-	assert.False(t, exists, "newdomain.com should not be tracked when at limit")
+	if exists {
+		t.Errorf("%s: exists is true", "newdomain.com should not be tracked when at limit")
+	}
 
 	// Original domains should still be tracked
 	for i := 1; i <= 3; i++ {
 		domain := fmt.Sprintf("domain%d.com", i)
 		_, exists := m.domainTracker.Load(strings.ToLower(domain))
-		assert.True(t, exists, fmt.Sprintf("%s should still be tracked", domain))
+		if !(exists) {
+			t.Errorf("%s: exists is false", fmt.Sprintf("%s should still be tracked", domain))
+		}
 	}
 }
 
@@ -253,7 +293,9 @@ func Test_DomainMetrics_CleanupKeepsTopDomains(t *testing.T) {
 	}
 
 	// Should have 2 domains
-	assert.Equal(t, int32(2), atomic.LoadInt32(&m.domainCount))
+	if !reflect.DeepEqual(int32(2), atomic.LoadInt32(&m.domainCount)) {
+		t.Errorf("atomic.LoadInt32(&m.domainCount) = %v, want %v", atomic.LoadInt32(&m.domainCount), int32(2))
+	}
 
 	// Add two more domains to go over limit
 	newDomains := []struct {
@@ -281,21 +323,31 @@ func Test_DomainMetrics_CleanupKeepsTopDomains(t *testing.T) {
 	m.maybeCleanupDomains()
 
 	// Should be back to limit
-	assert.LessOrEqual(t, int(atomic.LoadInt32(&m.domainCount)), 3)
+	if int(atomic.LoadInt32(&m.domainCount)) > 3 {
+		t.Errorf("int(atomic.LoadInt32(&m.domainCount)) = %v, want <= %v", int(atomic.LoadInt32(&m.domainCount)), 3)
+	}
 
 	// Top 3 domains should be tracked (domain3, domain2, domain1)
 	_, exists := m.domainTracker.Load(strings.ToLower(strings.TrimSuffix("domain3.com.", ".")))
-	assert.True(t, exists, "domain3.com (30 queries) should be tracked")
+	if !(exists) {
+		t.Errorf("%s: exists is false", "domain3.com (30 queries) should be tracked")
+	}
 
 	_, exists = m.domainTracker.Load(strings.ToLower(strings.TrimSuffix("domain2.com.", ".")))
-	assert.True(t, exists, "domain2.com (20 queries) should be tracked")
+	if !(exists) {
+		t.Errorf("%s: exists is false", "domain2.com (20 queries) should be tracked")
+	}
 
 	_, exists = m.domainTracker.Load(strings.ToLower(strings.TrimSuffix("domain1.com.", ".")))
-	assert.True(t, exists, "domain1.com (10 queries) should be tracked")
+	if !(exists) {
+		t.Errorf("%s: exists is false", "domain1.com (10 queries) should be tracked")
+	}
 
 	// Lowest count domain should be evicted
 	_, exists = m.domainTracker.Load(strings.ToLower(strings.TrimSuffix("domain4.com.", ".")))
-	assert.False(t, exists, "domain4.com (5 queries) should have been evicted")
+	if exists {
+		t.Errorf("%s: exists is true", "domain4.com (5 queries) should have been evicted")
+	}
 }
 
 func Test_DomainMetrics_SingleLabelFiltering(t *testing.T) {
@@ -328,7 +380,9 @@ func Test_DomainMetrics_SingleLabelFiltering(t *testing.T) {
 	}
 
 	// No single-label domains should be tracked
-	assert.Equal(t, int32(0), atomic.LoadInt32(&m.domainCount))
+	if !reflect.DeepEqual(int32(0), atomic.LoadInt32(&m.domainCount)) {
+		t.Errorf("atomic.LoadInt32(&m.domainCount) = %v, want %v", atomic.LoadInt32(&m.domainCount), int32(0))
+	}
 
 	// Test multi-label domains that should be tracked
 	multiLabelDomains := []string{
@@ -349,12 +403,16 @@ func Test_DomainMetrics_SingleLabelFiltering(t *testing.T) {
 	}
 
 	// All multi-label domains should be tracked
-	assert.Equal(t, int32(len(multiLabelDomains)), atomic.LoadInt32(&m.domainCount)) //nolint:gosec // G115 - test value
+	if want := int32(len(multiLabelDomains)); atomic.LoadInt32(&m.domainCount) != want { //nolint:gosec // G115 - test value
+		t.Errorf("atomic.LoadInt32(&m.domainCount) = %v, want %v", atomic.LoadInt32(&m.domainCount), want)
+	}
 
 	// Verify each multi-label domain is tracked
 	for _, domain := range multiLabelDomains {
 		normalized := strings.ToLower(strings.TrimSuffix(domain, "."))
 		_, exists := m.domainTracker.Load(normalized)
-		assert.True(t, exists, fmt.Sprintf("%s should be tracked", domain))
+		if !(exists) {
+			t.Errorf("%s: exists is false", fmt.Sprintf("%s should be tracked", domain))
+		}
 	}
 }

--- a/middleware/middleware_test.go
+++ b/middleware/middleware_test.go
@@ -2,12 +2,12 @@ package middleware
 
 import (
 	"context"
+	"reflect"
 	"sync"
 	"testing"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/config"
-	"github.com/stretchr/testify/assert"
 )
 
 type dummy struct{}
@@ -26,22 +26,42 @@ func Test_DefaultRegistry_Setup(t *testing.T) {
 
 	Register("dummy", func(*config.Config) Handler { return &dummy{} })
 
-	assert.Nil(t, Get("dummy"), "Get before Setup must return nil")
-	assert.False(t, Ready())
+	if Get("dummy") != nil {
+		t.Errorf("%s: Get('dummy') = %v, want nil", "Get before Setup must return nil", Get("dummy"))
+	}
+	if Ready() {
+		t.Errorf("Ready() is true")
+	}
 
 	Setup(&config.Config{})
 
-	assert.True(t, Ready())
-	assert.Panics(t, func() { Setup(&config.Config{}) }, "double Setup must panic")
+	if !(Ready()) {
+		t.Errorf("Ready() is false")
+	}
+	if !func() (panicked bool) {
+		defer func() { panicked = recover() != nil }()
+		Setup(&config.Config{})
+		return
+	}() {
+		t.Error("double Setup must panic")
+	}
 
-	assert.Equal(t, []string{"dummy"}, List())
-	assert.Equal(t, 1, len(Handlers()))
+	if !reflect.DeepEqual([]string{"dummy"}, List()) {
+		t.Errorf("List() = %v, want %v", List(), []string{"dummy"})
+	}
+	if !reflect.DeepEqual(1, len(Handlers())) {
+		t.Errorf("len(Handlers()) = %v, want %v", len(Handlers()), 1)
+	}
 
 	d := Get("dummy")
-	if assert.NotNil(t, d) {
-		assert.Equal(t, "dummy", d.Name())
+	if d == nil {
+		t.Error("d is nil")
+	} else if !reflect.DeepEqual("dummy", d.Name()) {
+		t.Errorf("d.Name() = %v, want %v", d.Name(), "dummy")
 	}
-	assert.Nil(t, Get("none"))
+	if Get("none") != nil {
+		t.Errorf("Get('none') = %v, want nil", Get("none"))
+	}
 }
 
 // Test_Get_SkipsDisabled guards against a regression where disabled
@@ -59,15 +79,25 @@ func Test_Get_SkipsDisabled(t *testing.T) {
 
 	Setup(&config.Config{})
 
-	assert.Equal(t, 2, len(Handlers()))
-	assert.Equal(t, []string{"first", "disabled", "second"}, List())
-
-	if h := Get("first"); assert.NotNil(t, h) {
-		assert.Equal(t, "first", h.Name())
+	if !reflect.DeepEqual(2, len(Handlers())) {
+		t.Errorf("len(Handlers()) = %v, want %v", len(Handlers()), 2)
 	}
-	assert.Nil(t, Get("disabled"))
-	if h := Get("second"); assert.NotNil(t, h) {
-		assert.Equal(t, "second", h.Name())
+	if !reflect.DeepEqual([]string{"first", "disabled", "second"}, List()) {
+		t.Errorf("List() = %v, want %v", List(), []string{"first", "disabled", "second"})
+	}
+
+	if h := Get("first"); h == nil {
+		t.Error("h is nil")
+	} else if !reflect.DeepEqual("first", h.Name()) {
+		t.Errorf("h.Name() = %v, want %v", h.Name(), "first")
+	}
+	if Get("disabled") != nil {
+		t.Errorf("Get('disabled') = %v, want nil", Get("disabled"))
+	}
+	if h := Get("second"); h == nil {
+		t.Error("h is nil")
+	} else if !reflect.DeepEqual("second", h.Name()) {
+		t.Errorf("h.Name() = %v, want %v", h.Name(), "second")
 	}
 }
 
@@ -78,20 +108,38 @@ func Test_Registry_RegisterAt(t *testing.T) {
 	r.RegisterAt("dummy2", func(*config.Config) Handler { return &dummy{} }, 0)
 	r.RegisterBefore("dummy3", func(*config.Config) Handler { return &dummy{} }, "dummy")
 
-	assert.Equal(t, []string{"dummy2", "dummy3", "dummy"}, r.List())
+	if !reflect.DeepEqual([]string{"dummy2", "dummy3", "dummy"}, r.List()) {
+		t.Errorf("r.List() = %v, want %v", r.List(), []string{"dummy2", "dummy3", "dummy"})
+	}
 
-	assert.Panics(t, func() {
+	if !func() (panicked bool) {
+		defer func() { panicked = recover() != nil }()
 		r.RegisterAt("tooHigh", func(*config.Config) Handler { return &dummy{} }, 99)
-	})
-	assert.Panics(t, func() {
+		return
+	}() {
+		t.Error("RegisterAt above the end must panic")
+	}
+	if !func() (panicked bool) {
+		defer func() { panicked = recover() != nil }()
 		r.RegisterAt("tooLow", func(*config.Config) Handler { return &dummy{} }, -1)
-	})
-	assert.Panics(t, func() {
+		return
+	}() {
+		t.Error("RegisterAt below zero must panic")
+	}
+	if !func() (panicked bool) {
+		defer func() { panicked = recover() != nil }()
 		r.RegisterBefore("orphan", func(*config.Config) Handler { return &dummy{} }, "nope")
-	})
-	assert.Panics(t, func() {
+		return
+	}() {
+		t.Error("RegisterBefore an unknown name must panic")
+	}
+	if !func() (panicked bool) {
+		defer func() { panicked = recover() != nil }()
 		r.Register("dummy", func(*config.Config) Handler { return &dummy{} })
-	}, "duplicate Register must panic")
+		return
+	}() {
+		t.Error("duplicate Register must panic")
+	}
 }
 
 func Test_Registry_Build_ConcurrentReads(t *testing.T) {
@@ -119,12 +167,24 @@ func Test_Registry_Build_ConcurrentReads(t *testing.T) {
 
 func Test_Pipeline_NilSafe(t *testing.T) {
 	var p *Pipeline
-	assert.Nil(t, p.Handlers())
-	assert.Nil(t, p.Get("anything"))
-	assert.Nil(t, p.List())
-	assert.Nil(t, p.SubPipeline("x"))
-	assert.Nil(t, p.NewChain())
-	assert.Nil(t, p.Purgers())
+	if p.Handlers() != nil {
+		t.Errorf("p.Handlers() = %v, want nil", p.Handlers())
+	}
+	if p.Get("anything") != nil {
+		t.Errorf("p.Get('anything') = %v, want nil", p.Get("anything"))
+	}
+	if p.List() != nil {
+		t.Errorf("p.List() = %v, want nil", p.List())
+	}
+	if p.SubPipeline("x") != nil {
+		t.Errorf("p.SubPipeline('x') = %v, want nil", p.SubPipeline("x"))
+	}
+	if p.NewChain() != nil {
+		t.Errorf("p.NewChain() = %v, want nil", p.NewChain())
+	}
+	if p.Purgers() != nil {
+		t.Errorf("p.Purgers() = %v, want nil", p.Purgers())
+	}
 }
 
 // purgerHandler implements both Handler and Purger; used to verify
@@ -149,14 +209,24 @@ func Test_Pipeline_SubPipeline_FiltersByName(t *testing.T) {
 	Setup(&config.Config{})
 
 	sub := GlobalPipeline().SubPipeline("b")
-	assert.Equal(t, 2, len(sub.Handlers()))
-	assert.Equal(t, "a", sub.Handlers()[0].Name())
-	assert.Equal(t, "c", sub.Handlers()[1].Name())
-	assert.Nil(t, sub.Get("b"), "filtered handler must not be reachable via Get")
+	if !reflect.DeepEqual(2, len(sub.Handlers())) {
+		t.Errorf("len(sub.Handlers()) = %v, want %v", len(sub.Handlers()), 2)
+	}
+	if !reflect.DeepEqual("a", sub.Handlers()[0].Name()) {
+		t.Errorf("sub.Handlers()[0].Name() = %v, want %v", sub.Handlers()[0].Name(), "a")
+	}
+	if !reflect.DeepEqual("c", sub.Handlers()[1].Name()) {
+		t.Errorf("sub.Handlers()[1].Name() = %v, want %v", sub.Handlers()[1].Name(), "c")
+	}
+	if sub.Get("b") != nil {
+		t.Errorf("%s: sub.Get('b') = %v, want nil", "filtered handler must not be reachable via Get", sub.Get("b"))
+	}
 
 	// Skipping a name that isn't in the pipeline is a no-op.
 	sub2 := GlobalPipeline().SubPipeline("nope")
-	assert.Equal(t, 3, len(sub2.Handlers()))
+	if !reflect.DeepEqual(3, len(sub2.Handlers())) {
+		t.Errorf("len(sub2.Handlers()) = %v, want %v", len(sub2.Handlers()), 3)
+	}
 }
 
 func Test_Pipeline_NewChain_IsFreshPerCall(t *testing.T) {
@@ -169,9 +239,15 @@ func Test_Pipeline_NewChain_IsFreshPerCall(t *testing.T) {
 	p := GlobalPipeline()
 	c1 := p.NewChain()
 	c2 := p.NewChain()
-	assert.NotNil(t, c1)
-	assert.NotNil(t, c2)
-	assert.NotSame(t, c1, c2, "each NewChain call must return a distinct instance")
+	if c1 == nil {
+		t.Fatalf("c1 is nil")
+	}
+	if c2 == nil {
+		t.Fatalf("c2 is nil")
+	}
+	if c1 == c2 {
+		t.Errorf("%s: %p is the same pointer", "each NewChain call must return a distinct instance", c1)
+	}
 }
 
 func Test_Pipeline_Purgers_EnumeratesOnlyPurgerHandlers(t *testing.T) {
@@ -187,12 +263,18 @@ func Test_Pipeline_Purgers_EnumeratesOnlyPurgerHandlers(t *testing.T) {
 	Setup(&config.Config{})
 
 	pp := GlobalPipeline().Purgers()
-	assert.Equal(t, 2, len(pp), "non-Purger handlers must be excluded")
+	if !reflect.DeepEqual(2, len(pp)) {
+		t.Errorf("%s: len(pp) = %v, want %v", "non-Purger handlers must be excluded", len(pp), 2)
+	}
 
 	q := dns.Question{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
 	for _, pr := range pp {
 		pr.Purge(q)
 	}
-	assert.Equal(t, []string{"example.com."}, p1.purgedQ)
-	assert.Equal(t, []string{"example.com."}, p2.purgedQ)
+	if !reflect.DeepEqual([]string{"example.com."}, p1.purgedQ) {
+		t.Errorf("p1.purgedQ = %v, want %v", p1.purgedQ, []string{"example.com."})
+	}
+	if !reflect.DeepEqual([]string{"example.com."}, p2.purgedQ) {
+		t.Errorf("p2.purgedQ = %v, want %v", p2.purgedQ, []string{"example.com."})
+	}
 }

--- a/middleware/ratelimit/rate_limit_complete_test.go
+++ b/middleware/ratelimit/rate_limit_complete_test.go
@@ -3,6 +3,7 @@ package ratelimit
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -12,7 +13,6 @@ import (
 	"github.com/semihalev/sdns/config"
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/semihalev/sdns/middleware"
-	"github.com/stretchr/testify/assert"
 )
 
 // TestRateLimitEnforcement verifies rate limiting works correctly
@@ -49,11 +49,15 @@ func TestRateLimitEnforcement(t *testing.T) {
 
 		// First 5 should be allowed (burst size)
 		for i := 0; i < 5; i++ {
-			assert.True(t, testRequest(ip), "Request %d should be allowed", i+1)
+			if !(testRequest(ip)) {
+				t.Errorf("%s: testRequest(ip) is false", fmt.Sprintf("Request %d should be allowed", i+1))
+			}
 		}
 
 		// 6th should be blocked
-		assert.False(t, testRequest(ip), "6th request should be blocked")
+		if testRequest(ip) {
+			t.Errorf("%s: testRequest(ip) is true", "6th request should be blocked")
+		}
 	})
 
 	// Test different IPs have separate limits
@@ -64,11 +68,15 @@ func TestRateLimitEnforcement(t *testing.T) {
 
 			// Each IP should get 5 requests
 			for j := 0; j < 5; j++ {
-				assert.True(t, testRequest(ip), "IP %s request %d should be allowed", ip, j+1)
+				if !(testRequest(ip)) {
+					t.Errorf("%s: testRequest(ip) is false", fmt.Sprintf("IP %s request %d should be allowed", ip, j+1))
+				}
 			}
 
 			// 6th should be blocked
-			assert.False(t, testRequest(ip), "IP %s 6th request should be blocked", ip)
+			if testRequest(ip) {
+				t.Errorf("%s: testRequest(ip) is true", fmt.Sprintf("IP %s 6th request should be blocked", ip))
+			}
 		}
 	})
 
@@ -97,17 +105,25 @@ func TestRateLimitEnforcement(t *testing.T) {
 		}
 
 		for i := range perMinute {
-			assert.True(t, allow(), "Initial request %d should be allowed", i+1)
+			if !(allow()) {
+				t.Errorf("%s: allow() is false", fmt.Sprintf("Initial request %d should be allowed", i+1))
+			}
 		}
-		assert.False(t, allow(), "Should be rate limited after burst")
+		if allow() {
+			t.Errorf("%s: allow() is true", "Should be rate limited after burst")
+		}
 
 		// One token's worth, plus enough margin that a slow scheduler does
 		// not turn this into a flake — but well under the two seconds that
 		// would hand out a second token.
 		time.Sleep(1200 * time.Millisecond)
 
-		assert.True(t, allow(), "Should allow after token regeneration")
-		assert.False(t, allow(), "Should block again after using regenerated token")
+		if !(allow()) {
+			t.Errorf("%s: allow() is false", "Should allow after token regeneration")
+		}
+		if allow() {
+			t.Errorf("%s: allow() is true", "Should block again after using regenerated token")
+		}
 	})
 }
 
@@ -137,7 +153,9 @@ func TestRateLimitBypassConditions(t *testing.T) {
 			ch.Reset(mw, req)
 
 			rl.ServeDNS(context.Background(), ch)
-			assert.True(t, allowed, "Request %d with no IP should bypass rate limit", i+1)
+			if !(allowed) {
+				t.Errorf("%s: allowed is false", fmt.Sprintf("Request %d with no IP should bypass rate limit", i+1))
+			}
 		}
 	})
 
@@ -156,7 +174,9 @@ func TestRateLimitBypassConditions(t *testing.T) {
 			ch.Reset(mw, req)
 
 			rl.ServeDNS(context.Background(), ch)
-			assert.True(t, allowed, "Loopback request %d should not be rate limited", i+1)
+			if !(allowed) {
+				t.Errorf("%s: allowed is false", fmt.Sprintf("Loopback request %d should not be rate limited", i+1))
+			}
 		}
 	})
 
@@ -177,7 +197,9 @@ func TestRateLimitBypassConditions(t *testing.T) {
 			ch.Reset(mw, req)
 
 			rl.ServeDNS(context.Background(), ch)
-			assert.True(t, allowed, "Request %d should not be limited when rate=0", i+1)
+			if !(allowed) {
+				t.Errorf("%s: allowed is false", fmt.Sprintf("Request %d should not be limited when rate=0", i+1))
+			}
 		}
 
 		rl.rate = 1 // Re-enable for other tests
@@ -222,7 +244,9 @@ func TestRateLimitConcurrency(t *testing.T) {
 	}
 
 	wg.Wait()
-	assert.Equal(t, int32(0), errors.Load(), "Should handle concurrent access without errors")
+	if !reflect.DeepEqual(int32(0), errors.Load()) {
+		t.Errorf("%s: errors.Load() = %v, want %v", "Should handle concurrent access without errors", errors.Load(), int32(0))
+	}
 }
 
 // TestRateLimitStoreCleanup verifies old limiters are cleaned up
@@ -243,14 +267,18 @@ func TestRateLimitStoreCleanup(t *testing.T) {
 	}
 
 	initialCount := rl.store.Len()
-	assert.Equal(t, 100, initialCount, "Should have 100 limiters")
+	if !reflect.DeepEqual(100, initialCount) {
+		t.Errorf("%s: initialCount = %v, want %v", "Should have 100 limiters", initialCount, 100)
+	}
 
 	// Wait a bit and trigger cleanup
 	time.Sleep(100 * time.Millisecond)
 	rl.store.Cleanup(50 * time.Millisecond)
 
 	finalCount := rl.store.Len()
-	assert.Equal(t, 0, finalCount, "All limiters should be cleaned up")
+	if !reflect.DeepEqual(0, finalCount) {
+		t.Errorf("%s: finalCount = %v, want %v", "All limiters should be cleaned up", finalCount, 0)
+	}
 }
 
 // TestRateLimitPerformanceUnderAttack simulates attack conditions
@@ -280,10 +308,14 @@ func TestRateLimitPerformanceUnderAttack(t *testing.T) {
 	elapsed := time.Since(start)
 
 	// Should handle 100k requests quickly even under attack
-	assert.Less(t, elapsed, 5*time.Second, "Should handle 100k requests in < 5 seconds")
+	if elapsed >= 5*time.Second {
+		t.Errorf("%s: elapsed = %v, want < %v", "Should handle 100k requests in < 5 seconds", elapsed, 5*time.Second)
+	}
 
 	// Cache should not exceed limit
-	assert.LessOrEqual(t, rl.store.Len(), cacheSize, "Cache should not exceed size limit")
+	if rl.store.Len() > cacheSize {
+		t.Errorf("%s: rl.store.Len() = %v, want <= %v", "Cache should not exceed size limit", rl.store.Len(), cacheSize)
+	}
 
 	t.Logf("Processed 100k attack requests in %v, cache size: %d", elapsed, rl.store.Len())
 }

--- a/middleware/ratelimit/ratelimit_test.go
+++ b/middleware/ratelimit/ratelimit_test.go
@@ -2,13 +2,13 @@ package ratelimit
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/config"
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/semihalev/sdns/middleware"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_RateLimit(t *testing.T) {
@@ -24,7 +24,9 @@ func Test_RateLimit(t *testing.T) {
 
 	r := middleware.Get("ratelimit").(*RateLimit)
 
-	assert.Equal(t, "ratelimit", r.Name())
+	if !reflect.DeepEqual("ratelimit", r.Name()) {
+		t.Errorf("r.Name() = %v, want %v", r.Name(), "ratelimit")
+	}
 
 	ch := middleware.NewChain([]middleware.Handler{})
 
@@ -46,8 +48,10 @@ func Test_RateLimit(t *testing.T) {
 	ch.Reset(mw, req)
 	r.ServeDNS(context.Background(), ch)
 	r.ServeDNS(context.Background(), ch)
-	if assert.True(t, mw.Written()) {
-		assert.Equal(t, dns.RcodeBadCookie, mw.Rcode())
+	if !(mw.Written()) {
+		t.Errorf("mw.Written() is false")
+	} else if !reflect.DeepEqual(dns.RcodeBadCookie, mw.Rcode()) {
+		t.Errorf("mw.Rcode() = %v, want %v", mw.Rcode(), dns.RcodeBadCookie)
 	}
 
 	opt.Option = nil
@@ -59,20 +63,26 @@ func Test_RateLimit(t *testing.T) {
 	mw = mock.NewWriter("udp", "10.0.0.1:0")
 	ch.Reset(mw, req)
 	r.ServeDNS(context.Background(), ch)
-	assert.False(t, mw.Written())
+	if mw.Written() {
+		t.Errorf("mw.Written() is true")
+	}
 
 	mw = mock.NewWriter("tcp", "10.0.0.2:0")
 	ch.Reset(mw, req)
 	r.ServeDNS(context.Background(), ch)
 	r.ServeDNS(context.Background(), ch)
-	assert.False(t, mw.Written())
+	if mw.Written() {
+		t.Errorf("mw.Written() is true")
+	}
 
 	opt.Option = nil
 	mw = mock.NewWriter("udp", "10.0.0.1:0")
 	ch.Reset(mw, req)
 	r.ServeDNS(context.Background(), ch)
 	r.ServeDNS(context.Background(), ch)
-	assert.False(t, mw.Written())
+	if mw.Written() {
+		t.Errorf("mw.Written() is true")
+	}
 
 	mw = mock.NewWriter("udp", "0.0.0.0:0")
 	ch.Reset(mw, req)

--- a/middleware/recovery/recovery_test.go
+++ b/middleware/recovery/recovery_test.go
@@ -3,6 +3,7 @@ package recovery
 import (
 	"context"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/miekg/dns"
@@ -10,7 +11,6 @@ import (
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/zlog/v2"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_Recovery(t *testing.T) {
@@ -27,7 +27,9 @@ func Test_Recovery(t *testing.T) {
 
 	r := middleware.Get("recovery").(*Recovery)
 
-	assert.Equal(t, "recovery", r.Name())
+	if !reflect.DeepEqual("recovery", r.Name()) {
+		t.Errorf("r.Name() = %v, want %v", r.Name(), "recovery")
+	}
 
 	ch := middleware.NewChain([]middleware.Handler{r, nil})
 
@@ -39,7 +41,9 @@ func Test_Recovery(t *testing.T) {
 
 	r.ServeDNS(context.Background(), ch)
 
-	assert.Equal(t, dns.RcodeServerFailure, mw.Msg().Rcode)
+	if !reflect.DeepEqual(dns.RcodeServerFailure, mw.Msg().Rcode) {
+		t.Errorf("mw.Msg().Rcode = %v, want %v", mw.Msg().Rcode, dns.RcodeServerFailure)
+	}
 
 	ch = middleware.NewChain([]middleware.Handler{r})
 	ch.Reset(mw, req)

--- a/middleware/reflex/reflex_test.go
+++ b/middleware/reflex/reflex_test.go
@@ -2,28 +2,34 @@ package reflex
 
 import (
 	"context"
+	"fmt"
+	"reflect"
 	"testing"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/config"
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/semihalev/sdns/middleware"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
 	t.Run("disabled returns nil", func(t *testing.T) {
 		cfg := &config.Config{ReflexEnabled: false}
 		r := New(cfg)
-		assert.Nil(t, r)
+		if r != nil {
+			t.Errorf("r = %v, want nil", r)
+		}
 	})
 
 	t.Run("enabled returns instance", func(t *testing.T) {
 		cfg := &config.Config{ReflexEnabled: true}
 		r := New(cfg)
-		require.NotNil(t, r)
-		assert.Equal(t, "reflex", r.Name())
+		if r == nil {
+			t.Fatalf("r is nil")
+		}
+		if !reflect.DeepEqual("reflex", r.Name()) {
+			t.Errorf("r.Name() = %v, want %v", r.Name(), "reflex")
+		}
 		_ = r.Close()
 	})
 }
@@ -41,7 +47,9 @@ func TestServeDNS_SkipConditions(t *testing.T) {
 		ch.Reset(mw, req)
 
 		r.ServeDNS(context.Background(), ch)
-		assert.False(t, mw.Written())
+		if mw.Written() {
+			t.Errorf("mw.Written() is true")
+		}
 	})
 
 	t.Run("skip loopback", func(t *testing.T) {
@@ -52,7 +60,9 @@ func TestServeDNS_SkipConditions(t *testing.T) {
 		ch.Reset(mw, req)
 
 		r.ServeDNS(context.Background(), ch)
-		assert.False(t, mw.Written())
+		if mw.Written() {
+			t.Errorf("mw.Written() is true")
+		}
 	})
 
 	t.Run("TCP improves reputation", func(t *testing.T) {
@@ -63,12 +73,16 @@ func TestServeDNS_SkipConditions(t *testing.T) {
 		ch.Reset(mw, req)
 
 		r.ServeDNS(context.Background(), ch)
-		assert.False(t, mw.Written())
+		if mw.Written() {
+			t.Errorf("mw.Written() is true")
+		}
 
 		// Check that TCP was recorded
 		entry := r.tracker.GetEntry("192.168.1.100")
 		if entry != nil {
-			assert.True(t, entry.HasTCP)
+			if !(entry.HasTCP) {
+				t.Errorf("entry.HasTCP is false")
+			}
 		}
 	})
 }
@@ -87,7 +101,9 @@ func TestServeDNS_NormalTraffic(t *testing.T) {
 		ch.Reset(mw, req)
 
 		r.ServeDNS(context.Background(), ch)
-		assert.False(t, mw.Written(), "normal query %d should not be blocked", i)
+		if mw.Written() {
+			t.Errorf("%s: mw.Written() is true", fmt.Sprintf("normal query %d should not be blocked", i))
+		}
 	}
 }
 
@@ -117,7 +133,9 @@ func TestServeDNS_AmplificationAttack(t *testing.T) {
 	}
 
 	// Should eventually block
-	assert.Greater(t, blocked, 0, "amplification attack should be detected")
+	if blocked <= 0 {
+		t.Errorf("%s: blocked = %v, want > %v", "amplification attack should be detected", blocked, 0)
+	}
 	t.Logf("Blocked %d of 50 suspicious queries", blocked)
 }
 
@@ -185,7 +203,9 @@ func TestServeDNS_LegitimateHighAmpWithNormal(t *testing.T) {
 	}
 
 	// Should NOT block legitimate traffic
-	assert.Equal(t, 0, blocked, "legitimate mixed traffic should not be blocked")
+	if !reflect.DeepEqual(0, blocked) {
+		t.Errorf("%s: blocked = %v, want %v", "legitimate mixed traffic should not be blocked", blocked, 0)
+	}
 }
 
 func TestServeDNS_TCPClearsReputation(t *testing.T) {
@@ -224,7 +244,9 @@ func TestServeDNS_TCPClearsReputation(t *testing.T) {
 	ch2.Reset(mw2, req2)
 	r.ServeDNS(context.Background(), ch2)
 
-	assert.False(t, mw2.Written(), "after TCP, UDP should not be blocked")
+	if mw2.Written() {
+		t.Errorf("%s: mw2.Written() is true", "after TCP, UDP should not be blocked")
+	}
 }
 
 func TestServeDNS_LearningMode(t *testing.T) {
@@ -254,7 +276,9 @@ func TestServeDNS_LearningMode(t *testing.T) {
 	}
 
 	// Learning mode should NOT block
-	assert.Equal(t, 0, blocked, "learning mode should not block")
+	if !reflect.DeepEqual(0, blocked) {
+		t.Errorf("%s: blocked = %v, want %v", "learning mode should not block", blocked, 0)
+	}
 }
 
 func TestClose(t *testing.T) {
@@ -262,7 +286,9 @@ func TestClose(t *testing.T) {
 	r := New(cfg)
 
 	err := r.Close()
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 }
 
 func TestServeDNS_CustomThreshold(t *testing.T) {
@@ -274,7 +300,9 @@ func TestServeDNS_CustomThreshold(t *testing.T) {
 	r := New(cfg)
 	defer func() { _ = r.Close() }()
 
-	assert.Equal(t, 0.5, r.threshold())
+	if !reflect.DeepEqual(0.5, r.threshold()) {
+		t.Errorf("r.threshold() = %v, want %v", r.threshold(), 0.5)
+	}
 }
 
 func TestServeDNS_MonitorMode(t *testing.T) {
@@ -286,7 +314,9 @@ func TestServeDNS_MonitorMode(t *testing.T) {
 	r := New(cfg)
 	defer func() { _ = r.Close() }()
 
-	assert.Equal(t, "monitor", r.mode())
+	if !reflect.DeepEqual("monitor", r.mode()) {
+		t.Errorf("r.mode() = %v, want %v", r.mode(), "monitor")
+	}
 
 	ip := "203.0.113.103"
 
@@ -305,7 +335,9 @@ func TestServeDNS_MonitorMode(t *testing.T) {
 		}
 	}
 
-	assert.Equal(t, 0, blocked, "monitor mode should not block")
+	if !reflect.DeepEqual(0, blocked) {
+		t.Errorf("%s: blocked = %v, want %v", "monitor mode should not block", blocked, 0)
+	}
 }
 
 func TestServeDNS_EmptyQuestion(t *testing.T) {
@@ -319,7 +351,9 @@ func TestServeDNS_EmptyQuestion(t *testing.T) {
 	ch.Reset(mw, req)
 
 	r.ServeDNS(context.Background(), ch)
-	assert.False(t, mw.Written())
+	if mw.Written() {
+		t.Errorf("mw.Written() is true")
+	}
 }
 
 func TestResponseWriter(t *testing.T) {
@@ -350,12 +384,18 @@ func TestResponseWriter(t *testing.T) {
 	})
 
 	err := rw.WriteMsg(res)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	// Check response was tracked
 	entry := tracker.GetEntry(ip)
-	assert.NotNil(t, entry)
-	assert.Greater(t, entry.TotalResponseBytes, uint64(0))
+	if entry == nil {
+		t.Fatalf("entry is nil")
+	}
+	if entry.TotalResponseBytes == 0 {
+		t.Errorf("entry.TotalResponseBytes = 0, want > 0")
+	}
 }
 
 func TestResponseWriter_NilResponse(t *testing.T) {
@@ -377,7 +417,9 @@ func TestResponseWriter_NilResponse(t *testing.T) {
 
 	// Write nil response - should not panic
 	err := rw.WriteMsg(nil)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 }
 
 func BenchmarkServeDNS_NormalQuery(b *testing.B) {

--- a/middleware/reflex/tracker_test.go
+++ b/middleware/reflex/tracker_test.go
@@ -1,11 +1,12 @@
 package reflex
 
 import (
+	"fmt"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/miekg/dns"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestIPTracker_Basic(t *testing.T) {
@@ -13,9 +14,13 @@ func TestIPTracker_Basic(t *testing.T) {
 
 	// First few queries should have zero score
 	score := tracker.RecordQuery("192.168.1.1", dns.TypeA, 1.0, 50)
-	assert.Equal(t, 0.0, score, "first query should have zero score")
+	if !reflect.DeepEqual(0.0, score) {
+		t.Errorf("%s: score = %v, want %v", "first query should have zero score", score, 0.0)
+	}
 
-	assert.Equal(t, 1, tracker.Count())
+	if !reflect.DeepEqual(1, tracker.Count()) {
+		t.Errorf("tracker.Count() = %v, want %v", tracker.Count(), 1)
+	}
 }
 
 func TestIPTracker_NormalQueries(t *testing.T) {
@@ -28,11 +33,17 @@ func TestIPTracker_NormalQueries(t *testing.T) {
 	}
 
 	entry := tracker.GetEntry(ip)
-	assert.NotNil(t, entry)
-	assert.True(t, entry.HasNormalQ)
+	if entry == nil {
+		t.Fatalf("entry is nil")
+	}
+	if !(entry.HasNormalQ) {
+		t.Errorf("entry.HasNormalQ is false")
+	}
 
 	score := tracker.calculateScore(entry)
-	assert.Less(t, score, 0.5, "normal queries should have low score")
+	if score >= 0.5 {
+		t.Errorf("%s: score = %v, want < %v", "normal queries should have low score", score, 0.5)
+	}
 	t.Logf("Normal traffic score: %.2f", score)
 }
 
@@ -46,15 +57,23 @@ func TestIPTracker_HighAmpQueries(t *testing.T) {
 	}
 
 	entry := tracker.GetEntry(ip)
-	assert.NotNil(t, entry)
-	assert.False(t, entry.HasNormalQ)
-	assert.Equal(t, uint32(20), entry.HighAmpQueries)
+	if entry == nil {
+		t.Fatalf("entry is nil")
+	}
+	if entry.HasNormalQ {
+		t.Errorf("entry.HasNormalQ is true")
+	}
+	if !reflect.DeepEqual(uint32(20), entry.HighAmpQueries) {
+		t.Errorf("entry.HighAmpQueries = %v, want %v", entry.HighAmpQueries, uint32(20))
+	}
 
 	score := tracker.calculateScore(entry)
 	// Score is 0.45: high-amp ratio (0.25) + no normal queries (0.15) + single type (0.05)
 	// This is below blocking threshold (0.7) which is correct -
 	// need HIGH RATE to block, not just high-amp types
-	assert.Greater(t, score, 0.3, "high-amp only queries should have elevated score")
+	if score <= 0.3 {
+		t.Errorf("%s: score = %v, want > %v", "high-amp only queries should have elevated score", score, 0.3)
+	}
 	t.Logf("High-amp traffic score: %.2f", score)
 }
 
@@ -76,8 +95,12 @@ func TestIPTracker_TCPClearsScore(t *testing.T) {
 	entry = tracker.GetEntry(ip)
 	scoreAfter := tracker.calculateScore(entry)
 
-	assert.Greater(t, scoreBefore, 0.3, "should have elevated score before TCP")
-	assert.Equal(t, 0.0, scoreAfter, "TCP should clear score")
+	if scoreBefore <= 0.3 {
+		t.Errorf("%s: scoreBefore = %v, want > %v", "should have elevated score before TCP", scoreBefore, 0.3)
+	}
+	if !reflect.DeepEqual(0.0, scoreAfter) {
+		t.Errorf("%s: scoreAfter = %v, want %v", "TCP should clear score", scoreAfter, 0.0)
+	}
 }
 
 func TestIPTracker_RecordResponse(t *testing.T) {
@@ -88,8 +111,12 @@ func TestIPTracker_RecordResponse(t *testing.T) {
 	tracker.RecordResponse(ip, 50, 500) // 10x amplification
 
 	entry := tracker.GetEntry(ip)
-	assert.Equal(t, uint64(50), entry.TotalRequestBytes)
-	assert.Equal(t, uint64(500), entry.TotalResponseBytes)
+	if !reflect.DeepEqual(uint64(50), entry.TotalRequestBytes) {
+		t.Errorf("entry.TotalRequestBytes = %v, want %v", entry.TotalRequestBytes, uint64(50))
+	}
+	if !reflect.DeepEqual(uint64(500), entry.TotalResponseBytes) {
+		t.Errorf("entry.TotalResponseBytes = %v, want %v", entry.TotalResponseBytes, uint64(500))
+	}
 }
 
 func TestIPTracker_AmplificationRatio(t *testing.T) {
@@ -106,7 +133,9 @@ func TestIPTracker_AmplificationRatio(t *testing.T) {
 	score := tracker.calculateScore(entry)
 
 	t.Logf("High amplification ratio score: %.2f", score)
-	assert.Greater(t, score, 0.4, "high amplification should increase score")
+	if score <= 0.4 {
+		t.Errorf("%s: score = %v, want > %v", "high amplification should increase score", score, 0.4)
+	}
 }
 
 func TestIPTracker_BoundedMemory(t *testing.T) {
@@ -119,7 +148,9 @@ func TestIPTracker_BoundedMemory(t *testing.T) {
 		tracker.RecordQuery(ip, dns.TypeA, 1.0, 50)
 	}
 
-	assert.LessOrEqual(t, tracker.Count(), maxSize)
+	if tracker.Count() > maxSize {
+		t.Errorf("tracker.Count() = %v, want <= %v", tracker.Count(), maxSize)
+	}
 }
 
 func TestIPTracker_Cleanup(t *testing.T) {
@@ -130,7 +161,9 @@ func TestIPTracker_Cleanup(t *testing.T) {
 	tracker.RecordQuery("192.168.1.2", dns.TypeA, 1.0, 50)
 	tracker.RecordQuery("192.168.1.3", dns.TypeA, 1.0, 50)
 
-	assert.Equal(t, 3, tracker.Count())
+	if !reflect.DeepEqual(3, tracker.Count()) {
+		t.Errorf("tracker.Count() = %v, want %v", tracker.Count(), 3)
+	}
 
 	// Age one entry
 	tracker.mu.Lock()
@@ -140,7 +173,9 @@ func TestIPTracker_Cleanup(t *testing.T) {
 	tracker.mu.Unlock()
 
 	tracker.Cleanup()
-	assert.Equal(t, 2, tracker.Count())
+	if !reflect.DeepEqual(2, tracker.Count()) {
+		t.Errorf("tracker.Count() = %v, want %v", tracker.Count(), 2)
+	}
 }
 
 func TestIPTracker_QueryTypeDiversity(t *testing.T) {
@@ -154,7 +189,9 @@ func TestIPTracker_QueryTypeDiversity(t *testing.T) {
 
 	entry := tracker.GetEntry(ip)
 	typeCount := popcount16(entry.QueryTypes)
-	assert.Equal(t, 1, typeCount)
+	if !reflect.DeepEqual(1, typeCount) {
+		t.Errorf("typeCount = %v, want %v", typeCount, 1)
+	}
 
 	score := tracker.calculateScore(entry)
 	t.Logf("Single type score: %.2f", score)
@@ -174,20 +211,36 @@ func TestIPTracker_MixedTypes(t *testing.T) {
 
 	entry := tracker.GetEntry(ip)
 	typeCount := popcount16(entry.QueryTypes)
-	assert.GreaterOrEqual(t, typeCount, 3)
-	assert.True(t, entry.HasNormalQ)
+	if typeCount < 3 {
+		t.Errorf("typeCount = %v, want >= %v", typeCount, 3)
+	}
+	if !(entry.HasNormalQ) {
+		t.Errorf("entry.HasNormalQ is false")
+	}
 
 	score := tracker.calculateScore(entry)
 	t.Logf("Mixed types score: %.2f", score)
-	assert.Less(t, score, 0.5, "mixed types with normal queries should be less suspicious")
+	if score >= 0.5 {
+		t.Errorf("%s: score = %v, want < %v", "mixed types with normal queries should be less suspicious", score, 0.5)
+	}
 }
 
 func TestPopcount16(t *testing.T) {
-	assert.Equal(t, 0, popcount16(0))
-	assert.Equal(t, 1, popcount16(1))
-	assert.Equal(t, 1, popcount16(2))
-	assert.Equal(t, 2, popcount16(3))
-	assert.Equal(t, 16, popcount16(0xFFFF))
+	if !reflect.DeepEqual(0, popcount16(0)) {
+		t.Errorf("popcount16(0) = %v, want %v", popcount16(0), 0)
+	}
+	if !reflect.DeepEqual(1, popcount16(1)) {
+		t.Errorf("popcount16(1) = %v, want %v", popcount16(1), 1)
+	}
+	if !reflect.DeepEqual(1, popcount16(2)) {
+		t.Errorf("popcount16(2) = %v, want %v", popcount16(2), 1)
+	}
+	if !reflect.DeepEqual(2, popcount16(3)) {
+		t.Errorf("popcount16(3) = %v, want %v", popcount16(3), 2)
+	}
+	if !reflect.DeepEqual(16, popcount16(0xFFFF)) {
+		t.Errorf("popcount16(0xFFFF) = %v, want %v", popcount16(0xFFFF), 16)
+	}
 }
 
 func TestQtypeToBit(t *testing.T) {
@@ -216,7 +269,9 @@ func TestQtypeToBit(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		assert.Equal(t, tt.expected, qtypeToBit(tt.qtype), "qtype %d", tt.qtype)
+		if !reflect.DeepEqual(tt.expected, qtypeToBit(tt.qtype)) {
+			t.Errorf("%s: qtypeToBit(tt.qtype) = %v, want %v", fmt.Sprintf("qtype %d", tt.qtype), qtypeToBit(tt.qtype), tt.expected)
+		}
 	}
 }
 
@@ -234,7 +289,9 @@ func TestCalculateScore_EdgeCases(t *testing.T) {
 		entry := tracker.GetEntry(ip)
 		score := tracker.calculateScore(entry)
 		t.Logf("High rate attack score: %.2f", score)
-		assert.GreaterOrEqual(t, score, 0.7, "high rate attack should have high score")
+		if score < 0.7 {
+			t.Errorf("%s: score = %v, want >= %v", "high rate attack should have high score", score, 0.7)
+		}
 	})
 
 	t.Run("moderate rate only high amp", func(t *testing.T) {

--- a/middleware/resolver/auto_trust_anchor_test.go
+++ b/middleware/resolver/auto_trust_anchor_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/semihalev/sdns/internal/authority"
 	"github.com/semihalev/sdns/middleware/resolver"
 	"github.com/semihalev/zlog/v2"
-	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -163,9 +162,15 @@ func Test_autota(t *testing.T) {
 
 	resp, err := r.Resolve(context.Background(), req, rootServers, true, 30, 0, false, nil)
 
-	assert.True(t, resp.AuthenticatedData)
-	assert.NoError(t, err)
-	assert.Len(t, resp.Answer, 4)
+	if !(resp.AuthenticatedData) {
+		t.Errorf("resp.AuthenticatedData is false")
+	}
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if len(resp.Answer) != 4 {
+		t.Errorf("len(resp.Answer) = %d, want %d", len(resp.Answer), 4)
+	}
 
 	_ = os.Remove(filepath.Join(cfg.Directory, "trust-anchor.db")) //nolint:gosec // G104 - cleanup best effort
 }

--- a/middleware/resolver/circuit_breaker_test.go
+++ b/middleware/resolver/circuit_breaker_test.go
@@ -1,13 +1,12 @@
 package resolver
 
 import (
+	"fmt"
+	"reflect"
 	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCircuitBreaker_Basic(t *testing.T) {
@@ -15,21 +14,29 @@ func TestCircuitBreaker_Basic(t *testing.T) {
 	server := "8.8.8.8:53"
 
 	// Initially, server should be queryable
-	assert.True(t, cb.canQuery(server))
+	if !(cb.canQuery(server)) {
+		t.Errorf("cb.canQuery(server) is false")
+	}
 
 	// Record 4 failures - should still be queryable
 	for i := 0; i < 4; i++ {
 		cb.recordFailure(server)
-		assert.True(t, cb.canQuery(server), "Should be queryable after %d failures", i+1)
+		if !(cb.canQuery(server)) {
+			t.Errorf("%s: cb.canQuery(server) is false", fmt.Sprintf("Should be queryable after %d failures", i+1))
+		}
 	}
 
 	// 5th failure should trip the circuit breaker
 	cb.recordFailure(server)
-	assert.False(t, cb.canQuery(server), "Circuit breaker should be tripped after 5 failures")
+	if cb.canQuery(server) {
+		t.Errorf("%s: cb.canQuery(server) is true", "Circuit breaker should be tripped after 5 failures")
+	}
 
 	// Success should reset the circuit breaker
 	cb.recordSuccess(server)
-	assert.True(t, cb.canQuery(server), "Circuit breaker should be reset after success")
+	if !(cb.canQuery(server)) {
+		t.Errorf("%s: cb.canQuery(server) is false", "Circuit breaker should be reset after success")
+	}
 }
 
 func TestCircuitBreaker_Timeout(t *testing.T) {
@@ -40,7 +47,9 @@ func TestCircuitBreaker_Timeout(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		cb.recordFailure(server)
 	}
-	assert.False(t, cb.canQuery(server))
+	if cb.canQuery(server) {
+		t.Errorf("cb.canQuery(server) is true")
+	}
 
 	// Manually set last failure time to 31 seconds ago
 	cb.mu.RLock()
@@ -49,7 +58,9 @@ func TestCircuitBreaker_Timeout(t *testing.T) {
 	sf.lastFailure.Store(time.Now().Add(-31 * time.Second).Unix())
 
 	// Should be queryable again after timeout
-	assert.True(t, cb.canQuery(server), "Circuit breaker should reset after 30 second timeout")
+	if !(cb.canQuery(server)) {
+		t.Errorf("%s: cb.canQuery(server) is false", "Circuit breaker should reset after 30 second timeout")
+	}
 }
 
 func TestCircuitBreaker_ConcurrentAccess(t *testing.T) {
@@ -107,17 +118,25 @@ func TestCircuitBreaker_MultipleServers(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		cb.recordFailure(server1)
 	}
-	assert.False(t, cb.canQuery(server1))
+	if cb.canQuery(server1) {
+		t.Errorf("cb.canQuery(server1) is true")
+	}
 
 	// server2 should still be queryable
-	assert.True(t, cb.canQuery(server2))
+	if !(cb.canQuery(server2)) {
+		t.Errorf("cb.canQuery(server2) is false")
+	}
 
 	// Record failures for server2
 	for i := 0; i < 3; i++ {
 		cb.recordFailure(server2)
 	}
-	assert.True(t, cb.canQuery(server2), "Server2 should still be queryable with 3 failures")
-	assert.False(t, cb.canQuery(server1), "Server1 should still be disabled")
+	if !(cb.canQuery(server2)) {
+		t.Errorf("%s: cb.canQuery(server2) is false", "Server2 should still be queryable with 3 failures")
+	}
+	if cb.canQuery(server1) {
+		t.Errorf("%s: cb.canQuery(server1) is true", "Server1 should still be disabled")
+	}
 }
 
 func TestCircuitBreaker_ResetBehavior(t *testing.T) {
@@ -135,12 +154,16 @@ func TestCircuitBreaker_ResetBehavior(t *testing.T) {
 	// Should need 5 more failures to trip
 	for i := 0; i < 4; i++ {
 		cb.recordFailure(server)
-		assert.True(t, cb.canQuery(server), "Should be queryable after reset + %d failures", i+1)
+		if !(cb.canQuery(server)) {
+			t.Errorf("%s: cb.canQuery(server) is false", fmt.Sprintf("Should be queryable after reset + %d failures", i+1))
+		}
 	}
 
 	// 5th failure after reset should trip
 	cb.recordFailure(server)
-	assert.False(t, cb.canQuery(server))
+	if cb.canQuery(server) {
+		t.Errorf("cb.canQuery(server) is true")
+	}
 }
 
 func TestCircuitBreaker_CleanupOldEntries(t *testing.T) {
@@ -157,11 +180,15 @@ func TestCircuitBreaker_CleanupOldEntries(t *testing.T) {
 	cb.mu.RLock()
 	_, exists := cb.failures[server]
 	cb.mu.RUnlock()
-	assert.True(t, exists)
+	if !(exists) {
+		t.Errorf("exists is false")
+	}
 
 	// Cleanup happens every 5 minutes in background
 	// For testing, we just verify the structure is correct
-	assert.NotNil(t, cb.failures)
+	if cb.failures == nil {
+		t.Fatalf("cb.failures is nil")
+	}
 }
 
 func TestResolverWithCircuitBreaker(t *testing.T) {
@@ -171,10 +198,14 @@ func TestResolverWithCircuitBreaker(t *testing.T) {
 	r := newWiredTestResolver(cfg)
 
 	// Verify circuit breaker is initialized
-	require.NotNil(t, r.circuitBreaker)
+	if r.circuitBreaker == nil {
+		t.Fatalf("r.circuitBreaker is nil")
+	}
 
 	// Verify max concurrent channel has correct capacity
-	assert.Equal(t, 100, cap(r.maxConcurrent))
+	if !reflect.DeepEqual(100, cap(r.maxConcurrent)) {
+		t.Errorf("cap(r.maxConcurrent) = %v, want %v", cap(r.maxConcurrent), 100)
+	}
 }
 
 func TestResolverGoroutineLimiting(t *testing.T) {
@@ -227,7 +258,9 @@ cleanup:
 done:
 
 	// Just verify the semaphore mechanism works
-	assert.True(t, cap(r.maxConcurrent) == 50, "Semaphore should have correct capacity")
+	if cap(r.maxConcurrent) != 50 {
+		t.Errorf("%s: cap(r.maxConcurrent) = %d, want 50", "Semaphore should have correct capacity", cap(r.maxConcurrent))
+	}
 }
 
 func TestResolverConcurrentQueryLimit(t *testing.T) {
@@ -269,8 +302,9 @@ func TestResolverConcurrentQueryLimit(t *testing.T) {
 	wg.Wait()
 
 	// Verify we never exceeded the limit
-	assert.LessOrEqual(t, int(maxObserved.Load()), 10,
-		"Should never exceed MaxConcurrentQueries limit")
+	if int(maxObserved.Load()) > 10 {
+		t.Errorf("%s: int(maxObserved.Load()) = %v, want <= %v", "Should never exceed MaxConcurrentQueries limit", int(maxObserved.Load()), 10)
+	}
 }
 
 func BenchmarkCircuitBreaker_CanQuery(b *testing.B) {
@@ -357,7 +391,9 @@ func TestCircuitBreaker_CleanupEvictsIdleWithFailures(t *testing.T) {
 	cb.mu.RLock()
 	_, exists := cb.failures[server]
 	cb.mu.RUnlock()
-	assert.False(t, exists, "idle entry with count>0 must be evicted")
+	if exists {
+		t.Errorf("%s: exists is true", "idle entry with count>0 must be evicted")
+	}
 
 	// A recently-failed entry must survive.
 	cb.recordFailure(server)
@@ -365,5 +401,7 @@ func TestCircuitBreaker_CleanupEvictsIdleWithFailures(t *testing.T) {
 	cb.mu.RLock()
 	_, exists = cb.failures[server]
 	cb.mu.RUnlock()
-	assert.True(t, exists, "recently-failed entry must be kept")
+	if !(exists) {
+		t.Errorf("%s: exists is false", "recently-failed entry must be kept")
+	}
 }

--- a/middleware/resolver/client_test.go
+++ b/middleware/resolver/client_test.go
@@ -1,13 +1,13 @@
 package resolver
 
 import (
+	"errors"
 	"net"
 	"testing"
 	"time"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/internal/dnsutil"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_ClientTimeout(t *testing.T) {
@@ -20,21 +20,31 @@ func Test_ClientTimeout(t *testing.T) {
 	// DNS server on the same machine (e.g. a live sdns), which turned this
 	// timeout test into a successful live query.
 	blackhole, err := net.ListenPacket("udp4", "127.0.0.1:0")
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 	defer func() { _ = blackhole.Close() }()
 
 	dialer := &net.Dialer{Deadline: time.Now().Add(2 * time.Second)}
 	co := &Conn{}
 
 	co.Conn, err = dialer.Dial("udp4", blackhole.LocalAddr().String())
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	err = co.SetDeadline(time.Now().Add(2 * time.Second))
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	_, _, err = co.Exchange(req)
-	assert.Error(t, err)
-	assert.NoError(t, co.Close())
+	if err == nil {
+		t.Errorf("expected an error, got nil")
+	}
+	if err := co.Close(); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 }
 
 func Test_Client(t *testing.T) {
@@ -53,14 +63,22 @@ func Test_Client(t *testing.T) {
 
 	var err error
 	co.Conn, err = dialer.Dial("udp4", addr)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	err = co.SetDeadline(time.Now().Add(2 * time.Second))
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	r, _, err := co.Exchange(req)
-	assert.NoError(t, err)
-	assert.NotNil(t, r)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if r == nil {
+		t.Fatalf("r is nil")
+	}
 }
 
 // startMismatchedQuestionServer returns a UDP server that always replies with
@@ -102,18 +120,24 @@ func Test_Client_RejectsMismatchedQuestion(t *testing.T) {
 
 	var err error
 	co.Conn, err = dialer.Dial("udp", addr)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 	defer func() { _ = co.Close() }()
 
 	err = co.SetDeadline(time.Now().Add(2 * time.Second))
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	// The upstream returns a response whose question is victim.test. but the
 	// outstanding request asked for attacker.test. — Exchange must surface
 	// this as an error rather than handing the unrelated message back to the
 	// caller (which would otherwise cache it under victim.test.).
 	_, _, err = co.Exchange(req)
-	assert.ErrorIs(t, err, ErrQuestion)
+	if !errors.Is(err, ErrQuestion) {
+		t.Errorf("error = %v, want %v", err, ErrQuestion)
+	}
 }
 
 // startEchoingQuestionServer answers every query with the question it was

--- a/middleware/resolver/ctxkey_test.go
+++ b/middleware/resolver/ctxkey_test.go
@@ -2,10 +2,10 @@ package resolver
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/miekg/dns"
-	"github.com/stretchr/testify/assert"
 )
 
 // Test_checkLoop_DnameDepthNoCollision guards the context-key layout.
@@ -24,21 +24,31 @@ func Test_checkLoop_DnameDepthNoCollision(t *testing.T) {
 
 	// IPv4 NS lookup path: checkLoop with qtype A must not read that int
 	// as a []string.
-	assert.NotPanics(t, func() {
+	if func() (panicked bool) {
+		defer func() { panicked = recover() != nil }()
 		ctx, _ = r.checkLoop(ctx, "ns1.example.com.", dns.TypeA)
-	})
+		return
+	}() {
+		t.Error("checkLoop panicked")
+	}
 
 	// The DNAME depth is untouched — the two keys are distinct.
 	depth, _ := ctx.Value(contextKeyDnameDepth).(int)
-	assert.Equal(t, 3, depth)
+	if !reflect.DeepEqual(3, depth) {
+		t.Errorf("depth = %v, want %v", depth, 3)
+	}
 
 	// Loop detection still works for A queries: a qname seen a third time
 	// trips the guard.
 	var loop bool
 	ctx, loop = r.checkLoop(ctx, "ns1.example.com.", dns.TypeA)
-	assert.False(t, loop)
+	if loop {
+		t.Errorf("loop is true")
+	}
 	_, loop = r.checkLoop(ctx, "ns1.example.com.", dns.TypeA)
-	assert.True(t, loop)
+	if !(loop) {
+		t.Errorf("loop is false")
+	}
 }
 
 // Test_checkLoop_KeyNoFixedCollision asserts that no qtype maps a derived

--- a/middleware/resolver/dnssec/nsec_test.go
+++ b/middleware/resolver/dnssec/nsec_test.go
@@ -1,10 +1,10 @@
 package dnssec
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/miekg/dns"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestNSECCovers(t *testing.T) {
@@ -69,7 +69,9 @@ func TestNSECCovers(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := nsecCovers(tt.owner, tt.next, tt.qname)
-			assert.Equal(t, tt.expected, result)
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("result = %v, want %v", result, tt.expected)
+			}
 		})
 	}
 }
@@ -92,27 +94,37 @@ func TestVerifyNODATANSEC(t *testing.T) {
 	}
 
 	err := VerifyNODATANSEC(msg, []dns.RR{nsec})
-	assert.NoError(t, err, "Valid NODATA should verify successfully")
+	if err != nil {
+		t.Errorf("%s: unexpected error: %v", "Valid NODATA should verify successfully", err)
+	}
 
 	// Test case 2: Invalid - type exists
 	nsec.TypeBitMap = []uint16{dns.TypeA, dns.TypeAAAA, dns.TypeNS, dns.TypeSOA}
 	err = VerifyNODATANSEC(msg, []dns.RR{nsec})
-	assert.Equal(t, ErrNSECTypeExists, err, "Should fail when type exists")
+	if !reflect.DeepEqual(ErrNSECTypeExists, err) {
+		t.Errorf("%s: err = %v, want %v", "Should fail when type exists", err, ErrNSECTypeExists)
+	}
 
 	// Test case 3: DS query at delegation point
 	msg.SetQuestion("example.com.", dns.TypeDS)
 	nsec.TypeBitMap = []uint16{dns.TypeNS} // Delegation point (has NS, no SOA)
 	err = VerifyNODATANSEC(msg, []dns.RR{nsec})
-	assert.NoError(t, err, "Valid DS NODATA at delegation should verify")
+	if err != nil {
+		t.Errorf("%s: unexpected error: %v", "Valid DS NODATA at delegation should verify", err)
+	}
 
 	// Test case 4: Invalid DS - has SOA (not a delegation)
 	nsec.TypeBitMap = []uint16{dns.TypeNS, dns.TypeSOA}
 	err = VerifyNODATANSEC(msg, []dns.RR{nsec})
-	assert.Equal(t, ErrNSECBadDelegation, err, "Should fail when SOA exists at delegation")
+	if !reflect.DeepEqual(ErrNSECBadDelegation, err) {
+		t.Errorf("%s: err = %v, want %v", "Should fail when SOA exists at delegation", err, ErrNSECBadDelegation)
+	}
 
 	// Test case 5: No NSEC records
 	err = VerifyNODATANSEC(msg, []dns.RR{})
-	assert.Equal(t, ErrNSECMissingCoverage, err, "Should fail with no NSEC records")
+	if !reflect.DeepEqual(ErrNSECMissingCoverage, err) {
+		t.Errorf("%s: err = %v, want %v", "Should fail with no NSEC records", err, ErrNSECMissingCoverage)
+	}
 }
 
 func TestVerifyNameErrorNSEC(t *testing.T) {
@@ -146,7 +158,9 @@ func TestVerifyNameErrorNSEC(t *testing.T) {
 	}
 
 	err := VerifyNameErrorNSEC(msg, []dns.RR{nsec1, nsec2})
-	assert.NoError(t, err, "Valid NXDOMAIN should verify successfully")
+	if err != nil {
+		t.Errorf("%s: unexpected error: %v", "Valid NXDOMAIN should verify successfully", err)
+	}
 
 	// Test case 2: No covering NSEC
 	nsecNoCover := &dns.NSEC{
@@ -161,11 +175,15 @@ func TestVerifyNameErrorNSEC(t *testing.T) {
 	}
 
 	err = VerifyNameErrorNSEC(msg, []dns.RR{nsecNoCover})
-	assert.Equal(t, ErrNSECMissingCoverage, err, "Should fail when no NSEC covers the name")
+	if !reflect.DeepEqual(ErrNSECMissingCoverage, err) {
+		t.Errorf("%s: err = %v, want %v", "Should fail when no NSEC covers the name", err, ErrNSECMissingCoverage)
+	}
 
 	// Test case 3: No NSEC records
 	err = VerifyNameErrorNSEC(msg, []dns.RR{})
-	assert.Equal(t, ErrNSECMissingCoverage, err, "Should fail with no NSEC records")
+	if !reflect.DeepEqual(ErrNSECMissingCoverage, err) {
+		t.Errorf("%s: err = %v, want %v", "Should fail with no NSEC records", err, ErrNSECMissingCoverage)
+	}
 }
 
 // TestVerifyNODATANSEC_Wildcard locks in the RFC 4035 §3.1.3.4 wildcard
@@ -188,7 +206,9 @@ func TestVerifyNODATANSEC_Wildcard(t *testing.T) {
 		TypeBitMap: []uint16{dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC},
 	}
 	err := VerifyNODATANSEC(msg, []dns.RR{covering, wildcard})
-	assert.NoError(t, err, "Wildcard NODATA proof should verify")
+	if err != nil {
+		t.Errorf("%s: unexpected error: %v", "Wildcard NODATA proof should verify", err)
+	}
 
 	// Same shape but wildcard bitmap *does* include the queried type —
 	// must be rejected because the wildcard could synthesize an answer.
@@ -198,5 +218,7 @@ func TestVerifyNODATANSEC_Wildcard(t *testing.T) {
 		TypeBitMap: []uint16{dns.TypeA, dns.TypeAAAA, dns.TypeRRSIG, dns.TypeNSEC},
 	}
 	err = VerifyNODATANSEC(msg, []dns.RR{covering, wildcardWithType})
-	assert.Equal(t, ErrNSECTypeExists, err)
+	if !reflect.DeepEqual(ErrNSECTypeExists, err) {
+		t.Errorf("err = %v, want %v", err, ErrNSECTypeExists)
+	}
 }

--- a/middleware/resolver/dnssec_test.go
+++ b/middleware/resolver/dnssec_test.go
@@ -2,10 +2,10 @@ package resolver
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/miekg/dns"
-	"github.com/stretchr/testify/assert"
 )
 
 // TestADBitWithCDFlag verifies that AD bit is not set when CD flag is set.
@@ -35,7 +35,9 @@ func TestADBitWithCDFlag(t *testing.T) {
 		resp.AuthenticatedData = true
 	}
 
-	assert.True(t, resp.AuthenticatedData, "AD bit should be set when CD=0 and validation succeeds")
+	if !(resp.AuthenticatedData) {
+		t.Errorf("%s: resp.AuthenticatedData is false", "AD bit should be set when CD=0 and validation succeeds")
+	}
 
 	// Test case 2: CD=1, AD bit should never be set
 	req2 := new(dns.Msg)
@@ -61,7 +63,9 @@ func TestADBitWithCDFlag(t *testing.T) {
 		resp2.AuthenticatedData = false
 	}
 
-	assert.False(t, resp2.AuthenticatedData, "AD bit should not be set when CD=1")
+	if resp2.AuthenticatedData {
+		t.Errorf("%s: resp2.AuthenticatedData is true", "AD bit should not be set when CD=1")
+	}
 }
 
 // TestCDFlagPreservation verifies that CD flag is properly preserved in responses.
@@ -93,8 +97,9 @@ func TestCDFlagPreservation(t *testing.T) {
 			resp.SetReply(req)
 
 			// CD flag should be preserved from request
-			assert.Equal(t, tt.expectedRespCD, resp.CheckingDisabled,
-				"CD flag should be preserved from request to response")
+			if !reflect.DeepEqual(tt.expectedRespCD, resp.CheckingDisabled) {
+				t.Errorf("%s: resp.CheckingDisabled = %v, want %v", "CD flag should be preserved from request to response", resp.CheckingDisabled, tt.expectedRespCD)
+			}
 		})
 	}
 }
@@ -141,12 +146,17 @@ func TestDNSSECValidationSkippedWithCD(t *testing.T) {
 
 	// With CD=1, validation should be skipped and response should be returned
 	// without AD bit set
-	assert.True(t, req.CheckingDisabled, "CD flag should be set in request")
-	assert.False(t, resp.AuthenticatedData, "AD bit should not be set when CD=1")
+	if !(req.CheckingDisabled) {
+		t.Errorf("%s: req.CheckingDisabled is false", "CD flag should be set in request")
+	}
+	if resp.AuthenticatedData {
+		t.Errorf("%s: resp.AuthenticatedData is true", "AD bit should not be set when CD=1")
+	}
 
 	// The response should still be valid (not SERVFAIL) because validation was skipped
-	assert.Equal(t, dns.RcodeSuccess, resp.Rcode,
-		"Response should be successful when CD=1 even with invalid signatures")
+	if !reflect.DeepEqual(dns.RcodeSuccess, resp.Rcode) {
+		t.Errorf("%s: resp.Rcode = %v, want %v", "Response should be successful when CD=1 even with invalid signatures", resp.Rcode, dns.RcodeSuccess)
+	}
 }
 
 // makeDS creates a DS record for the given owner name.
@@ -263,7 +273,9 @@ func Test_isZoneSecure(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := r.isZoneSecure(ctx, tt.qname, tt.parentDS, tt.zone)
-			assert.Equal(t, tt.expected, result)
+			if !reflect.DeepEqual(tt.expected, result) {
+				t.Errorf("result = %v, want %v", result, tt.expected)
+			}
 		})
 	}
 }
@@ -323,15 +335,23 @@ func Test_isZoneSecureIntegration(t *testing.T) {
 			resp, err := hermeticResolve(t, r, tt.qname, dns.TypeA)
 
 			if tt.expectErr {
-				assert.Error(t, err)
+				if err == nil {
+					t.Errorf("expected an error, got nil")
+				}
 			} else {
-				assert.NoError(t, err)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
 			}
 
 			if tt.expectNil {
-				assert.Nil(t, resp)
+				if resp != nil {
+					t.Errorf("resp = %v, want nil", resp)
+				}
 			} else {
-				assert.NotNil(t, resp)
+				if resp == nil {
+					t.Fatalf("resp is nil")
+				}
 			}
 		})
 	}

--- a/middleware/resolver/errors_test.go
+++ b/middleware/resolver/errors_test.go
@@ -2,12 +2,13 @@ package resolver
 
 import (
 	"errors"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/internal/dnsutil"
 	"github.com/semihalev/sdns/middleware/resolver/dnssec"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestEDEError(t *testing.T) {
@@ -18,48 +19,80 @@ func TestEDEError(t *testing.T) {
 		Message: "network failed",
 		Err:     wrapped,
 	}
-	assert.Contains(t, err.Error(), "network failed")
-	assert.Contains(t, err.Error(), "wrapped error")
+	if !strings.Contains(err.Error(), "network failed") {
+		t.Errorf("%q does not contain %q", err.Error(), "network failed")
+	}
+	if !strings.Contains(err.Error(), "wrapped error") {
+		t.Errorf("%q does not contain %q", err.Error(), "wrapped error")
+	}
 
 	// Test Error() without wrapped error
 	errNoWrap := &dnsutil.EDEError{
 		Code:    dns.ExtendedErrorCodeDNSBogus,
 		Message: "bogus response",
 	}
-	assert.Equal(t, "bogus response", errNoWrap.Error())
+	if !reflect.DeepEqual("bogus response", errNoWrap.Error()) {
+		t.Errorf("errNoWrap.Error() = %v, want %v", errNoWrap.Error(), "bogus response")
+	}
 
 	// Test Unwrap()
-	assert.Equal(t, wrapped, err.Unwrap())
-	assert.Nil(t, errNoWrap.Unwrap())
+	if !reflect.DeepEqual(wrapped, err.Unwrap()) {
+		t.Errorf("err.Unwrap() = %v, want %v", err.Unwrap(), wrapped)
+	}
+	if errNoWrap.Unwrap() != nil {
+		t.Errorf("errNoWrap.Unwrap() = %v, want nil", errNoWrap.Unwrap())
+	}
 
 	// Test EDECode()
-	assert.Equal(t, dns.ExtendedErrorCodeNetworkError, err.EDECode())
+	if !reflect.DeepEqual(dns.ExtendedErrorCodeNetworkError, err.EDECode()) {
+		t.Errorf("err.EDECode() = %v, want %v", err.EDECode(), dns.ExtendedErrorCodeNetworkError)
+	}
 }
 
 func TestNewNetworkError(t *testing.T) {
 	wrapped := errors.New("connection refused")
 	err := NewNetworkError(wrapped)
 
-	assert.Equal(t, dns.ExtendedErrorCodeNetworkError, err.Code)
-	assert.Equal(t, "network error", err.Message)
-	assert.Equal(t, wrapped, err.Err)
-	assert.Contains(t, err.Error(), "connection refused")
+	if !reflect.DeepEqual(dns.ExtendedErrorCodeNetworkError, err.Code) {
+		t.Errorf("err.Code = %v, want %v", err.Code, dns.ExtendedErrorCodeNetworkError)
+	}
+	if !reflect.DeepEqual("network error", err.Message) {
+		t.Errorf("err.Message = %v, want %v", err.Message, "network error")
+	}
+	if !reflect.DeepEqual(wrapped, err.Err) {
+		t.Errorf("err.Err = %v, want %v", err.Err, wrapped)
+	}
+	if !strings.Contains(err.Error(), "connection refused") {
+		t.Errorf("%q does not contain %q", err.Error(), "connection refused")
+	}
 }
 
 func TestNewNoReachableAuthorityError(t *testing.T) {
 	err := NewNoReachableAuthorityError("all servers timed out")
 
-	assert.Equal(t, dns.ExtendedErrorCodeNoReachableAuthority, err.Code)
-	assert.Equal(t, "all servers timed out", err.Message)
-	assert.Nil(t, err.Err)
+	if !reflect.DeepEqual(dns.ExtendedErrorCodeNoReachableAuthority, err.Code) {
+		t.Errorf("err.Code = %v, want %v", err.Code, dns.ExtendedErrorCodeNoReachableAuthority)
+	}
+	if !reflect.DeepEqual("all servers timed out", err.Message) {
+		t.Errorf("err.Message = %v, want %v", err.Message, "all servers timed out")
+	}
+	if err.Err != nil {
+		t.Errorf("err.Err = %v, want nil", err.Err)
+	}
 }
 
 func TestNoReachableAuthAtZone(t *testing.T) {
 	err := NoReachableAuthAtZone("example.com.")
 
-	assert.Equal(t, dns.ExtendedErrorCodeNoReachableAuthority, err.Code)
-	assert.Contains(t, err.Message, "example.com.")
-	assert.Contains(t, err.Message, "delegation")
+	if !reflect.DeepEqual(dns.ExtendedErrorCodeNoReachableAuthority, err.Code) {
+		t.Errorf("err.Code = %v, want %v", err.Code, dns.ExtendedErrorCodeNoReachableAuthority)
+	}
+	if !strings.Contains(err.Message, "example.com.") {
+		t.Errorf("%q does not contain %q", err.Message, "example.com.")
+	}
+	if !strings.Contains(err.Message, "delegation") {
+		t.Errorf("%q does not contain %q", err.Message, "delegation")
+	}
 }
 
 func TestEDEErrorWithContext(t *testing.T) {
@@ -70,26 +103,46 @@ func TestEDEErrorWithContext(t *testing.T) {
 
 	withCtx := original.WithContext("zone %s", "example.com.")
 
-	assert.Equal(t, dns.ExtendedErrorCodeDNSBogus, withCtx.Code)
-	assert.Contains(t, withCtx.Message, "validation failed")
-	assert.Contains(t, withCtx.Message, "example.com.")
+	if !reflect.DeepEqual(dns.ExtendedErrorCodeDNSBogus, withCtx.Code) {
+		t.Errorf("withCtx.Code = %v, want %v", withCtx.Code, dns.ExtendedErrorCodeDNSBogus)
+	}
+	if !strings.Contains(withCtx.Message, "validation failed") {
+		t.Errorf("%q does not contain %q", withCtx.Message, "validation failed")
+	}
+	if !strings.Contains(withCtx.Message, "example.com.") {
+		t.Errorf("%q does not contain %q", withCtx.Message, "example.com.")
+	}
 }
 
 func TestDNSKEYMissingForZone(t *testing.T) {
 	err := dnssec.DNSKEYMissingForZone("secure.example.com.")
 
-	assert.Equal(t, dns.ExtendedErrorCodeDNSKEYMissing, err.Code)
-	assert.Contains(t, err.Message, "secure.example.com.")
-	assert.Contains(t, err.Message, "DNSKEY")
+	if !reflect.DeepEqual(dns.ExtendedErrorCodeDNSKEYMissing, err.Code) {
+		t.Errorf("err.Code = %v, want %v", err.Code, dns.ExtendedErrorCodeDNSKEYMissing)
+	}
+	if !strings.Contains(err.Message, "secure.example.com.") {
+		t.Errorf("%q does not contain %q", err.Message, "secure.example.com.")
+	}
+	if !strings.Contains(err.Message, "DNSKEY") {
+		t.Errorf("%q does not contain %q", err.Message, "DNSKEY")
+	}
 }
 
 func TestSignatureExpiredForRRset(t *testing.T) {
 	err := dnssec.SignatureExpiredForRRset("A", "example.com.")
 
-	assert.Equal(t, dns.ExtendedErrorCodeSignatureExpired, err.Code)
-	assert.Contains(t, err.Message, "A")
-	assert.Contains(t, err.Message, "example.com.")
-	assert.Contains(t, err.Message, "expired")
+	if !reflect.DeepEqual(dns.ExtendedErrorCodeSignatureExpired, err.Code) {
+		t.Errorf("err.Code = %v, want %v", err.Code, dns.ExtendedErrorCodeSignatureExpired)
+	}
+	if !strings.Contains(err.Message, "A") {
+		t.Errorf("%q does not contain %q", err.Message, "A")
+	}
+	if !strings.Contains(err.Message, "example.com.") {
+		t.Errorf("%q does not contain %q", err.Message, "example.com.")
+	}
+	if !strings.Contains(err.Message, "expired") {
+		t.Errorf("%q does not contain %q", err.Message, "expired")
+	}
 }
 
 func TestPredefinedEDEErrors(t *testing.T) {
@@ -110,8 +163,12 @@ func TestPredefinedEDEErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.code, tt.err.EDECode())
-			assert.NotEmpty(t, tt.err.Error())
+			if !reflect.DeepEqual(tt.code, tt.err.EDECode()) {
+				t.Errorf("tt.err.EDECode() = %v, want %v", tt.err.EDECode(), tt.code)
+			}
+			if len(tt.err.Error()) == 0 {
+				t.Errorf("tt.err.Error() is empty")
+			}
 		})
 	}
 }

--- a/middleware/resolver/handler_test.go
+++ b/middleware/resolver/handler_test.go
@@ -2,9 +2,11 @@ package resolver
 
 import (
 	"context"
+	"math"
 	"net"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -16,7 +18,6 @@ import (
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/sdns/middleware/edns"
 	"github.com/semihalev/zlog/v2"
-	"github.com/stretchr/testify/assert"
 )
 
 func makeTestConfig() *config.Config {
@@ -144,16 +145,24 @@ func Test_handler(t *testing.T) {
 
 	ctx := context.Background()
 	handler := New(cfg)
-	assert.Equal(t, "resolver", handler.Name())
+	if !reflect.DeepEqual("resolver", handler.Name()) {
+		t.Errorf("handler.Name() = %v, want %v", handler.Name(), "resolver")
+	}
 
 	m := new(dns.Msg)
 	m.SetQuestion("www.test.", dns.TypeA)
 	r := handler.handle(ctx, m)
-	assert.Equal(t, dns.RcodeSuccess, r.Rcode)
-	if assert.Equal(t, 1, len(r.Answer)) {
-		assert.Equal(t, "192.0.2.10", r.Answer[0].(*dns.A).A.String())
+	if !reflect.DeepEqual(dns.RcodeSuccess, r.Rcode) {
+		t.Errorf("r.Rcode = %v, want %v", r.Rcode, dns.RcodeSuccess)
 	}
-	assert.Equal(t, 1, queries("www.test."), "the answer must come off the wire once")
+	if len(r.Answer) != 1 {
+		t.Errorf("len(r.Answer) = %v, want %v", len(r.Answer), 1)
+	} else if !reflect.DeepEqual("192.0.2.10", r.Answer[0].(*dns.A).A.String()) {
+		t.Errorf("r.Answer[0].(*dns.A).A.String() = %v, want %v", r.Answer[0].(*dns.A).A.String(), "192.0.2.10")
+	}
+	if !reflect.DeepEqual(1, queries("www.test.")) {
+		t.Errorf("%s: queries('www.test.') = %v, want %v", "the answer must come off the wire once", queries("www.test."), 1)
+	}
 
 	// The same question again. Answers are cached by the cache middleware,
 	// which this chain does not carry, so the resolver asks again — one
@@ -161,28 +170,42 @@ func Test_handler(t *testing.T) {
 	m = new(dns.Msg)
 	m.SetQuestion("www.test.", dns.TypeA)
 	r = handler.handle(ctx, m)
-	assert.Equal(t, dns.RcodeSuccess, r.Rcode)
-	assert.Equal(t, 1, len(r.Answer))
-	assert.Equal(t, 2, queries("www.test."), "the repeat must cost exactly one more query")
+	if !reflect.DeepEqual(dns.RcodeSuccess, r.Rcode) {
+		t.Errorf("r.Rcode = %v, want %v", r.Rcode, dns.RcodeSuccess)
+	}
+	if !reflect.DeepEqual(1, len(r.Answer)) {
+		t.Errorf("len(r.Answer) = %v, want %v", len(r.Answer), 1)
+	}
+	if !reflect.DeepEqual(2, queries("www.test.")) {
+		t.Errorf("%s: queries('www.test.') = %v, want %v", "the repeat must cost exactly one more query", queries("www.test."), 2)
+	}
 
 	// A name the authority denies.
 	m = new(dns.Msg)
 	m.SetQuestion("absent.test.", dns.TypeA)
 	r = handler.handle(ctx, m)
-	assert.Equal(t, dns.RcodeNameError, r.Rcode)
-	assert.Equal(t, 0, len(r.Answer))
+	if !reflect.DeepEqual(dns.RcodeNameError, r.Rcode) {
+		t.Errorf("r.Rcode = %v, want %v", r.Rcode, dns.RcodeNameError)
+	}
+	if !reflect.DeepEqual(0, len(r.Answer)) {
+		t.Errorf("len(r.Answer) = %v, want %v", len(r.Answer), 0)
+	}
 
 	// Questions the handler answers on its own, without asking anyone.
 	m = new(dns.Msg)
 	m.SetQuestion(".", dns.TypeANY)
 	r = handler.handle(ctx, m)
-	assert.Equal(t, dns.RcodeNotImplemented, r.Rcode)
+	if !reflect.DeepEqual(dns.RcodeNotImplemented, r.Rcode) {
+		t.Errorf("r.Rcode = %v, want %v", r.Rcode, dns.RcodeNotImplemented)
+	}
 
 	m = new(dns.Msg)
 	m.SetQuestion(".", dns.TypeNS)
 	m.RecursionDesired = false
 	r = handler.handle(ctx, m)
-	assert.NotEqual(t, dns.RcodeServerFailure, r.Rcode)
+	if reflect.DeepEqual(dns.RcodeServerFailure, r.Rcode) {
+		t.Errorf("r.Rcode = %v, want a different value", r.Rcode)
+	}
 }
 
 func Test_HandlerHINFO(t *testing.T) {
@@ -197,7 +220,9 @@ func Test_HandlerHINFO(t *testing.T) {
 	debugns = true
 	resp := handler.handle(ctx, m)
 
-	assert.Equal(t, true, len(resp.Ns) > 0)
+	if !reflect.DeepEqual(true, len(resp.Ns) > 0) {
+		t.Errorf("len(resp.Ns) > 0 = %v, want %v", len(resp.Ns) > 0, true)
+	}
 }
 
 func Test_HandlerServe(t *testing.T) {
@@ -215,7 +240,9 @@ func Test_HandlerServe(t *testing.T) {
 	ch.Reset(mw, req)
 
 	h.ServeDNS(context.Background(), ch)
-	assert.Equal(t, true, ch.Writer.Written())
+	if !reflect.DeepEqual(true, ch.Writer.Written()) {
+		t.Errorf("ch.Writer.Written() = %v, want %v", ch.Writer.Written(), true)
+	}
 }
 
 func Test_withQueryDeadline(t *testing.T) {
@@ -226,20 +253,32 @@ func Test_withQueryDeadline(t *testing.T) {
 	bounded, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	got, gotCancel := withQueryDeadline(bounded, timeout)
-	assert.Equal(t, bounded, got, "an earlier-bounded parent must not grow a child")
+	if !reflect.DeepEqual(bounded, got) {
+		t.Errorf("%s: got = %v, want %v", "an earlier-bounded parent must not grow a child", got, bounded)
+	}
 	parentDeadline, _ := bounded.Deadline()
 	gotDeadline, ok := got.Deadline()
-	assert.True(t, ok)
-	assert.Equal(t, parentDeadline, gotDeadline)
+	if !(ok) {
+		t.Errorf("ok is false")
+	}
+	if !reflect.DeepEqual(parentDeadline, gotDeadline) {
+		t.Errorf("gotDeadline = %v, want %v", gotDeadline, parentDeadline)
+	}
 	gotCancel()
-	assert.NoError(t, bounded.Err(), "the no-op cancel must not cancel the parent")
+	if err := bounded.Err(); err != nil {
+		t.Errorf("%s: unexpected error: %v", "the no-op cancel must not cancel the parent", err)
+	}
 
 	// An unbounded parent gets the timeout.
 	got, gotCancel = withQueryDeadline(context.Background(), timeout)
 	defer gotCancel()
 	gotDeadline, ok = got.Deadline()
-	assert.True(t, ok, "an unbounded parent must gain a deadline")
-	assert.InDelta(t, time.Until(gotDeadline).Seconds(), timeout.Seconds(), 1.0)
+	if !(ok) {
+		t.Errorf("%s: ok is false", "an unbounded parent must gain a deadline")
+	}
+	if diff := math.Abs(time.Until(gotDeadline).Seconds() - timeout.Seconds()); diff > 1.0 {
+		t.Errorf("deadline is %v seconds away, want within 1.0 of %v", time.Until(gotDeadline).Seconds(), timeout.Seconds())
+	}
 
 	// A parent bounded later than the timeout is tightened.
 	loose, cancel2 := context.WithTimeout(context.Background(), time.Hour)
@@ -248,7 +287,9 @@ func Test_withQueryDeadline(t *testing.T) {
 	defer gotCancel()
 	gotDeadline, _ = got.Deadline()
 	looseDeadline, _ := loose.Deadline()
-	assert.True(t, gotDeadline.Before(looseDeadline), "a later-bounded parent must be tightened")
+	if !(gotDeadline.Before(looseDeadline)) {
+		t.Errorf("%s: gotDeadline.Before(looseDeadline) is false", "a later-bounded parent must be tightened")
+	}
 }
 
 func Test_requestIDFromContext(t *testing.T) {
@@ -284,5 +325,7 @@ func Test_withQueryDeadline_LazyParentAllocsNothing(t *testing.T) {
 		cancel()
 		_ = ctx
 	})
-	assert.Zero(t, allocs, "deriving the query deadline under a server-bounded parent must not allocate")
+	if allocs != 0 {
+		t.Errorf("%s: allocs = %v, want 0", "deriving the query deadline under a server-bounded parent must not allocate", allocs)
+	}
 }

--- a/middleware/resolver/hermetic_recovery_test.go
+++ b/middleware/resolver/hermetic_recovery_test.go
@@ -2,13 +2,14 @@ package resolver
 
 import (
 	"net"
+	"reflect"
+	"slices"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/internal/authority"
-	"github.com/stretchr/testify/assert"
 )
 
 // TestHermeticResolveRefreshesStaleAuthority drives the recovery a resolver
@@ -38,8 +39,12 @@ func TestHermeticResolveRefreshesStaleAuthority(t *testing.T) {
 	r := world.handlerWithConfig(cfg).resolver
 
 	resp, err := hermeticResolve(t, r, "www.shop.test.", dns.TypeA)
-	assert.NoError(t, err)
-	assert.NotNil(t, resp)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("resp is nil")
+	}
 
 	question := dns.Question{
 		Name: "www.shop.test.", Qtype: dns.TypeA, Qclass: dns.ClassINET,
@@ -69,15 +74,21 @@ func TestHermeticResolveRefreshesStaleAuthority(t *testing.T) {
 
 	resp, err = hermeticResolve(t, r, "www.shop.test.", dns.TypeA)
 
-	assert.NoError(t, err, "the resolver did not recover from a stale authority")
-	if assert.NotNil(t, resp) {
+	if err != nil {
+		t.Errorf("%s: unexpected error: %v", "the resolver did not recover from a stale authority", err)
+	}
+	if resp == nil {
+		t.Error("resp is nil")
+	} else {
 		addresses := []string{}
 		for _, answer := range resp.Answer {
 			if a, ok := answer.(*dns.A); ok {
 				addresses = append(addresses, a.A.String())
 			}
 		}
-		assert.Equal(t, []string{"192.0.2.60"}, addresses)
+		if !reflect.DeepEqual([]string{"192.0.2.60"}, addresses) {
+			t.Errorf("addresses = %v, want %v", addresses, []string{"192.0.2.60"})
+		}
 	}
 
 	// The refresh is the point, and it shows in two places: the resolver
@@ -86,18 +97,22 @@ func TestHermeticResolveRefreshesStaleAuthority(t *testing.T) {
 	// refresh adds what works rather than pruning what does not — so this
 	// asks whether the working address is present, not whether the dead one
 	// is gone.
-	assert.Greater(t, helper.asked("ns1.helper.test.", dns.TypeA), lookupsBefore,
-		"the nameserver's address was never looked up again, so nothing was refreshed")
+	if helper.asked("ns1.helper.test.", dns.TypeA) <= lookupsBefore {
+		t.Errorf("%s: helper.asked('ns1.helper.test.', dns.TypeA) = %v, want > %v", "the nameserver's address was never looked up again, so nothing was refreshed", helper.asked("ns1.helper.test.", dns.TypeA), lookupsBefore)
+	}
 
 	working := net.JoinHostPort(shop.glue.String(), "53")
 	after := r.searchCache(question, false, "www.shop.test.")
-	if assert.NotNil(t, after.servers) {
+	if after.servers == nil {
+		t.Error("after.servers is nil")
+	} else {
 		addrs := make([]string, 0, len(after.servers.List))
 		for _, server := range after.servers.List {
 			addrs = append(addrs, server.Addr)
 		}
-		assert.Contains(t, addrs, working,
-			"the refreshed delegation does not carry the address that answers")
+		if !slices.Contains(addrs, working) {
+			t.Errorf("the refreshed delegation %v does not carry the address that answers (%s)", addrs, working)
+		}
 	}
 }
 

--- a/middleware/resolver/hermetic_resolver_test.go
+++ b/middleware/resolver/hermetic_resolver_test.go
@@ -2,13 +2,13 @@ package resolver
 
 import (
 	"context"
+	"reflect"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/internal/dnsutil"
-	"github.com/stretchr/testify/assert"
 )
 
 // hermeticResolve runs one query through a resolver wired to net, starting
@@ -43,9 +43,14 @@ func TestHermeticResolve(t *testing.T) {
 
 	r := net.Resolver()
 	resp, err := hermeticResolve(t, r, "www.shop.test.", dns.TypeA)
-	assert.NoError(t, err)
-	assert.NotNil(t, resp)
-	assert.True(t, len(resp.Answer) > 0)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("resp is nil")
+	} else if len(resp.Answer) == 0 {
+		t.Errorf("len(resp.Answer) > 0 is false")
+	}
 
 	question := dns.Question{
 		Name: "www.shop.test.", Qtype: dns.TypeA, Qclass: dns.ClassINET,
@@ -55,9 +60,12 @@ func TestHermeticResolve(t *testing.T) {
 		t.Fatal("the delegation used to answer was not cached")
 	}
 
-	assert.Equal(t, "shop.test.", match.servers.Zone)
-	assert.Equal(t, uint32(0), atomic.LoadUint32(&match.servers.ErrorCount),
-		"a delegation that answered should not be carrying failures")
+	if !reflect.DeepEqual("shop.test.", match.servers.Zone) {
+		t.Errorf("match.servers.Zone = %v, want %v", match.servers.Zone, "shop.test.")
+	}
+	if !reflect.DeepEqual(uint32(0), atomic.LoadUint32(&match.servers.ErrorCount)) {
+		t.Errorf("%s: atomic.LoadUint32(&match.servers.ErrorCount) = %v, want %v", "a delegation that answered should not be carrying failures", atomic.LoadUint32(&match.servers.ErrorCount), uint32(0))
+	}
 }
 
 // TestHermeticResolveMinimize walks a deep name with QNAME minimisation on,
@@ -74,9 +82,14 @@ func TestHermeticResolveMinimize(t *testing.T) {
 	resp, err := hermeticResolve(t, handler.resolver, "a.b.c.deep.test.", dns.TypeA,
 		func(m *dns.Msg) { m.CheckingDisabled = true })
 
-	assert.NoError(t, err)
-	assert.NotNil(t, resp)
-	assert.True(t, len(resp.Answer) > 0)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("resp is nil")
+	} else if len(resp.Answer) == 0 {
+		t.Errorf("len(resp.Answer) > 0 is false")
+	}
 }
 
 // TestHermeticResolveNXDOMAIN asks for a name the root does not delegate.
@@ -86,9 +99,14 @@ func TestHermeticResolveNXDOMAIN(t *testing.T) {
 
 	resp, err := hermeticResolve(t, net.Resolver(), "nothing-here.", dns.TypeNS)
 
-	assert.NoError(t, err)
-	assert.NotNil(t, resp)
-	assert.Equal(t, dns.RcodeNameError, resp.Rcode)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("resp is nil")
+	} else if !reflect.DeepEqual(dns.RcodeNameError, resp.Rcode) {
+		t.Errorf("resp.Rcode = %v, want %v", resp.Rcode, dns.RcodeNameError)
+	}
 }
 
 // TestHermeticResolveEmptyNonTerminal asks for a label that only exists
@@ -103,11 +121,18 @@ func TestHermeticResolveEmptyNonTerminal(t *testing.T) {
 
 	resp, err := hermeticResolve(t, net.Resolver(), "test.", dns.TypeA)
 
-	assert.NoError(t, err)
-	if assert.NotNil(t, resp) {
-		assert.Equal(t, dns.RcodeSuccess, resp.Rcode,
-			"a label above a delegation exists; denying it denies the subtree")
-		assert.Equal(t, 0, len(resp.Answer))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Error("resp is nil")
+	} else {
+		if !reflect.DeepEqual(dns.RcodeSuccess, resp.Rcode) {
+			t.Errorf("%s: resp.Rcode = %v, want %v", "a label above a delegation exists; denying it denies the subtree", resp.Rcode, dns.RcodeSuccess)
+		}
+		if !reflect.DeepEqual(0, len(resp.Answer)) {
+			t.Errorf("len(resp.Answer) = %v, want %v", len(resp.Answer), 0)
+		}
 	}
 }
 
@@ -120,10 +145,19 @@ func TestHermeticResolveNODATA(t *testing.T) {
 
 	resp, err := hermeticResolve(t, net.Resolver(), "host.nodata2.test.", dns.TypeAAAA)
 
-	assert.NoError(t, err)
-	assert.NotNil(t, resp)
-	assert.Equal(t, dns.RcodeSuccess, resp.Rcode)
-	assert.Equal(t, 0, len(resp.Answer))
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("resp is nil")
+	} else {
+		if !reflect.DeepEqual(dns.RcodeSuccess, resp.Rcode) {
+			t.Errorf("resp.Rcode = %v, want %v", resp.Rcode, dns.RcodeSuccess)
+		}
+		if !reflect.DeepEqual(0, len(resp.Answer)) {
+			t.Errorf("len(resp.Answer) = %v, want %v", len(resp.Answer), 0)
+		}
+	}
 }
 
 // TestHermeticResolveUnreachableAuthority pins that a zone whose authority
@@ -142,7 +176,9 @@ func TestHermeticResolveUnreachableAuthority(t *testing.T) {
 
 	_, err := hermeticResolve(t, r, "www.dead.test.", dns.TypeA)
 
-	assert.Error(t, err)
+	if err == nil {
+		t.Errorf("expected an error, got nil")
+	}
 }
 
 // TestHermeticResolveRootKeys pins that the root's own DNSKEY resolves,
@@ -152,7 +188,12 @@ func TestHermeticResolveRootKeys(t *testing.T) {
 
 	resp, err := hermeticResolve(t, net.Resolver(), ".", dns.TypeDNSKEY)
 
-	assert.NoError(t, err)
-	assert.NotNil(t, resp)
-	assert.True(t, len(resp.Answer) > 0)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("resp is nil")
+	} else if len(resp.Answer) == 0 {
+		t.Errorf("len(resp.Answer) > 0 is false")
+	}
 }

--- a/middleware/resolver/integration_test.go
+++ b/middleware/resolver/integration_test.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -12,7 +13,6 @@ import (
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/internal/authority"
 	"github.com/semihalev/sdns/internal/dnsutil"
-	"github.com/stretchr/testify/assert"
 )
 
 // TestCircuitBreakerIntegration tests circuit breaker with real failing servers
@@ -41,22 +41,29 @@ func TestCircuitBreakerIntegration(t *testing.T) {
 		go func(n int) {
 			defer wg.Done()
 			_, err := r.lookup(ctx, &resolveState{requestID: req.Id}, req, servers)
-			assert.Error(t, err, "Query %d should fail", n)
+			if err == nil {
+				t.Errorf("%s: expected an error, got nil", fmt.Sprintf("Query %d should fail", n))
+			}
 		}(i)
 		time.Sleep(10 * time.Millisecond) // Small delay between queries
 	}
 	wg.Wait()
 
 	// After 5 failures, circuit breaker should be tripped
-	assert.False(t, r.circuitBreaker.canQuery(badServer.Addr),
-		"Circuit breaker should be tripped after failures")
+	if r.circuitBreaker.canQuery(badServer.Addr) {
+		t.Errorf("%s: r.circuitBreaker.canQuery(badServer.Addr) is true", "Circuit breaker should be tripped after failures")
+	}
 
 	// Verify the server is in failed state
 	r.circuitBreaker.mu.RLock()
 	sf, exists := r.circuitBreaker.failures[badServer.Addr]
 	r.circuitBreaker.mu.RUnlock()
-	assert.True(t, exists, "Server should be tracked in failures")
-	assert.True(t, sf.disabled.Load(), "Server should be disabled")
+	if !(exists) {
+		t.Errorf("%s: exists is false", "Server should be tracked in failures")
+	}
+	if !(sf.disabled.Load()) {
+		t.Errorf("%s: sf.disabled.Load() is false", "Server should be disabled")
+	}
 }
 
 // TestGoroutineLimitUnderLoad tests that goroutine limit prevents runaway growth
@@ -129,8 +136,9 @@ func TestGoroutineLimitUnderLoad(t *testing.T) {
 	// Since we're starting 100 goroutines but only allow 20 concurrent,
 	// we expect to see all 100 trying to acquire (which is what we measure)
 	// but only 20 will be actively running queries at once
-	assert.LessOrEqual(t, int(maxObserved), 100,
-		"Should track the goroutines we started")
+	if int(maxObserved) > 100 {
+		t.Errorf("%s: int(maxObserved) = %v, want <= %v", "Should track the goroutines we started", int(maxObserved), 100)
+	}
 }
 
 // TestCircuitBreakerRecovery tests that circuit breaker recovers after timeout
@@ -149,8 +157,9 @@ func TestCircuitBreakerRecovery(t *testing.T) {
 		r.circuitBreaker.recordFailure(server)
 	}
 
-	assert.False(t, r.circuitBreaker.canQuery(server),
-		"Circuit breaker should be tripped")
+	if r.circuitBreaker.canQuery(server) {
+		t.Errorf("%s: r.circuitBreaker.canQuery(server) is true", "Circuit breaker should be tripped")
+	}
 
 	// Manually set last failure to 31 seconds ago
 	r.circuitBreaker.mu.RLock()
@@ -159,17 +168,20 @@ func TestCircuitBreakerRecovery(t *testing.T) {
 	sf.lastFailure.Store(time.Now().Add(-31 * time.Second).Unix())
 
 	// Should be queryable again
-	assert.True(t, r.circuitBreaker.canQuery(server),
-		"Circuit breaker should reset after timeout")
+	if !(r.circuitBreaker.canQuery(server)) {
+		t.Errorf("%s: r.circuitBreaker.canQuery(server) is false", "Circuit breaker should reset after timeout")
+	}
 
 	// Record a success to fully reset
 	r.circuitBreaker.recordSuccess(server)
 
 	// Verify it's fully reset
-	assert.Equal(t, int32(0), sf.count.Load(),
-		"Failure count should be reset")
-	assert.False(t, sf.disabled.Load(),
-		"Server should not be disabled")
+	if !reflect.DeepEqual(int32(0), sf.count.Load()) {
+		t.Errorf("%s: sf.count.Load() = %v, want %v", "Failure count should be reset", sf.count.Load(), int32(0))
+	}
+	if sf.disabled.Load() {
+		t.Errorf("%s: sf.disabled.Load() is true", "Server should not be disabled")
+	}
 }
 
 // TestNoGoroutineLeaks verifies that goroutines are properly cleaned up
@@ -220,8 +232,9 @@ func TestNoGoroutineLeaks(t *testing.T) {
 		initialGoroutines, finalGoroutines, leaked)
 
 	// Allow some variance for background tasks
-	assert.LessOrEqual(t, leaked, 10,
-		"Should not leak many goroutines")
+	if leaked > 10 {
+		t.Errorf("%s: leaked = %v, want <= %v", "Should not leak many goroutines", leaked, 10)
+	}
 }
 
 // TestCircuitBreakerWithMixedServers tests behavior with both good and bad servers
@@ -271,12 +284,14 @@ func TestCircuitBreakerWithMixedServers(t *testing.T) {
 	wg.Wait()
 
 	// Should have some successes from the good server
-	assert.Greater(t, int(successes.Load()), 0,
-		"Should have some successful queries from good server")
+	if int(successes.Load()) <= 0 {
+		t.Errorf("%s: int(successes.Load()) = %v, want > %v", "Should have some successful queries from good server", int(successes.Load()), 0)
+	}
 
 	// Bad servers should be in circuit breaker
-	assert.True(t, r.circuitBreaker.canQuery(goodAddr),
-		"Good server should still be queryable")
+	if !(r.circuitBreaker.canQuery(goodAddr)) {
+		t.Errorf("%s: r.circuitBreaker.canQuery(goodAddr) is false", "Good server should still be queryable")
+	}
 }
 
 // TestHighLoadWithCircuitBreaker simulates the exact Google scenario
@@ -387,8 +402,9 @@ func TestHighLoadWithCircuitBreaker(t *testing.T) {
 	// Growth should be controlled by MaxConcurrentQueries
 	// Note: Since queries spawn goroutines that then acquire semaphore,
 	// we may temporarily exceed the limit while goroutines wait for slots
-	assert.LessOrEqual(t, goroutineGrowth, cfg.MaxConcurrentQueries*3,
-		"Goroutine growth should be limited by MaxConcurrentQueries")
+	if goroutineGrowth > cfg.MaxConcurrentQueries*3 {
+		t.Errorf("%s: goroutineGrowth = %v, want <= %v", "Goroutine growth should be limited by MaxConcurrentQueries", goroutineGrowth, cfg.MaxConcurrentQueries*3)
+	}
 
 	// Wait for cleanup, but only as long as it actually takes: the test is
 	// about the goroutines going away, not about how long we are willing to
@@ -408,8 +424,9 @@ func TestHighLoadWithCircuitBreaker(t *testing.T) {
 		finalGoroutines, startGoroutines)
 
 	// Should return close to initial count
-	assert.LessOrEqual(t, finalGoroutines-startGoroutines, 20,
-		"Goroutines should be cleaned up after load stops")
+	if finalGoroutines-startGoroutines > 20 {
+		t.Errorf("%s: finalGoroutines-startGoroutines = %v, want <= %v", "Goroutines should be cleaned up after load stops", finalGoroutines-startGoroutines, 20)
+	}
 }
 
 // TestConcurrentCircuitBreakerOperations tests thread safety

--- a/middleware/resolver/parallel_integration_test.go
+++ b/middleware/resolver/parallel_integration_test.go
@@ -2,11 +2,12 @@ package resolver
 
 import (
 	"context"
+	"reflect"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/miekg/dns"
-	"github.com/stretchr/testify/assert"
 )
 
 // The parallel lookup paths used to be exercised against www.github.com. and
@@ -50,26 +51,35 @@ func TestParallelLookupIntegration(t *testing.T) {
 	resp, err := r.Resolve(ctx, req, r.rootServers, true, 30, 0, false, nil)
 	elapsed := time.Since(start)
 
-	assert.NoError(t, err)
-	assert.NotNil(t, resp)
-
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 	// Both assertions together are what a serial implementation cannot
 	// satisfy. The answering nameserver was held until the silent one had
 	// been contacted, so an answer arriving at all means the two were in
 	// flight together; and it arrived well inside the budget, so nothing
 	// waited the silent one out first.
-	assert.Greater(t, zone.silentAsked("www.parallel.test.", dns.TypeA), 0,
-		"the second nameserver was never contacted, so nothing was raced")
-	assert.Less(t, elapsed, cfg.Timeout.Duration,
-		"the answer arrived only after the silent nameserver's budget expired")
+	if zone.silentAsked("www.parallel.test.", dns.TypeA) <= 0 {
+		t.Errorf("%s: zone.silentAsked('www.parallel.test.', dns.TypeA) = %v, want > %v", "the second nameserver was never contacted, so nothing was raced", zone.silentAsked("www.parallel.test.", dns.TypeA), 0)
+	}
+	if elapsed >= cfg.Timeout.Duration {
+		t.Errorf("%s: elapsed = %v, want < %v", "the answer arrived only after the silent nameserver's budget expired", elapsed, cfg.Timeout.Duration)
+	}
 
-	addresses := []string{}
-	for _, answer := range resp.Answer {
-		if a, ok := answer.(*dns.A); ok {
-			addresses = append(addresses, a.A.String())
+	if resp == nil {
+		t.Error("resp is nil")
+	} else {
+		addresses := []string{}
+		for _, answer := range resp.Answer {
+			if a, ok := answer.(*dns.A); ok {
+				addresses = append(addresses, a.A.String())
+			}
+		}
+		slices.Sort(addresses)
+		if want := []string{"192.0.2.71", "192.0.2.72"}; !reflect.DeepEqual(want, addresses) {
+			t.Errorf("addresses = %v, want %v", addresses, want)
 		}
 	}
-	assert.ElementsMatch(t, []string{"192.0.2.71", "192.0.2.72"}, addresses)
 }
 
 func TestParallelLookupIPv6(t *testing.T) {
@@ -92,8 +102,12 @@ func TestParallelLookupIPv6(t *testing.T) {
 
 	// The previous version logged whatever happened and asserted nothing,
 	// so an AAAA lookup that quietly stopped working looked like a pass.
-	assert.NoError(t, err)
-	assert.NotNil(t, resp)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("resp is nil")
+	}
 	// A signed answer carries its RRSIG alongside the data, so the records
 	// are selected by type rather than counted.
 	addresses := []string{}
@@ -102,7 +116,9 @@ func TestParallelLookupIPv6(t *testing.T) {
 			addresses = append(addresses, aaaa.AAAA.String())
 		}
 	}
-	assert.Equal(t, []string{"2001:db8::71"}, addresses)
+	if !reflect.DeepEqual([]string{"2001:db8::71"}, addresses) {
+		t.Errorf("addresses = %v, want %v", addresses, []string{"2001:db8::71"})
+	}
 }
 
 func BenchmarkParallelLookup(b *testing.B) {

--- a/middleware/resolver/resolver_tcp_test.go
+++ b/middleware/resolver/resolver_tcp_test.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"context"
 	"net"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -10,8 +11,6 @@ import (
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/config"
 	"github.com/semihalev/sdns/internal/authority"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestResolverTCPPoolIntegration(t *testing.T) {
@@ -48,41 +47,63 @@ func TestResolverTCPPoolIntegration(t *testing.T) {
 	req.SetQuestion(".", dns.TypeNS)
 
 	resp, err := r.exchange(context.Background(), &resolveState{requestID: req.Id}, nil, "tcp", req, r.rootServers.List[0], 0)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("resp is nil")
+	}
 
 	// Wait briefly for connection to be returned to pool
 	time.Sleep(10 * time.Millisecond)
 
 	// Check pool stats
 	hits, misses, active := r.tcpPool.Stats()
-	assert.Equal(t, int64(0), hits)
-	assert.Equal(t, int64(1), misses) // Get was called but missed
-	assert.Equal(t, 1, active)        // Connection should be pooled
+	if !reflect.DeepEqual(int64(0), hits) {
+		t.Errorf("hits = %v, want %v", hits, int64(0))
+	}
+	if !reflect.DeepEqual(int64(1), misses) {
+		t.Errorf("misses = %v, want %v", misses, int64(1))
+	} // Get was called but missed
+	if !reflect.DeepEqual(1, active) {
+		t.Errorf("active = %v, want %v", active, 1)
+	} // Connection should be pooled
 
 	// Test 2: Second query should reuse connection
 	resp2, err := r.exchange(context.Background(), &resolveState{requestID: req.Id}, nil, "tcp", req, r.rootServers.List[0], 0)
-	require.NoError(t, err)
-	require.NotNil(t, resp2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp2 == nil {
+		t.Fatalf("resp2 is nil")
+	}
 
 	// Wait for connection to be returned to pool again
 	time.Sleep(10 * time.Millisecond)
 
 	// Should have one hit now
 	hits, _, active = r.tcpPool.Stats()
-	assert.Equal(t, int64(1), hits)
-	assert.Equal(t, 1, active) // Connection should still be in pool
+	if !reflect.DeepEqual(int64(1), hits) {
+		t.Errorf("hits = %v, want %v", hits, int64(1))
+	}
+	if !reflect.DeepEqual(1, active) {
+		t.Errorf("active = %v, want %v", active, 1)
+	} // Connection should still be in pool
 
 	// Verify we made two requests total
 	server.mu.Lock()
 	reqCount := server.requests
 	server.mu.Unlock()
-	assert.Equal(t, 2, reqCount)
+	if !reflect.DeepEqual(2, reqCount) {
+		t.Errorf("reqCount = %v, want %v", reqCount, 2)
+	}
 
 	// The connection pool should have reused the connection,
 	// so we should still have just one active connection
 	_, _, active = r.tcpPool.Stats()
-	assert.Equal(t, 1, active)
+	if !reflect.DeepEqual(1, active) {
+		t.Errorf("active = %v, want %v", active, 1)
+	}
 }
 
 func TestResolverTCPPoolConcurrent(t *testing.T) {
@@ -135,12 +156,16 @@ func TestResolverTCPPoolConcurrent(t *testing.T) {
 
 	// Check for errors
 	for err := range errors {
-		assert.NoError(t, err)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
 	}
 
 	// Pool should be at max capacity
 	_, _, active := r.tcpPool.Stats()
-	assert.LessOrEqual(t, active, 2)
+	if active > 2 {
+		t.Errorf("active = %v, want <= %v", active, 2)
+	}
 }
 
 func TestResolverTCPPoolWithEDNSKeepalive(t *testing.T) {
@@ -174,11 +199,17 @@ func TestResolverTCPPoolWithEDNSKeepalive(t *testing.T) {
 	req.SetQuestion(".", dns.TypeNS)
 
 	resp, err := r.exchange(context.Background(), &resolveState{requestID: req.Id}, nil, "tcp", req, authServer, 0)
-	require.NoError(t, err)
-	require.NotNil(t, resp)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp == nil {
+		t.Fatalf("resp is nil")
+	}
 
 	// Check that EDNS-Keepalive was added to request
-	assert.NotNil(t, req.IsEdns0())
+	if req.IsEdns0() == nil {
+		t.Fatalf("req.IsEdns0() is nil")
+	}
 	hasKeepalive := false
 	for _, opt := range req.IsEdns0().Option {
 		if _, ok := opt.(*dns.EDNS0_TCP_KEEPALIVE); ok {
@@ -186,14 +217,18 @@ func TestResolverTCPPoolWithEDNSKeepalive(t *testing.T) {
 			break
 		}
 	}
-	assert.True(t, hasKeepalive)
+	if !(hasKeepalive) {
+		t.Errorf("hasKeepalive is false")
+	}
 
 	// Sleep briefly to allow connection to be returned to pool
 	time.Sleep(10 * time.Millisecond)
 
 	// Check pool stats instead of direct access
 	_, _, active := r.tcpPool.Stats()
-	assert.Equal(t, 1, active)
+	if !reflect.DeepEqual(1, active) {
+		t.Errorf("active = %v, want %v", active, 1)
+	}
 }
 
 // testDNSServer is a mock DNS server for testing.
@@ -245,7 +280,9 @@ func (s *testDNSServer) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 func startTestDNSServer(t *testing.T, handler dns.Handler) (string, func()) {
 	// Start on random port
 	pc, err := net.Listen("tcp", "127.0.0.1:0")
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	server := &dns.Server{
 		Net:      "tcp",

--- a/middleware/resolver/resolver_test.go
+++ b/middleware/resolver/resolver_test.go
@@ -2,11 +2,11 @@ package resolver
 
 import (
 	"context"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/miekg/dns"
-	"github.com/stretchr/testify/assert"
 )
 
 // Resolution itself — an ordinary answer, QNAME minimisation, NXDOMAIN,
@@ -21,7 +21,9 @@ import (
 
 func Test_EqualServers(t *testing.T) {
 	r := newWiredTestResolver(makeTestConfig())
-	assert.Equal(t, true, r.equalServers(r.rootServers, r.rootServers))
+	if !reflect.DeepEqual(true, r.equalServers(r.rootServers, r.rootServers)) {
+		t.Errorf("r.equalServers(r.rootServers, r.rootServers) = %v, want %v", r.equalServers(r.rootServers, r.rootServers), true)
+	}
 }
 
 func Test_OutboundIPs(t *testing.T) {
@@ -34,8 +36,12 @@ func Test_OutboundIPs(t *testing.T) {
 	cfg.OutboundIP6s = []string{"::1", "1"}
 
 	r := newWiredTestResolver(cfg)
-	assert.Len(t, r.outboundIPv4, 1)
-	assert.Len(t, r.outboundIPv6, 1)
+	if len(r.outboundIPv4) != 1 {
+		t.Errorf("len(r.outboundIPv4) = %d, want %d", len(r.outboundIPv4), 1)
+	}
+	if len(r.outboundIPv6) != 1 {
+		t.Errorf("len(r.outboundIPv6) = %d, want %d", len(r.outboundIPv6), 1)
+	}
 
 	req := new(dns.Msg)
 	req.SetQuestion("example.com.", dns.TypeA)
@@ -46,5 +52,7 @@ func Test_OutboundIPs(t *testing.T) {
 	defer cancel()
 
 	_, err := r.lookup(ctx, &resolveState{requestID: req.Id}, req, r.rootServers)
-	assert.Error(t, err)
+	if err == nil {
+		t.Errorf("expected an error, got nil")
+	}
 }

--- a/middleware/resolver/tcp_pool_test.go
+++ b/middleware/resolver/tcp_pool_test.go
@@ -2,26 +2,40 @@ package resolver
 
 import (
 	"net"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/miekg/dns"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestNewTCPConnPool(t *testing.T) {
 	// Test with defaults
 	pool := NewTCPConnPool(0, 0, 0)
-	assert.NotNil(t, pool)
-	assert.Equal(t, 5*time.Second, pool.rootTimeout)
-	assert.Equal(t, 10*time.Second, pool.tldTimeout)
-	assert.Equal(t, 100, pool.maxConns)
+	if pool == nil {
+		t.Fatalf("pool is nil")
+	}
+	if !reflect.DeepEqual(5*time.Second, pool.rootTimeout) {
+		t.Errorf("pool.rootTimeout = %v, want %v", pool.rootTimeout, 5*time.Second)
+	}
+	if !reflect.DeepEqual(10*time.Second, pool.tldTimeout) {
+		t.Errorf("pool.tldTimeout = %v, want %v", pool.tldTimeout, 10*time.Second)
+	}
+	if !reflect.DeepEqual(100, pool.maxConns) {
+		t.Errorf("pool.maxConns = %v, want %v", pool.maxConns, 100)
+	}
 
 	// Test with custom values
 	pool2 := NewTCPConnPool(3*time.Second, 7*time.Second, 50)
-	assert.Equal(t, 3*time.Second, pool2.rootTimeout)
-	assert.Equal(t, 7*time.Second, pool2.tldTimeout)
-	assert.Equal(t, 50, pool2.maxConns)
+	if !reflect.DeepEqual(3*time.Second, pool2.rootTimeout) {
+		t.Errorf("pool2.rootTimeout = %v, want %v", pool2.rootTimeout, 3*time.Second)
+	}
+	if !reflect.DeepEqual(7*time.Second, pool2.tldTimeout) {
+		t.Errorf("pool2.tldTimeout = %v, want %v", pool2.tldTimeout, 7*time.Second)
+	}
+	if !reflect.DeepEqual(50, pool2.maxConns) {
+		t.Errorf("pool2.maxConns = %v, want %v", pool2.maxConns, 50)
+	}
 
 	// Clean up
 	pool.Close()
@@ -34,13 +48,21 @@ func TestTCPConnPoolGetPut(t *testing.T) {
 
 	// Test getting from empty pool
 	conn := pool.Get("192.5.5.241:53", true, false)
-	assert.Nil(t, conn)
+	if conn != nil {
+		t.Errorf("conn = %v, want nil", conn)
+	}
 
 	// Test stats for miss
 	hits, misses, active := pool.Stats()
-	assert.Equal(t, int64(0), hits)
-	assert.Equal(t, int64(1), misses)
-	assert.Equal(t, 0, active)
+	if !reflect.DeepEqual(int64(0), hits) {
+		t.Errorf("hits = %v, want %v", hits, int64(0))
+	}
+	if !reflect.DeepEqual(int64(1), misses) {
+		t.Errorf("misses = %v, want %v", misses, int64(1))
+	}
+	if !reflect.DeepEqual(0, active) {
+		t.Errorf("active = %v, want %v", active, 0)
+	}
 
 	// Create a mock connection
 	mockConn := &mockNetConn{remoteAddr: "192.5.5.241:53"}
@@ -51,16 +73,24 @@ func TestTCPConnPoolGetPut(t *testing.T) {
 
 	// Check active connections
 	_, _, active = pool.Stats()
-	assert.Equal(t, 1, active)
+	if !reflect.DeepEqual(1, active) {
+		t.Errorf("active = %v, want %v", active, 1)
+	}
 
 	// Get the connection back
 	conn = pool.Get("192.5.5.241:53", true, false)
-	assert.NotNil(t, conn)
+	if conn == nil {
+		t.Fatalf("conn is nil")
+	}
 
 	// Check hit stats
 	hits, _, active = pool.Stats()
-	assert.Equal(t, int64(1), hits)
-	assert.Equal(t, 0, active) // Connection removed from pool
+	if !reflect.DeepEqual(int64(1), hits) {
+		t.Errorf("hits = %v, want %v", hits, int64(1))
+	}
+	if !reflect.DeepEqual(0, active) {
+		t.Errorf("active = %v, want %v", active, 0)
+	} // Connection removed from pool
 
 	// Put it back
 	pool.Put(&dns.Conn{Conn: mockConn}, "192.5.5.241:53", true, false, nil)
@@ -70,7 +100,9 @@ func TestTCPConnPoolGetPut(t *testing.T) {
 	pool.Put(&dns.Conn{Conn: tldConn}, "192.5.6.30:53", false, true, nil)
 
 	conn = pool.Get("192.5.6.30:53", false, true)
-	assert.NotNil(t, conn)
+	if conn == nil {
+		t.Fatalf("conn is nil")
+	}
 }
 
 func TestTCPConnPoolMaxConnections(t *testing.T) {
@@ -85,7 +117,9 @@ func TestTCPConnPoolMaxConnections(t *testing.T) {
 	pool.Put(&dns.Conn{Conn: conn2}, "192.203.230.10:53", true, false, nil)
 
 	_, _, active := pool.Stats()
-	assert.Equal(t, 2, active)
+	if !reflect.DeepEqual(2, active) {
+		t.Errorf("active = %v, want %v", active, 2)
+	}
 
 	// Try to add third connection - should be rejected
 	conn3 := &mockNetConn{remoteAddr: "192.33.4.12:53"}
@@ -93,10 +127,14 @@ func TestTCPConnPoolMaxConnections(t *testing.T) {
 
 	// Should still have 2 connections
 	_, _, active = pool.Stats()
-	assert.Equal(t, 2, active)
+	if !reflect.DeepEqual(2, active) {
+		t.Errorf("active = %v, want %v", active, 2)
+	}
 
 	// Verify conn3 was closed
-	assert.True(t, conn3.closed)
+	if !(conn3.closed) {
+		t.Errorf("conn3.closed is false")
+	}
 }
 
 func TestTCPConnPoolKeepalive(t *testing.T) {
@@ -120,10 +158,18 @@ func TestTCPConnPoolKeepalive(t *testing.T) {
 	pooledConn := pool.rootConns["192.5.5.241:53"]
 	pool.mu.RUnlock()
 
-	assert.NotNil(t, pooledConn)
-	assert.True(t, pooledConn.supportsKA)
-	assert.Equal(t, uint16(20), pooledConn.kaTimeout)
-	assert.Equal(t, 2*time.Second, pooledConn.idleTime)
+	if pooledConn == nil {
+		t.Fatalf("pooledConn is nil")
+	}
+	if !(pooledConn.supportsKA) {
+		t.Errorf("pooledConn.supportsKA is false")
+	}
+	if !reflect.DeepEqual(uint16(20), pooledConn.kaTimeout) {
+		t.Errorf("pooledConn.kaTimeout = %v, want %v", pooledConn.kaTimeout, uint16(20))
+	}
+	if !reflect.DeepEqual(2*time.Second, pooledConn.idleTime) {
+		t.Errorf("pooledConn.idleTime = %v, want %v", pooledConn.idleTime, 2*time.Second)
+	}
 }
 
 // A keepalive timeout of zero is the server saying "close now"
@@ -149,9 +195,15 @@ func TestTCPConnPoolRefusesKeepaliveZero(t *testing.T) {
 	active := pool.active
 	pool.mu.RUnlock()
 
-	assert.Nil(t, pooled, "a connection the server asked to close was pooled")
-	assert.True(t, conn.closed, "the connection was neither pooled nor closed — leaked")
-	assert.Equal(t, 0, active)
+	if pooled != nil {
+		t.Errorf("%s: pooled = %v, want nil", "a connection the server asked to close was pooled", pooled)
+	}
+	if !(conn.closed) {
+		t.Errorf("%s: conn.closed is false", "the connection was neither pooled nor closed — leaked")
+	}
+	if !reflect.DeepEqual(0, active) {
+		t.Errorf("active = %v, want %v", active, 0)
+	}
 }
 
 func TestTCPConnPoolCleanup(t *testing.T) {
@@ -166,7 +218,9 @@ func TestTCPConnPoolCleanup(t *testing.T) {
 	pool.Put(&dns.Conn{Conn: conn2}, "192.5.6.30:53", false, true, nil)
 
 	_, _, active := pool.Stats()
-	assert.Equal(t, 2, active)
+	if !reflect.DeepEqual(2, active) {
+		t.Errorf("active = %v, want %v", active, 2)
+	}
 
 	// Wait for connections to expire
 	time.Sleep(150 * time.Millisecond)
@@ -176,11 +230,17 @@ func TestTCPConnPoolCleanup(t *testing.T) {
 
 	// All connections should be cleaned up
 	_, _, active = pool.Stats()
-	assert.Equal(t, 0, active)
+	if !reflect.DeepEqual(0, active) {
+		t.Errorf("active = %v, want %v", active, 0)
+	}
 
 	// Verify connections were closed
-	assert.True(t, conn1.closed)
-	assert.True(t, conn2.closed)
+	if !(conn1.closed) {
+		t.Errorf("conn1.closed is false")
+	}
+	if !(conn2.closed) {
+		t.Errorf("conn2.closed is false")
+	}
 }
 
 func TestIsRootServer(t *testing.T) {
@@ -202,7 +262,9 @@ func TestIsRootServer(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.server, func(t *testing.T) {
 			result := isRootServer(tc.server)
-			assert.Equal(t, tc.expected, result)
+			if !reflect.DeepEqual(tc.expected, result) {
+				t.Errorf("result = %v, want %v", result, tc.expected)
+			}
 		})
 	}
 }
@@ -222,7 +284,9 @@ func TestIsTLDServer(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.qname, func(t *testing.T) {
 			result := isTLDServer(tc.qname)
-			assert.Equal(t, tc.expected, result)
+			if !reflect.DeepEqual(tc.expected, result) {
+				t.Errorf("result = %v, want %v", result, tc.expected)
+			}
 		})
 	}
 }
@@ -234,12 +298,20 @@ func TestSetEDNSKeepalive(t *testing.T) {
 
 	SetEDNSKeepalive(msg, 50)
 
-	assert.NotNil(t, msg.IsEdns0())
-	assert.Equal(t, 1, len(msg.IsEdns0().Option))
+	if msg.IsEdns0() == nil {
+		t.Fatalf("msg.IsEdns0() is nil")
+	}
+	if !reflect.DeepEqual(1, len(msg.IsEdns0().Option)) {
+		t.Errorf("len(msg.IsEdns0().Option) = %v, want %v", len(msg.IsEdns0().Option), 1)
+	}
 
 	ka, ok := msg.IsEdns0().Option[0].(*dns.EDNS0_TCP_KEEPALIVE)
-	assert.True(t, ok)
-	assert.Equal(t, uint16(50), ka.Timeout)
+	if !(ok) {
+		t.Errorf("ok is false")
+	}
+	if !reflect.DeepEqual(uint16(50), ka.Timeout) {
+		t.Errorf("ka.Timeout = %v, want %v", ka.Timeout, uint16(50))
+	}
 
 	// Test adding to message with existing EDNS
 	msg2 := new(dns.Msg)
@@ -248,11 +320,15 @@ func TestSetEDNSKeepalive(t *testing.T) {
 
 	SetEDNSKeepalive(msg2, 100)
 
-	assert.Equal(t, 1, len(msg2.IsEdns0().Option))
+	if !reflect.DeepEqual(1, len(msg2.IsEdns0().Option)) {
+		t.Errorf("len(msg2.IsEdns0().Option) = %v, want %v", len(msg2.IsEdns0().Option), 1)
+	}
 
 	// Test duplicate prevention
 	SetEDNSKeepalive(msg2, 200)
-	assert.Equal(t, 1, len(msg2.IsEdns0().Option))
+	if !reflect.DeepEqual(1, len(msg2.IsEdns0().Option)) {
+		t.Errorf("len(msg2.IsEdns0().Option) = %v, want %v", len(msg2.IsEdns0().Option), 1)
+	}
 }
 
 // mockNetConn is a mock implementation of net.Conn for testing.

--- a/middleware/resolver/utils_test.go
+++ b/middleware/resolver/utils_test.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 	"net"
 	"net/netip"
+	"reflect"
 	"testing"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/internal/dnsutil"
 	"github.com/semihalev/sdns/middleware/resolver/dnssec"
 	"github.com/semihalev/zlog/v2"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_shuffleStr(t *testing.T) {
@@ -31,10 +31,14 @@ func Test_searchAddr(t *testing.T) {
 	m.SetQuestion(testDomain, dns.TypeA)
 
 	m.SetEdns0(512, true)
-	assert.Equal(t, isDO(m), true)
+	if !reflect.DeepEqual(isDO(m), true) {
+		t.Errorf("true = %v, want %v", true, isDO(m))
+	}
 
 	m.Extra = []dns.RR{}
-	assert.Equal(t, isDO(m), false)
+	if !reflect.DeepEqual(isDO(m), false) {
+		t.Errorf("false = %v, want %v", false, isDO(m))
+	}
 
 	a1 := &dns.A{
 		Hdr: dns.RR_Header{
@@ -59,10 +63,18 @@ func Test_searchAddr(t *testing.T) {
 	m.Answer = append(m.Answer, a2)
 
 	addrs, found := searchAddrs(m)
-	assert.Equal(t, len(addrs), 1)
-	assert.NotEqual(t, addrs[0], netip.MustParseAddr("127.0.0.1"))
-	assert.Equal(t, addrs[0], netip.MustParseAddr("192.0.2.1"))
-	assert.Equal(t, found, true)
+	if !reflect.DeepEqual(len(addrs), 1) {
+		t.Errorf("1 = %v, want %v", 1, len(addrs))
+	}
+	if reflect.DeepEqual(addrs[0], netip.MustParseAddr("127.0.0.1")) {
+		t.Errorf("netip.MustParseAddr('127.0.0.1') = %v, want a different value", netip.MustParseAddr("127.0.0.1"))
+	}
+	if !reflect.DeepEqual(addrs[0], netip.MustParseAddr("192.0.2.1")) {
+		t.Errorf("netip.MustParseAddr('192.0.2.1') = %v, want %v", netip.MustParseAddr("192.0.2.1"), addrs[0])
+	}
+	if !reflect.DeepEqual(found, true) {
+		t.Errorf("true = %v, want %v", true, found)
+	}
 }
 
 func Test_extractRRSet(t *testing.T) {
@@ -73,7 +85,9 @@ func Test_extractRRSet(t *testing.T) {
 	}
 
 	rre := dnsutil.ExtractRRSet(rr, "test.com.", dns.TypeA)
-	assert.Len(t, rre, 3)
+	if len(rre) != 3 {
+		t.Errorf("len(rre) = %d, want %d", len(rre), 3)
+	}
 }
 
 func Test_extractRRSetMultipleTypes(t *testing.T) {
@@ -85,15 +99,21 @@ func Test_extractRRSetMultipleTypes(t *testing.T) {
 
 	// Test with multiple types
 	rre := dnsutil.ExtractRRSet(rr, "test.com.", dns.TypeA, dns.TypeAAAA)
-	assert.Len(t, rre, 2)
+	if len(rre) != 2 {
+		t.Errorf("len(rre) = %d, want %d", len(rre), 2)
+	}
 
 	// Test with empty input
 	rre = dnsutil.ExtractRRSet(nil, "", dns.TypeA)
-	assert.Nil(t, rre)
+	if rre != nil {
+		t.Errorf("rre = %v, want nil", rre)
+	}
 
 	// Test with name filter mismatch
 	rre = dnsutil.ExtractRRSet(rr, "other.com.", dns.TypeA)
-	assert.Len(t, rre, 0)
+	if len(rre) != 0 {
+		t.Errorf("len(rre) = %d, want %d", len(rre), 0)
+	}
 }
 
 func Test_verifyNSEC(t *testing.T) {
@@ -113,12 +133,16 @@ func Test_verifyNSEC(t *testing.T) {
 
 	// Should find A type
 	typeMatch := dnssec.VerifyNSEC(q, []dns.RR{nsec})
-	assert.True(t, typeMatch)
+	if !(typeMatch) {
+		t.Errorf("typeMatch is false")
+	}
 
 	// Query for type not in bitmap
 	q2 := dns.Question{Name: "example.com.", Qtype: dns.TypeMX}
 	typeMatch = dnssec.VerifyNSEC(q2, []dns.RR{nsec})
-	assert.False(t, typeMatch)
+	if typeMatch {
+		t.Errorf("typeMatch is true")
+	}
 }
 
 func Test_getDnameTarget(t *testing.T) {
@@ -127,7 +151,9 @@ func Test_getDnameTarget(t *testing.T) {
 
 	// No DNAME record
 	target := dnsutil.DnameTarget(msg)
-	assert.Empty(t, target)
+	if len(target) != 0 {
+		t.Errorf("target not empty: %v", target)
+	}
 
 	// Exact-owner match: RFC 6672 §2.3 — the DNAME owner itself is
 	// *not* redirected, so no target is returned.
@@ -142,7 +168,9 @@ func Test_getDnameTarget(t *testing.T) {
 	}
 	msg.Answer = []dns.RR{dname}
 	target = dnsutil.DnameTarget(msg)
-	assert.Empty(t, target, "DNAME owner must not be redirected")
+	if len(target) != 0 {
+		t.Errorf("%s: target not empty: %v", "DNAME owner must not be redirected", target)
+	}
 
 	// Test with subdomain
 	msg.Question = []dns.Question{{Name: "deep.sub.example.com.", Qtype: dns.TypeA}}
@@ -157,7 +185,9 @@ func Test_getDnameTarget(t *testing.T) {
 	}
 	msg.Answer = []dns.RR{dname2}
 	target = dnsutil.DnameTarget(msg)
-	assert.Equal(t, "deep.newtarget.com.", target)
+	if !reflect.DeepEqual("deep.newtarget.com.", target) {
+		t.Errorf("target = %v, want %v", target, "deep.newtarget.com.")
+	}
 
 	// Cousin name: qname shares a suffix with the DNAME owner but is
 	// not a descendant. dns.CompareDomainName reports the shared
@@ -166,7 +196,9 @@ func Test_getDnameTarget(t *testing.T) {
 	msg.Question = []dns.Question{{Name: "other.example.com.", Qtype: dns.TypeA}}
 	msg.Answer = []dns.RR{dname2} // DNAME owner is sub.example.com.
 	target = dnsutil.DnameTarget(msg)
-	assert.Empty(t, target, "cousin of DNAME owner must not be redirected")
+	if len(target) != 0 {
+		t.Errorf("%s: target not empty: %v", "cousin of DNAME owner must not be redirected", target)
+	}
 }
 
 // Test_verifyRRSIG_RejectsForeignPiggyback pins the defense that
@@ -208,8 +240,12 @@ func Test_verifyRRSIG_RejectsForeignPiggyback(t *testing.T) {
 	msg := &dns.Msg{Answer: []dns.RR{a, sig, evil}}
 
 	ok, err := dnssec.VerifyRRSIG("example.com.", keys, msg)
-	assert.False(t, ok)
-	assert.Equal(t, dnssec.ErrMissingSigned, err, "foreign RRset must make the whole response bogus")
+	if ok {
+		t.Errorf("ok is true")
+	}
+	if !reflect.DeepEqual(dnssec.ErrMissingSigned, err) {
+		t.Errorf("%s: err = %v, want %v", "foreign RRset must make the whole response bogus", err, dnssec.ErrMissingSigned)
+	}
 }
 
 // Test_isSupportedDNSKEYAlgorithm_RSAMD5 locks in the RFC 8624 /
@@ -218,11 +254,18 @@ func Test_verifyRRSIG_RejectsForeignPiggyback(t *testing.T) {
 // would be treated as usable and then bogus at RRSIG.Verify time
 // instead of downgraded to insecure.
 func Test_isSupportedDNSKEYAlgorithm_RSAMD5(t *testing.T) {
-	assert.False(t, dnssec.IsSupportedDNSKEYAlgorithm(dns.RSAMD5),
-		"RSAMD5 must be treated as unsupported — miekg/dns RRSIG.Verify returns ErrAlg for it")
-	assert.True(t, dnssec.IsSupportedDNSKEYAlgorithm(dns.RSASHA256))
-	assert.True(t, dnssec.IsSupportedDNSKEYAlgorithm(dns.ECDSAP256SHA256))
-	assert.True(t, dnssec.IsSupportedDNSKEYAlgorithm(dns.ED25519))
+	if dnssec.IsSupportedDNSKEYAlgorithm(dns.RSAMD5) {
+		t.Errorf("%s: dnssec.IsSupportedDNSKEYAlgorithm(dns.RSAMD5) is true", "RSAMD5 must be treated as unsupported — miekg/dns RRSIG.Verify returns ErrAlg for it")
+	}
+	if !(dnssec.IsSupportedDNSKEYAlgorithm(dns.RSASHA256)) {
+		t.Errorf("dnssec.IsSupportedDNSKEYAlgorithm(dns.RSASHA256) is false")
+	}
+	if !(dnssec.IsSupportedDNSKEYAlgorithm(dns.ECDSAP256SHA256)) {
+		t.Errorf("dnssec.IsSupportedDNSKEYAlgorithm(dns.ECDSAP256SHA256) is false")
+	}
+	if !(dnssec.IsSupportedDNSKEYAlgorithm(dns.ED25519)) {
+		t.Errorf("dnssec.IsSupportedDNSKEYAlgorithm(dns.ED25519) is false")
+	}
 }
 
 // Test_filterToZone_NSECNextDomain pins the defense against the
@@ -242,8 +285,12 @@ func Test_filterToZone_NSECNextDomain(t *testing.T) {
 	}
 
 	got := dnsutil.FilterRRsToZone([]dns.RR{crossZone, inZone}, "example.com.")
-	assert.Len(t, got, 1, "NSEC with cross-zone NextDomain must be filtered out")
-	assert.Equal(t, "!.example.com.", got[0].Header().Name)
+	if len(got) != 1 {
+		t.Errorf("%s: len(got) = %d, want %d", "NSEC with cross-zone NextDomain must be filtered out", len(got), 1)
+	}
+	if !reflect.DeepEqual("!.example.com.", got[0].Header().Name) {
+		t.Errorf("got[0].Header().Name = %v, want %v", got[0].Header().Name, "!.example.com.")
+	}
 }
 
 func Test_debugLogEnabled(t *testing.T) {
@@ -251,9 +298,13 @@ func Test_debugLogEnabled(t *testing.T) {
 	defer zlog.SetLevel(old)
 
 	zlog.SetLevel(zlog.LevelInfo)
-	assert.False(t, debugLogEnabled())
+	if debugLogEnabled() {
+		t.Errorf("debugLogEnabled() is true")
+	}
 	zlog.SetLevel(zlog.LevelDebug)
-	assert.True(t, debugLogEnabled())
+	if !(debugLogEnabled()) {
+		t.Errorf("debugLogEnabled() is false")
+	}
 }
 
 // Test_debugLogEnabled_GuardAllocsNothing pins what the guard is for: with
@@ -270,5 +321,7 @@ func Test_debugLogEnabled_GuardAllocsNothing(t *testing.T) {
 			zlog.Debug("Query inserted", "query", dnsutil.FormatQuestion(q))
 		}
 	})
-	assert.Zero(t, allocs, "guarded debug call site must be free when debug is off")
+	if allocs != 0 {
+		t.Errorf("%s: allocs = %v, want 0", "guarded debug call site must be free when debug is off", allocs)
+	}
 }

--- a/middleware/views/views_test.go
+++ b/middleware/views/views_test.go
@@ -2,13 +2,13 @@ package views
 
 import (
 	"context"
+	"reflect"
 	"testing"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/config"
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/semihalev/sdns/middleware"
-	"github.com/stretchr/testify/assert"
 )
 
 // makeChain wires up a single-handler chain pointed at the view
@@ -27,7 +27,9 @@ func TestViews_NoConfig_FallsThrough(t *testing.T) {
 	v := New(&config.Config{})
 	ch := makeChain(v, "8.8.8.8:0", "example.com.", dns.TypeA)
 	v.ServeDNS(context.Background(), ch)
-	assert.False(t, ch.Writer.Written(), "no view configured: nothing should be written")
+	if ch.Writer.Written() {
+		t.Errorf("%s: ch.Writer.Written() is true", "no view configured: nothing should be written")
+	}
 }
 
 func TestViews_MatchesClientCIDRAndWildcard(t *testing.T) {
@@ -44,14 +46,26 @@ func TestViews_MatchesClientCIDRAndWildcard(t *testing.T) {
 	// Client inside the view's CIDR querying a wildcard-covered name.
 	ch := makeChain(v, "192.168.1.42:5353", "foo.birb.it.", dns.TypeA)
 	v.ServeDNS(context.Background(), ch)
-	assert.True(t, ch.Writer.Written(), "matching view must write a reply")
+	if !(ch.Writer.Written()) {
+		t.Errorf("%s: ch.Writer.Written() is false", "matching view must write a reply")
+	}
 	resp := ch.Writer.Msg()
-	assert.Len(t, resp.Answer, 1)
+	if len(resp.Answer) != 1 {
+		t.Errorf("len(resp.Answer) = %d, want %d", len(resp.Answer), 1)
+	}
 	a, ok := resp.Answer[0].(*dns.A)
-	assert.True(t, ok)
-	assert.Equal(t, "foo.birb.it.", a.Hdr.Name, "owner name in response must be the query name, not the wildcard")
-	assert.Equal(t, "192.168.1.3", a.A.String())
-	assert.True(t, resp.Authoritative)
+	if !(ok) {
+		t.Errorf("ok is false")
+	}
+	if !reflect.DeepEqual("foo.birb.it.", a.Hdr.Name) {
+		t.Errorf("%s: a.Hdr.Name = %v, want %v", "owner name in response must be the query name, not the wildcard", a.Hdr.Name, "foo.birb.it.")
+	}
+	if !reflect.DeepEqual("192.168.1.3", a.A.String()) {
+		t.Errorf("a.A.String() = %v, want %v", a.A.String(), "192.168.1.3")
+	}
+	if !(resp.Authoritative) {
+		t.Errorf("resp.Authoritative is false")
+	}
 }
 
 func TestViews_QtypeMissingFallsThrough(t *testing.T) {
@@ -68,7 +82,9 @@ func TestViews_QtypeMissingFallsThrough(t *testing.T) {
 	// over.
 	ch := makeChain(v, "192.168.1.42:5353", "foo.birb.it.", dns.TypeAAAA)
 	v.ServeDNS(context.Background(), ch)
-	assert.False(t, ch.Writer.Written(), "matched-view-but-no-record must fall through")
+	if ch.Writer.Written() {
+		t.Errorf("%s: ch.Writer.Written() is true", "matched-view-but-no-record must fall through")
+	}
 }
 
 func TestViews_ClientOutsideAllViewsFallsThrough(t *testing.T) {
@@ -80,7 +96,9 @@ func TestViews_ClientOutsideAllViewsFallsThrough(t *testing.T) {
 	v := New(cfg)
 	ch := makeChain(v, "8.8.8.8:5353", "foo.birb.it.", dns.TypeA)
 	v.ServeDNS(context.Background(), ch)
-	assert.False(t, ch.Writer.Written())
+	if ch.Writer.Written() {
+		t.Errorf("ch.Writer.Written() is true")
+	}
 }
 
 func TestViews_FirstMatchWins(t *testing.T) {
@@ -102,7 +120,9 @@ func TestViews_FirstMatchWins(t *testing.T) {
 	v.ServeDNS(context.Background(), ch)
 	resp := ch.Writer.Msg()
 	a := resp.Answer[0].(*dns.A)
-	assert.Equal(t, "100.64.0.2", a.A.String(), "vpnnet view must have answered for a 100.64.0.0/24 client")
+	if !reflect.DeepEqual("100.64.0.2", a.A.String()) {
+		t.Errorf("%s: a.A.String() = %v, want %v", "vpnnet view must have answered for a 100.64.0.0/24 client", a.A.String(), "100.64.0.2")
+	}
 }
 
 func TestViews_ExactNameMatch(t *testing.T) {
@@ -116,12 +136,16 @@ func TestViews_ExactNameMatch(t *testing.T) {
 	ch := makeChain(v, "192.168.1.42:5353", "router.local.", dns.TypeA)
 	v.ServeDNS(context.Background(), ch)
 	a := ch.Writer.Msg().Answer[0].(*dns.A)
-	assert.Equal(t, "192.168.1.1", a.A.String())
+	if !reflect.DeepEqual("192.168.1.1", a.A.String()) {
+		t.Errorf("a.A.String() = %v, want %v", a.A.String(), "192.168.1.1")
+	}
 
 	// Sub-name must NOT match a non-wildcard owner.
 	ch = makeChain(v, "192.168.1.42:5353", "sub.router.local.", dns.TypeA)
 	v.ServeDNS(context.Background(), ch)
-	assert.False(t, ch.Writer.Written(), "non-wildcard owner must require an exact name match")
+	if ch.Writer.Written() {
+		t.Errorf("%s: ch.Writer.Written() is true", "non-wildcard owner must require an exact name match")
+	}
 }
 
 func TestViews_ExactOverridesWildcard(t *testing.T) {
@@ -141,15 +165,23 @@ func TestViews_ExactOverridesWildcard(t *testing.T) {
 	ch := makeChain(v, "192.168.1.42:5353", "router.example.lan.", dns.TypeA)
 	v.ServeDNS(context.Background(), ch)
 	resp := ch.Writer.Msg()
-	assert.Len(t, resp.Answer, 1, "exact owner must suppress the covering wildcard")
-	assert.Equal(t, "192.168.1.1", resp.Answer[0].(*dns.A).A.String())
+	if len(resp.Answer) != 1 {
+		t.Errorf("%s: len(resp.Answer) = %d, want %d", "exact owner must suppress the covering wildcard", len(resp.Answer), 1)
+	}
+	if !reflect.DeepEqual("192.168.1.1", resp.Answer[0].(*dns.A).A.String()) {
+		t.Errorf("resp.Answer[0].(*dns.A).A.String() = %v, want %v", resp.Answer[0].(*dns.A).A.String(), "192.168.1.1")
+	}
 
 	// And a sibling under the wildcard still gets the wildcard answer.
 	ch = makeChain(v, "192.168.1.42:5353", "other.example.lan.", dns.TypeA)
 	v.ServeDNS(context.Background(), ch)
 	resp = ch.Writer.Msg()
-	assert.Len(t, resp.Answer, 1)
-	assert.Equal(t, "192.168.1.3", resp.Answer[0].(*dns.A).A.String())
+	if len(resp.Answer) != 1 {
+		t.Errorf("len(resp.Answer) = %d, want %d", len(resp.Answer), 1)
+	}
+	if !reflect.DeepEqual("192.168.1.3", resp.Answer[0].(*dns.A).A.String()) {
+		t.Errorf("resp.Answer[0].(*dns.A).A.String() = %v, want %v", resp.Answer[0].(*dns.A).A.String(), "192.168.1.3")
+	}
 }
 
 func TestViews_LongestWildcardWins(t *testing.T) {
@@ -171,15 +203,23 @@ func TestViews_LongestWildcardWins(t *testing.T) {
 	ch := makeChain(v, "192.168.1.42:5353", "host.sub.example.lan.", dns.TypeA)
 	v.ServeDNS(context.Background(), ch)
 	resp := ch.Writer.Msg()
-	assert.Len(t, resp.Answer, 1, "only the longest-suffix wildcard should apply")
-	assert.Equal(t, "192.168.1.4", resp.Answer[0].(*dns.A).A.String())
+	if len(resp.Answer) != 1 {
+		t.Errorf("%s: len(resp.Answer) = %d, want %d", "only the longest-suffix wildcard should apply", len(resp.Answer), 1)
+	}
+	if !reflect.DeepEqual("192.168.1.4", resp.Answer[0].(*dns.A).A.String()) {
+		t.Errorf("resp.Answer[0].(*dns.A).A.String() = %v, want %v", resp.Answer[0].(*dns.A).A.String(), "192.168.1.4")
+	}
 
 	// host.example.lan. is only covered by the outer wildcard.
 	ch = makeChain(v, "192.168.1.42:5353", "host.example.lan.", dns.TypeA)
 	v.ServeDNS(context.Background(), ch)
 	resp = ch.Writer.Msg()
-	assert.Len(t, resp.Answer, 1)
-	assert.Equal(t, "192.168.1.3", resp.Answer[0].(*dns.A).A.String())
+	if len(resp.Answer) != 1 {
+		t.Errorf("len(resp.Answer) = %d, want %d", len(resp.Answer), 1)
+	}
+	if !reflect.DeepEqual("192.168.1.3", resp.Answer[0].(*dns.A).A.String()) {
+		t.Errorf("resp.Answer[0].(*dns.A).A.String() = %v, want %v", resp.Answer[0].(*dns.A).A.String(), "192.168.1.3")
+	}
 }
 
 func TestViews_BadCIDRsAndRecordsAreSkipped(t *testing.T) {
@@ -196,16 +236,30 @@ func TestViews_BadCIDRsAndRecordsAreSkipped(t *testing.T) {
 	// Bad inputs are skipped, the surviving CIDR + record still match.
 	ch := makeChain(v, "192.168.1.10:5353", "x.birb.it.", dns.TypeA)
 	v.ServeDNS(context.Background(), ch)
-	assert.True(t, ch.Writer.Written())
+	if !(ch.Writer.Written()) {
+		t.Errorf("ch.Writer.Written() is false")
+	}
 }
 
 func TestViews_WildcardBoundary(t *testing.T) {
 	// "*.birb.it." must match "foo.birb.it." but NOT "birb.it." or
 	// any name that just happens to end with the suffix.
-	assert.True(t, nameMatches("*.birb.it.", "foo.birb.it."))
-	assert.True(t, nameMatches("*.birb.it.", "deep.path.birb.it."))
-	assert.False(t, nameMatches("*.birb.it.", "birb.it."))
-	assert.False(t, nameMatches("*.birb.it.", "notbirb.it."))
-	assert.True(t, nameMatches("router.local.", "router.local."))
-	assert.False(t, nameMatches("router.local.", "sub.router.local."))
+	if !(nameMatches("*.birb.it.", "foo.birb.it.")) {
+		t.Errorf("nameMatches('*.birb.it.', 'foo.birb.it.') is false")
+	}
+	if !(nameMatches("*.birb.it.", "deep.path.birb.it.")) {
+		t.Errorf("nameMatches('*.birb.it.', 'deep.path.birb.it.') is false")
+	}
+	if nameMatches("*.birb.it.", "birb.it.") {
+		t.Errorf("nameMatches('*.birb.it.', 'birb.it.') is true")
+	}
+	if nameMatches("*.birb.it.", "notbirb.it.") {
+		t.Errorf("nameMatches('*.birb.it.', 'notbirb.it.') is true")
+	}
+	if !(nameMatches("router.local.", "router.local.")) {
+		t.Errorf("nameMatches('router.local.', 'router.local.') is false")
+	}
+	if nameMatches("router.local.", "sub.router.local.") {
+		t.Errorf("nameMatches('router.local.', 'sub.router.local.') is true")
+	}
 }

--- a/server/certmanager_test.go
+++ b/server/certmanager_test.go
@@ -10,18 +10,21 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/semihalev/sdns/config"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCertManager(t *testing.T) {
 	// Create temp directory for test certificates
 	tmpDir, err := os.MkdirTemp("", "certmanager-test")
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	defer os.RemoveAll(tmpDir)
 
 	certPath := filepath.Join(tmpDir, "test.crt")
@@ -33,21 +36,33 @@ func TestCertManager(t *testing.T) {
 
 	// Create certificate manager
 	cm, err := NewCertManager(certPath, keyPath)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	defer cm.Stop()
 
 	// Verify initial certificate
 	tlsConfig := cm.GetTLSConfig()
-	require.NotNil(t, tlsConfig)
+	if tlsConfig == nil {
+		t.Fatalf("tlsConfig is nil")
+	}
 
 	cert, err := cm.GetCertificate(&tls.ClientHelloInfo{})
-	require.NoError(t, err)
-	require.NotNil(t, cert)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cert == nil {
+		t.Fatalf("cert is nil")
+	}
 
 	// Verify certificate subject
 	x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
-	require.NoError(t, err)
-	assert.Equal(t, "test1.example.com", x509Cert.Subject.CommonName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual("test1.example.com", x509Cert.Subject.CommonName) {
+		t.Errorf("x509Cert.Subject.CommonName = %v, want %v", x509Cert.Subject.CommonName, "test1.example.com")
+	}
 
 	// Generate new certificate
 	cert2, key2 := generateTestCert(t, "test2.example.com")
@@ -64,11 +79,17 @@ func TestCertManager(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 
 		cert, err = cm.GetCertificate(&tls.ClientHelloInfo{})
-		require.NoError(t, err)
-		require.NotNil(t, cert)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cert == nil {
+			t.Fatalf("cert is nil")
+		}
 
 		x509Cert, err = x509.ParseCertificate(cert.Certificate[0])
-		require.NoError(t, err)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 
 		if x509Cert.Subject.CommonName == "test2.example.com" {
 			break
@@ -79,13 +100,17 @@ func TestCertManager(t *testing.T) {
 		}
 	}
 
-	assert.Equal(t, "test2.example.com", x509Cert.Subject.CommonName)
+	if !reflect.DeepEqual("test2.example.com", x509Cert.Subject.CommonName) {
+		t.Errorf("x509Cert.Subject.CommonName = %v, want %v", x509Cert.Subject.CommonName, "test2.example.com")
+	}
 }
 
 func TestCertManagerReload(t *testing.T) {
 	// Create temp directory for test certificates
 	tmpDir, err := os.MkdirTemp("", "certmanager-reload-test")
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	defer os.RemoveAll(tmpDir)
 
 	certPath := filepath.Join(tmpDir, "test.crt")
@@ -97,7 +122,9 @@ func TestCertManagerReload(t *testing.T) {
 
 	// Create certificate manager
 	cm, err := NewCertManager(certPath, keyPath)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	defer cm.Stop()
 
 	// Generate new certificate
@@ -106,22 +133,34 @@ func TestCertManagerReload(t *testing.T) {
 
 	// Force reload
 	err = cm.Reload()
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	// Verify certificate was reloaded
 	cert, err := cm.GetCertificate(&tls.ClientHelloInfo{})
-	require.NoError(t, err)
-	require.NotNil(t, cert)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cert == nil {
+		t.Fatalf("cert is nil")
+	}
 
 	x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
-	require.NoError(t, err)
-	assert.Equal(t, "reload2.example.com", x509Cert.Subject.CommonName)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !reflect.DeepEqual("reload2.example.com", x509Cert.Subject.CommonName) {
+		t.Errorf("x509Cert.Subject.CommonName = %v, want %v", x509Cert.Subject.CommonName, "reload2.example.com")
+	}
 }
 
 func generateTestCert(t *testing.T, commonName string) ([]byte, []byte) {
 	// Generate private key
 	priv, err := rsa.GenerateKey(rand.Reader, 2048)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	// Create certificate template
 	template := x509.Certificate{
@@ -138,7 +177,9 @@ func generateTestCert(t *testing.T, commonName string) ([]byte, []byte) {
 
 	// Create certificate
 	certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	// Encode certificate
 	certPEM := pem.EncodeToMemory(&pem.Block{
@@ -148,7 +189,9 @@ func generateTestCert(t *testing.T, commonName string) ([]byte, []byte) {
 
 	// Encode private key
 	keyDER, err := x509.MarshalPKCS8PrivateKey(priv)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	keyPEM := pem.EncodeToMemory(&pem.Block{
 		Type:  "PRIVATE KEY",
@@ -160,22 +203,32 @@ func generateTestCert(t *testing.T, commonName string) ([]byte, []byte) {
 
 func writeCertAndKey(t *testing.T, certPath, keyPath string, cert, key []byte) {
 	err := os.WriteFile(certPath, cert, 0644) //nolint:gosec // G306 - test file
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	err = os.WriteFile(keyPath, key, 0600)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }
 
 func TestCertManagerErrors(t *testing.T) {
 	t.Run("NonExistentFiles", func(t *testing.T) {
 		cm, err := NewCertManager("/nonexistent/cert.pem", "/nonexistent/key.pem")
-		assert.Error(t, err)
-		assert.Nil(t, cm)
+		if err == nil {
+			t.Errorf("expected an error, got nil")
+		}
+		if cm != nil {
+			t.Errorf("cm = %v, want nil", cm)
+		}
 	})
 
 	t.Run("InvalidCertificate", func(t *testing.T) {
 		tmpDir, err := os.MkdirTemp("", "certmanager-error-test")
-		require.NoError(t, err)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		defer os.RemoveAll(tmpDir)
 
 		certPath := filepath.Join(tmpDir, "invalid.crt")
@@ -183,18 +236,28 @@ func TestCertManagerErrors(t *testing.T) {
 
 		// Write invalid certificate data
 		err = os.WriteFile(certPath, []byte("invalid cert data"), 0644) //nolint:gosec // G306 - test file
-		require.NoError(t, err)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		err = os.WriteFile(keyPath, []byte("invalid key data"), 0600)
-		require.NoError(t, err)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 
 		cm, err := NewCertManager(certPath, keyPath)
-		assert.Error(t, err)
-		assert.Nil(t, cm)
+		if err == nil {
+			t.Errorf("expected an error, got nil")
+		}
+		if cm != nil {
+			t.Errorf("cm = %v, want nil", cm)
+		}
 	})
 
 	t.Run("ExpiredCertificate", func(t *testing.T) {
 		tmpDir, err := os.MkdirTemp("", "certmanager-expired-test")
-		require.NoError(t, err)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		defer os.RemoveAll(tmpDir)
 
 		certPath := filepath.Join(tmpDir, "expired.crt")
@@ -202,7 +265,9 @@ func TestCertManagerErrors(t *testing.T) {
 
 		// Generate expired certificate
 		priv, err := rsa.GenerateKey(rand.Reader, 2048)
-		require.NoError(t, err)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 
 		template := x509.Certificate{
 			SerialNumber: big.NewInt(1),
@@ -217,7 +282,9 @@ func TestCertManagerErrors(t *testing.T) {
 		}
 
 		certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
-		require.NoError(t, err)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 
 		certPEM := pem.EncodeToMemory(&pem.Block{
 			Type:  "CERTIFICATE",
@@ -225,7 +292,9 @@ func TestCertManagerErrors(t *testing.T) {
 		})
 
 		keyDER, err := x509.MarshalPKCS8PrivateKey(priv)
-		require.NoError(t, err)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 
 		keyPEM := pem.EncodeToMemory(&pem.Block{
 			Type:  "PRIVATE KEY",
@@ -235,14 +304,22 @@ func TestCertManagerErrors(t *testing.T) {
 		writeCertAndKey(t, certPath, keyPath, certPEM, keyPEM)
 
 		cm, err := NewCertManager(certPath, keyPath)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "certificate expired")
-		assert.Nil(t, cm)
+		if err == nil {
+			t.Errorf("expected an error, got nil")
+		}
+		if !strings.Contains(err.Error(), "certificate expired") {
+			t.Errorf("%q does not contain %q", err.Error(), "certificate expired")
+		}
+		if cm != nil {
+			t.Errorf("cm = %v, want nil", cm)
+		}
 	})
 
 	t.Run("NotYetValidCertificate", func(t *testing.T) {
 		tmpDir, err := os.MkdirTemp("", "certmanager-notyet-test")
-		require.NoError(t, err)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 		defer os.RemoveAll(tmpDir)
 
 		certPath := filepath.Join(tmpDir, "notyet.crt")
@@ -250,7 +327,9 @@ func TestCertManagerErrors(t *testing.T) {
 
 		// Generate not yet valid certificate
 		priv, err := rsa.GenerateKey(rand.Reader, 2048)
-		require.NoError(t, err)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 
 		template := x509.Certificate{
 			SerialNumber: big.NewInt(1),
@@ -265,7 +344,9 @@ func TestCertManagerErrors(t *testing.T) {
 		}
 
 		certDER, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
-		require.NoError(t, err)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 
 		certPEM := pem.EncodeToMemory(&pem.Block{
 			Type:  "CERTIFICATE",
@@ -273,7 +354,9 @@ func TestCertManagerErrors(t *testing.T) {
 		})
 
 		keyDER, err := x509.MarshalPKCS8PrivateKey(priv)
-		require.NoError(t, err)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
 
 		keyPEM := pem.EncodeToMemory(&pem.Block{
 			Type:  "PRIVATE KEY",
@@ -283,16 +366,24 @@ func TestCertManagerErrors(t *testing.T) {
 		writeCertAndKey(t, certPath, keyPath, certPEM, keyPEM)
 
 		cm, err := NewCertManager(certPath, keyPath)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "certificate not yet valid")
-		assert.Nil(t, cm)
+		if err == nil {
+			t.Errorf("expected an error, got nil")
+		}
+		if !strings.Contains(err.Error(), "certificate not yet valid") {
+			t.Errorf("%q does not contain %q", err.Error(), "certificate not yet valid")
+		}
+		if cm != nil {
+			t.Errorf("cm = %v, want nil", cm)
+		}
 	})
 }
 
 func TestCertManagerWatcherErrors(t *testing.T) {
 	// Test directory watch failure
 	tmpDir, err := os.MkdirTemp("", "certmanager-watcher-test")
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	defer os.RemoveAll(tmpDir)
 
 	certPath := filepath.Join(tmpDir, "test.crt")
@@ -302,7 +393,9 @@ func TestCertManagerWatcherErrors(t *testing.T) {
 	writeCertAndKey(t, certPath, keyPath, cert, key)
 
 	cm, err := NewCertManager(certPath, keyPath)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	defer cm.Stop()
 
 	// Remove the directory to cause stat errors
@@ -313,8 +406,12 @@ func TestCertManagerWatcherErrors(t *testing.T) {
 
 	// Certificate should still be accessible
 	tlsCert, err := cm.GetCertificate(nil)
-	assert.NoError(t, err)
-	assert.NotNil(t, tlsCert)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if tlsCert == nil {
+		t.Fatalf("tlsCert is nil")
+	}
 }
 
 func TestCertManagerConcurrency(t *testing.T) {
@@ -323,7 +420,9 @@ func TestCertManagerConcurrency(t *testing.T) {
 	}
 
 	tmpDir, err := os.MkdirTemp("", "certmanager-concurrent-test")
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	defer os.RemoveAll(tmpDir)
 
 	certPath := filepath.Join(tmpDir, "test.crt")
@@ -333,7 +432,9 @@ func TestCertManagerConcurrency(t *testing.T) {
 	writeCertAndKey(t, certPath, keyPath, cert, key)
 
 	cm, err := NewCertManager(certPath, keyPath)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	defer cm.Stop()
 
 	// Run concurrent operations
@@ -344,23 +445,40 @@ func TestCertManagerConcurrency(t *testing.T) {
 		go func() {
 			for j := 0; j < 100; j++ {
 				cert, err := cm.GetCertificate(nil)
-				assert.NoError(t, err)
-				assert.NotNil(t, cert)
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+				if cert == nil {
+					// Errorf, not Fatalf: FailNow must not run off the
+					// test goroutine.
+					t.Errorf("cert is nil")
+					break
+				}
 			}
 			done <- true
 		}()
 	}
 
-	// Concurrent reloads
+	// Concurrent reloads. The write+reload pairs are serialized against
+	// each other: two goroutines rewriting the same PEM files can hand
+	// Reload a torn certificate, which is a bug in the test, not in the
+	// manager — the concurrency under test is readers racing reloads,
+	// and that stays fully concurrent. (This flaked ~1 run in 10 on an
+	// untouched tree too; it just went unnoticed.)
+	var reloadMu sync.Mutex
 	for i := 0; i < 3; i++ {
 		go func(id int) {
 			for j := 0; j < 10; j++ {
+				reloadMu.Lock()
 				// Generate new cert for each reload
 				cert, key := generateTestCert(t, "concurrent-reload.example.com")
 				writeCertAndKey(t, certPath, keyPath, cert, key)
 
 				err := cm.Reload()
-				assert.NoError(t, err)
+				reloadMu.Unlock()
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
 				time.Sleep(time.Millisecond)
 			}
 			done <- true
@@ -375,7 +493,9 @@ func TestCertManagerConcurrency(t *testing.T) {
 
 func TestGetTLSConfigFreshness(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "certmanager-config-test")
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	defer os.RemoveAll(tmpDir)
 
 	certPath := filepath.Join(tmpDir, "test.crt")
@@ -385,7 +505,9 @@ func TestGetTLSConfigFreshness(t *testing.T) {
 	writeCertAndKey(t, certPath, keyPath, cert, key)
 
 	cm, err := NewCertManager(certPath, keyPath)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	defer cm.Stop()
 
 	// Get multiple TLS configs
@@ -393,18 +515,30 @@ func TestGetTLSConfigFreshness(t *testing.T) {
 	config2 := cm.GetTLSConfig()
 
 	// Should return fresh configs each time
-	assert.NotSame(t, config1, config2)
+	if config1 == config2 {
+		t.Errorf("%p is the same pointer", config1)
+	}
 
 	// Both should work correctly
-	assert.NotNil(t, config1.GetCertificate)
-	assert.NotNil(t, config2.GetCertificate)
-	assert.Equal(t, uint16(tls.VersionTLS12), config1.MinVersion)
-	assert.Equal(t, uint16(tls.VersionTLS12), config2.MinVersion)
+	if config1.GetCertificate == nil {
+		t.Fatalf("config1.GetCertificate is nil")
+	}
+	if config2.GetCertificate == nil {
+		t.Fatalf("config2.GetCertificate is nil")
+	}
+	if !reflect.DeepEqual(uint16(tls.VersionTLS12), config1.MinVersion) {
+		t.Errorf("config1.MinVersion = %v, want %v", config1.MinVersion, uint16(tls.VersionTLS12))
+	}
+	if !reflect.DeepEqual(uint16(tls.VersionTLS12), config2.MinVersion) {
+		t.Errorf("config2.MinVersion = %v, want %v", config2.MinVersion, uint16(tls.VersionTLS12))
+	}
 }
 
 func TestReloadWithRetry(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "certmanager-retry-test")
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	defer os.RemoveAll(tmpDir)
 
 	certPath := filepath.Join(tmpDir, "test.crt")
@@ -414,7 +548,9 @@ func TestReloadWithRetry(t *testing.T) {
 	writeCertAndKey(t, certPath, keyPath, cert, key)
 
 	cm, err := NewCertManager(certPath, keyPath)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	defer cm.Stop()
 
 	// Remove certificate to cause reload failure
@@ -422,8 +558,12 @@ func TestReloadWithRetry(t *testing.T) {
 
 	// This should fail after retries
 	err = cm.reloadWithRetry()
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "failed after 3 attempts")
+	if err == nil {
+		t.Errorf("expected an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "failed after 3 attempts") {
+		t.Errorf("%q does not contain %q", err.Error(), "failed after 3 attempts")
+	}
 }
 
 // A stopped Server must never grow a new certificate manager: the DoQ

--- a/server/doh/doh_test.go
+++ b/server/doh/doh_test.go
@@ -8,10 +8,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"reflect"
 	"testing"
 
 	"github.com/miekg/dns"
-	"github.com/stretchr/testify/assert"
 )
 
 func handleTest(w http.ResponseWriter, r *http.Request) {
@@ -48,22 +48,32 @@ func Test_dohJSON(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	request, err := http.NewRequest("GET", "/dns-query?name=www.google.com&type=a&do=true&cd=true", nil)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	request.RemoteAddr = "127.0.0.1:0"
 
 	handleTest(w, request)
 
-	assert.Equal(t, w.Code, http.StatusOK)
+	if !reflect.DeepEqual(w.Code, http.StatusOK) {
+		t.Errorf("http.StatusOK = %v, want %v", http.StatusOK, w.Code)
+	}
 
 	data, err := io.ReadAll(w.Body)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	var dm Msg
 	err = json.Unmarshal(data, &dm)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
-	assert.Equal(t, len(dm.Answer) > 0, true)
+	if !reflect.DeepEqual(len(dm.Answer) > 0, true) {
+		t.Errorf("true = %v, want %v", true, len(dm.Answer) > 0)
+	}
 }
 
 func Test_dohJSONerror(t *testing.T) {
@@ -72,13 +82,17 @@ func Test_dohJSONerror(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	request, err := http.NewRequest("GET", "/dns-query?name=", nil)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	request.RemoteAddr = "127.0.0.1:0"
 
 	handleTest(w, request)
 
-	assert.Equal(t, w.Code, http.StatusBadRequest)
+	if !reflect.DeepEqual(w.Code, http.StatusBadRequest) {
+		t.Errorf("http.StatusBadRequest = %v, want %v", http.StatusBadRequest, w.Code)
+	}
 }
 
 func Test_dohJSONaccepthtml(t *testing.T) {
@@ -87,15 +101,21 @@ func Test_dohJSONaccepthtml(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	request, err := http.NewRequest("GET", "/dns-query?name=www.google.com", nil)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	request.RemoteAddr = "127.0.0.1:0"
 
 	request.Header.Add("Accept", "text/html")
 	handleTest(w, request)
 
-	assert.Equal(t, w.Code, http.StatusOK)
-	assert.Equal(t, w.Header().Get("Content-Type"), "application/x-javascript")
+	if !reflect.DeepEqual(w.Code, http.StatusOK) {
+		t.Errorf("http.StatusOK = %v, want %v", http.StatusOK, w.Code)
+	}
+	if !reflect.DeepEqual(w.Header().Get("Content-Type"), "application/x-javascript") {
+		t.Errorf("'application/x-javascript' = %v, want %v", "application/x-javascript", w.Header().Get("Content-Type"))
+	}
 }
 
 func Test_dohWireGET(t *testing.T) {
@@ -107,29 +127,43 @@ func Test_dohWireGET(t *testing.T) {
 	req.SetQuestion("www.google.com.", dns.TypeA)
 
 	data, err := req.Pack()
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	dq := base64.RawURLEncoding.EncodeToString(data)
 
 	request, err := http.NewRequest("GET", fmt.Sprintf("/dns-query?dns=%s", dq), nil)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	request.RemoteAddr = "127.0.0.1:0"
 
 	handleTest(w, request)
 
-	assert.Equal(t, w.Code, http.StatusOK)
+	if !reflect.DeepEqual(w.Code, http.StatusOK) {
+		t.Errorf("http.StatusOK = %v, want %v", http.StatusOK, w.Code)
+	}
 
 	data, err = io.ReadAll(w.Body)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	msg := new(dns.Msg)
 	err = msg.Unpack(data)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
-	assert.Equal(t, msg.Rcode, dns.RcodeSuccess)
+	if !reflect.DeepEqual(msg.Rcode, dns.RcodeSuccess) {
+		t.Errorf("dns.RcodeSuccess = %v, want %v", dns.RcodeSuccess, msg.Rcode)
+	}
 
-	assert.Equal(t, len(msg.Answer) > 0, true)
+	if !reflect.DeepEqual(len(msg.Answer) > 0, true) {
+		t.Errorf("true = %v, want %v", true, len(msg.Answer) > 0)
+	}
 }
 
 func Test_dohWireGETerror(t *testing.T) {
@@ -138,13 +172,17 @@ func Test_dohWireGETerror(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	request, err := http.NewRequest("GET", "/dns-query?dns=", nil)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	request.RemoteAddr = "127.0.0.1:0"
 
 	handleTest(w, request)
 
-	assert.Equal(t, w.Code, http.StatusBadRequest)
+	if !reflect.DeepEqual(w.Code, http.StatusBadRequest) {
+		t.Errorf("http.StatusBadRequest = %v, want %v", http.StatusBadRequest, w.Code)
+	}
 }
 
 func Test_dohWireGETbadquery(t *testing.T) {
@@ -153,13 +191,17 @@ func Test_dohWireGETbadquery(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	request, err := http.NewRequest("GET", "/dns-query?dns=Df4", nil)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	request.RemoteAddr = "127.0.0.1:0"
 
 	handleTest(w, request)
 
-	assert.Equal(t, w.Code, http.StatusBadRequest)
+	if !reflect.DeepEqual(w.Code, http.StatusBadRequest) {
+		t.Errorf("http.StatusBadRequest = %v, want %v", http.StatusBadRequest, w.Code)
+	}
 }
 
 func Test_dohWireHEAD(t *testing.T) {
@@ -168,13 +210,17 @@ func Test_dohWireHEAD(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	request, err := http.NewRequest("HEAD", "/dns-query?dns=", nil)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	request.RemoteAddr = "127.0.0.1:0"
 
 	handleTest(w, request)
 
-	assert.Equal(t, w.Code, http.StatusMethodNotAllowed)
+	if !reflect.DeepEqual(w.Code, http.StatusMethodNotAllowed) {
+		t.Errorf("http.StatusMethodNotAllowed = %v, want %v", http.StatusMethodNotAllowed, w.Code)
+	}
 }
 
 func Test_dohWirePOST(t *testing.T) {
@@ -186,28 +232,42 @@ func Test_dohWirePOST(t *testing.T) {
 	req.SetQuestion("www.google.com.", dns.TypeA)
 
 	data, err := req.Pack()
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	request, err := http.NewRequest("POST", "/dns-query", bytes.NewReader(data))
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	request.RemoteAddr = "127.0.0.1:0"
 	request.Header.Add("Content-Type", "application/dns-message")
 
 	handleTest(w, request)
 
-	assert.Equal(t, w.Code, http.StatusOK)
+	if !reflect.DeepEqual(w.Code, http.StatusOK) {
+		t.Errorf("http.StatusOK = %v, want %v", http.StatusOK, w.Code)
+	}
 
 	data, err = io.ReadAll(w.Body)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	msg := new(dns.Msg)
 	err = msg.Unpack(data)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
-	assert.Equal(t, msg.Rcode, dns.RcodeSuccess)
+	if !reflect.DeepEqual(msg.Rcode, dns.RcodeSuccess) {
+		t.Errorf("dns.RcodeSuccess = %v, want %v", dns.RcodeSuccess, msg.Rcode)
+	}
 
-	assert.Equal(t, len(msg.Answer) > 0, true)
+	if !reflect.DeepEqual(len(msg.Answer) > 0, true) {
+		t.Errorf("true = %v, want %v", true, len(msg.Answer) > 0)
+	}
 }
 
 func Test_dohWirePOSTError(t *testing.T) {
@@ -216,14 +276,18 @@ func Test_dohWirePOSTError(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	request, err := http.NewRequest("POST", "/dns-query", bytes.NewReader([]byte{}))
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	request.RemoteAddr = "127.0.0.1:0"
 	request.Header.Add("Content-Type", "text/html")
 
 	handleTest(w, request)
 
-	assert.Equal(t, w.Code, http.StatusUnsupportedMediaType)
+	if !reflect.DeepEqual(w.Code, http.StatusUnsupportedMediaType) {
+		t.Errorf("http.StatusUnsupportedMediaType = %v, want %v", http.StatusUnsupportedMediaType, w.Code)
+	}
 }
 
 func Test_dohWireHandlerReturnsNil(t *testing.T) {
@@ -238,15 +302,21 @@ func Test_dohWireHandlerReturnsNil(t *testing.T) {
 	req := new(dns.Msg)
 	req.SetQuestion("example.com.", dns.TypeA)
 	data, err := req.Pack()
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	request, err := http.NewRequest("POST", "/dns-query", bytes.NewReader(data))
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 	request.Header.Add("Content-Type", "application/dns-message")
 
 	HandleWireFormat(nilHandle)(w, request)
 
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+	if !reflect.DeepEqual(http.StatusBadRequest, w.Code) {
+		t.Errorf("w.Code = %v, want %v", w.Code, http.StatusBadRequest)
+	}
 }
 
 func Test_dohJSONHandlerReturnsNil(t *testing.T) {
@@ -259,11 +329,15 @@ func Test_dohJSONHandlerReturnsNil(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	request, err := http.NewRequest("GET", "/dns-query?name=example.com&type=A", nil)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	HandleJSON(nilHandle)(w, request)
 
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+	if !reflect.DeepEqual(http.StatusBadRequest, w.Code) {
+		t.Errorf("w.Code = %v, want %v", w.Code, http.StatusBadRequest)
+	}
 }
 
 func Test_dohJSONInvalidType(t *testing.T) {
@@ -276,11 +350,15 @@ func Test_dohJSONInvalidType(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	request, err := http.NewRequest("GET", "/dns-query?name=example.com&type=INVALID", nil)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	HandleJSON(handle)(w, request)
 
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+	if !reflect.DeepEqual(http.StatusBadRequest, w.Code) {
+		t.Errorf("w.Code = %v, want %v", w.Code, http.StatusBadRequest)
+	}
 }
 
 func Test_dohJSONMethodNotAllowed(t *testing.T) {
@@ -293,9 +371,13 @@ func Test_dohJSONMethodNotAllowed(t *testing.T) {
 	w := httptest.NewRecorder()
 
 	request, err := http.NewRequest("POST", "/dns-query?name=example.com&type=A", nil)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	HandleJSON(handle)(w, request)
 
-	assert.Equal(t, http.StatusMethodNotAllowed, w.Code)
+	if !reflect.DeepEqual(http.StatusMethodNotAllowed, w.Code) {
+		t.Errorf("w.Code = %v, want %v", w.Code, http.StatusMethodNotAllowed)
+	}
 }

--- a/server/doh/msg_test.go
+++ b/server/doh/msg_test.go
@@ -1,31 +1,41 @@
 package doh
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/miekg/dns"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_Msg(t *testing.T) {
 	m := NewMsg(nil)
-	assert.Nil(t, m)
+	if m != nil {
+		t.Errorf("m = %v, want nil", m)
+	}
 
 	msg := new(dns.Msg)
 	msg.SetQuestion(".", dns.TypeNS)
 
 	rr, err := dns.NewRR(".			518400	IN	NS	a.root-servers.net.")
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	msg.Answer = append(msg.Answer, rr)
 
 	rr, err = dns.NewRR("a.gtld-servers.net.	172800	IN	A	192.5.6.30")
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	msg.Ns = append(msg.Ns, rr)
 
 	m = NewMsg(msg)
 
-	assert.Equal(t, m.Answer[0].Data, msg.Answer[0].(*dns.NS).Ns)
-	assert.Equal(t, m.Authority[0].Data, msg.Ns[0].(*dns.A).A.String())
+	if !reflect.DeepEqual(m.Answer[0].Data, msg.Answer[0].(*dns.NS).Ns) {
+		t.Errorf("msg.Answer[0].(*dns.NS).Ns = %v, want %v", msg.Answer[0].(*dns.NS).Ns, m.Answer[0].Data)
+	}
+	if !reflect.DeepEqual(m.Authority[0].Data, msg.Ns[0].(*dns.A).A.String()) {
+		t.Errorf("msg.Ns[0].(*dns.A).A.String() = %v, want %v", msg.Ns[0].(*dns.A).A.String(), m.Authority[0].Data)
+	}
 }

--- a/server/doh/qtype_test.go
+++ b/server/doh/qtype_test.go
@@ -1,22 +1,30 @@
 package doh
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/miekg/dns"
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_ParseQTYPE(t *testing.T) {
 	qtype := ParseQTYPE("")
-	assert.Equal(t, qtype, dns.TypeA)
+	if !reflect.DeepEqual(qtype, dns.TypeA) {
+		t.Errorf("dns.TypeA = %v, want %v", dns.TypeA, qtype)
+	}
 
 	qtype = ParseQTYPE("1")
-	assert.Equal(t, qtype, dns.TypeA)
+	if !reflect.DeepEqual(qtype, dns.TypeA) {
+		t.Errorf("dns.TypeA = %v, want %v", dns.TypeA, qtype)
+	}
 
 	qtype = ParseQTYPE("CNAME")
-	assert.Equal(t, qtype, dns.TypeCNAME)
+	if !reflect.DeepEqual(qtype, dns.TypeCNAME) {
+		t.Errorf("dns.TypeCNAME = %v, want %v", dns.TypeCNAME, qtype)
+	}
 
 	qtype = ParseQTYPE("TEST")
-	assert.Equal(t, qtype, dns.TypeNone)
+	if !reflect.DeepEqual(qtype, dns.TypeNone) {
+		t.Errorf("dns.TypeNone = %v, want %v", dns.TypeNone, qtype)
+	}
 }

--- a/server/doq/doq_test.go
+++ b/server/doq/doq_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/quic-go/quic-go"
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/semihalev/sdns/middleware"
-	"github.com/stretchr/testify/assert"
 )
 
 type dummyHandler struct{}
@@ -134,7 +133,9 @@ func generateCertificate() error {
 
 func Test_doq(t *testing.T) {
 	err := generateCertificate()
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	cert := filepath.Join(os.TempDir(), "test.cert")
 	privkey := filepath.Join(os.TempDir(), "test.key")
@@ -161,7 +162,9 @@ func Test_doq(t *testing.T) {
 		if err == quic.ErrServerClosed {
 			return
 		}
-		assert.NoError(t, err)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
 	}()
 
 	time.Sleep(time.Second)
@@ -171,76 +174,118 @@ func Test_doq(t *testing.T) {
 		NextProtos:         []string{"doq"},
 	}
 	conn, err := quic.DialAddr(context.Background(), s.Addr, tlsConf, nil)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	stream, err := conn.OpenStreamSync(context.Background())
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	req := new(dns.Msg)
 	req.SetQuestion("example.com.", dns.TypeA)
 	req.Id = 0
 
 	buf, err := req.Pack()
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	n, err := stream.Write(addPrefixLen(buf))
-	assert.NoError(t, err)
-	assert.Greater(t, n, 17)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if n <= 17 {
+		t.Errorf("n = %v, want > %v", n, 17)
+	}
 
 	err = stream.Close()
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	data, err := io.ReadAll(stream)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	msg := new(dns.Msg)
 	err = msg.Unpack(data[2:])
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	stream, err = conn.OpenStreamSync(context.Background())
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	time.Sleep(6 * time.Second)
 
 	_, err = stream.Write([]byte{0, 0})
-	assert.Error(t, err)
+	if err == nil {
+		t.Errorf("expected an error, got nil")
+	}
 
 	conn, err = quic.DialAddr(context.Background(), s.Addr, tlsConf, nil)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	stream, err = conn.OpenStreamSync(context.Background())
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	_, err = stream.Write([]byte{0, 0})
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	err = stream.Close()
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	_, err = io.ReadAll(stream)
-	assert.Error(t, err)
+	if err == nil {
+		t.Errorf("expected an error, got nil")
+	}
 
 	conn, err = quic.DialAddr(context.Background(), s.Addr, tlsConf, nil)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	stream, err = conn.OpenStreamSync(context.Background())
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	msg = new(dns.Msg)
 	msg.SetEdns0(512, true)
 	buf, _ = msg.Pack()
 
 	_, err = stream.Write(buf)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	err = stream.Close()
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	_, err = io.ReadAll(stream)
-	assert.Error(t, err)
+	if err == nil {
+		t.Errorf("expected an error, got nil")
+	}
 
 	err = s.Shutdown()
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 }
 
 func TestServerDispatchesStreamContextToAwareHandler(t *testing.T) {

--- a/server/listener_test.go
+++ b/server/listener_test.go
@@ -4,16 +4,16 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"fmt"
 	"net"
 	"net/http"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/middleware"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // noopMsgHandler is a doq.Handler stub for listeners that are only
@@ -65,15 +65,31 @@ func TestBindAll_CriticalFailureUnwindsSuccessfulBinds(t *testing.T) {
 
 	active, err := bindAll(context.Background(), []Listener{udp, tcp, tls})
 
-	require.Error(t, err, "bindAll must surface critical bind errors")
-	assert.Nil(t, active, "no listeners should be returned on critical failure")
-	assert.Contains(t, err.Error(), "bind: address already in use")
+	if err == nil {
+		t.Fatalf("%s: expected an error, got nil", "bindAll must surface critical bind errors")
+	}
+	if active != nil {
+		t.Errorf("%s: active = %v, want nil", "no listeners should be returned on critical failure", active)
+	}
+	if !strings.Contains(err.Error(), "bind: address already in use") {
+		t.Errorf("%q does not contain %q", err.Error(), "bind: address already in use")
+	}
 
-	assert.True(t, udp.bound.Load(), "UDP should have bound")
-	assert.True(t, udp.shutdown.Load(), "UDP must be shut down to release the socket")
-	assert.False(t, tcp.bound.Load(), "TCP should not have bound")
-	assert.True(t, tls.bound.Load(), "non-critical TLS should have bound")
-	assert.True(t, tls.shutdown.Load(), "non-critical TLS must also be shut down")
+	if !(udp.bound.Load()) {
+		t.Errorf("%s: udp.bound.Load() is false", "UDP should have bound")
+	}
+	if !(udp.shutdown.Load()) {
+		t.Errorf("%s: udp.shutdown.Load() is false", "UDP must be shut down to release the socket")
+	}
+	if tcp.bound.Load() {
+		t.Errorf("%s: tcp.bound.Load() is true", "TCP should not have bound")
+	}
+	if !(tls.bound.Load()) {
+		t.Errorf("%s: tls.bound.Load() is false", "non-critical TLS should have bound")
+	}
+	if !(tls.shutdown.Load()) {
+		t.Errorf("%s: tls.shutdown.Load() is false", "non-critical TLS must also be shut down")
+	}
 }
 
 func TestBindAll_NonCriticalFailureDoesNotAbort(t *testing.T) {
@@ -85,15 +101,29 @@ func TestBindAll_NonCriticalFailureDoesNotAbort(t *testing.T) {
 
 	active, err := bindAll(context.Background(), []Listener{udp, tcp, tls})
 
-	require.NoError(t, err)
-	assert.Len(t, active, 2)
-	assert.True(t, udp.bound.Load())
-	assert.True(t, tcp.bound.Load())
-	assert.False(t, tls.bound.Load())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(active) != 2 {
+		t.Errorf("len(active) = %d, want %d", len(active), 2)
+	}
+	if !(udp.bound.Load()) {
+		t.Errorf("udp.bound.Load() is false")
+	}
+	if !(tcp.bound.Load()) {
+		t.Errorf("tcp.bound.Load() is false")
+	}
+	if tls.bound.Load() {
+		t.Errorf("tls.bound.Load() is true")
+	}
 	// Nothing should be shut down — everything currently bound is
 	// still serving.
-	assert.False(t, udp.shutdown.Load())
-	assert.False(t, tcp.shutdown.Load())
+	if udp.shutdown.Load() {
+		t.Errorf("udp.shutdown.Load() is true")
+	}
+	if tcp.shutdown.Load() {
+		t.Errorf("tcp.shutdown.Load() is true")
+	}
 }
 
 // TestListenerShutdownBeforeServeReleasesSocket verifies that every
@@ -130,11 +160,15 @@ func TestListenerShutdownBeforeServeReleasesSocket(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			l := tc.build("127.0.0.1:0")
-			require.NoError(t, l.Bind(context.Background()), "Bind")
+			if err := l.Bind(context.Background()); err != nil {
+				t.Fatalf("%s: unexpected error: %v", "Bind", err)
+			}
 
 			// Capture the bound port so we can try to re-bind it.
 			addr := boundAddr(t, l)
-			require.NoError(t, l.Shutdown(context.Background()), "Shutdown")
+			if err := l.Shutdown(context.Background()); err != nil {
+				t.Fatalf("%s: unexpected error: %v", "Shutdown", err)
+			}
 
 			// If Shutdown actually released the FD, we can open a
 			// fresh socket on the same port immediately. Use the
@@ -164,22 +198,34 @@ func boundAddr(t *testing.T, l Listener) string {
 	t.Helper()
 	switch v := l.(type) {
 	case *udpListener:
-		require.NotEmpty(t, v.pcs, "udp listener must have at least one PacketConn")
+		if len(v.pcs) == 0 {
+			t.Fatalf("%s: v.pcs is empty", "udp listener must have at least one PacketConn")
+		}
 		return v.pcs[0].LocalAddr().String()
 	case *tcpListener:
-		require.NotNil(t, v.ln, "tcp listener must have a net.Listener")
+		if v.ln == nil {
+			t.Fatalf("%s: v.ln is nil", "tcp listener must have a net.Listener")
+		}
 		return v.ln.Addr().String()
 	case *tlsListener:
-		require.NotNil(t, v.ln, "tls listener must have a net.Listener")
+		if v.ln == nil {
+			t.Fatalf("%s: v.ln is nil", "tls listener must have a net.Listener")
+		}
 		return v.ln.Addr().String()
 	case *dohListener:
-		require.NotNil(t, v.ln, "doh listener must have a net.Listener")
+		if v.ln == nil {
+			t.Fatalf("%s: v.ln is nil", "doh listener must have a net.Listener")
+		}
 		return v.ln.Addr().String()
 	case *doh3Listener:
-		require.NotNil(t, v.pc, "doh3 listener must have a PacketConn")
+		if v.pc == nil {
+			t.Fatalf("%s: v.pc is nil", "doh3 listener must have a PacketConn")
+		}
 		return v.pc.LocalAddr().String()
 	case *doqListener:
-		require.NotNil(t, v.pc, "doq listener must have a PacketConn")
+		if v.pc == nil {
+			t.Fatalf("%s: v.pc is nil", "doq listener must have a PacketConn")
+		}
 		return v.pc.LocalAddr().String()
 	default:
 		t.Fatalf("unsupported listener type %T", l)
@@ -190,18 +236,26 @@ func boundAddr(t *testing.T, l Listener) string {
 func probeUDP(t *testing.T, addr string) {
 	t.Helper()
 	ua, err := net.ResolveUDPAddr("udp", addr)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	pc, err := net.ListenUDP("udp", ua)
-	require.NoError(t, err, "port %s must be free after Shutdown", addr)
+	if err != nil {
+		t.Fatalf("%s: unexpected error: %v", fmt.Sprintf("port %s must be free after Shutdown", addr), err)
+	}
 	_ = pc.Close()
 }
 
 func probeTCP(t *testing.T, addr string) {
 	t.Helper()
 	ta, err := net.ResolveTCPAddr("tcp", addr)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	ln, err := net.ListenTCP("tcp", ta)
-	require.NoError(t, err, "port %s must be free after Shutdown", addr)
+	if err != nil {
+		t.Fatalf("%s: unexpected error: %v", fmt.Sprintf("port %s must be free after Shutdown", addr), err)
+	}
 	_ = ln.Close()
 }
 
@@ -219,7 +273,9 @@ func minimalTLSConfig(t *testing.T) *tls.Config {
 	t.Helper()
 	cert, key := generateTestCert(t, "listener-test.local")
 	tlsCert, err := tls.X509KeyPair(cert, key)
-	require.NoError(t, err)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	return &tls.Config{
 		Certificates: []tls.Certificate{tlsCert},
 		MinVersion:   tls.VersionTLS12,

--- a/server/listener_udp_linux_test.go
+++ b/server/listener_udp_linux_test.go
@@ -4,14 +4,15 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"net"
+	"reflect"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/middleware"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // TestUDPListener_ZeroPortFanoutSharesOnePort pins the fix for
@@ -27,21 +28,28 @@ func TestUDPListener_ZeroPortFanoutSharesOnePort(t *testing.T) {
 		l.sockets = 4
 	}
 
-	require.NoError(t, l.Bind(context.Background()))
+	if err := l.Bind(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	t.Cleanup(func() { _ = l.Shutdown(context.Background()) })
 
 	// One PacketConn per socket. The engine's handler workers are a
 	// separate, independently sized pool — asserting against them was a
 	// leftover from when the two counts were the same field.
-	require.Len(t, l.pcs, l.sockets, "one PacketConn per socket")
+	if len(l.pcs) != l.sockets {
+		t.Fatalf("%s: len(l.pcs) = %d, want %d", "one PacketConn per socket", len(l.pcs), l.sockets)
+	}
 
 	want := l.pcs[0].LocalAddr().String()
-	require.NotContains(t, want, ":0", "kernel should have assigned a real port")
+	if strings.Contains(want, ":0") {
+		t.Fatalf("%s: %q contains %q", "kernel should have assigned a real port", want, ":0")
+	}
 
 	for i, pc := range l.pcs[1:] {
 		got := pc.LocalAddr().String()
-		assert.Equalf(t, want, got,
-			"worker %d bound to %s, expected shared %s", i+1, got, want)
+		if !reflect.DeepEqual(want, got) {
+			t.Errorf("%s: got = %v, want %v", fmt.Sprintf("worker %d bound to %s, expected shared %s", i+1, got, want), got, want)
+		}
 	}
 }
 

--- a/server/server_graceful_test.go
+++ b/server/server_graceful_test.go
@@ -2,12 +2,11 @@ package server
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/semihalev/sdns/config"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestServerGracefulDegradation(t *testing.T) {
@@ -25,21 +24,37 @@ func TestServerGracefulDegradation(t *testing.T) {
 	}
 
 	s := New(cfg)
-	require.NotNil(t, s)
+	if s == nil {
+		t.Fatalf("s is nil")
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	require.NoError(t, s.Run(ctx))
+	if err := s.Run(ctx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	time.Sleep(100 * time.Millisecond)
 
-	assert.True(t, s.HasListener("udp"), "UDP should be active")
-	assert.True(t, s.HasListener("tcp"), "TCP should be active")
+	if !(s.HasListener("udp")) {
+		t.Errorf("%s: s.HasListener('udp') is false", "UDP should be active")
+	}
+	if !(s.HasListener("tcp")) {
+		t.Errorf("%s: s.HasListener('tcp') is false", "TCP should be active")
+	}
 
-	assert.False(t, s.HasListener("tls"), "TLS should be disabled")
-	assert.False(t, s.HasListener("doh"), "DoH should be disabled")
-	assert.False(t, s.HasListener("doh3"), "DoH3 should be disabled")
-	assert.False(t, s.HasListener("doq"), "DoQ should be disabled")
+	if s.HasListener("tls") {
+		t.Errorf("%s: s.HasListener('tls') is true", "TLS should be disabled")
+	}
+	if s.HasListener("doh") {
+		t.Errorf("%s: s.HasListener('doh') is true", "DoH should be disabled")
+	}
+	if s.HasListener("doh3") {
+		t.Errorf("%s: s.HasListener('doh3') is true", "DoH3 should be disabled")
+	}
+	if s.HasListener("doq") {
+		t.Errorf("%s: s.HasListener('doq') is true", "DoQ should be disabled")
+	}
 
 	cancel()
 
@@ -70,21 +85,35 @@ func TestServerWithValidCertificate(t *testing.T) {
 	}
 
 	s := New(cfg)
-	require.NotNil(t, s)
+	if s == nil {
+		t.Fatalf("s is nil")
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	require.NoError(t, s.Run(ctx))
+	if err := s.Run(ctx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	time.Sleep(200 * time.Millisecond)
 
-	assert.True(t, s.HasListener("udp"), "UDP should be active")
-	assert.True(t, s.HasListener("tcp"), "TCP should be active")
-	assert.True(t, s.HasListener("tls"), "TLS should be active")
-	assert.True(t, s.HasListener("doh"), "DoH should be active")
+	if !(s.HasListener("udp")) {
+		t.Errorf("%s: s.HasListener('udp') is false", "UDP should be active")
+	}
+	if !(s.HasListener("tcp")) {
+		t.Errorf("%s: s.HasListener('tcp') is false", "TCP should be active")
+	}
+	if !(s.HasListener("tls")) {
+		t.Errorf("%s: s.HasListener('tls') is false", "TLS should be active")
+	}
+	if !(s.HasListener("doh")) {
+		t.Errorf("%s: s.HasListener('doh') is false", "DoH should be active")
+	}
 	// DoH3 can fail on constrained CI runners (UDP buffer size, QUIC
 	// features); leave it unchecked. DoQ reuses the same certificate.
-	assert.True(t, s.HasListener("doq"), "DoQ should be active")
+	if !(s.HasListener("doq")) {
+		t.Errorf("%s: s.HasListener('doq') is false", "DoQ should be active")
+	}
 
 	cancel()
 	time.Sleep(100 * time.Millisecond)
@@ -113,10 +142,14 @@ func TestServerHasListenerReflectsServeState(t *testing.T) {
 	}
 
 	s := New(cfg)
-	require.NotNil(t, s)
+	if s == nil {
+		t.Fatalf("s is nil")
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
-	require.NoError(t, s.Run(ctx))
+	if err := s.Run(ctx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 
 	// Before Serve has had a chance to run, HasListener may be
 	// false; give goroutines time to start.
@@ -129,11 +162,21 @@ func TestServerHasListenerReflectsServeState(t *testing.T) {
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	assert.True(t, s.HasListener("udp"))
-	assert.True(t, s.HasListener("tcp"))
-	assert.True(t, s.HasListener("doh"))
-	assert.True(t, s.HasListener("doh3"))
-	assert.True(t, s.HasListener("doq"))
+	if !(s.HasListener("udp")) {
+		t.Errorf("s.HasListener('udp') is false")
+	}
+	if !(s.HasListener("tcp")) {
+		t.Errorf("s.HasListener('tcp') is false")
+	}
+	if !(s.HasListener("doh")) {
+		t.Errorf("s.HasListener('doh') is false")
+	}
+	if !(s.HasListener("doh3")) {
+		t.Errorf("s.HasListener('doh3') is false")
+	}
+	if !(s.HasListener("doq")) {
+		t.Errorf("s.HasListener('doq') is false")
+	}
 
 	// Stop the server — every listener's Serve goroutine exits and
 	// HasListener must flip back to false.
@@ -145,11 +188,21 @@ func TestServerHasListenerReflectsServeState(t *testing.T) {
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	assert.False(t, s.HasListener("udp"), "UDP should no longer be serving")
-	assert.False(t, s.HasListener("tcp"))
-	assert.False(t, s.HasListener("doh"))
-	assert.False(t, s.HasListener("doh3"))
-	assert.False(t, s.HasListener("doq"))
+	if s.HasListener("udp") {
+		t.Errorf("%s: s.HasListener('udp') is true", "UDP should no longer be serving")
+	}
+	if s.HasListener("tcp") {
+		t.Errorf("s.HasListener('tcp') is true")
+	}
+	if s.HasListener("doh") {
+		t.Errorf("s.HasListener('doh') is true")
+	}
+	if s.HasListener("doh3") {
+		t.Errorf("s.HasListener('doh3') is true")
+	}
+	if s.HasListener("doq") {
+		t.Errorf("s.HasListener('doq') is true")
+	}
 }
 
 // TestServerRestartReleasesSockets reproduces the graceful-restart case
@@ -175,14 +228,22 @@ func TestServerRestartReleasesSockets(t *testing.T) {
 
 	for i := 0; i < 2; i++ {
 		s := New(cfg)
-		require.NotNil(t, s, "cycle %d: New", i)
+		if s == nil {
+			t.Fatalf("%s: s is nil", fmt.Sprintf("cycle %d: New", i))
+		}
 
 		ctx, cancel := context.WithCancel(context.Background())
-		require.NoError(t, s.Run(ctx), "cycle %d: Run", i)
+		if err := s.Run(ctx); err != nil {
+			t.Fatalf("%s: unexpected error: %v", fmt.Sprintf("cycle %d: Run", i), err)
+		}
 
 		time.Sleep(100 * time.Millisecond)
-		require.True(t, s.HasListener("doh3"), "cycle %d: DoH3 should bind on a fresh socket", i)
-		require.True(t, s.HasListener("doq"), "cycle %d: DoQ should bind on a fresh socket", i)
+		if !(s.HasListener("doh3")) {
+			t.Fatalf("%s: s.HasListener('doh3') is false", fmt.Sprintf("cycle %d: DoH3 should bind on a fresh socket", i))
+		}
+		if !(s.HasListener("doq")) {
+			t.Fatalf("%s: s.HasListener('doq') is false", fmt.Sprintf("cycle %d: DoQ should bind on a fresh socket", i))
+		}
 
 		cancel()
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -16,6 +16,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
@@ -26,7 +27,6 @@ import (
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/semihalev/sdns/middleware/blocklist"
 	"github.com/semihalev/zlog/v2"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestMain(m *testing.M) {
@@ -150,7 +150,9 @@ func Test_ServerBindFail(t *testing.T) {
 func Test_Server(t *testing.T) {
 	cfg := &config.Config{}
 	err := generateCertificate()
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	cert := filepath.Join(os.TempDir(), "test.cert")
 	privkey := filepath.Join(os.TempDir(), "test.key")
@@ -187,39 +189,57 @@ func Test_Server(t *testing.T) {
 	mw := mock.NewWriter("udp", "127.0.0.1:0")
 	s.ServeMsg(context.Background(), mw, req)
 
-	assert.True(t, mw.Written())
-	if assert.NotNil(t, mw.Msg()) {
-		assert.Equal(t, true, len(mw.Msg().Answer) > 0)
+	if !(mw.Written()) {
+		t.Errorf("mw.Written() is false")
+	}
+	if mw.Msg() == nil {
+		t.Error("mw.Msg() is nil")
+	} else if !reflect.DeepEqual(true, len(mw.Msg().Answer) > 0) {
+		t.Errorf("len(mw.Msg().Answer) > 0 = %v, want %v", len(mw.Msg().Answer) > 0, true)
 	}
 
 	request, err := http.NewRequest("GET", "/dns-query?name=test.com", nil)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	hw := httptest.NewRecorder()
 
 	s.ServeHTTP(hw, request)
-	assert.Equal(t, 200, hw.Code)
+	if !reflect.DeepEqual(200, hw.Code) {
+		t.Errorf("hw.Code = %v, want %v", hw.Code, 200)
+	}
 
 	data, err := req.Pack()
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	dq := base64.RawURLEncoding.EncodeToString(data)
 
 	request, err = http.NewRequest("GET", fmt.Sprintf("/dns-query?dns=%s", dq), nil)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	hw = httptest.NewRecorder()
 
 	s.ServeHTTP(hw, request)
-	assert.Equal(t, 200, hw.Code)
+	if !reflect.DeepEqual(200, hw.Code) {
+		t.Errorf("hw.Code = %v, want %v", hw.Code, 200)
+	}
 
 	request, err = http.NewRequest("GET", "/dns-query?name=example.com", nil)
-	assert.NoError(t, err)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
 
 	hw = httptest.NewRecorder()
 
 	s.ServeHTTP(hw, request)
-	assert.Equal(t, 400, hw.Code)
+	if !reflect.DeepEqual(400, hw.Code) {
+		t.Errorf("hw.Code = %v, want %v", hw.Code, 400)
+	}
 
 	time.Sleep(2 * time.Second)
 
@@ -237,9 +257,19 @@ func Test_ServerEmptyQuestion(t *testing.T) {
 	req.Id = dns.Id()
 	mw := mock.NewWriter("udp", "127.0.0.1:0")
 
-	assert.NotPanics(t, func() { s.ServeMsg(context.Background(), mw, req) })
-	assert.True(t, mw.Written())
-	if assert.NotNil(t, mw.Msg()) {
-		assert.Equal(t, dns.RcodeFormatError, mw.Msg().Rcode)
+	if func() (panicked bool) {
+		defer func() { panicked = recover() != nil }()
+		s.ServeMsg(context.Background(), mw, req)
+		return
+	}() {
+		t.Error("ServeMsg panicked on an empty question")
+	}
+	if !(mw.Written()) {
+		t.Errorf("mw.Written() is false")
+	}
+	if mw.Msg() == nil {
+		t.Error("mw.Msg() is nil")
+	} else if !reflect.DeepEqual(dns.RcodeFormatError, mw.Msg().Rcode) {
+		t.Errorf("mw.Msg().Rcode = %v, want %v", mw.Msg().Rcode, dns.RcodeFormatError)
 	}
 }


### PR DESCRIPTION
Every `assert`/`require` call in the tree (~1450 sites across 68 files) becomes a plain standard-library testing check, and `stretchr/testify` leaves `go.mod` along with its transitive baggage.

## How the conversion preserves semantics

- `require.*` → `t.Fatalf` (fail fast), `assert.*` → `t.Errorf` (mark and continue) — testify's exact stop/continue split.
- `Equal`/`NotEqual` go through `reflect.DeepEqual`, which is what testify computed.
- Guard forms (`if assert.NotNil(t, x) { … }`) keep their control flow: the failing side marks, the passing side runs the body.
- `Len`/`Contains`/`Greater`-family/`Same`/`Empty`/`ErrorIs` map to their direct expressions; `Panics`/`InDelta`/`Zero`/`ElementsMatch` are hand-written recover-closures, `math.Abs` bounds, zero-value compares and sorted-compare respectively.
- Containment that hid behind testify's type-blind `Contains` now says what it means: `slices.Contains` for slices, key lookups for maps.
- Nil guards whose failure could only dereference nil on the next line fail fast instead of continuing into a panic.

The bulk (~1380 statement-form sites) was rewritten by a position-based AST tool; the 71 expression-form and rare-method sites were converted by hand; every file then passed `gofmt`, `goimports`, `go vet` and the repo's `golangci-lint` config on all three release GOOS targets.

## Fixed on the way

- Two `Fatalf`-from-non-test-goroutine violations that testify's `require`-in-goroutine had been hiding from vet.
- `TestCertManagerConcurrency`'s own file-write race: three goroutines rewriting the same PEM files handed `Reload` a torn certificate roughly one run in ten — **on an untouched tree as well** (verified against pristine main). The write+reload pairs are now serialized while the readers stay fully concurrent, which is the concurrency the test exists to exercise. 10/10 clean after.

## Verification

Full `go test -race ./...`: zero failures. `golangci-lint` (cache-cleaned): zero issues on darwin, linux, freebsd. No production code changed — the diff is test files, `go.mod`/`go.sum`, and nothing else.