### PR TITLE
metrics: wire-aware domain metrics — stop materializing every request

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ example.com.		0	CH	HINFO	"Host" "IPv6:[2001:500:8d::53]:53 rtt:148ms health:[GOO
 | **ratelimit**        | Global query rate limit per second. 0 disables. Default: 0                                                          |
 | **clientratelimit**  | Per-client rate limit per minute. 0 disables. Default: 0                                                            |
 | **domainmetrics**    | Enable per-domain query metrics collection. Default: false                                                          |
-| **domainmetricslimit** | Maximum number of domains to track in metrics. 0 = unlimited (use with caution). Default: 10000                  |
+| **domainmetricslimit** | Maximum number of domains to track in metrics. 0 = unlimited (use with caution). Default: 1000                  |
 | **blocklist**        | Manual domain blocklist. Domains listed here will be blocked                                                        |
 | **whitelist**        | Manual domain whitelist. Overrides blocklist matches                                                                |
 | **cookiesecret**     | DNS cookie secret (RFC 7873) for client verification. Auto-generated if not set                                     |

--- a/config/config.go
+++ b/config/config.go
@@ -744,8 +744,7 @@ domainmetrics = false
 
 # Maximum number of domains to track in metrics
 # 0 = unlimited (use with caution - may consume memory)
-# Recommended: 10000-100000 for production
-domainmetricslimit = 10000
+domainmetricslimit = 1000
 
 # ============================
 # Custom Lists

--- a/contrib/linux/sdns.conf
+++ b/contrib/linux/sdns.conf
@@ -306,8 +306,7 @@ domainmetrics = false
 
 # Maximum number of domains to track in metrics
 # 0 = unlimited (use with caution - may consume memory)
-# Recommended: 10000-100000 for production
-domainmetricslimit = 10000
+domainmetricslimit = 1000
 
 # ============================
 # Custom Lists

--- a/middleware/metrics/metrics.go
+++ b/middleware/metrics/metrics.go
@@ -78,19 +78,14 @@ func (m *Metrics) ClientOnly() bool { return true }
 
 // (*Metrics).ServeDNS serveDNS implements the Handle interface. The
 // per-query counter reads the parsed qtype, so a wire-born request is
-// observed without a decoded message; domain metrics (unbounded
-// cardinality, allocating) need the decoded name, force materialization,
-// and are documented as disabling the zero guarantee.
+// observed without a decoded message. Domain metrics used to force
+// materialization up front — which parked the cache's byte path for
+// every query the moment the option was enabled, priced on a live
+// profile at a full decode per request, 18% of all allocation. The name
+// is now read from the wire directly after the serve: one string per
+// query, and the fast path stays a fast path.
 func (m *Metrics) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	req := ch.Request
-	if m.domainMetricsEnabled && req.Undecoded() {
-		var decoded *dns.Msg
-		ctx, decoded = ch.Materialize(ctx)
-		if decoded == nil {
-			return
-		}
-	}
-
 	ch.Next(ctx)
 
 	if !ch.Writer.Written() {
@@ -101,8 +96,23 @@ func (m *Metrics) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 
 	// Update domain metrics if enabled
 	if m.domainMetricsEnabled {
-		m.recordDomainQuery(req.Msg().Question[0].Name)
+		m.recordDomainQuery(questionName(req))
 	}
+}
+
+// questionName returns the query name without forcing a wire-born
+// request to materialize. ParseWire admits exactly one uncompressed
+// question name, so unpacking from offset zero is total; a name the
+// library cannot render counts as no domain at all.
+func questionName(req *middleware.Request) string {
+	if req.Undecoded() {
+		name, _, err := dns.UnpackDomainName(req.WireName(), 0)
+		if err != nil {
+			return ""
+		}
+		return name
+	}
+	return req.Msg().Question[0].Name
 }
 
 // observe records one response with caller-stack key scratch — no pool,

