### PR TITLE
resolver: copy what the copy is for — minimal-allocation query views

### DIFF
--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -1751,10 +1751,11 @@ func filterCacheableAnswer(res *dns.Msg) *dns.Msg {
 	}
 
 	// Every consumer reads the result synchronously and retains bytes, not
-	// records — NewCacheEntryWithKey builds its own shallow storable view
-	// and PackClones it on the spot — so a deep copy duplicated every RR in
-	// every section for a reader that only wants a different Answer slice.
-	// The common shape, no chain tail to drop, passes through untouched.
+	// records — NewCacheEntryWithKey builds its own shallow storable view,
+	// PackClones it on the spot, and value-copies the one option it keeps
+	// (the EDE) — so a deep copy duplicated every RR in every section for
+	// a reader that only wants a different Answer slice. The common shape,
+	// no chain tail to drop, passes through untouched.
 	drop := false
 	for _, r := range res.Answer {
 		if !keep(r) {

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -1741,25 +1741,41 @@ func filterCacheableAnswer(res *dns.Msg) *dns.Msg {
 		return res
 	}
 
-	filtered := res.Copy()
-	var answer []dns.RR
-
-	for _, r := range filtered.Answer {
+	keep := func(r dns.RR) bool {
 		if r.Header().Rrtype == dns.TypeDNAME ||
 			strings.EqualFold(res.Question[0].Name, r.Header().Name) {
-			answer = append(answer, r)
-			continue
+			return true
 		}
+		rrsig, ok := r.(*dns.RRSIG)
+		return ok && rrsig.TypeCovered == dns.TypeDNAME
+	}
 
-		if rrsig, ok := r.(*dns.RRSIG); ok {
-			if rrsig.TypeCovered == dns.TypeDNAME {
-				answer = append(answer, r)
-			}
+	// Every consumer reads the result synchronously and retains bytes, not
+	// records — NewCacheEntryWithKey builds its own shallow storable view
+	// and PackClones it on the spot — so a deep copy duplicated every RR in
+	// every section for a reader that only wants a different Answer slice.
+	// The common shape, no chain tail to drop, passes through untouched.
+	drop := false
+	for _, r := range res.Answer {
+		if !keep(r) {
+			drop = true
+			break
+		}
+	}
+	if !drop {
+		return res
+	}
+
+	answer := make([]dns.RR, 0, len(res.Answer))
+	for _, r := range res.Answer {
+		if keep(r) {
+			answer = append(answer, r)
 		}
 	}
 
+	filtered := *res
 	filtered.Answer = answer
-	return filtered
+	return &filtered
 }
 
 // messagePool reduces allocations by reusing dns.Msg structs.

--- a/middleware/cache/filter_shallow_test.go
+++ b/middleware/cache/filter_shallow_test.go
@@ -1,0 +1,61 @@
+package cache
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// TestFilterCacheableAnswerShallow pins the copy discipline: a response
+// with nothing to drop passes through as itself, and a response with a
+// chain tail gets a shallow view — same records, same other sections —
+// with only the Answer slice rebuilt and the original untouched.
+func TestFilterCacheableAnswerShallow(t *testing.T) {
+	mk := func(owner string, target string) dns.RR {
+		return &dns.CNAME{
+			Hdr:    dns.RR_Header{Name: owner, Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 60},
+			Target: target,
+		}
+	}
+	a := &dns.A{Hdr: dns.RR_Header{Name: "Example.COM.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60}}
+	soa := &dns.SOA{Hdr: dns.RR_Header{Name: "com.", Rrtype: dns.TypeSOA, Class: dns.ClassINET, Ttl: 300}, Ns: "a.", Mbox: "."}
+
+	res := new(dns.Msg)
+	res.SetQuestion("example.com.", dns.TypeA)
+	res.Answer = []dns.RR{a}
+	res.Ns = []dns.RR{soa}
+
+	// Case-insensitive owner match: nothing to drop, no copy at all.
+	if got := filterCacheableAnswer(res); got != res {
+		t.Fatal("clean answer must pass through as the same message")
+	}
+
+	// A chain tail with a foreign owner drops; the view is shallow.
+	tail := mk("tail.example.net.", "x.")
+	res.Answer = []dns.RR{a, tail}
+	got := filterCacheableAnswer(res)
+	if got == res {
+		t.Fatal("a dropped record must produce a new view")
+	}
+	if len(got.Answer) != 1 || got.Answer[0] != dns.RR(a) {
+		t.Fatalf("filtered answer = %v, want the qname record shared by pointer", got.Answer)
+	}
+	if len(res.Answer) != 2 {
+		t.Fatal("the original message was mutated")
+	}
+	if &got.Ns[0] != &res.Ns[0] {
+		t.Fatal("authority section must be shared, not copied")
+	}
+	if got.Id != res.Id || got.Question[0] != res.Question[0] {
+		t.Fatal("header/question must carry over")
+	}
+
+	// DNAME and its covering RRSIG survive under a foreign owner.
+	dname := &dns.DNAME{Hdr: dns.RR_Header{Name: "sub.example.com.", Rrtype: dns.TypeDNAME, Class: dns.ClassINET, Ttl: 60}, Target: "other.net."}
+	sig := &dns.RRSIG{Hdr: dns.RR_Header{Name: "sub.example.com.", Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 60}, TypeCovered: dns.TypeDNAME}
+	res.Answer = []dns.RR{dname, sig, tail}
+	got = filterCacheableAnswer(res)
+	if len(got.Answer) != 2 {
+		t.Fatalf("DNAME+RRSIG must survive, tail must drop: %v", got.Answer)
+	}
+}

--- a/middleware/cache/filter_shallow_test.go
+++ b/middleware/cache/filter_shallow_test.go
@@ -58,4 +58,17 @@ func TestFilterCacheableAnswerShallow(t *testing.T) {
 	if len(got.Answer) != 2 {
 		t.Fatalf("DNAME+RRSIG must survive, tail must drop: %v", got.Answer)
 	}
+
+	// A foreign-owner RRSIG covering a non-DNAME type drops with its tail.
+	tailSig := &dns.RRSIG{Hdr: dns.RR_Header{Name: "tail.example.net.", Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 60}, TypeCovered: dns.TypeA}
+	res.Answer = []dns.RR{a, tail, tailSig}
+	if got = filterCacheableAnswer(res); len(got.Answer) != 1 {
+		t.Fatalf("foreign RRSIG over non-DNAME must drop: %v", got.Answer)
+	}
+
+	// Everything dropping leaves an empty — but servable — answer section.
+	res.Answer = []dns.RR{tail, tailSig}
+	if got = filterCacheableAnswer(res); len(got.Answer) != 0 || got == res {
+		t.Fatalf("all-dropped must yield an empty answer in a new view: %v", got.Answer)
+	}
 }

--- a/middleware/cache/types.go
+++ b/middleware/cache/types.go
@@ -155,10 +155,13 @@ func NewCacheEntryWithKey(msg *dns.Msg, ttl time.Duration, rateLimit int, key ui
 		extra := make([]dns.RR, 0, len(msg.Extra))
 		for _, rr := range msg.Extra {
 			if opt, ok := rr.(*dns.OPT); ok {
-				// Extract EDE from OPT record if present
+				// Extract EDE from OPT record if present. By value: the
+				// long-lived entry must not alias an option inside the
+				// caller's live message.
 				for _, option := range opt.Option {
 					if e, ok := option.(*dns.EDNS0_EDE); ok {
-						ede = e
+						private := *e
+						ede = &private
 						break
 					}
 				}

--- a/middleware/resolver/lookup_benchmark_test.go
+++ b/middleware/resolver/lookup_benchmark_test.go
@@ -42,7 +42,7 @@ func BenchmarkLookupPerformance(b *testing.B) {
 	ctx := context.Background()
 	for i := 0; i < b.N; i++ {
 		// This will use our optimized lookup with parallel queries and adaptive timeout
-		_, _ = r.groupLookup(ctx, &resolveState{requestID: req.Id}, req, servers)
+		_, _ = r.groupLookup(ctx, &resolveState{requestID: req.Id}, req, servers, false)
 	}
 }
 

--- a/middleware/resolver/minimize_copy_test.go
+++ b/middleware/resolver/minimize_copy_test.go
@@ -1,0 +1,48 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// TestMinimizeCopiesOnlyWhenMinimizing pins the ownership contract behind
+// groupLookup's owned flag: every outcome that does not shorten the name
+// hands back the caller's request itself, and the one that does returns a
+// private copy with the original untouched.
+func TestMinimizeCopiesOnlyWhenMinimizing(t *testing.T) {
+	r := &Resolver{qnameMinLevel: 5}
+
+	req := new(dns.Msg)
+	req.SetQuestion("www.deep.example.com.", dns.TypeA)
+
+	// Disabled and nomin entries pass through.
+	if got, min := (&Resolver{}).minimize(req, 0, false); got != req || min {
+		t.Fatalf("disabled: got %p minimized=%v, want the request itself", got, min)
+	}
+	if got, min := r.minimize(req, 0, true); got != req || min {
+		t.Fatalf("nomin: got %p minimized=%v, want the request itself", got, min)
+	}
+
+	// Beyond the minimization depth: no copy.
+	if got, min := r.minimize(req, 5, false); got != req || min {
+		t.Fatalf("deep level: got %p minimized=%v, want the request itself", got, min)
+	}
+
+	// A level that cannot shorten the name (past its label count): no copy.
+	if got, min := r.minimize(req, 4, false); got != req || min {
+		t.Fatalf("unshortenable: got %p minimized=%v, want the request itself", got, min)
+	}
+
+	// The real minimization: private copy, shortened name, original intact.
+	got, min := r.minimize(req, 1, false)
+	if !min || got == req {
+		t.Fatalf("level 1: minimized=%v same=%v, want a private copy", min, got == req)
+	}
+	if got.Question[0].Name != "example.com." {
+		t.Fatalf("minimized name = %q, want example.com.", got.Question[0].Name)
+	}
+	if got.Question[0].Qtype != dns.TypeA || req.Question[0].Name != "www.deep.example.com." {
+		t.Fatalf("qtype/original disturbed: %v / %q", got.Question[0].Qtype, req.Question[0].Name)
+	}
+}

--- a/middleware/resolver/query_copy.go
+++ b/middleware/resolver/query_copy.go
@@ -1,0 +1,43 @@
+package resolver
+
+import "github.com/miekg/dns"
+
+// acquireAttemptReq builds the per-server view of a lookup's immutable
+// leader request from the message pool: header by value, question and
+// extra re-appended into the shell's own backings, records shared by
+// pointer — except the OPT, which gets a private shell. PackBuffer
+// writes the extended rcode into the OPT header on every pack (miekg
+// msg.go, "set extended rcode unconditionally"), so concurrent attempts
+// cannot share the OPT struct; its options CAN stay shared, because
+// packing only reads them and the one appender — the TCP leg's
+// keepalive — privatizes the whole OPT first (privatizeOPT). One small
+// allocation per attempt replaces the full deep copy that priced every
+// upstream fan-out at an OPT-and-options clone per server.
+func acquireAttemptReq(leader *dns.Msg) *dns.Msg {
+	dst := AcquireMsg()
+	dst.MsgHdr = leader.MsgHdr
+	dst.Compress = leader.Compress
+	dst.Question = append(dst.Question[:0], leader.Question...)
+	dst.Answer = dst.Answer[:0]
+	dst.Ns = dst.Ns[:0]
+	dst.Extra = dst.Extra[:0]
+	for _, rr := range leader.Extra {
+		if opt, ok := rr.(*dns.OPT); ok {
+			shell := *opt
+			rr = &shell
+		}
+		dst.Extra = append(dst.Extra, rr)
+	}
+	return dst
+}
+
+// privatizeOPT replaces req's OPT with a deep copy so a subsequent
+// in-place OPT edit stays private to this attempt. No-op without an OPT.
+func privatizeOPT(req *dns.Msg) {
+	for i, rr := range req.Extra {
+		if opt, ok := rr.(*dns.OPT); ok {
+			req.Extra[i] = dns.Copy(opt)
+			return
+		}
+	}
+}

--- a/middleware/resolver/query_copy.go
+++ b/middleware/resolver/query_copy.go
@@ -3,8 +3,8 @@ package resolver
 import "github.com/miekg/dns"
 
 // acquireAttemptReq builds the per-server view of a lookup's immutable
-// leader request from the message pool: header by value, question and
-// extra re-appended into the shell's own backings, records shared by
+// leader request from the message pool: header by value, every section
+// re-appended into the shell's own backings, records shared by
 // pointer — except the OPT, which gets a private shell. PackBuffer
 // writes the extended rcode into the OPT header on every pack (miekg
 // msg.go, "set extended rcode unconditionally"), so concurrent attempts
@@ -18,8 +18,8 @@ func acquireAttemptReq(leader *dns.Msg) *dns.Msg {
 	dst.MsgHdr = leader.MsgHdr
 	dst.Compress = leader.Compress
 	dst.Question = append(dst.Question[:0], leader.Question...)
-	dst.Answer = dst.Answer[:0]
-	dst.Ns = dst.Ns[:0]
+	dst.Answer = append(dst.Answer[:0], leader.Answer...)
+	dst.Ns = append(dst.Ns[:0], leader.Ns...)
 	dst.Extra = dst.Extra[:0]
 	for _, rr := range leader.Extra {
 		if opt, ok := rr.(*dns.OPT); ok {
@@ -31,13 +31,15 @@ func acquireAttemptReq(leader *dns.Msg) *dns.Msg {
 	return dst
 }
 
-// privatizeOPT replaces req's OPT with a deep copy so a subsequent
-// in-place OPT edit stays private to this attempt. No-op without an OPT.
+// privatizeOPT replaces req's OPT records with deep copies so a subsequent
+// in-place OPT edit stays private to this attempt. Every OPT is covered
+// because SetEDNSKeepalive appends to the LAST one (miekg's IsEdns0 scans
+// backward), and stopping at the first would leave a multi-OPT decoded
+// request's edit target on shared state. No-op without an OPT.
 func privatizeOPT(req *dns.Msg) {
 	for i, rr := range req.Extra {
 		if opt, ok := rr.(*dns.OPT); ok {
 			req.Extra[i] = dns.Copy(opt)
-			return
 		}
 	}
 }

--- a/middleware/resolver/query_copy_test.go
+++ b/middleware/resolver/query_copy_test.go
@@ -1,0 +1,113 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+func leaderWithOPT() *dns.Msg {
+	m := new(dns.Msg)
+	m.SetQuestion("example.com.", dns.TypeA)
+	m.SetEdns0(1232, true)
+	return m
+}
+
+// TestAcquireAttemptReqSharesRecordsOwnsBackings pins the per-attempt copy
+// contract: header and question carry over into the shell's own backings —
+// mutating the attempt never touches the leader — while the OPT record
+// itself is shared by pointer.
+func TestAcquireAttemptReqSharesRecordsOwnsBackings(t *testing.T) {
+	leader := leaderWithOPT()
+
+	att := acquireAttemptReq(leader)
+	defer ReleaseMsg(att)
+
+	if att.Question[0] != leader.Question[0] || att.MsgHdr != leader.MsgHdr {
+		t.Fatal("header/question must carry over")
+	}
+	// The OPT shell is private — packing writes the extended rcode into
+	// its header — while its options stay shared.
+	if len(att.Extra) != 1 || att.Extra[0] == leader.Extra[0] {
+		t.Fatal("the OPT shell must be private per attempt")
+	}
+	attOpt, leaderOpt := att.IsEdns0(), leader.IsEdns0()
+	if attOpt.Hdr != leaderOpt.Hdr || attOpt.UDPSize() != leaderOpt.UDPSize() || attOpt.Do() != leaderOpt.Do() {
+		t.Fatal("OPT shell contents must carry over")
+	}
+	attOpt.SetExtendedRcode(0xFF0)
+	if leaderOpt.Hdr.Ttl == attOpt.Hdr.Ttl {
+		t.Fatal("extended-rcode write leaked into the leader's OPT")
+	}
+
+	att.Id = 42
+	att.Question[0].Name = "other.test."
+	if leader.Id == 42 || leader.Question[0].Name != "example.com." {
+		t.Fatal("attempt mutation leaked into the leader")
+	}
+}
+
+// TestPrivatizeOPTIsolatesKeepalive pins the TCP leg's copy-on-write: after
+// privatizeOPT, the keepalive append lands on a private OPT and the
+// leader's option list stays untouched.
+func TestPrivatizeOPTIsolatesKeepalive(t *testing.T) {
+	leader := leaderWithOPT()
+	att := acquireAttemptReq(leader)
+	defer ReleaseMsg(att)
+
+	privatizeOPT(att)
+	if att.Extra[0] == leader.Extra[0] {
+		t.Fatal("privatizeOPT must replace the shared OPT")
+	}
+
+	SetEDNSKeepalive(att, 0)
+	if len(att.IsEdns0().Option) != 1 {
+		t.Fatal("keepalive not appended to the attempt's OPT")
+	}
+	if len(leader.IsEdns0().Option) != 0 {
+		t.Fatal("keepalive contaminated the leader's OPT")
+	}
+	if !leader.IsEdns0().Do() {
+		t.Fatal("leader OPT flags disturbed")
+	}
+}
+
+// BenchmarkAttemptCopy compares the per-server view against the full deep
+// copy it replaced.
+func BenchmarkAttemptCopy(b *testing.B) {
+	leader := leaderWithOPT()
+
+	b.Run("acquireAttemptReq", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			ReleaseMsg(acquireAttemptReq(leader))
+		}
+	})
+	b.Run("CopyTo", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			ReleaseMsg(leader.CopyTo(AcquireMsg()))
+		}
+	})
+}
+
+// TestAcquireAttemptReqAllocatesNothing pins the point: after the pool
+// warms, a per-server attempt view costs zero heap allocations.
+func TestAcquireAttemptReqAllocatesNothing(t *testing.T) {
+	leader := leaderWithOPT()
+
+	// Warm one shell so its backings exist.
+	ReleaseMsg(acquireAttemptReq(leader))
+
+	// dns.Id stays out of the loop: it allocates its own 2-byte buffer
+	// inside binary.Read, a pre-existing per-attempt cost this test does
+	// not own. The one allocation left is the private OPT shell —
+	// packing writes into the OPT header, so attempts cannot share it.
+	if n := testing.AllocsPerRun(100, func() {
+		att := acquireAttemptReq(leader)
+		att.Id = 42
+		ReleaseMsg(att)
+	}); n != 1 {
+		t.Fatalf("allocs = %v, want exactly the OPT shell", n)
+	}
+}

--- a/middleware/resolver/query_copy_test.go
+++ b/middleware/resolver/query_copy_test.go
@@ -10,6 +10,11 @@ func leaderWithOPT() *dns.Msg {
 	m := new(dns.Msg)
 	m.SetQuestion("example.com.", dns.TypeA)
 	m.SetEdns0(1232, true)
+	// Spare capacity behind an existing option: the shape where an
+	// unprivatized keepalive append would land in shared backing.
+	opt := m.IsEdns0()
+	opt.Option = make([]dns.EDNS0, 1, 4)
+	opt.Option[0] = &dns.EDNS0_NSID{Code: dns.EDNS0NSID}
 	return m
 }
 
@@ -35,6 +40,9 @@ func TestAcquireAttemptReqSharesRecordsOwnsBackings(t *testing.T) {
 	if attOpt.Hdr != leaderOpt.Hdr || attOpt.UDPSize() != leaderOpt.UDPSize() || attOpt.Do() != leaderOpt.Do() {
 		t.Fatal("OPT shell contents must carry over")
 	}
+	if len(attOpt.Option) != 1 || attOpt.Option[0] != leaderOpt.Option[0] {
+		t.Fatal("options must be shared by pointer")
+	}
 	attOpt.SetExtendedRcode(0xFF0)
 	if leaderOpt.Hdr.Ttl == attOpt.Hdr.Ttl {
 		t.Fatal("extended-rcode write leaked into the leader's OPT")
@@ -44,6 +52,32 @@ func TestAcquireAttemptReqSharesRecordsOwnsBackings(t *testing.T) {
 	att.Question[0].Name = "other.test."
 	if leader.Id == 42 || leader.Question[0].Name != "example.com." {
 		t.Fatal("attempt mutation leaked into the leader")
+	}
+}
+
+// TestAcquireAttemptReqCarriesSections pins section parity with the deep
+// copy it replaced: a leader carrying answer/authority/other-extra records
+// hands them to the attempt shared by pointer.
+func TestAcquireAttemptReqCarriesSections(t *testing.T) {
+	leader := leaderWithOPT()
+	a := &dns.A{Hdr: dns.RR_Header{Name: "example.com.", Rrtype: dns.TypeA, Class: dns.ClassINET}}
+	soa := &dns.SOA{Hdr: dns.RR_Header{Name: "com.", Rrtype: dns.TypeSOA, Class: dns.ClassINET}, Ns: "a.", Mbox: "."}
+	txt := &dns.TXT{Hdr: dns.RR_Header{Name: "x.", Rrtype: dns.TypeTXT, Class: dns.ClassINET}, Txt: []string{"y"}}
+	leader.Answer = []dns.RR{a}
+	leader.Ns = []dns.RR{soa}
+	leader.Extra = append(leader.Extra, txt)
+
+	att := acquireAttemptReq(leader)
+	defer ReleaseMsg(att)
+
+	if len(att.Answer) != 1 || att.Answer[0] != dns.RR(a) {
+		t.Fatal("answer section must carry over shared")
+	}
+	if len(att.Ns) != 1 || att.Ns[0] != dns.RR(soa) {
+		t.Fatal("authority section must carry over shared")
+	}
+	if len(att.Extra) != 2 || att.Extra[1] != dns.RR(txt) {
+		t.Fatal("non-OPT extra must carry over shared")
 	}
 }
 
@@ -59,13 +93,20 @@ func TestPrivatizeOPTIsolatesKeepalive(t *testing.T) {
 	if att.Extra[0] == leader.Extra[0] {
 		t.Fatal("privatizeOPT must replace the shared OPT")
 	}
+	if att.IsEdns0().Option[0] == leader.IsEdns0().Option[0] {
+		t.Fatal("privatizeOPT must deep-copy the options")
+	}
+
+	// The leader's option backing has spare capacity behind its one
+	// option — exactly where an unprivatized append would land.
+	spare := leader.IsEdns0().Option[:2]
 
 	SetEDNSKeepalive(att, 0)
-	if len(att.IsEdns0().Option) != 1 {
+	if len(att.IsEdns0().Option) != 2 {
 		t.Fatal("keepalive not appended to the attempt's OPT")
 	}
-	if len(leader.IsEdns0().Option) != 0 {
-		t.Fatal("keepalive contaminated the leader's OPT")
+	if len(leader.IsEdns0().Option) != 1 || spare[1] != nil {
+		t.Fatal("keepalive contaminated the leader's OPT backing")
 	}
 	if !leader.IsEdns0().Do() {
 		t.Fatal("leader OPT flags disturbed")

--- a/middleware/resolver/recursion_work_test.go
+++ b/middleware/resolver/recursion_work_test.go
@@ -416,6 +416,7 @@ func TestRecursionWorkSingleflightFollowersRegroupOnLeaderLimit(t *testing.T) {
 			&resolveState{req: req, requestID: req.Id, work: leaderLedger},
 			req,
 			servers,
+			false,
 		)
 		leaderDone <- lookupOutcome{resp: resp, err: err}
 	}()
@@ -446,6 +447,7 @@ func TestRecursionWorkSingleflightFollowersRegroupOnLeaderLimit(t *testing.T) {
 				&resolveState{req: request, requestID: request.Id, work: ledger},
 				request,
 				servers,
+				false,
 			)
 			followerDone <- lookupOutcome{index: index, id: request.Id, resp: resp, err: err}
 		}(i, followerCtx, followerReq, followerLedgers[i])
@@ -573,6 +575,7 @@ func TestRecursionWorkSingleflightHealthyFollowerRegroupsPastLowBudgetLeader(t *
 			&resolveState{req: baseReq, requestID: baseReq.Id, work: firstLedger},
 			baseReq,
 			servers,
+			false,
 		)
 		firstDone <- lookupOutcome{resp: resp, err: err}
 	}()
@@ -599,6 +602,7 @@ func TestRecursionWorkSingleflightHealthyFollowerRegroupsPastLowBudgetLeader(t *
 			&resolveState{req: healthyReq, requestID: healthyReq.Id, work: healthyLedger},
 			healthyReq,
 			servers,
+			false,
 		)
 		healthyDone <- lookupOutcome{resp: resp, err: err}
 	}()
@@ -622,6 +626,7 @@ func TestRecursionWorkSingleflightHealthyFollowerRegroupsPastLowBudgetLeader(t *
 			&resolveState{req: lowReq, requestID: lowReq.Id, work: lowLedger},
 			lowReq,
 			servers,
+			false,
 		)
 		lowDone <- lookupOutcome{resp: resp, err: err}
 	}()

--- a/middleware/resolver/resolution_attempt_test.go
+++ b/middleware/resolver/resolution_attempt_test.go
@@ -716,6 +716,7 @@ func TestResolutionAttemptSingleflightFollowerRegroups(t *testing.T) {
 			&resolveState{req: req, requestID: req.Id},
 			req,
 			servers,
+			false,
 		)
 		leaderDone <- result{resp: resp, err: err}
 	}()
@@ -737,6 +738,7 @@ func TestResolutionAttemptSingleflightFollowerRegroups(t *testing.T) {
 			&resolveState{req: followerReq, requestID: followerReq.Id},
 			followerReq,
 			servers,
+			false,
 		)
 		followerDone <- result{resp: resp, err: err}
 	}()
@@ -802,6 +804,7 @@ func TestCanceledSingleflightLeaderDoesNotFailHealthyFollower(t *testing.T) {
 			&resolveState{req: req, requestID: req.Id},
 			req,
 			servers,
+			false,
 		)
 		leaderDone <- result{resp: resp, err: err}
 	}()
@@ -827,6 +830,7 @@ func TestCanceledSingleflightLeaderDoesNotFailHealthyFollower(t *testing.T) {
 			&resolveState{req: followerReq, requestID: followerReq.Id},
 			followerReq,
 			servers,
+			false,
 		)
 		followerDone <- result{resp: resp, err: err}
 	}()

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -428,7 +428,7 @@ func (r *Resolver) resolve(ctx context.Context, rs *resolveState) (*dns.Msg, err
 		zlog.Debug("Query inserted", "reqid", minReq.Id, "zone", rs.servers.Zone, "query", dnsutil.FormatQuestion(minReq.Question[0]), "cd", rs.req.CheckingDisabled, "qname-minimize", minimized)
 	}
 
-	resp, err := r.groupLookup(ctx, rs, minReq, rs.servers)
+	resp, err := r.groupLookup(ctx, rs, minReq, rs.servers, minimized)
 	if err != nil {
 		return r.handleLookupError(ctx, err, rs, minReq, minimized)
 	}
@@ -496,7 +496,7 @@ func (r *Resolver) resolve(ctx context.Context, rs *resolveState) (*dns.Msg, err
 	return m, nil
 }
 
-func (r *Resolver) groupLookup(ctx context.Context, rs *resolveState, req *dns.Msg, servers *authority.Servers) (resp *dns.Msg, err error) {
+func (r *Resolver) groupLookup(ctx context.Context, rs *resolveState, req *dns.Msg, servers *authority.Servers, owned bool) (resp *dns.Msg, err error) {
 	q := req.Question[0]
 
 	// Key by question, CD flag, AND a fingerprint of the
@@ -526,12 +526,20 @@ func (r *Resolver) groupLookup(ctx context.Context, rs *resolveState, req *dns.M
 	// The leader closure can outlive this caller: TimedDoChan returns on this
 	// caller's timeout/cancel while the shared generation remains registered
 	// until its closure finishes (or bounded stuck cleanup retires it). After
-	// we return, req resumes its lifecycle upstack — the response re-attaches
-	// the request OPT and the edns writer mutates it in place — so an
-	// abandoned leader copying req (lookup's per-server CopyTo) would race on
-	// caller-owned memory. Hand the closure its own private copy, made here
-	// while we still exclusively own req.
-	leaderReq := req.Copy()
+	// we return, a shared req resumes its lifecycle upstack — the response
+	// re-attaches the request OPT and the edns writer mutates it in place —
+	// so an abandoned leader copying req (lookup's per-server CopyTo) would
+	// race on caller-owned memory. Hand the closure its own private copy,
+	// made here while we still exclusively own req.
+	//
+	// An owned req (a minimized copy) needs no second copy: the leader only
+	// reads it — per-server CopyTo sources from it, queryServer mutates the
+	// copies — and after we return its only touch upstack is a read in
+	// handleLookupError's debug log before it is dropped.
+	leaderReq := req
+	if !owned {
+		leaderReq = req.Copy()
+	}
 
 	for {
 		// Use TimedDoChan for automatic timeout handling. When a follower
@@ -868,23 +876,26 @@ func (r *Resolver) minimize(req *dns.Msg, level int, nomin bool) (*dns.Msg, bool
 
 	q := req.Question[0]
 
-	minReq := req.Copy()
-	minimized := false
-
-	if level < r.qnameMinLevel && q.Name != rootzone {
-		prev, end := dns.PrevLabel(q.Name, level+1)
-		if !end {
-			minimized = true
-			minReq.Question[0].Name = q.Name[prev:]
-			if minReq.Question[0].Name == q.Name {
-				minimized = false
-			} else {
-				minReq.Question[0].Qtype = req.Question[0].Qtype
-			}
-		}
+	if level >= r.qnameMinLevel || q.Name == rootzone {
+		return req, false
 	}
 
-	return minReq, minimized
+	prev, end := dns.PrevLabel(q.Name, level+1)
+	if end {
+		return req, false
+	}
+	minName := q.Name[prev:]
+	if minName == q.Name {
+		return req, false
+	}
+
+	// Only the outcome that queries a different name pays for a private
+	// copy; every other path hands the caller's request back untouched,
+	// exactly as the nomin/disabled entries above already do. The copy is
+	// what makes the returned request lookup-owned — see groupLookup.
+	minReq := req.Copy()
+	minReq.Question[0].Name = minName
+	return minReq, true
 }
 
 func (r *Resolver) setTags(req, resp *dns.Msg) *dns.Msg {
@@ -1394,9 +1405,10 @@ mainloop:
 				"query", dnsutil.FormatQuestion(req.Question[0]))
 		}
 
-		// Make a copy for this server before launching goroutine
-		// We do this serially to avoid concurrent CopyTo() which is not thread-safe
-		serverReq := req.CopyTo(AcquireMsg())
+		// A pooled per-attempt view of the leader request: own slice
+		// backings, shared records. Built serially so every attempt reads
+		// the leader before anything downstream could touch it.
+		serverReq := acquireAttemptReq(req)
 
 		// Acquire semaphore slot before starting goroutine
 		select {
@@ -1823,6 +1835,10 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, interrupts *I
 
 	// Add EDNS-Keepalive option if using TCP pooling
 	if proto == "tcp" && r.tcpPool != nil && r.cfg.TCPKeepalive && (isRoot || isTLD) {
+		// The attempt shares the leader's OPT; the keepalive append below
+		// is the one OPT write on this path, so it pays for a private OPT
+		// here, on the rare TCP leg.
+		privatizeOPT(req)
 		SetEDNSKeepalive(req, 0) // Request keepalive with no specific timeout
 	}
 

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -496,6 +496,13 @@ func (r *Resolver) resolve(ctx context.Context, rs *resolveState) (*dns.Msg, err
 	return m, nil
 }
 
+// groupLookup collapses concurrent identical lookups onto one leader
+// through singleflight. owned declares the request handed over: the leader
+// closure may retain and read it past this call's return, so owned=true is
+// only correct when nothing upstack mutates req afterward — today that is
+// exactly minimize's private copy, which handleLookupError at most reads.
+// A shared request (rs.req) must pass owned=false so the leader gets its
+// own copy, made while the caller still exclusively owns the memory.
 func (r *Resolver) groupLookup(ctx context.Context, rs *resolveState, req *dns.Msg, servers *authority.Servers, owned bool) (resp *dns.Msg, err error) {
 	q := req.Question[0]
 

--- a/middleware/resolver/utils.go
+++ b/middleware/resolver/utils.go
@@ -179,14 +179,17 @@ func ReleaseMsg(req *dns.Msg) {
 	req.CheckingDisabled = false
 	req.Rcode = 0
 	req.Compress = false
+	// clear zeroes the elements — no released message pins records for the
+	// GC — while the trim keeps the backing arrays, so a recycled shell
+	// rebuilds its sections without reallocating them.
 	clear(req.Question)
 	clear(req.Answer)
 	clear(req.Ns)
 	clear(req.Extra)
-	req.Question = nil
-	req.Answer = nil
-	req.Ns = nil
-	req.Extra = nil
+	req.Question = req.Question[:0]
+	req.Answer = req.Answer[:0]
+	req.Ns = req.Ns[:0]
+	req.Extra = req.Extra[:0]
 
 	reqPool.Put(req)
 }


### PR DESCRIPTION
## Problem

`Msg.Copy` + `CopyTo` were **8.4% of live allocation** (125MB of a 1.5GB window), spread over four sites — per-server fan-out ~23%, groupLookup leader/follower ~30%, minimize ~25%, filterCacheableAnswer ~22% — with `OPT.copy` alone at 36MB. Each site needed a different fraction of what a blind deep copy pays for, so each gets exactly that fraction.

## Per site

**Per-server fan-out** — an attempt needs its own ID and independent packing, nothing more. `acquireAttemptReq`: pooled shell, own slice backings, records shared by pointer — **except the OPT, which gets a private shell**. The race detector caught why during development: miekg's `PackBuffer` *writes* the extended rcode into the OPT header on every pack ("set extended rcode unconditionally", msg.go), so concurrent attempts cannot share the OPT struct. Its options CAN stay shared — packing only reads them, and the one option writer (the TCP leg's keepalive append) now privatizes the whole OPT first, copy-on-write on that rare branch. `ReleaseMsg` keeps the pool's backings across release (`clear` already provides the GC hygiene the old nil-ing was for), so:

```
acquireAttemptReq   26.3 ns/op    64 B/op   1 alloc  (the OPT shell)
CopyTo (replaced)   51.9 ns/op   104 B/op   3 allocs (worse in production: options multiply it)
```

**groupLookup** — the leader copy exists because the caller's upstack mutates the request OPT in place after return. A *minimized* request is already lookup-private, so `minimize` now copies only when it actually shortens the name and `groupLookup` takes an `owned` flag to skip the leader copy for handed-over requests. With minimization on by default this also retires the follower-side copies, which were **never used at all** — every contended follower paid a full deep copy for nothing.

**filterCacheableAnswer** — needed a different Answer slice, not new records: every consumer (`NewCacheEntryWithKey` first among them) reads the result synchronously and retains packed bytes, and the entry constructor already builds its own shallow storable view. The clean shape — no chain tail — passes through as the same message; a drop builds a shallow view sharing every record.

## Safety

- Race suite: full `-race` runs green on resolver + cache; the shared-OPT design iteration was caught BY the race detector against the hermetic authority tests and fixed with the private shell before landing.
- New pins: attempt-view isolation (ID/question mutations cannot reach the leader; extended-rcode write stays private; keepalive cannot contaminate the leader's OPT), exact per-attempt allocation count, minimize copy-only-when-minimizing with the original untouched, shallow-filter record sharing with the original unmutated.
- `dns.Id()` allocates a 2-byte buffer per call inside `binary.Read` — pre-existing, per-attempt, deliberately out of scope; noted for a separate decision since ID generation is anti-spoofing surface.

Full suite green, `golangci-lint` clean on darwin/linux/freebsd. The exit measurement is the canary allocation profile after deploy: the Copy/CopyTo bucket should collapse from 8.4%.