### PR TITLE
as112: answer and pass arpa queries on the wire path

### DIFF
--- a/internal/dnsname/wire.go
+++ b/internal/dnsname/wire.go
@@ -127,8 +127,10 @@ const MaxLabels = 127
 // form with ASCII A–Z lowered and the trailing dot kept, dns.CanonicalName's
 // answer — and records where each label starts inside the appended region.
 // offs needs capacity MaxLabels; the returned count says how many entries
-// were filled. Suffix matching against canonical zone keys then indexes a
-// map with canon[offs[i]:] without ever building a string.
+// were filled, and its contents are undefined on refusal. Suffix matching
+// against canonical zone keys then indexes a map with canon[offs[i]:]
+// without ever building a string — a recipe that assumes an empty dst,
+// since the offsets are relative to the appended region, not the slice.
 func AppendCanonicalLabels(dst, wire []byte, offs []int) ([]byte, int, bool) {
 	return appendWireName(dst, wire, true, true, offs)
 }

--- a/internal/dnsname/wire.go
+++ b/internal/dnsname/wire.go
@@ -42,15 +42,20 @@ func isPresentationSpecial(b byte) bool {
 // dst comes back truncated to its original length in that case (a grown
 // append may have moved it to a new backing array, so callers must use the
 // returned slice, never the original).
-func appendWireName(dst, wire []byte, fold, rooted bool) ([]byte, bool) {
+//
+// A non-nil offs additionally records each label's start offset within the
+// appended region; the int return is how many entries were filled, and a
+// name with more labels than offs holds refuses.
+func appendWireName(dst, wire []byte, fold, rooted bool, offs []int) ([]byte, int, bool) {
 	if len(wire) == 0 || len(wire) > maxWireNameOctets {
-		return dst, false
+		return dst, 0, false
 	}
 	mark := len(dst)
+	n := 0
 	off := 0
 	for {
 		if off >= len(wire) {
-			return dst[:mark], false
+			return dst[:mark], 0, false
 		}
 		c := int(wire[off])
 		off++
@@ -58,8 +63,15 @@ func appendWireName(dst, wire []byte, fold, rooted bool) ([]byte, bool) {
 			break
 		}
 		if c&0xC0 != 0 || off+c > len(wire) {
-			return dst[:mark], false
+			return dst[:mark], 0, false
 		}
+		if offs != nil {
+			if n == len(offs) {
+				return dst[:mark], 0, false
+			}
+			offs[n] = len(dst) - mark
+		}
+		n++
 		for _, b := range wire[off : off+c] {
 			switch {
 			case isPresentationSpecial(b):
@@ -77,7 +89,7 @@ func appendWireName(dst, wire []byte, fold, rooted bool) ([]byte, bool) {
 		off += c
 	}
 	if off != len(wire) {
-		return dst[:mark], false
+		return dst[:mark], 0, false
 	}
 	switch {
 	case len(dst) == mark:
@@ -87,14 +99,15 @@ func appendWireName(dst, wire []byte, fold, rooted bool) ([]byte, bool) {
 	case !rooted:
 		dst = dst[:len(dst)-1]
 	}
-	return dst, true
+	return dst, n, true
 }
 
 // AppendPresentation appends the presentation form of an uncompressed
 // wire-form name to dst — byte-identical to what dns.UnpackDomainName
 // returns for the same bytes, trailing dot included, case preserved.
 func AppendPresentation(dst, wire []byte) ([]byte, bool) {
-	return appendWireName(dst, wire, false, true)
+	out, _, ok := appendWireName(dst, wire, false, true, nil)
+	return out, ok
 }
 
 // AppendFoldedKey appends the lookup-key form: the presentation form with
@@ -102,7 +115,22 @@ func AppendPresentation(dst, wire []byte) ([]byte, bool) {
 // This is the spelling hostsfile keys its database with and domain metrics
 // tracks, so a stack-buffered key indexes those maps with zero allocation.
 func AppendFoldedKey(dst, wire []byte) ([]byte, bool) {
-	return appendWireName(dst, wire, true, false)
+	out, _, ok := appendWireName(dst, wire, true, false, nil)
+	return out, ok
+}
+
+// MaxLabels bounds the label count of any legal wire name: every label
+// needs a length byte plus one octet inside the 255-octet wire bound.
+const MaxLabels = 127
+
+// AppendCanonicalLabels appends the canonical spelling — the presentation
+// form with ASCII A–Z lowered and the trailing dot kept, dns.CanonicalName's
+// answer — and records where each label starts inside the appended region.
+// offs needs capacity MaxLabels; the returned count says how many entries
+// were filled. Suffix matching against canonical zone keys then indexes a
+// map with canon[offs[i]:] without ever building a string.
+func AppendCanonicalLabels(dst, wire []byte, offs []int) ([]byte, int, bool) {
+	return appendWireName(dst, wire, true, true, offs)
 }
 
 // WireLabelCount returns the number of labels in an uncompressed wire-form

--- a/internal/dnsname/wire_test.go
+++ b/internal/dnsname/wire_test.go
@@ -127,6 +127,78 @@ func TestWireLabelCount(t *testing.T) {
 	}
 }
 
+// TestAppendCanonicalLabels pins the canonical spelling against
+// dns.CanonicalName and the recorded offsets against real label-aligned
+// suffixes.
+func TestAppendCanonicalLabels(t *testing.T) {
+	for _, name := range []string{
+		"WWW.Example.COM.",
+		"1.0.0.10.IN-ADDR.ARPA.",
+		`Sp\ ACE.Mixed.CASE.`,
+		"a.",
+	} {
+		wire := packName(t, name)
+		var offs [MaxLabels]int
+		canon, n, ok := AppendCanonicalLabels(nil, wire, offs[:])
+		if !ok {
+			t.Fatalf("%q refused", name)
+		}
+		pres, _, err := dns.UnpackDomainName(wire, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if want := dns.CanonicalName(pres); string(canon) != want {
+			t.Fatalf("%q: canonical %q, want %q", name, canon, want)
+		}
+		if want := dns.CountLabel(pres); n != want {
+			t.Fatalf("%q: labels = %d, want %d", name, n, want)
+		}
+		// Every recorded offset must land on a label start: the suffix
+		// from there equals the canonical form of the wire tail.
+		off := 0
+		for i := 0; i < n; i++ {
+			tail, tailN, ok := AppendCanonicalLabels(nil, wire[off:], nil)
+			if !ok || tailN != n-i {
+				t.Fatalf("%q label %d: tail walk failed", name, i)
+			}
+			if string(canon[offs[i]:]) != string(tail) {
+				t.Fatalf("%q label %d: suffix %q, want %q", name, i, canon[offs[i]:], tail)
+			}
+			off += int(wire[off]) + 1
+		}
+	}
+}
+
+// TestAppendCanonicalLabelsOffsCapacity pins the offs contract: a name
+// with more labels than offs holds refuses with dst truncated back, the
+// root fits a zero-length offs, and a maximal 127-label name fills
+// exactly MaxLabels entries.
+func TestAppendCanonicalLabelsOffsCapacity(t *testing.T) {
+	wire := packName(t, "a.b.c.")
+	var two [2]int
+	if out, _, ok := AppendCanonicalLabels([]byte("keep"), wire, two[:]); ok || string(out) != "keep" {
+		t.Fatalf("3 labels into 2 offs: ok=%v out=%q, want refusal with dst truncated", ok, out)
+	}
+
+	if _, n, ok := AppendCanonicalLabels(nil, []byte{0}, []int{}); !ok || n != 0 {
+		t.Fatalf("root with zero-length offs: n=%d ok=%v, want 0/true", n, ok)
+	}
+	if _, _, ok := AppendCanonicalLabels(nil, packName(t, "a."), []int{}); ok {
+		t.Fatal("1 label into zero-length offs must refuse")
+	}
+
+	// 127 one-octet labels: exactly 255 wire octets, the legal maximum.
+	max := make([]byte, 0, 255)
+	for i := 0; i < 127; i++ {
+		max = append(max, 1, 'a')
+	}
+	max = append(max, 0)
+	var offs [MaxLabels]int
+	if _, n, ok := AppendCanonicalLabels(nil, max, offs[:]); !ok || n != MaxLabels {
+		t.Fatalf("127-label maximum: n=%d ok=%v, want %d/true", n, ok, MaxLabels)
+	}
+}
+
 // TestWireWalkersAllocateNothing pins the zero-allocation contract with a
 // stack destination.
 func TestWireWalkersAllocateNothing(t *testing.T) {

--- a/middleware/as112/as112.go
+++ b/middleware/as112/as112.go
@@ -29,7 +29,10 @@ func New(cfg *config.Config) *AS112 {
 				continue
 			}
 
-			zones[dns.Fqdn(zone)] = true
+			// Canonical, not merely rooted: both lookup paths probe with
+			// canonical lowercase names, so a mixed-case configured zone
+			// stored verbatim would be a dead key that never serves.
+			zones[dns.CanonicalName(zone)] = true
 		}
 
 		if len(zones) > 0 {
@@ -173,7 +176,7 @@ func (a *AS112) serveWire(ctx context.Context, ch *middleware.Chain) {
 	zone := ""
 	wholeZone := false
 	for i := start; i < n; i++ {
-		if suffix := canon[offs[i]:]; a.zones[string(suffix)] {
+		if suffix := canon[offs[i]:]; hasKey(a.zones, suffix) {
 			zone = string(suffix)
 			wholeZone = i == 0 && start == 0
 			break
@@ -184,6 +187,8 @@ func (a *AS112) serveWire(ctx context.Context, ch *middleware.Chain) {
 		return
 	}
 
+	// Unreachable refusal: the same bytes already passed the canonical
+	// walk, and presentation rendering shares its acceptance.
 	pres, ok := dnsname.AppendPresentation(buf[:0], req.WireName())
 	if !ok {
 		ch.Next(ctx)
@@ -250,6 +255,15 @@ func (a *AS112) serveWire(ctx context.Context, ch *middleware.Chain) {
 
 	_ = ch.Writer.WriteMsg(msg)
 	ch.Cancel()
+}
+
+// hasKey is Match's presence probe over a stack-buffered suffix: the map
+// index conversion is allocation-free, and testing presence rather than
+// the stored value keeps the two paths' semantics identical by
+// construction.
+func hasKey(zones map[string]bool, suffix []byte) bool {
+	_, ok := zones[string(suffix)]
+	return ok
 }
 
 // (*AS112).Match match returns whether or not a name contains in the zones.

--- a/middleware/as112/as112.go
+++ b/middleware/as112/as112.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/dnsname"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/zlog/v2"
 )
@@ -44,25 +45,30 @@ func New(cfg *config.Config) *AS112 {
 // (*AS112).Name name return middleware name.
 func (a *AS112) Name() string { return name }
 
-// (*AS112).ServeDNS serveDNS implements the Handle interface.
+// (*AS112).ServeDNS serveDNS implements the Handle interface. A wire-born
+// request never decodes here: non-arpa names pass on one case-folded
+// suffix compare, arpa names that miss the empty zones — every legitimate
+// reverse lookup — pass after a zero-allocation canonical suffix walk, and
+// an empty-zone hit builds its response from parsed scalars.
 func (a *AS112) ServeDNS(ctx context.Context, ch *middleware.Chain) {
-	// A wire-born request takes the non-arpa fast path without decoding:
-	// one case-folded suffix compare on the wire name. A false positive
-	// only materializes and re-checks below.
-	if ch.Request.Undecoded() && !wireNameHasArpaSuffix(ch.Request.WireName()) {
-		ch.Next(ctx)
+	if ch.Request.Undecoded() {
+		if !wireNameHasArpaSuffix(ch.Request.WireName()) {
+			ch.Next(ctx)
+			return
+		}
+		a.serveWire(ctx, ch)
 		return
 	}
 
-	ctx, req := ch.Materialize(ctx)
-	if req == nil {
-		return
-	}
+	req := ch.Request.Msg()
 	w := ch.Writer
 
 	q := req.Question[0]
 
-	if !strings.HasSuffix(q.Name, "arpa.") {
+	// Case-insensitively, like every other name comparison here: the old
+	// case-sensitive suffix check let 10.IN-ADDR.ARPA.-style spellings
+	// leak past the empty zones to recursion.
+	if n := len(q.Name); n < 5 || !strings.EqualFold(q.Name[n-5:], "arpa.") {
 		ch.Next(ctx)
 		return
 	}
@@ -130,6 +136,119 @@ func (a *AS112) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 
 	_ = w.WriteMsg(msg)
 
+	ch.Cancel()
+}
+
+// serveWire answers or passes a wire-born arpa query without decoding it.
+// The canonical form and its label offsets come from one stack-buffered
+// walk, so the suffix probe against the zone set — Match's loop — indexes
+// the map without building a string. The overwhelmingly common outcome, a
+// reverse lookup under a delegated zone, continues down the chain
+// undecoded; only an empty-zone hit builds strings, for the response it is
+// about to write.
+func (a *AS112) serveWire(ctx context.Context, ch *middleware.Chain) {
+	req := ch.Request
+
+	var buf [dnsname.MaxPresentationLength]byte
+	var offs [dnsname.MaxLabels]int
+	canon, n, ok := dnsname.AppendCanonicalLabels(buf[:0], req.WireName(), offs[:])
+	if !ok {
+		ch.Next(ctx)
+		return
+	}
+
+	// Match strips the owner label for DS: the record lives at the parent.
+	start := 0
+	if req.Qtype() == dns.TypeDS {
+		if n < 2 {
+			ch.Next(ctx)
+			return
+		}
+		start = 1
+	}
+
+	// An empty-zone hit finally pays for its string; misses index the map
+	// straight off the stack buffer. wholeZone mirrors the decoded body's
+	// zone == qname: the match began at the first unstripped label.
+	zone := ""
+	wholeZone := false
+	for i := start; i < n; i++ {
+		if suffix := canon[offs[i]:]; a.zones[string(suffix)] {
+			zone = string(suffix)
+			wholeZone = i == 0 && start == 0
+			break
+		}
+	}
+	if zone == "" {
+		ch.Next(ctx)
+		return
+	}
+
+	pres, ok := dnsname.AppendPresentation(buf[:0], req.WireName())
+	if !ok {
+		ch.Next(ctx)
+		return
+	}
+	qname := string(pres)
+
+	msg := new(dns.Msg)
+	msg.MsgHdr = dns.MsgHdr{
+		Id:                 req.ID(),
+		Response:           true,
+		Opcode:             req.Opcode(),
+		Authoritative:      true,
+		RecursionDesired:   req.RD(),
+		RecursionAvailable: true,
+		CheckingDisabled:   req.CD(),
+	}
+	msg.Question = []dns.Question{{Name: qname, Qtype: req.Qtype(), Qclass: req.Qclass()}}
+
+	soa := &dns.SOA{
+		Hdr: dns.RR_Header{
+			Name:   qname,
+			Rrtype: dns.TypeSOA,
+			Class:  dns.ClassINET,
+			Ttl:    86400,
+		},
+		Ns:      zone,
+		Mbox:    rootzone,
+		Serial:  0,
+		Refresh: 28800,
+		Retry:   7200,
+		Expire:  604800,
+		Minttl:  86400,
+	}
+
+	switch req.Qtype() {
+	case dns.TypeNS:
+		if wholeZone {
+			msg.Answer = append(msg.Answer, &dns.NS{
+				Hdr: dns.RR_Header{
+					Name:   qname,
+					Rrtype: dns.TypeNS,
+					Class:  dns.ClassINET,
+					Ttl:    0,
+				},
+				Ns: zone,
+			})
+		} else {
+			msg.Ns = append(msg.Ns, soa)
+		}
+	case dns.TypeSOA:
+		if wholeZone {
+			msg.Answer = append(msg.Answer, soa)
+		} else {
+			msg.Ns = append(msg.Ns, soa)
+		}
+	default:
+		msg.Ns = append(msg.Ns, soa)
+	}
+
+	if !wholeZone {
+		msg.Rcode = dns.RcodeNameError
+	}
+
+	_ = ch.Writer.WriteMsg(msg)
 	ch.Cancel()
 }
 

--- a/middleware/as112/as112_wire_test.go
+++ b/middleware/as112/as112_wire_test.go
@@ -1,0 +1,200 @@
+package as112
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/dnsname"
+	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/middleware"
+)
+
+func wireAS112Request(t *testing.T, qname string, qtype uint16) *middleware.Request {
+	t.Helper()
+
+	q := new(dns.Msg)
+	q.SetQuestion(qname, qtype)
+	q.RecursionDesired = true
+	raw, err := q.Pack()
+	if err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+	req := new(middleware.Request)
+	if !req.ParseWire(raw, time.Now(), nil) {
+		t.Fatal("eligible query refused by ParseWire")
+	}
+	return req
+}
+
+// TestAS112WireLegitimateReverseStaysUndecoded pins the point: a PTR under
+// a delegated (non-empty) reverse zone — a third of real traffic — passes
+// through without being materialized.
+func TestAS112WireLegitimateReverseStaysUndecoded(t *testing.T) {
+	a := New(new(config.Config))
+
+	var sawUndecoded bool
+	next := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		sawUndecoded = ch.Request.Undecoded()
+		ch.Cancel()
+	})
+
+	for _, qname := range []string{
+		"4.4.8.8.in-addr.arpa.",
+		"1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.8.8.8.0.6.2.ip6.arpa.",
+		"HOME.ARPA.example.com.arpa.",
+	} {
+		sawUndecoded = false
+		req := wireAS112Request(t, qname, dns.TypePTR)
+		w := mock.NewWriter("udp", "192.0.2.1:40000")
+		ch := middleware.NewChain([]middleware.Handler{a, next})
+		ch.ResetWire(w, req)
+		ch.Next(context.Background())
+		if !sawUndecoded {
+			t.Fatalf("%s: delegated-zone reverse lookup was decoded", qname)
+		}
+	}
+}
+
+// TestAS112WireHitParity drives the same empty-zone queries once wire-born
+// and once message-born and requires byte-identical responses.
+func TestAS112WireHitParity(t *testing.T) {
+	a := New(new(config.Config))
+
+	cases := []struct {
+		qname string
+		qtype uint16
+	}{
+		{"1.0.0.10.IN-ADDR.ARPA.", dns.TypePTR},    // below the zone: NXDOMAIN + SOA
+		{"10.in-addr.arpa.", dns.TypeSOA},          // whole zone: SOA answer
+		{"10.in-addr.arpa.", dns.TypeNS},           // whole zone: NS answer
+		{"home.arpa.", dns.TypeA},                  // whole zone, other type: NOERROR + SOA
+		{"x.168.192.in-addr.arpa.", dns.TypeDS},    // DS: parent-side match, NXDOMAIN
+		{"sub.deep.127.in-addr.arpa.", dns.TypeMX}, // deep below: NXDOMAIN + SOA
+	}
+	for _, tc := range cases {
+		req := wireAS112Request(t, tc.qname, tc.qtype)
+		w := mock.NewWriter("udp", "192.0.2.2:40000")
+		ch := middleware.NewChain([]middleware.Handler{a})
+		ch.ResetWire(w, req)
+		ch.Next(context.Background())
+
+		if !w.Written() {
+			t.Fatalf("%s/%d: wire hit not served", tc.qname, tc.qtype)
+		}
+		if !req.Undecoded() {
+			t.Fatalf("%s/%d: wire hit materialized the request", tc.qname, tc.qtype)
+		}
+
+		q := new(dns.Msg)
+		q.SetQuestion(tc.qname, tc.qtype)
+		q.RecursionDesired = true
+		wd := mock.NewWriter("udp", "192.0.2.2:40000")
+		chd := middleware.NewChain([]middleware.Handler{a})
+		chd.Reset(wd, q)
+		chd.Next(context.Background())
+
+		if !wd.Written() {
+			t.Fatalf("%s/%d: decoded hit not served", tc.qname, tc.qtype)
+		}
+
+		got, want := w.Msg(), wd.Msg()
+		got.Id, want.Id = 0, 0
+		if got.MsgHdr != want.MsgHdr {
+			t.Fatalf("%s/%d: header mismatch\nwire:    %+v\ndecoded: %+v", tc.qname, tc.qtype, got.MsgHdr, want.MsgHdr)
+		}
+		if !reflect.DeepEqual(got.Question, want.Question) {
+			t.Fatalf("%s/%d: question mismatch: %v vs %v", tc.qname, tc.qtype, got.Question, want.Question)
+		}
+		if !reflect.DeepEqual(got.Answer, want.Answer) {
+			t.Fatalf("%s/%d: answer mismatch: %v vs %v", tc.qname, tc.qtype, got.Answer, want.Answer)
+		}
+		if !reflect.DeepEqual(got.Ns, want.Ns) {
+			t.Fatalf("%s/%d: authority mismatch: %v vs %v", tc.qname, tc.qtype, got.Ns, want.Ns)
+		}
+	}
+}
+
+// TestAS112WireDSSingleLabel: a DS query for a name whose only label is
+// arpa-suffixed walks the parent — the root — and must pass through.
+func TestAS112WireDSSingleLabel(t *testing.T) {
+	a := New(new(config.Config))
+
+	var passed bool
+	next := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		passed = true
+		ch.Cancel()
+	})
+
+	req := wireAS112Request(t, "arpa.", dns.TypeDS)
+	w := mock.NewWriter("udp", "192.0.2.3:40000")
+	ch := middleware.NewChain([]middleware.Handler{a, next})
+	ch.ResetWire(w, req)
+	ch.Next(context.Background())
+	if !passed || w.Written() {
+		t.Fatalf("DS at a single label must pass: passed=%v written=%v", passed, w.Written())
+	}
+}
+
+// TestAS112WireEscapedDotNoFalseMatch: a single label whose bytes spell an
+// empty zone with embedded dots must not match — the suffix walk works on
+// label boundaries, not rendered dots.
+func TestAS112WireEscapedDotNoFalseMatch(t *testing.T) {
+	a := New(new(config.Config))
+
+	var sawUndecoded bool
+	next := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		sawUndecoded = ch.Request.Undecoded()
+		ch.Cancel()
+	})
+
+	// One label containing "10.in-addr" (dots inside), then "arpa": the
+	// canonical form renders 10\.in-addr.arpa. — never the zone key.
+	raw := []byte{
+		0x00, 0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		10, '1', '0', '.', 'i', 'n', '-', 'a', 'd', 'd', 'r',
+		4, 'a', 'r', 'p', 'a',
+		0,
+		0x00, 0x0C, 0x00, 0x01,
+	}
+	req := new(middleware.Request)
+	if !req.ParseWire(raw, time.Now(), nil) {
+		t.Fatal("crafted query refused by ParseWire")
+	}
+	w := mock.NewWriter("udp", "192.0.2.4:40000")
+	ch := middleware.NewChain([]middleware.Handler{a, next})
+	ch.ResetWire(w, req)
+	ch.Next(context.Background())
+	if w.Written() {
+		t.Fatal("escaped-dot label falsely matched an empty zone")
+	}
+	if !sawUndecoded {
+		t.Fatal("escaped-dot miss should continue undecoded")
+	}
+}
+
+// TestAS112WireMissAllocatesNothing pins the fast path's cost: the suffix
+// probe for a delegated-zone reverse name is zero-allocation.
+func TestAS112WireMissAllocatesNothing(t *testing.T) {
+	a := New(new(config.Config))
+	req := wireAS112Request(t, "4.4.8.8.in-addr.arpa.", dns.TypePTR)
+
+	if n := testing.AllocsPerRun(100, func() {
+		var buf [dnsname.MaxPresentationLength]byte
+		var offs [dnsname.MaxLabels]int
+		canon, labels, ok := dnsname.AppendCanonicalLabels(buf[:0], req.WireName(), offs[:])
+		if !ok {
+			t.Fatal("refused")
+		}
+		for i := 0; i < labels; i++ {
+			if a.zones[string(canon[offs[i]:])] {
+				t.Fatal("unexpected zone match")
+			}
+		}
+	}); n != 0 {
+		t.Fatalf("allocs = %v, want 0", n)
+	}
+}

--- a/middleware/as112/as112_wire_test.go
+++ b/middleware/as112/as112_wire_test.go
@@ -176,6 +176,35 @@ func TestAS112WireEscapedDotNoFalseMatch(t *testing.T) {
 	}
 }
 
+// TestAS112ConfigZoneCaseNormalized: a mixed-case emptyzones entry must
+// serve — the old dns.Fqdn storage left it a dead key that neither path
+// could ever match.
+func TestAS112ConfigZoneCaseNormalized(t *testing.T) {
+	cfg := new(config.Config)
+	cfg.EmptyZones = []string{"10.In-Addr.ARPA"}
+	a := New(cfg)
+
+	req := wireAS112Request(t, "1.0.0.10.in-addr.arpa.", dns.TypePTR)
+	w := mock.NewWriter("udp", "192.0.2.5:40000")
+	ch := middleware.NewChain([]middleware.Handler{a})
+	ch.ResetWire(w, req)
+	ch.Next(context.Background())
+	if !w.Written() || w.Rcode() != dns.RcodeNameError {
+		t.Fatalf("configured mixed-case zone did not serve on wire: written=%v rcode=%v", w.Written(), w.Rcode())
+	}
+
+	// Decoded path too.
+	q := new(dns.Msg)
+	q.SetQuestion("1.0.0.10.in-addr.arpa.", dns.TypePTR)
+	wd := mock.NewWriter("udp", "192.0.2.5:40000")
+	chd := middleware.NewChain([]middleware.Handler{a})
+	chd.Reset(wd, q)
+	chd.Next(context.Background())
+	if !wd.Written() || wd.Rcode() != dns.RcodeNameError {
+		t.Fatalf("decoded path: written=%v rcode=%v", wd.Written(), wd.Rcode())
+	}
+}
+
 // TestAS112WireMissAllocatesNothing pins the fast path's cost: the suffix
 // probe for a delegated-zone reverse name is zero-allocation.
 func TestAS112WireMissAllocatesNothing(t *testing.T) {


### PR DESCRIPTION
## Problem

as112's wire guard only covered the **non**-arpa case: any name ending in `arpa.` — which includes every legitimate reverse lookup under a delegated zone — materialized just to learn from `Match` that it wasn't in an empty zone, then continued down the chain decoded. On the live deployment **a third of all queries are PTR**, so after #563/#564 this was the last middleware still decoding a major traffic class before the cache.

## Fix

- `internal/dnsname` gains `AppendCanonicalLabels`: the canonical spelling (folded, rooted — `dns.CanonicalName`'s answer) rendered into a caller buffer **with each label's start offset recorded**, from the same single walker core as the other variants (the escape mapping still exists exactly once). Suffix matching against canonical zone keys then indexes the map with `canon[offs[i]:]` — no strings, no allocation.
- `as112.serveWire`: non-arpa names keep the one-compare fast path; arpa names get the canonical walk + zone-set probe (`Match`'s exact semantics, including the DS parent-label strip and its single-label root case). A miss — the common outcome — continues undecoded and allocation-free (pinned by `AllocsPerRun`). An empty-zone hit builds its response from parsed scalars: the handler no longer materializes anything on any path.
- Suffix probing works on **label boundaries from the wire**, not rendered dots, so a crafted single label spelling `10.in-addr` with embedded dots cannot false-match a zone (test included).

## Bonus: pre-existing decoded-path bug found by the parity test

The decoded body's early-out was `strings.HasSuffix(q.Name, "arpa.")` — **case-sensitive**. A `1.0.0.10.IN-ADDR.ARPA.` query sailed past the empty zones into recursion. `Match` itself always folded; only the gate was wrong. It now folds too, and the wire/decoded parity test (which is what caught it) pins both paths to identical responses across PTR/SOA/NS/DS/other-type shapes, whole-zone and below-zone.

## Tests

Wire/decoded response parity (headers, question echo, answers, authority) over six shapes; delegated-zone PTR/ip6/mixed-case passes stay undecoded; DS-at-single-label passes; escaped-dot no-false-match; zero-allocation pin for the miss probe. Full suite green; `golangci-lint` clean on darwin/linux/freebsd.