--- a/middleware/metrics/metrics_wire_test.go
+++ b/middleware/metrics/metrics_wire_test.go
@@ -1,0 +1,86 @@
+package metrics
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/middleware"
+)
+
+// TestDomainMetricsStayOnTheWire pins the contract that put domain
+// metrics back on the fast path: a wire-born request is counted by
+// domain without ever being materialized. The old pre-serve
+// materialization parked the cache's byte path for every query the
+// moment the option was enabled.
+func TestDomainMetricsStayOnTheWire(t *testing.T) {
+	m := New(&config.Config{
+		DomainMetrics:      true,
+		DomainMetricsLimit: 10,
+	})
+
+	q := new(dns.Msg)
+	q.SetQuestion("Wire.Example.COM.", dns.TypeA)
+	q.RecursionDesired = true
+	raw, err := q.Pack()
+	if err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+	req := new(middleware.Request)
+	if !req.ParseWire(raw, time.Now(), nil) {
+		t.Fatal("eligible query refused")
+	}
+
+	responder := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		resp := new(dns.Msg)
+		resp.SetReply(ch.Request.Msg())
+		_ = ch.Writer.WriteMsg(resp)
+		ch.Cancel()
+	})
+	// The responder above materializes deliberately (SetReply needs the
+	// message); the assertion below therefore uses a second, byte-only
+	// serve where nothing in the chain decodes.
+	writer := mock.NewWriter("udp", "192.0.2.5:40000")
+	ch := middleware.NewChain([]middleware.Handler{m, responder})
+	ch.ResetWire(writer, req)
+	ch.AllowDirectPack()
+	ch.Next(context.Background())
+	if !writer.Written() {
+		t.Fatal("no response written")
+	}
+	if atomic.LoadInt32(&m.domainCount) != 1 {
+		t.Fatalf("domainCount = %d, want 1", atomic.LoadInt32(&m.domainCount))
+	}
+	if _, ok := m.domainTracker.Load(strings.ToLower(strings.TrimSuffix("Wire.Example.COM.", "."))); !ok {
+		t.Fatal("wire-born query's domain was not tracked")
+	}
+
+	// The byte-only pass: the transport answers from raw bytes and the
+	// request must come out the far side still undecoded.
+	byteResponder := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		if _, err := ch.Writer.Write(raw); err != nil {
+			t.Fatalf("raw write: %v", err)
+		}
+		ch.Cancel()
+	})
+	req2 := new(middleware.Request)
+	if !req2.ParseWire(raw, time.Now(), nil) {
+		t.Fatal("eligible query refused")
+	}
+	writer2 := mock.NewWriter("udp", "192.0.2.6:40000")
+	ch2 := middleware.NewChain([]middleware.Handler{m, byteResponder})
+	ch2.ResetWire(writer2, req2)
+	ch2.AllowDirectPack()
+	ch2.Next(context.Background())
+	if !writer2.Written() {
+		t.Fatal("no response written on the byte pass")
+	}
+	if !req2.Undecoded() {
+		t.Fatal("domain metrics materialized a wire-born request; the name must come from the wire")
+	}
+}


### PR DESCRIPTION
## Problem

With `domainmetrics = true`, the metrics middleware called `ch.Materialize()` on every request **before** the cache ran. That forced a full message decode per query and disabled the byte-serving fast path entirely — the single config option silently turned off the core optimization of the server rewrite.

On a live allocation profile with the option enabled, this pre-serve materialization accounted for **~18% of all allocation** (16.7M forced decodes in the sample window); disabling the option moved wire-served hits from 0% to ~80% of cache hits. Independently spotted by a Codex review as well.

## Fix

- The pre-`Next` materialize block is gone. Domain recording moves after the serve, where it always belonged (it needs a name, not a decoded message).
- `questionName()` reads the qname of an undecoded request straight from the wire via `dns.UnpackDomainName(req.WireName(), 0)` — one string allocation instead of a full decode. `ParseWire` admits exactly one uncompressed question, so unpacking at offset zero is total; an unrenderable name counts as no domain.
- Decoded requests keep reading `Question[0].Name` as before. `dns_queries_total` (qtype/rcode) was already wire-safe and is untouched.
- Generated-config default for `domainmetricslimit` drops from 10000 to 1000 (README, template, and the packaged `contrib/linux/sdns.conf` kept in parity).

## Behavior

Per-domain counting is unchanged: same normalization (lowercase, trailing dot stripped), same single-label filter, same limit/cleanup machinery. The only difference is that the fast path stays a fast path while it happens.

## Tests

`TestDomainMetricsStayOnTheWire` drives wire-born requests through the middleware and pins both halves of the contract: the domain **is** tracked, and a byte-only serve leaves the request `Undecoded()` afterwards. Full suite + `golangci-lint` (darwin/linux/freebsd) green.