### PR TITLE
middleware: wire-aware ratelimit and hostsfile — the guards stop materializing

### DIFF
--- a/middleware/hostsfile/hostsfile.go
+++ b/middleware/hostsfile/hostsfile.go
@@ -118,6 +118,10 @@ func (h *Hostsfile) Name() string {
 }
 
 // (*Hostsfile).ServeDNS serveDNS handles DNS queries using the hosts database.
+// A wire-born request is looked up by its wire question name — one string,
+// no decode — and on the overwhelmingly common miss continues down the
+// chain undecoded; a hit builds its response from parsed scalars, so this
+// handler never materializes anything.
 func (h *Hostsfile) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	// Safety check for nil receiver
 	if h == nil {
@@ -125,11 +129,12 @@ func (h *Hostsfile) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		return
 	}
 
-	// The hosts lookup is keyed on the presentation-form name.
-	ctx, req := ch.Materialize(ctx)
-	if req == nil {
+	if ch.Request.Undecoded() {
+		h.serveWire(ctx, ch)
 		return
 	}
+
+	req := ch.Request.Msg()
 	w := ch.Writer
 
 	if len(req.Question) == 0 {
@@ -144,25 +149,7 @@ func (h *Hostsfile) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	atomic.AddUint64(&db.stats.lookups, 1)
 	hostsfileLookups.Inc()
 
-	// Handle different query types
-	var answer []dns.RR
-	var found bool
-
-	switch q.Qtype {
-	case dns.TypeA:
-		answer, found = h.lookupA(db, q.Name)
-	case dns.TypeAAAA:
-		answer, found = h.lookupAAAA(db, q.Name)
-	case dns.TypePTR:
-		answer, found = h.lookupPTR(db, q.Name)
-	case dns.TypeCNAME:
-		answer, found = h.lookupCNAME(db, q.Name)
-	default:
-		// For other types, check if host exists to return NODATA
-		if h.hostExists(db, q.Name) {
-			found = true
-		}
-	}
+	answer, found := h.lookup(db, q.Name, q.Qtype)
 
 	if !found {
 		ch.Next(ctx)
@@ -197,6 +184,74 @@ func (h *Hostsfile) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 
 	_ = w.WriteMsg(resp)
 	ch.Cancel()
+}
+
+// serveWire answers a wire-born request from the hosts database without
+// decoding it. The lookup key is the presentation-form name, which
+// UnpackDomainName produces straight from the wire question.
+func (h *Hostsfile) serveWire(ctx context.Context, ch *middleware.Chain) {
+	req := ch.Request
+
+	qname, _, err := dns.UnpackDomainName(req.WireName(), 0)
+	if err != nil {
+		ch.Next(ctx)
+		return
+	}
+
+	db := h.getDB()
+
+	atomic.AddUint64(&db.stats.lookups, 1)
+	hostsfileLookups.Inc()
+
+	answer, found := h.lookup(db, qname, req.Qtype())
+
+	if !found {
+		ch.Next(ctx)
+		return
+	}
+
+	atomic.AddUint64(&db.stats.hits, 1)
+	hostsfileHits.Inc()
+
+	// Header discipline matches the decoded body below; the question is
+	// rebuilt from parsed scalars instead of aliasing a decoded one.
+	resp := new(dns.Msg)
+	resp.MsgHdr = dns.MsgHdr{
+		Id:                 req.ID(),
+		Response:           true,
+		Opcode:             req.Opcode(),
+		Authoritative:      true,
+		RecursionDesired:   req.RD(),
+		RecursionAvailable: true,
+		CheckingDisabled:   req.CD(),
+	}
+	resp.Question = []dns.Question{{Name: qname, Qtype: req.Qtype(), Qclass: req.Qclass()}}
+	resp.Answer = answer
+
+	_ = ch.Writer.WriteMsg(resp)
+	ch.Cancel()
+}
+
+// lookup answers qname/qtype from db: A, AAAA, PTR, and CNAME get their
+// records; any other type reports bare existence, which the callers turn
+// into NODATA.
+func (h *Hostsfile) lookup(db *HostsDB, qname string, qtype uint16) ([]dns.RR, bool) {
+	switch qtype {
+	case dns.TypeA:
+		return h.lookupA(db, qname)
+	case dns.TypeAAAA:
+		return h.lookupAAAA(db, qname)
+	case dns.TypePTR:
+		return h.lookupPTR(db, qname)
+	case dns.TypeCNAME:
+		return h.lookupCNAME(db, qname)
+	default:
+		// For other types, check if host exists to return NODATA
+		if h.hostExists(db, qname) {
+			return nil, true
+		}
+		return nil, false
+	}
 }
 
 // lookupA finds A records for a hostname.

--- a/middleware/hostsfile/hostsfile_wire_test.go
+++ b/middleware/hostsfile/hostsfile_wire_test.go
@@ -1,0 +1,147 @@
+package hostsfile
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/middleware"
+)
+
+func wireHostsfile(t *testing.T) *Hostsfile {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "hosts")
+	if err := os.WriteFile(path, []byte("127.0.0.1 probe.test\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	h := New(&config.Config{HostsFile: path})
+	if h == nil {
+		t.Fatal("hostsfile failed to load")
+	}
+	return h
+}
+
+func wireHostsRequest(t *testing.T, qname string, qtype uint16) *middleware.Request {
+	t.Helper()
+
+	q := new(dns.Msg)
+	q.SetQuestion(qname, qtype)
+	q.RecursionDesired = true
+	raw, err := q.Pack()
+	if err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+	req := new(middleware.Request)
+	if !req.ParseWire(raw, time.Now(), nil) {
+		t.Fatal("eligible query refused by ParseWire")
+	}
+	return req
+}
+
+// TestHostsfileWireMissStaysUndecoded pins the common case: a wire-born
+// query that misses the hosts database continues down the chain without
+// ever being materialized.
+func TestHostsfileWireMissStaysUndecoded(t *testing.T) {
+	h := wireHostsfile(t)
+
+	var sawUndecoded bool
+	next := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		sawUndecoded = ch.Request.Undecoded()
+		ch.Cancel()
+	})
+
+	req := wireHostsRequest(t, "other.test.", dns.TypeA)
+	w := mock.NewWriter("udp", "192.0.2.1:40000")
+	ch := middleware.NewChain([]middleware.Handler{h, next})
+	ch.ResetWire(w, req)
+	ch.Next(context.Background())
+
+	if !sawUndecoded {
+		t.Fatal("a hosts miss must not decode the request")
+	}
+}
+
+// TestHostsfileWireHitParity serves the same query once wire-born and once
+// message-born and requires identical responses; the wire serve must also
+// leave the request undecoded — a hit is built from parsed scalars.
+func TestHostsfileWireHitParity(t *testing.T) {
+	h := wireHostsfile(t)
+
+	req := wireHostsRequest(t, "probe.test.", dns.TypeA)
+	w := mock.NewWriter("udp", "192.0.2.1:40000")
+	ch := middleware.NewChain([]middleware.Handler{h})
+	ch.ResetWire(w, req)
+	ch.Next(context.Background())
+
+	if !w.Written() {
+		t.Fatal("wire hit not served")
+	}
+	if !req.Undecoded() {
+		t.Fatal("wire hit materialized the request")
+	}
+
+	q := new(dns.Msg)
+	q.SetQuestion("probe.test.", dns.TypeA)
+	q.RecursionDesired = true
+	wd := mock.NewWriter("udp", "192.0.2.1:40000")
+	chd := middleware.NewChain([]middleware.Handler{h})
+	chd.Reset(wd, q)
+	chd.Next(context.Background())
+
+	if !wd.Written() {
+		t.Fatal("decoded hit not served")
+	}
+
+	got, want := w.Msg(), wd.Msg()
+	if got.Id != req.ID() {
+		t.Fatalf("wire reply Id = %d, want the request's %d", got.Id, req.ID())
+	}
+	// The two requests carry different random Ids; equalize before the
+	// whole-header comparison.
+	got.Id, want.Id = 0, 0
+	if got.MsgHdr != want.MsgHdr {
+		t.Fatalf("header mismatch: wire %+v, decoded %+v", got.MsgHdr, want.MsgHdr)
+	}
+	if !reflect.DeepEqual(got.Question, want.Question) {
+		t.Fatalf("question mismatch: wire %v, decoded %v", got.Question, want.Question)
+	}
+	if !reflect.DeepEqual(got.Answer, want.Answer) {
+		t.Fatalf("answer mismatch: wire %v, decoded %v", got.Answer, want.Answer)
+	}
+	if len(got.Answer) != 1 {
+		t.Fatalf("answers = %d, want 1", len(got.Answer))
+	}
+	if a, ok := got.Answer[0].(*dns.A); !ok || !a.A.Equal(net.ParseIP("127.0.0.1")) {
+		t.Fatalf("answer = %v, want probe.test A 127.0.0.1", got.Answer[0])
+	}
+}
+
+// TestHostsfileWireNODATA: a known host queried for a type the hosts
+// database cannot answer gets an empty NOERROR, matching the decoded body.
+func TestHostsfileWireNODATA(t *testing.T) {
+	h := wireHostsfile(t)
+
+	req := wireHostsRequest(t, "probe.test.", dns.TypeMX)
+	w := mock.NewWriter("udp", "192.0.2.1:40000")
+	ch := middleware.NewChain([]middleware.Handler{h})
+	ch.ResetWire(w, req)
+	ch.Next(context.Background())
+
+	if !w.Written() {
+		t.Fatal("NODATA for a known host must be served")
+	}
+	if w.Rcode() != dns.RcodeSuccess || len(w.Msg().Answer) != 0 {
+		t.Fatalf("rcode = %v answers = %d, want NOERROR with no answers", w.Rcode(), len(w.Msg().Answer))
+	}
+	if !req.Undecoded() {
+		t.Fatal("NODATA serve materialized the request")
+	}
+}

