### PR TITLE
dnsname: retire dns.UnpackDomainName for zero-allocation wire walkers

### DIFF
--- a/internal/dnsname/wire.go
+++ b/internal/dnsname/wire.go
@@ -39,7 +39,9 @@ func isPresentationSpecial(b byte) bool {
 // trailing dot and renders the root name empty — the lookup-key spelling.
 //
 // A name that is not a plain, exactly-consumed uncompressed name refuses;
-// dst is returned unchanged in that case.
+// dst comes back truncated to its original length in that case (a grown
+// append may have moved it to a new backing array, so callers must use the
+// returned slice, never the original).
 func appendWireName(dst, wire []byte, fold, rooted bool) ([]byte, bool) {
 	if len(wire) == 0 || len(wire) > maxWireNameOctets {
 		return dst, false

--- a/internal/dnsname/wire.go
+++ b/internal/dnsname/wire.go
@@ -1,0 +1,133 @@
+package dnsname
+
+// This file renders uncompressed wire-form names into presentation form
+// without heap allocation: the caller supplies the destination, typically a
+// stack buffer. The escape mapping is byte-identical to miekg's
+// UnpackDomainName — the special set {'.', ' ', '\'', '@', ';', '(', ')',
+// '"', '\\'} is backslash-prefixed, bytes outside 0x20–0x7E become \DDD —
+// which is the same contract internal/cache's wire key hasher already
+// depends on. The parity test drives every byte value through both
+// implementations.
+//
+// dns.UnpackDomainName is retired from SDNS's own paths in favor of these:
+// it is allocation-friendly (its scratch stays on the stack; the result
+// string is its only allocation), but a result string is one allocation
+// more than a lookup needs. A key written into a stack buffer indexes a map
+// with string(buf) for free, and that is how the hot paths stay at zero.
+
+// maxWireNameOctets is the RFC 1035 name length bound in wire form.
+const maxWireNameOctets = 255
+
+// MaxPresentationLength bounds the presentation form of any legal wire
+// name: every octet escaping to \DDD, plus label separators. Callers size
+// stack buffers with it.
+const MaxPresentationLength = 61*4 + 1 + 63*4 + 1 + 63*4 + 1 + 63*4 + 1
+
+// isPresentationSpecial mirrors miekg's isDomainNameLabelSpecial.
+func isPresentationSpecial(b byte) bool {
+	switch b {
+	case '.', ' ', '\'', '@', ';', '(', ')', '"', '\\':
+		return true
+	}
+	return false
+}
+
+// appendWireName is the one walker behind the exported variants. fold
+// lowercases ASCII A–Z (escape digits and specials are never A–Z, so
+// folding the escaped form equals escaping the folded form). rooted keeps
+// the trailing dot and renders the root name as "."; unrooted drops the
+// trailing dot and renders the root name empty — the lookup-key spelling.
+//
+// A name that is not a plain, exactly-consumed uncompressed name refuses;
+// dst is returned unchanged in that case.
+func appendWireName(dst, wire []byte, fold, rooted bool) ([]byte, bool) {
+	if len(wire) == 0 || len(wire) > maxWireNameOctets {
+		return dst, false
+	}
+	mark := len(dst)
+	off := 0
+	for {
+		if off >= len(wire) {
+			return dst[:mark], false
+		}
+		c := int(wire[off])
+		off++
+		if c == 0 {
+			break
+		}
+		if c&0xC0 != 0 || off+c > len(wire) {
+			return dst[:mark], false
+		}
+		for _, b := range wire[off : off+c] {
+			switch {
+			case isPresentationSpecial(b):
+				dst = append(dst, '\\', b)
+			case b < ' ' || b > '~':
+				dst = append(dst, '\\', '0'+b/100, '0'+b/10%10, '0'+b%10)
+			default:
+				if fold && b >= 'A' && b <= 'Z' {
+					b += 'a' - 'A'
+				}
+				dst = append(dst, b)
+			}
+		}
+		dst = append(dst, '.')
+		off += c
+	}
+	if off != len(wire) {
+		return dst[:mark], false
+	}
+	switch {
+	case len(dst) == mark:
+		if rooted {
+			dst = append(dst, '.')
+		}
+	case !rooted:
+		dst = dst[:len(dst)-1]
+	}
+	return dst, true
+}
+
+// AppendPresentation appends the presentation form of an uncompressed
+// wire-form name to dst — byte-identical to what dns.UnpackDomainName
+// returns for the same bytes, trailing dot included, case preserved.
+func AppendPresentation(dst, wire []byte) ([]byte, bool) {
+	return appendWireName(dst, wire, false, true)
+}
+
+// AppendFoldedKey appends the lookup-key form: the presentation form with
+// ASCII A–Z lowered and no trailing dot (the root name comes back empty).
+// This is the spelling hostsfile keys its database with and domain metrics
+// tracks, so a stack-buffered key indexes those maps with zero allocation.
+func AppendFoldedKey(dst, wire []byte) ([]byte, bool) {
+	return appendWireName(dst, wire, true, false)
+}
+
+// WireLabelCount returns the number of labels in an uncompressed wire-form
+// name — dns.CountLabel's answer without the string. The root name has
+// zero.
+func WireLabelCount(wire []byte) (int, bool) {
+	if len(wire) == 0 || len(wire) > maxWireNameOctets {
+		return 0, false
+	}
+	n, off := 0, 0
+	for {
+		if off >= len(wire) {
+			return 0, false
+		}
+		c := int(wire[off])
+		off++
+		if c == 0 {
+			break
+		}
+		if c&0xC0 != 0 || off+c > len(wire) {
+			return 0, false
+		}
+		n++
+		off += c
+	}
+	if off != len(wire) {
+		return 0, false
+	}
+	return n, true
+}

--- a/internal/dnsname/wire_test.go
+++ b/internal/dnsname/wire_test.go
@@ -1,0 +1,148 @@
+package dnsname
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func packName(t *testing.T, name string) []byte {
+	t.Helper()
+	buf := make([]byte, 512)
+	off, err := dns.PackDomainName(name, buf, 0, nil, false)
+	if err != nil {
+		t.Fatalf("pack %q: %v", name, err)
+	}
+	return buf[:off]
+}
+
+// TestAppendPresentationParity: byte-identical to dns.UnpackDomainName on
+// every name both accept — including every possible label byte.
+func TestAppendPresentationParity(t *testing.T) {
+	names := []string{
+		".",
+		"example.com.",
+		"WWW.Example.COM.",
+		"a.b.c.d.e.f.g.h.",
+		`ex\.ample.com.`,
+		`sp\ ace.com.`,
+		strings.Repeat("a", 63) + "." + strings.Repeat("b", 63) + ".com.",
+	}
+	for _, name := range names {
+		wire := packName(t, name)
+		want, end, err := dns.UnpackDomainName(wire, 0)
+		if err != nil || end != len(wire) {
+			t.Fatalf("%q: unpack err=%v end=%d len=%d", name, err, end, len(wire))
+		}
+		got, ok := AppendPresentation(nil, wire)
+		if !ok {
+			t.Fatalf("%q: walker refused a name the library accepts", name)
+		}
+		if string(got) != want {
+			t.Fatalf("%q: got %q want %q", name, got, want)
+		}
+	}
+
+	// Exhaustive single-byte labels.
+	for c := 0; c < 256; c++ {
+		wire := []byte{1, byte(c), 0}
+		want, _, err := dns.UnpackDomainName(wire, 0)
+		if err != nil {
+			continue
+		}
+		got, ok := AppendPresentation(nil, wire)
+		if !ok || string(got) != want {
+			t.Fatalf("byte %d: got %q (ok=%v) want %q", c, got, ok, want)
+		}
+	}
+}
+
+// TestAppendFoldedKey matches the lookup-key spelling both hostsfile and
+// domain metrics derive from the decoded presentation form.
+func TestAppendFoldedKey(t *testing.T) {
+	for _, tc := range []struct{ name, want string }{
+		{"Probe.Test.", "probe.test"},
+		{"WWW.EXAMPLE.COM.", "www.example.com"},
+		{"already.lower.", "already.lower"},
+		{".", ""},
+		{`Sp\ ACE.com.`, `sp\ ace.com`},
+	} {
+		wire := packName(t, tc.name)
+		got, ok := AppendFoldedKey(nil, wire)
+		if !ok {
+			t.Fatalf("%q refused", tc.name)
+		}
+		// The reference derivation: unpack, strip the trailing dot, fold.
+		want, _, err := dns.UnpackDomainName(wire, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		want = strings.ToLower(strings.TrimSuffix(want, "."))
+		if want != tc.want {
+			t.Fatalf("%q: reference derivation %q, expected %q", tc.name, want, tc.want)
+		}
+		if string(got) != want {
+			t.Fatalf("%q: got %q want %q", tc.name, got, want)
+		}
+	}
+}
+
+func TestAppendWireNameRefusals(t *testing.T) {
+	long := make([]byte, 256)
+	for _, wire := range [][]byte{
+		nil,
+		{},
+		{1, 'a'},            // truncated: no root byte
+		{0xC0, 0x02},        // compression pointer
+		{0x40, 'a', 0},      // reserved label type
+		{1, 'a', 0, 1, 'b'}, // trailing bytes after root
+		long,                // over the wire-form bound
+		{63, 'a'},           // label runs past the buffer
+	} {
+		if _, ok := AppendPresentation(nil, wire); ok {
+			t.Fatalf("accepted malformed wire %v", wire)
+		}
+		if _, ok := WireLabelCount(wire); ok {
+			t.Fatalf("label count accepted malformed wire %v", wire)
+		}
+	}
+}
+
+func TestWireLabelCount(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		want int
+	}{
+		{".", 0},
+		{"com.", 1},
+		{"example.com.", 2},
+		{"a.b.c.d.e.", 5},
+	} {
+		wire := packName(t, tc.name)
+		got, ok := WireLabelCount(wire)
+		if !ok || got != tc.want {
+			t.Fatalf("%q: got %d (ok=%v) want %d", tc.name, got, ok, tc.want)
+		}
+	}
+}
+
+// TestWireWalkersAllocateNothing pins the zero-allocation contract with a
+// stack destination.
+func TestWireWalkersAllocateNothing(t *testing.T) {
+	wire := packName(t, "WWW.Example.COM.")
+	if n := testing.AllocsPerRun(100, func() {
+		var buf [MaxPresentationLength]byte
+		if _, ok := AppendFoldedKey(buf[:0], wire); !ok {
+			t.Fatal("refused")
+		}
+		if _, ok := AppendPresentation(buf[:0], wire); !ok {
+			t.Fatal("refused")
+		}
+		if _, ok := WireLabelCount(wire); !ok {
+			t.Fatal("refused")
+		}
+	}); n != 0 {
+		t.Fatalf("allocs = %v, want 0", n)
+	}
+}

--- a/middleware/hostsfile/hostsfile.go
+++ b/middleware/hostsfile/hostsfile.go
@@ -233,12 +233,11 @@ func (h *Hostsfile) serveWire(ctx context.Context, ch *middleware.Chain) {
 		return
 	}
 
-	atomic.AddUint64(&db.stats.hits, 1)
-	hostsfileHits.Inc()
-
 	// A hit finally pays for its strings: the echoed question wants the
 	// client's exact spelling, case included. The key is spent, so the
-	// buffer is reused.
+	// buffer is reused. Derived before the hit counters so a refusal —
+	// unreachable while AppendFoldedKey and AppendPresentation share
+	// acceptance — could never count a hit it does not serve.
 	if qname == "" {
 		pres, ok := dnsname.AppendPresentation(buf[:0], req.WireName())
 		if !ok {
@@ -247,6 +246,9 @@ func (h *Hostsfile) serveWire(ctx context.Context, ch *middleware.Chain) {
 		}
 		qname = string(pres)
 	}
+
+	atomic.AddUint64(&db.stats.hits, 1)
+	hostsfileHits.Inc()
 
 	// Header discipline matches the decoded body below; the question is
 	// rebuilt from parsed scalars instead of aliasing a decoded one.
@@ -305,9 +307,12 @@ func lookupKeyed[K interface{ ~string | ~[]byte }](h *Hostsfile, db *HostsDB, ke
 		if entry, ok := db.hosts[string(key)]; ok && len(entry.aRRs) > 0 {
 			return entry.aRRs, true
 		}
-		for _, wc := range db.wildcards {
-			if k := string(key); matchWildcard(wc.Pattern, k) && len(wc.IPv4) > 0 {
-				return buildARRs(k, wc.IPv4, h.ttl), true
+		if len(db.wildcards) > 0 {
+			k := string(key)
+			for _, wc := range db.wildcards {
+				if matchWildcard(wc.Pattern, k) && len(wc.IPv4) > 0 {
+					return buildARRs(k, wc.IPv4, h.ttl), true
+				}
 			}
 		}
 		return nil, false
@@ -315,9 +320,12 @@ func lookupKeyed[K interface{ ~string | ~[]byte }](h *Hostsfile, db *HostsDB, ke
 		if entry, ok := db.hosts[string(key)]; ok && len(entry.aaaaRRs) > 0 {
 			return entry.aaaaRRs, true
 		}
-		for _, wc := range db.wildcards {
-			if k := string(key); matchWildcard(wc.Pattern, k) && len(wc.IPv6) > 0 {
-				return buildAAAARRs(k, wc.IPv6, h.ttl), true
+		if len(db.wildcards) > 0 {
+			k := string(key)
+			for _, wc := range db.wildcards {
+				if matchWildcard(wc.Pattern, k) && len(wc.IPv6) > 0 {
+					return buildAAAARRs(k, wc.IPv6, h.ttl), true
+				}
 			}
 		}
 		return nil, false
@@ -331,9 +339,12 @@ func lookupKeyed[K interface{ ~string | ~[]byte }](h *Hostsfile, db *HostsDB, ke
 		if _, ok := db.hosts[string(key)]; ok {
 			return nil, true
 		}
-		for _, wc := range db.wildcards {
-			if matchWildcard(wc.Pattern, string(key)) {
-				return nil, true
+		if len(db.wildcards) > 0 {
+			k := string(key)
+			for _, wc := range db.wildcards {
+				if matchWildcard(wc.Pattern, k) {
+					return nil, true
+				}
 			}
 		}
 		return nil, false

--- a/middleware/hostsfile/hostsfile.go
+++ b/middleware/hostsfile/hostsfile.go
@@ -16,6 +16,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/dnsname"
 	"github.com/semihalev/sdns/internal/dnsutil"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/zlog/v2"
@@ -187,23 +188,45 @@ func (h *Hostsfile) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 }
 
 // serveWire answers a wire-born request from the hosts database without
-// decoding it. The lookup key is the presentation-form name, which
-// UnpackDomainName produces straight from the wire question.
+// decoding it — and, on the miss that is this handler's whole life, without
+// allocating: the folded lookup key is written into a stack buffer and
+// indexes the database directly. Only a hit builds strings, for the
+// response it is about to write anyway. PTR keeps the presentation form
+// because the reverse-IP parser wants the spelling the client sent.
 func (h *Hostsfile) serveWire(ctx context.Context, ch *middleware.Chain) {
 	req := ch.Request
 
-	qname, _, err := dns.UnpackDomainName(req.WireName(), 0)
-	if err != nil {
-		ch.Next(ctx)
-		return
-	}
+	var buf [dnsname.MaxPresentationLength]byte
+	var answer []dns.RR
+	var found bool
+	var qname string
 
 	db := h.getDB()
 
-	atomic.AddUint64(&db.stats.lookups, 1)
-	hostsfileLookups.Inc()
+	if req.Qtype() == dns.TypePTR {
+		pres, ok := dnsname.AppendPresentation(buf[:0], req.WireName())
+		if !ok {
+			ch.Next(ctx)
+			return
+		}
+		qname = string(pres)
 
-	answer, found := h.lookup(db, qname, req.Qtype())
+		atomic.AddUint64(&db.stats.lookups, 1)
+		hostsfileLookups.Inc()
+
+		answer, found = h.lookupPTR(db, qname)
+	} else {
+		key, ok := dnsname.AppendFoldedKey(buf[:0], req.WireName())
+		if !ok {
+			ch.Next(ctx)
+			return
+		}
+
+		atomic.AddUint64(&db.stats.lookups, 1)
+		hostsfileLookups.Inc()
+
+		answer, found = lookupKeyed(h, db, key, req.Qtype())
+	}
 
 	if !found {
 		ch.Next(ctx)
@@ -212,6 +235,18 @@ func (h *Hostsfile) serveWire(ctx context.Context, ch *middleware.Chain) {
 
 	atomic.AddUint64(&db.stats.hits, 1)
 	hostsfileHits.Inc()
+
+	// A hit finally pays for its strings: the echoed question wants the
+	// client's exact spelling, case included. The key is spent, so the
+	// buffer is reused.
+	if qname == "" {
+		pres, ok := dnsname.AppendPresentation(buf[:0], req.WireName())
+		if !ok {
+			ch.Next(ctx)
+			return
+		}
+		qname = string(pres)
+	}
 
 	// Header discipline matches the decoded body below; the question is
 	// rebuilt from parsed scalars instead of aliasing a decoded one.
@@ -254,46 +289,65 @@ func (h *Hostsfile) lookup(db *HostsDB, qname string, qtype uint16) ([]dns.RR, b
 	}
 }
 
-// lookupA finds A records for a hostname.
-func (h *Hostsfile) lookupA(db *HostsDB, name string) ([]dns.RR, bool) {
+// lookupKeyed answers every hosts-database question except PTR from a
+// pre-derived lookup key. The key type is generic so the wire path can
+// pass a stack buffer — string(key) at a map index costs nothing for
+// either instantiation — and the decoded path its lookupKey string.
+// Wildcard fallback still builds RRs at query time because the owner name
+// depends on the query; wildcards are uncommon in practice, so the
+// conversion and allocation there are acceptable.
+func lookupKeyed[K interface{ ~string | ~[]byte }](h *Hostsfile, db *HostsDB, key K, qtype uint16) ([]dns.RR, bool) {
 	db.mu.RLock()
 	defer db.mu.RUnlock()
 
-	key := lookupKey(name)
-
-	// Direct lookup — return the pre-built shared slice.
-	if entry, ok := db.hosts[key]; ok && len(entry.aRRs) > 0 {
-		return entry.aRRs, true
-	}
-
-	// Wildcard fallback still builds RRs at query time because the
-	// owner name depends on the query. Wildcards are uncommon in
-	// practice, so the allocation here is acceptable.
-	for _, wc := range db.wildcards {
-		if matchWildcard(wc.Pattern, key) && len(wc.IPv4) > 0 {
-			return buildARRs(key, wc.IPv4, h.ttl), true
+	switch qtype {
+	case dns.TypeA:
+		if entry, ok := db.hosts[string(key)]; ok && len(entry.aRRs) > 0 {
+			return entry.aRRs, true
 		}
+		for _, wc := range db.wildcards {
+			if k := string(key); matchWildcard(wc.Pattern, k) && len(wc.IPv4) > 0 {
+				return buildARRs(k, wc.IPv4, h.ttl), true
+			}
+		}
+		return nil, false
+	case dns.TypeAAAA:
+		if entry, ok := db.hosts[string(key)]; ok && len(entry.aaaaRRs) > 0 {
+			return entry.aaaaRRs, true
+		}
+		for _, wc := range db.wildcards {
+			if k := string(key); matchWildcard(wc.Pattern, k) && len(wc.IPv6) > 0 {
+				return buildAAAARRs(k, wc.IPv6, h.ttl), true
+			}
+		}
+		return nil, false
+	case dns.TypeCNAME:
+		if entry, ok := db.hosts[string(key)]; ok && entry.cnameRR != nil {
+			return []dns.RR{entry.cnameRR}, true
+		}
+		return nil, false
+	default:
+		// For other types, bare existence turns into NODATA upstream.
+		if _, ok := db.hosts[string(key)]; ok {
+			return nil, true
+		}
+		for _, wc := range db.wildcards {
+			if matchWildcard(wc.Pattern, string(key)) {
+				return nil, true
+			}
+		}
+		return nil, false
 	}
-	return nil, false
+}
+
+// lookupA finds A records for a hostname.
+func (h *Hostsfile) lookupA(db *HostsDB, name string) ([]dns.RR, bool) {
+	return lookupKeyed(h, db, lookupKey(name), dns.TypeA)
 }
 
 // lookupAAAA finds AAAA records for a hostname.
 func (h *Hostsfile) lookupAAAA(db *HostsDB, name string) ([]dns.RR, bool) {
-	db.mu.RLock()
-	defer db.mu.RUnlock()
-
-	key := lookupKey(name)
-
-	if entry, ok := db.hosts[key]; ok && len(entry.aaaaRRs) > 0 {
-		return entry.aaaaRRs, true
-	}
-
-	for _, wc := range db.wildcards {
-		if matchWildcard(wc.Pattern, key) && len(wc.IPv6) > 0 {
-			return buildAAAARRs(key, wc.IPv6, h.ttl), true
-		}
-	}
-	return nil, false
+	return lookupKeyed(h, db, lookupKey(name), dns.TypeAAAA)
 }
 
 // lookupPTR finds PTR records for an IP address.
@@ -316,32 +370,13 @@ func (h *Hostsfile) lookupPTR(db *HostsDB, name string) ([]dns.RR, bool) {
 
 // lookupCNAME finds CNAME records (aliases).
 func (h *Hostsfile) lookupCNAME(db *HostsDB, name string) ([]dns.RR, bool) {
-	db.mu.RLock()
-	defer db.mu.RUnlock()
-
-	key := lookupKey(name)
-
-	if entry, ok := db.hosts[key]; ok && entry.cnameRR != nil {
-		return []dns.RR{entry.cnameRR}, true
-	}
-	return nil, false
+	return lookupKeyed(h, db, lookupKey(name), dns.TypeCNAME)
 }
 
 // hostExists checks if a hostname exists in the database.
 func (h *Hostsfile) hostExists(db *HostsDB, name string) bool {
-	db.mu.RLock()
-	defer db.mu.RUnlock()
-
-	key := lookupKey(name)
-	if _, ok := db.hosts[key]; ok {
-		return true
-	}
-	for _, wc := range db.wildcards {
-		if matchWildcard(wc.Pattern, key) {
-			return true
-		}
-	}
-	return false
+	_, ok := lookupKeyed(h, db, lookupKey(name), dns.TypeNone)
+	return ok
 }
 
 // load reads and parses the hosts file.

--- a/middleware/hostsfile/hostsfile_wire_test.go
+++ b/middleware/hostsfile/hostsfile_wire_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/dnsname"
 	"github.com/semihalev/sdns/internal/mock"
 	"github.com/semihalev/sdns/middleware"
 )
@@ -121,6 +122,30 @@ func TestHostsfileWireHitParity(t *testing.T) {
 	}
 	if a, ok := got.Answer[0].(*dns.A); !ok || !a.A.Equal(net.ParseIP("127.0.0.1")) {
 		t.Fatalf("answer = %v, want probe.test A 127.0.0.1", got.Answer[0])
+	}
+}
+
+// TestHostsfileWireLookupAllocatesNothing pins the point of the wire
+// branch: deriving the key and asking the database costs zero heap
+// allocations, hit and miss alike.
+func TestHostsfileWireLookupAllocatesNothing(t *testing.T) {
+	h := wireHostsfile(t)
+	db := h.getDB()
+
+	hit := wireHostsRequest(t, "Probe.Test.", dns.TypeA)
+	miss := wireHostsRequest(t, "other.example.", dns.TypeA)
+
+	if n := testing.AllocsPerRun(100, func() {
+		var buf [dnsname.MaxPresentationLength]byte
+		for _, req := range []*middleware.Request{hit, miss} {
+			key, ok := dnsname.AppendFoldedKey(buf[:0], req.WireName())
+			if !ok {
+				t.Fatal("refused")
+			}
+			lookupKeyed(h, db, key, dns.TypeA)
+		}
+	}); n != 0 {
+		t.Fatalf("allocs = %v, want 0", n)
 	}
 }
 

--- a/middleware/metrics/metrics.go
+++ b/middleware/metrics/metrics.go
@@ -12,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/dnsname"
 	"github.com/semihalev/sdns/internal/metric"
 	"github.com/semihalev/sdns/middleware"
 )
@@ -96,23 +97,28 @@ func (m *Metrics) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 
 	// Update domain metrics if enabled
 	if m.domainMetricsEnabled {
-		m.recordDomainQuery(questionName(req))
+		if req.Undecoded() {
+			m.recordWireDomain(req.WireName())
+		} else {
+			m.recordDomainQuery(req.Msg().Question[0].Name)
+		}
 	}
 }
 
-// questionName returns the query name without forcing a wire-born
-// request to materialize. ParseWire admits exactly one uncompressed
-// question name, so unpacking from offset zero is total; a name the
-// library cannot render counts as no domain at all.
-func questionName(req *middleware.Request) string {
-	if req.Undecoded() {
-		name, _, err := dns.UnpackDomainName(req.WireName(), 0)
-		if err != nil {
-			return ""
-		}
-		return name
+// recordWireDomain tracks a wire-born request's domain without building
+// intermediate strings: the label filter reads the wire directly, and the
+// normalized tracking key — lowercase, no trailing dot — is written into a
+// stack buffer, so the one allocation left is the key recordDomain keeps.
+func (m *Metrics) recordWireDomain(wire []byte) {
+	if n, ok := dnsname.WireLabelCount(wire); !ok || n < 2 {
+		return
 	}
-	return req.Msg().Question[0].Name
+	var buf [dnsname.MaxPresentationLength]byte
+	key, ok := dnsname.AppendFoldedKey(buf[:0], wire)
+	if !ok {
+		return
+	}
+	m.recordDomain(string(key))
 }
 
 // observe records one response with caller-stack key scratch — no pool,
@@ -130,8 +136,11 @@ func (m *Metrics) recordDomainQuery(qname string) {
 	}
 
 	// Normalize domain name (lowercase and remove trailing dot)
-	domain := strings.ToLower(strings.TrimSuffix(qname, "."))
+	m.recordDomain(strings.ToLower(strings.TrimSuffix(qname, ".")))
+}
 
+// recordDomain tracks one query against a normalized domain key.
+func (m *Metrics) recordDomain(domain string) {
 	// Fast path: increment if already tracking
 	if _, exists := m.domainTracker.Load(domain); exists {
 		// Domain already tracked, just increment

--- a/middleware/ratelimit/ratelimit.go
+++ b/middleware/ratelimit/ratelimit.go
@@ -181,28 +181,49 @@ func (r *RateLimit) serveWire(ctx context.Context, ch *middleware.Chain) {
 		}
 
 		if w.Proto() == "udp" {
+			// Mirror the decoded body's ordering: the request and its
+			// cookie option are in hand before any token is consumed or
+			// state stored, so a refused decode mutates nothing.
+			mctx, req := ch.Materialize(ctx)
+			if req == nil {
+				return
+			}
+			var cookieOpt *dns.EDNS0_COOKIE
+			if opt := req.IsEdns0(); opt != nil {
+				for _, option := range opt.Option {
+					if option.Option() == dns.EDNS0COOKIE {
+						cookieOpt = option.(*dns.EDNS0_COOKIE)
+						break
+					}
+				}
+			}
+			if cookieOpt != nil {
+				if !l.rl.Allow() {
+					rateLimitExceeded.Inc()
+					ch.Cancel()
+					return
+				}
+
+				l.cookie.Store(servercookie)
+				cookieOpt.Cookie = servercookie
+
+				ch.CancelWithRcode(dns.RcodeBadCookie, false)
+				return
+			}
+
+			// No cookie option in the decoded form — unreachable while
+			// ratelimit precedes edns in the chain, but the decoded body
+			// would take the plain limiter, so take it here too, on the
+			// materialized context.
 			if !l.rl.Allow() {
 				rateLimitExceeded.Inc()
 				ch.Cancel()
 				return
 			}
 
+			ch.Next(mctx)
+
 			l.cookie.Store(servercookie)
-
-			_, req := ch.Materialize(ctx)
-			if req == nil {
-				return
-			}
-			if opt := req.IsEdns0(); opt != nil {
-				for _, option := range opt.Option {
-					if option.Option() == dns.EDNS0COOKIE {
-						option.(*dns.EDNS0_COOKIE).Cookie = servercookie
-						break
-					}
-				}
-			}
-
-			ch.CancelWithRcode(dns.RcodeBadCookie, false)
 			return
 		}
 

--- a/middleware/ratelimit/ratelimit_wire_test.go
+++ b/middleware/ratelimit/ratelimit_wire_test.go
@@ -2,6 +2,7 @@ package ratelimit
 
 import (
 	"context"
+	"net"
 	"testing"
 	"time"
 
@@ -120,6 +121,87 @@ func TestRateLimitWireBadCookie(t *testing.T) {
 	}
 	if got != want {
 		t.Fatalf("reply cookie = %q, want %q", got, want)
+	}
+}
+
+// TestRateLimitWireTCPMismatchFallsThrough pins the spoof-proof-transport
+// leg: a stale cookie over TCP takes the plain limiter, continues down the
+// chain undecoded, and still refreshes the stored server cookie afterward.
+func TestRateLimitWireTCPMismatchFallsThrough(t *testing.T) {
+	r := New(&config.Config{ClientRateLimit: 100, CookieSecret: "secret"})
+
+	var passed, sawUndecoded bool
+	next := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		passed = true
+		sawUndecoded = ch.Request.Undecoded()
+		ch.Cancel()
+	})
+
+	serve := func() *mock.Writer {
+		req := wireRequest(t, wireTestCookie)
+		w := mock.NewWriter("tcp", "10.0.0.5:0")
+		ch := middleware.NewChain([]middleware.Handler{r, next})
+		ch.ResetWire(w, req)
+		ch.Next(context.Background())
+		return w
+	}
+
+	serve() // primes the stored server cookie; the bare echo now mismatches
+
+	l := r.getLimiter(net.ParseIP("10.0.0.5"))
+	stored := l.cookie.Load().(string)
+	if stored == "" {
+		t.Fatal("first serve stored no cookie")
+	}
+
+	passed, sawUndecoded = false, false
+	if w := serve(); w.Written() {
+		t.Fatal("TCP mismatch must not be answered by the limiter")
+	}
+	if !passed || !sawUndecoded {
+		t.Fatalf("TCP mismatch: passed=%v undecoded=%v, want both true", passed, sawUndecoded)
+	}
+	if refreshed := l.cookie.Load().(string); refreshed == "" {
+		t.Fatal("post-Next cookie store was dropped")
+	}
+}
+
+// TestRateLimitWireFullEchoMatch pins the recovery leg of the BADCOOKIE
+// cycle: a client echoing the stored full cookie — client half plus server
+// half, the 40-byte maximum — verifies and passes undecoded.
+func TestRateLimitWireFullEchoMatch(t *testing.T) {
+	r := New(&config.Config{ClientRateLimit: 100, CookieSecret: "secret"})
+
+	var passed, sawUndecoded bool
+	next := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		passed = true
+		sawUndecoded = ch.Request.Undecoded()
+		ch.Cancel()
+	})
+
+	req := wireRequest(t, wireTestCookie)
+	w := mock.NewWriter("udp", "10.0.0.6:0")
+	ch := middleware.NewChain([]middleware.Handler{r, next})
+	ch.ResetWire(w, req)
+	ch.Next(context.Background())
+
+	stored := r.getLimiter(net.ParseIP("10.0.0.6")).cookie.Load().(string)
+	if len(stored) != 80 {
+		t.Fatalf("stored cookie length = %d hex chars, want 80 (8+32 bytes)", len(stored))
+	}
+
+	passed, sawUndecoded = false, false
+	req = wireRequest(t, stored)
+	w = mock.NewWriter("udp", "10.0.0.6:0")
+	ch = middleware.NewChain([]middleware.Handler{r, next})
+	ch.ResetWire(w, req)
+	ch.Next(context.Background())
+
+	if w.Written() {
+		t.Fatal("a verifying full echo must not be answered by the limiter")
+	}
+	if !passed || !sawUndecoded {
+		t.Fatalf("full echo: passed=%v undecoded=%v, want both true", passed, sawUndecoded)
 	}
 }
 

--- a/middleware/resolver/dnssec/wildcard.go
+++ b/middleware/resolver/dnssec/wildcard.go
@@ -1,6 +1,10 @@
 package dnssec
 
-import "github.com/miekg/dns"
+import (
+	"github.com/miekg/dns"
+
+	"github.com/semihalev/sdns/internal/dnsname"
+)
 
 // VerifyWildcardAnswer enforces the RFC 4035 §5.3.4 / RFC 5155 §8.8
 // requirement for positive answers synthesized from a wildcard.
@@ -80,13 +84,12 @@ func VerifyWildcardAnswerForZoneWithWork(
 		// canonicalization and can alias distinct octet names (for example,
 		// Kelvin sign and ASCII "k").
 		nextCloserName := owner.suffix(int(sig.Labels) + 1)
-		nextCloser, end, unpackErr := dns.UnpackDomainName(
-			nextCloserName.wire,
-			0,
-		)
-		if unpackErr != nil || end != len(nextCloserName.wire) {
+		var nb [dnsname.MaxPresentationLength]byte
+		pres, ok := dnsname.AppendPresentation(nb[:0], nextCloserName.wire)
+		if !ok {
 			return false, aggressiveFallback("invalid wildcard next-closer name")
 		}
+		nextCloser := string(pres)
 		denied, authenticated, err := nextCloserDeniedWithWork(
 			nextCloser,
 			signer,


### PR DESCRIPTION
**Stacked on #563** — merge that first; this builds on its `serveWire` branches.

## What

`dns.UnpackDomainName` is gone from SDNS's own paths. `internal/dnsname` gains the wire walkers that replace it:

- **`AppendPresentation(dst, wire)`** — the presentation form rendered into a caller (stack) buffer, byte-identical to `UnpackDomainName` output: same escape mapping (`\.` specials, `\DDD` unprintables) that `internal/cache/key_wire.go`'s hasher already pins as the canonical-key contract. Parity-tested against the library over **every byte value** plus multi-label/root/max-length shapes.
- **`AppendFoldedKey(dst, wire)`** — lowercase, no trailing dot: the exact lookup-key spelling `hostsfile` keys its database with and domain metrics tracks.
- **`WireLabelCount(wire)`** — `dns.CountLabel` without the string.

## Why

`UnpackDomainName` is well-behaved (its 1KB scratch stays on the stack; the result string is its only allocation) — but a result string is one allocation more than a lookup needs. A key written into a stack buffer indexes a map via `string(buf)` at zero cost.

## Call sites converted

- **hostsfile wire branch**: folded key on the stack; lookups go through `lookupKeyed`, generic over `~string | ~[]byte`, so neither the wire (`[]byte`) nor decoded (`string`) instantiation allocates at the map index. The miss path — 218k lookups / 58 hits on a live sample — is now **zero-allocation**, pinned by an `AllocsPerRun` test (hit and miss). A hit builds its strings for the response it writes anyway; PTR keeps the client's spelling for the reverse-IP parser. The old name-keyed helpers remain as thin wrappers, so existing tests and the fuzz harness are untouched.
- **metrics wire branch**: the label filter reads the wire (`WireLabelCount`), and the one allocation left is the normalized tracking key itself — the `UnpackDomainName` + `ToLower` + `TrimSuffix` chain is gone.
- **DNSSEC wildcard next-closer**: same walker, identical refusal behavior (exact-consumption is enforced by the walk itself).

Micro-benchmarks that motivated this: stack-buffer key + map lookup 14.9 ns/op, 0 B, 0 allocs vs UnpackDomainName + lookup 25.1 ns/op, 16 B, 1 alloc.

## Tests

Exhaustive presentation parity, folded-key reference-derivation parity, malformed-wire refusals, zero-alloc pins for both the walkers and the hostsfile lookup, full suite green, `golangci-lint` clean on darwin/linux/freebsd.