--- a/middleware/ratelimit/ratelimit.go
+++ b/middleware/ratelimit/ratelimit.go
@@ -2,6 +2,7 @@ package ratelimit
 
 import (
 	"context"
+	"encoding/hex"
 	"net"
 	"sync/atomic"
 	"time"
@@ -89,6 +90,14 @@ func (r *RateLimit) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		return
 	}
 
+	// A wire-born request carries its cookie as parsed offsets, so the
+	// limiter runs without decoding; only the BADCOOKIE reply needs the
+	// message. Everything else takes the decoded body below.
+	if ch.Request.Undecoded() {
+		r.serveWire(ctx, ch)
+		return
+	}
+
 	// An active limit needs the request's cookie options.
 	ctx, req := ch.Materialize(ctx)
 	if req == nil {
@@ -145,6 +154,79 @@ func (r *RateLimit) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	if servercookie != "" {
 		l.cookie.Store(servercookie)
 	}
+}
+
+// serveWire mirrors the decoded body over parsed wire facts. The cookie
+// comparison works on the hex form option.String() produces, so a request
+// whose cookie verifies — or that has no cookie and passes the limiter —
+// continues down the chain undecoded. The one branch that must write a
+// cookie back to the client, UDP BADCOOKIE, materializes; it is the
+// stale-cookie retry path, not the steady state.
+func (r *RateLimit) serveWire(ctx context.Context, ch *middleware.Chain) {
+	w := ch.Writer
+
+	l := r.getLimiter(w.RemoteIP())
+	cachedcookie := l.cookie.Load().(string)
+
+	if echo := ch.Request.CookieEcho(); echo != nil {
+		fullcookie := hex.EncodeToString(echo)
+		clientcookie := fullcookie[:cookieSize]
+		servercookie := dnsutil.GenerateServerCookie(r.cookiesecret, w.RemoteIP().String(), clientcookie)
+
+		if cachedcookie == "" || cachedcookie == fullcookie {
+			ch.Next(ctx)
+
+			l.cookie.Store(servercookie)
+			return
+		}
+
+		if w.Proto() == "udp" {
+			if !l.rl.Allow() {
+				rateLimitExceeded.Inc()
+				ch.Cancel()
+				return
+			}
+
+			l.cookie.Store(servercookie)
+
+			_, req := ch.Materialize(ctx)
+			if req == nil {
+				return
+			}
+			if opt := req.IsEdns0(); opt != nil {
+				for _, option := range opt.Option {
+					if option.Option() == dns.EDNS0COOKIE {
+						option.(*dns.EDNS0_COOKIE).Cookie = servercookie
+						break
+					}
+				}
+			}
+
+			ch.CancelWithRcode(dns.RcodeBadCookie, false)
+			return
+		}
+
+		// A mismatched cookie over a spoof-proof transport: like the
+		// decoded body, fall through to the plain limiter.
+		if !l.rl.Allow() {
+			rateLimitExceeded.Inc()
+			ch.Cancel()
+			return
+		}
+
+		ch.Next(ctx)
+
+		l.cookie.Store(servercookie)
+		return
+	}
+
+	if !l.rl.Allow() {
+		rateLimitExceeded.Inc()
+		ch.Cancel()
+		return
+	}
+
+	ch.Next(ctx)
 }
 
 func (r *RateLimit) getLimiter(remoteip net.IP) *limiter {

--- a/middleware/ratelimit/ratelimit_wire_test.go
+++ b/middleware/ratelimit/ratelimit_wire_test.go
@@ -1,0 +1,151 @@
+package ratelimit
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/dnsutil"
+	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/middleware"
+)
+
+const wireTestCookie = "aabbccdd11223344" // 8 raw bytes in the hex form miekg packs
+
+func wireRequest(t *testing.T, cookie string) *middleware.Request {
+	t.Helper()
+
+	q := new(dns.Msg)
+	q.SetQuestion("example.com.", dns.TypeA)
+	q.SetEdns0(4096, true)
+	if cookie != "" {
+		opt := q.IsEdns0()
+		opt.Option = append(opt.Option, &dns.EDNS0_COOKIE{
+			Code:   dns.EDNS0COOKIE,
+			Cookie: cookie,
+		})
+	}
+	raw, err := q.Pack()
+	if err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+	req := new(middleware.Request)
+	if !req.ParseWire(raw, time.Now(), nil) {
+		t.Fatal("eligible query refused by ParseWire")
+	}
+	return req
+}
+
+// TestRateLimitWireStaysUndecoded pins the fast path: a wire-born request
+// with no cookie, and one whose cookie verifies, both pass the limiter
+// without being materialized.
+func TestRateLimitWireStaysUndecoded(t *testing.T) {
+	r := New(&config.Config{ClientRateLimit: 100, CookieSecret: "secret"})
+
+	var passed, sawUndecoded bool
+	next := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		passed = true
+		sawUndecoded = ch.Request.Undecoded()
+		ch.Cancel()
+	})
+
+	// No cookie at all.
+	req := wireRequest(t, "")
+	w := mock.NewWriter("udp", "10.0.0.1:0")
+	ch := middleware.NewChain([]middleware.Handler{r, next})
+	ch.ResetWire(w, req)
+	ch.Next(context.Background())
+	if !passed || !sawUndecoded {
+		t.Fatalf("no-cookie: passed=%v undecoded=%v, want both true", passed, sawUndecoded)
+	}
+
+	// A fresh cookie against an empty limiter cache verifies and passes.
+	passed, sawUndecoded = false, false
+	req = wireRequest(t, wireTestCookie)
+	w = mock.NewWriter("udp", "10.0.0.2:0")
+	ch = middleware.NewChain([]middleware.Handler{r, next})
+	ch.ResetWire(w, req)
+	ch.Next(context.Background())
+	if !passed || !sawUndecoded {
+		t.Fatalf("fresh cookie: passed=%v undecoded=%v, want both true", passed, sawUndecoded)
+	}
+}
+
+// TestRateLimitWireBadCookie drives the one wire branch that decodes: a
+// stale cookie over UDP earns BADCOOKIE carrying the refreshed server
+// cookie, exactly as the decoded body produces it.
+func TestRateLimitWireBadCookie(t *testing.T) {
+	r := New(&config.Config{ClientRateLimit: 100, CookieSecret: "secret"})
+
+	next := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		ch.Cancel()
+	})
+
+	// First serve stores the server cookie for this client.
+	req := wireRequest(t, wireTestCookie)
+	w := mock.NewWriter("udp", "10.0.0.3:0")
+	ch := middleware.NewChain([]middleware.Handler{r, next})
+	ch.ResetWire(w, req)
+	ch.Next(context.Background())
+	if w.Written() {
+		t.Fatal("first serve should pass through, not answer")
+	}
+
+	// Second serve echoes the same bare client cookie; the limiter now
+	// holds client+server, so the echo no longer matches.
+	req = wireRequest(t, wireTestCookie)
+	w = mock.NewWriter("udp", "10.0.0.3:0")
+	ch = middleware.NewChain([]middleware.Handler{r, next})
+	ch.ResetWire(w, req)
+	ch.Next(context.Background())
+	if !w.Written() {
+		t.Fatal("stale cookie over UDP should be answered")
+	}
+	if w.Rcode() != dns.RcodeBadCookie {
+		t.Fatalf("rcode = %v, want BADCOOKIE", w.Rcode())
+	}
+
+	want := dnsutil.GenerateServerCookie("secret", "10.0.0.3", wireTestCookie)
+	opt := w.Msg().IsEdns0()
+	if opt == nil {
+		t.Fatal("BADCOOKIE reply has no OPT")
+	}
+	var got string
+	for _, option := range opt.Option {
+		if cookie, ok := option.(*dns.EDNS0_COOKIE); ok {
+			got = cookie.Cookie
+		}
+	}
+	if got != want {
+		t.Fatalf("reply cookie = %q, want %q", got, want)
+	}
+}
+
+// TestRateLimitWireOverLimit checks the plain limiter still bites on the
+// wire path: with a rate of 1, the second cookieless query is dropped
+// without a reply.
+func TestRateLimitWireOverLimit(t *testing.T) {
+	r := New(&config.Config{ClientRateLimit: 1, CookieSecret: "secret"})
+
+	var passes int
+	next := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		passes++
+		ch.Cancel()
+	})
+
+	for i := 0; i < 3; i++ {
+		req := wireRequest(t, "")
+		w := mock.NewWriter("udp", "10.0.0.4:0")
+		ch := middleware.NewChain([]middleware.Handler{r, next})
+		ch.ResetWire(w, req)
+		ch.Next(context.Background())
+		if w.Written() {
+			t.Fatal("over-limit drop must not write a reply")
+		}
+	}
+	if passes >= 3 {
+		t.Fatalf("passes = %d, want the limiter to drop some of 3", passes)
+	}
+}

--- a/middleware/request.go
+++ b/middleware/request.go
@@ -302,6 +302,16 @@ func (r *Request) ClientCookie() []byte {
 	if r.cookieLen == 0 {
 		return nil
 	}
+	return r.raw[r.cookieOff : r.cookieOff+8]
+}
+
+// CookieEcho returns the full cookie option bytes the client sent — the
+// client half plus any echoed server half — or nil. Valid only for
+// wire-born requests.
+func (r *Request) CookieEcho() []byte {
+	if r.cookieLen == 0 {
+		return nil
+	}
 	return r.raw[r.cookieOff : r.cookieOff+r.cookieLen]
 }
 
@@ -453,12 +463,15 @@ func (r *Request) parseWireOPT(off int) bool {
 		}
 		switch code {
 		case dns.EDNS0COOKIE:
-			// RFC 7873: client half is 8 bytes, full cookie 8..40.
-			if optLen < 8 || optLen > 40 {
+			// RFC 7873: client half is 8 bytes, full cookie 8..40. A
+			// packet with more than one cookie option is not a shape the
+			// strict path knows — the decoded entry keeps its option-loop
+			// semantics for it.
+			if optLen < 8 || optLen > 40 || r.cookieLen != 0 {
 				return false
 			}
 			r.cookieOff = off
-			r.cookieLen = 8
+			r.cookieLen = optLen
 		case dns.EDNS0NSID:
 			r.hasNSID = true
 		case dns.EDNS0SUBNET:


### PR DESCRIPTION
## Problem

The metrics fix (#562) was not the last pre-cache materializer. On a live allocation profile of a deployment running `clientratelimit` and `hostsfile`, the ratelimit middleware showed up as the chain's **first materializer**: with a limit configured it decoded every non-loopback request just to read the cookie option (~50% of allocation flowed through its ServeDNS, with a ~100MB direct edge into `Chain.Materialize` on the sample window). The hostsfile middleware decoded every request behind it for a lookup that misses in practice almost always (58 hits in 218k lookups on the same box). Either option alone was enough to park the cache's byte path for the entire deployment.

## Fix

**ratelimit** — the limiter now runs on parsed wire facts:
- `Request` keeps the **full echoed cookie** (client half + any server half) instead of clamping to 8 bytes; `ClientCookie()` still returns the client half, new `CookieEcho()` returns the whole option.
- The wire branch compares the echo in the same hex form the decoded body gets from `option.String()`, generates the server cookie identically, and passes verified-cookie and no-cookie traffic down the chain **undecoded**.
- The one branch that must write a cookie back — UDP BADCOOKIE — materializes; it is the stale-cookie retry path, not the steady state.
- A packet with more than one cookie option is refused by `ParseWire` and takes the decoded entry, preserving the old option-loop semantics exactly.

**hostsfile** — never materializes at all now:
- The wire branch unpacks the question name straight from the wire (one string), keys the same presentation-form lookup, and lets misses continue undecoded.
- A hit builds its response from parsed scalars (`ID/Opcode/RD/CD/Qclass`); header discipline matches the decoded body, verified by a parity test.
- The qtype dispatch is extracted into one `lookup` helper shared by both bodies.

## Behavior

Limiter decisions, cookie storage timing, BADCOOKIE replies, hosts answers, NODATA for known hosts, and both hit/lookup counters are unchanged — the parity tests drive the same scenarios through both entries. `blocklist` has the same shape when lists are non-empty; it is left for the Track B byte-path pass rather than widened here.

## Tests

- ratelimit: no-cookie and verified-cookie wire requests pass **and stay undecoded**; stale-cookie UDP earns BADCOOKIE with the exact refreshed server cookie; the plain limiter still drops over-limit traffic.
- hostsfile: wire miss stays undecoded; wire hit and NODATA are byte-for-byte header/answer-identical to the decoded body and leave the request undecoded.
- Full suite green; `golangci-lint` clean on darwin/linux/freebsd.