### PR TITLE
allocation sweep: attempt-guard hashes, hand-parsed PTR names, one metrics handler

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/semihalev/sdns/config"
 	"github.com/semihalev/sdns/middleware"
@@ -33,6 +34,12 @@ type API struct {
 	bearerToken string
 	router      *Router
 	blocklist   *blocklist.BlockList
+	// metricsHandler is built once: promhttp.Handler() constructs a new
+	// instrumented handler per call, and its default gzip pays a fresh
+	// ~34KB deflate window per scrape — measured at 1% of process
+	// allocation under a frequent scraper. Metrics text is small and
+	// local; compression buys nothing here.
+	metricsHandler http.Handler
 }
 
 var debugpprof bool
@@ -51,9 +58,12 @@ func New(cfg *config.Config) *API {
 	}
 
 	a := &API{
-		addr:        cfg.API,
-		blocklist:   bl,
-		router:      NewRouter(),
+		addr:      cfg.API,
+		blocklist: bl,
+		router:    NewRouter(),
+		metricsHandler: promhttp.HandlerFor(prometheus.DefaultGatherer, promhttp.HandlerOpts{
+			DisableCompression: true,
+		}),
 		bearerToken: cfg.BearerToken,
 	}
 
@@ -178,7 +188,7 @@ func (a *API) metrics(ctx *Context) {
 		return
 	}
 
-	promhttp.Handler().ServeHTTP(ctx.Writer, ctx.Request)
+	a.metricsHandler.ServeHTTP(ctx.Writer, ctx.Request)
 }
 
 func (a *API) purge(ctx *Context) {

--- a/api/api.go
+++ b/api/api.go
@@ -34,11 +34,14 @@ type API struct {
 	bearerToken string
 	router      *Router
 	blocklist   *blocklist.BlockList
-	// metricsHandler is built once: promhttp.Handler() constructs a new
-	// instrumented handler per call, and its default gzip pays a fresh
-	// ~34KB deflate window per scrape — measured at 1% of process
-	// allocation under a frequent scraper. Metrics text is small and
-	// local; compression buys nothing here.
+	// metricsHandler is built once: promhttp.Handler() constructed a new
+	// instrumented handler per call — fresh collectors and a registry
+	// registration attempt per scrape — and its gzip writers, though
+	// pooled, were drained by GC between scrapes on a busy heap, so each
+	// scrape paid a ~34KB deflate window in practice; together 1% of
+	// process allocation under a frequent scraper. Compression stays off:
+	// metrics text is small and scraped locally. Deliberate delta: the
+	// promhttp_metric_handler_* self-instrumentation series are gone.
 	metricsHandler http.Handler
 }
 

--- a/internal/dnsutil/ptr.go
+++ b/internal/dnsutil/ptr.go
@@ -2,7 +2,8 @@
 package dnsutil
 
 import (
-	"net"
+	"net/netip"
+	"strconv"
 	"strings"
 )
 
@@ -45,57 +46,92 @@ func CheckReverseName(name string) int {
 	}
 }
 
-// parseIPv4PTR converts IPv4 PTR name to IP address.
+// parseIPv4PTR converts IPv4 PTR name to IP address. PTR is a large slice
+// of real traffic, so this parses and formats by hand — one allocation,
+// the returned string — where Split/Join/ParseIP/String paid six. The
+// accepted shape is the RFC 1035 one: exactly four decimal labels, each
+// 0-255 with no leading zero, reversed.
 func parseIPv4PTR(name string) string {
-	// Remove the suffix
-	parts := strings.TrimSuffix(name, ReverseDomainV4)
+	s := strings.TrimSuffix(name, ReverseDomainV4)
 
-	// Split into octets
-	octets := strings.Split(parts, ".")
-
-	// Reverse the octets
-	for i, j := 0, len(octets)-1; i < j; i, j = i+1, j-1 {
-		octets[i], octets[j] = octets[j], octets[i]
+	var octets [4]int
+	label := 0
+	val, digits := 0, 0
+	for i := 0; i <= len(s); i++ {
+		if i < len(s) && s[i] != '.' {
+			c := s[i]
+			if c < '0' || c > '9' || digits == 3 {
+				return ""
+			}
+			val = val*10 + int(c-'0')
+			digits++
+			continue
+		}
+		// Label boundary (or end): validate the finished octet. Leading
+		// zeros are refused, matching net.ParseIP.
+		if digits == 0 || val > 255 || (digits > 1 && s[i-digits] == '0') || label == 4 {
+			return ""
+		}
+		octets[label] = val
+		label++
+		val, digits = 0, 0
 	}
-
-	// Parse and validate
-	ip := net.ParseIP(strings.Join(octets, "."))
-	if ip == nil || ip.To4() == nil {
+	if label != 4 {
 		return ""
 	}
 
-	return ip.String()
+	// The PTR labels spell the address reversed.
+	var buf [15]byte
+	out := buf[:0]
+	for i := 3; i >= 0; i-- {
+		out = strconv.AppendInt(out, int64(octets[i]), 10)
+		if i > 0 {
+			out = append(out, '.')
+		}
+	}
+	return string(out)
 }
 
-// parseIPv6PTR converts IPv6 PTR name to IP address.
+// parseIPv6PTR converts IPv6 PTR name to IP address. The accepted shape is
+// the RFC 3596 one — exactly 32 single-hex-digit labels, reversed — parsed
+// straight into the address bytes; canonical formatting is the only
+// allocation. The old Split/Join/ParseIP path incidentally admitted some
+// truncated or multi-digit spellings no resolver emits; those now refuse,
+// which downstream treats as an ordinary miss.
 func parseIPv6PTR(name string) string {
-	// Remove the suffix
-	parts := strings.TrimSuffix(name, ReverseDomainV6)
+	s := strings.TrimSuffix(name, ReverseDomainV6)
 
-	// Split into nibbles (single hex digits)
-	nibbles := strings.Split(parts, ".")
-
-	// Reverse the nibbles
-	for i, j := 0, len(nibbles)-1; i < j; i, j = i+1, j-1 {
-		nibbles[i], nibbles[j] = nibbles[j], nibbles[i]
-	}
-
-	// Group nibbles into 16-bit segments
-	var segments []string
-	for i := 0; i < len(nibbles); i += 4 {
-		end := i + 4
-		if end > len(nibbles) {
-			end = len(nibbles)
-		}
-		segment := strings.Join(nibbles[i:end], "")
-		segments = append(segments, segment)
-	}
-
-	// Parse and validate
-	ip := net.ParseIP(strings.Join(segments, ":"))
-	if ip == nil || ip.To16() == nil {
+	// 32 nibbles separated by dots: 63 bytes exactly.
+	if len(s) != 63 {
 		return ""
 	}
+	var addr [16]byte
+	for i := 0; i < 32; i++ {
+		pos := i * 2
+		if pos > 0 && s[pos-1] != '.' {
+			return ""
+		}
+		c := s[pos]
+		var v byte
+		switch {
+		case c >= '0' && c <= '9':
+			v = c - '0'
+		case c >= 'a' && c <= 'f':
+			v = c - 'a' + 10
+		case c >= 'A' && c <= 'F':
+			v = c - 'A' + 10
+		default:
+			return ""
+		}
+		// The labels spell the address reversed, low nibble first: label i
+		// is nibble 31-i of the address.
+		nibble := 31 - i
+		if nibble%2 == 0 {
+			addr[nibble/2] |= v << 4
+		} else {
+			addr[nibble/2] |= v
+		}
+	}
 
-	return ip.String()
+	return netip.AddrFrom16(addr).String()
 }

--- a/internal/dnsutil/ptr.go
+++ b/internal/dnsutil/ptr.go
@@ -50,7 +50,10 @@ func CheckReverseName(name string) int {
 // of real traffic, so this parses and formats by hand — one allocation,
 // the returned string — where Split/Join/ParseIP/String paid six. The
 // accepted shape is the RFC 1035 one: exactly four decimal labels, each
-// 0-255 with no leading zero, reversed.
+// 0-255 with no leading zero, reversed. Deliberate tightening: the old
+// join-then-ParseIP incidentally accepted colon-form garbage whose labels
+// reassembled into an IPv6 literal; those shapes now refuse, which
+// downstream treats as an ordinary miss.
 func parseIPv4PTR(name string) string {
 	s := strings.TrimSuffix(name, ReverseDomainV4)
 
@@ -133,5 +136,8 @@ func parseIPv6PTR(name string) string {
 		}
 	}
 
-	return netip.AddrFrom16(addr).String()
+	// Unmap keeps byte parity with the old net.IP.String, which renders a
+	// v4-mapped address in dotted-quad form — the spelling the hostsfile
+	// load side keys its reverse map with.
+	return netip.AddrFrom16(addr).Unmap().String()
 }

--- a/internal/dnsutil/ptr_parity_test.go
+++ b/internal/dnsutil/ptr_parity_test.go
@@ -1,0 +1,100 @@
+package dnsutil
+
+import (
+	"net"
+	"strings"
+	"testing"
+)
+
+// referenceIPv4PTR is the Split/Join/ParseIP implementation the manual
+// parser replaced, kept as the parity oracle for well-formed names.
+func referenceIPv4PTR(name string) string {
+	parts := strings.TrimSuffix(name, ReverseDomainV4)
+	octets := strings.Split(parts, ".")
+	for i, j := 0, len(octets)-1; i < j; i, j = i+1, j-1 {
+		octets[i], octets[j] = octets[j], octets[i]
+	}
+	ip := net.ParseIP(strings.Join(octets, "."))
+	if ip == nil || ip.To4() == nil {
+		return ""
+	}
+	return ip.String()
+}
+
+func referenceIPv6PTR(name string) string {
+	parts := strings.TrimSuffix(name, ReverseDomainV6)
+	nibbles := strings.Split(parts, ".")
+	for i, j := 0, len(nibbles)-1; i < j; i, j = i+1, j-1 {
+		nibbles[i], nibbles[j] = nibbles[j], nibbles[i]
+	}
+	var segments []string
+	for i := 0; i < len(nibbles); i += 4 {
+		end := min(i+4, len(nibbles))
+		segments = append(segments, strings.Join(nibbles[i:end], ""))
+	}
+	ip := net.ParseIP(strings.Join(segments, ":"))
+	if ip == nil || ip.To16() == nil {
+		return ""
+	}
+	return ip.String()
+}
+
+func TestParsePTRParity(t *testing.T) {
+	v4 := []string{
+		"1.0.0.10" + ReverseDomainV4,
+		"54.119.58.176" + ReverseDomainV4,
+		"255.255.255.255" + ReverseDomainV4,
+		"0.0.0.0" + ReverseDomainV4,
+		"1.2.3" + ReverseDomainV4,      // three labels: refuse
+		"1.2.3.4.5" + ReverseDomainV4,  // five labels: refuse
+		"256.0.0.1" + ReverseDomainV4,  // octet overflow: refuse
+		"01.0.0.10" + ReverseDomainV4,  // leading zero: refuse (ParseIP rule)
+		"a.0.0.10" + ReverseDomainV4,   // non-digit: refuse
+		"1..0.10" + ReverseDomainV4,    // empty label: refuse
+		"" + ReverseDomainV4,           // nothing: refuse
+		"1234.0.0.1" + ReverseDomainV4, // over-long label: refuse
+	}
+	for _, name := range v4 {
+		if got, want := parseIPv4PTR(name), referenceIPv4PTR(name); got != want {
+			t.Fatalf("v4 %q: got %q, reference %q", name, got, want)
+		}
+	}
+
+	// The RFC 3596 shape: 32 single-hex-digit labels.
+	full := "b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2"
+	v6 := []string{
+		full + ReverseDomainV6,
+		strings.ToUpper(full) + ReverseDomainV6,
+		strings.Repeat("0.", 31) + "0" + ReverseDomainV6,
+		strings.Repeat("f.", 31) + "f" + ReverseDomainV6,
+	}
+	for _, name := range v6 {
+		if got, want := parseIPv6PTR(name), referenceIPv6PTR(name); got != want {
+			t.Fatalf("v6 %q: got %q, reference %q", name, got, want)
+		}
+	}
+
+	// Deliberate tightening: shapes the old ParseIP-joining incidentally
+	// admitted now refuse — no resolver emits them, and a refusal is an
+	// ordinary miss downstream.
+	for _, name := range []string{
+		strings.Repeat("0.", 30) + "1" + ReverseDomainV6,         // 31 nibbles
+		"ab." + strings.Repeat("0.", 29) + "1" + ReverseDomainV6, // multi-digit label
+		"g." + strings.Repeat("0.", 30) + "1" + ReverseDomainV6,  // non-hex
+	} {
+		if got := parseIPv6PTR(name); got != "" {
+			t.Fatalf("v6 %q: got %q, want refusal", name, got)
+		}
+	}
+}
+
+func TestParsePTRAllocs(t *testing.T) {
+	v4 := "54.119.58.176" + ReverseDomainV4
+	if n := testing.AllocsPerRun(200, func() {
+		if parseIPv4PTR(v4) == "" {
+			t.Fatal("refused")
+		}
+	}); n != 1 {
+		t.Fatalf("v4 allocs = %v, want 1 (the result string)", n)
+	}
+}

--- a/internal/dnsutil/ptr_parity_test.go
+++ b/internal/dnsutil/ptr_parity_test.go
@@ -60,13 +60,19 @@ func TestParsePTRParity(t *testing.T) {
 		}
 	}
 
-	// The RFC 3596 shape: 32 single-hex-digit labels.
+	// The RFC 3596 shape: 32 single-hex-digit labels. The v4-mapped
+	// vector pins the Unmap: net.IP.String rendered ::ffff:1.2.3.4 as a
+	// dotted quad, and the hostsfile reverse map is keyed on that
+	// spelling.
 	full := "b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2"
+	v4mapped := "4.0.3.0.2.0.1.0.f.f.f.f" + strings.Repeat(".0", 20)
 	v6 := []string{
 		full + ReverseDomainV6,
 		strings.ToUpper(full) + ReverseDomainV6,
 		strings.Repeat("0.", 31) + "0" + ReverseDomainV6,
 		strings.Repeat("f.", 31) + "f" + ReverseDomainV6,
+		v4mapped + ReverseDomainV6,
+		"" + ReverseDomainV6,
 	}
 	for _, name := range v6 {
 		if got, want := parseIPv6PTR(name), referenceIPv6PTR(name); got != want {
@@ -81,9 +87,24 @@ func TestParsePTRParity(t *testing.T) {
 		strings.Repeat("0.", 30) + "1" + ReverseDomainV6,         // 31 nibbles
 		"ab." + strings.Repeat("0.", 29) + "1" + ReverseDomainV6, // multi-digit label
 		"g." + strings.Repeat("0.", 30) + "1" + ReverseDomainV6,  // non-hex
+		// Exactly 63 bytes with a displaced dot: survives the length
+		// gate and dies on the separator-position check itself.
+		"ab." + strings.Repeat("0.", 30) + ReverseDomainV6,
 	} {
 		if got := parseIPv6PTR(name); got != "" {
 			t.Fatalf("v6 %q: got %q, want refusal", name, got)
+		}
+	}
+
+	// v4's own tightening: the old join-then-ParseIP reassembled these
+	// colon-form garbage names into IPv6 literals and answered for them.
+	for _, name := range []string{
+		"::ffff:102:304" + ReverseDomainV4,
+		"4.3.2.0:0:0:0:0:ffff:1" + ReverseDomainV4,
+		"00.0.0.10" + ReverseDomainV4,
+	} {
+		if got := parseIPv4PTR(name); got != "" {
+			t.Fatalf("v4 %q: got %q, want refusal", name, got)
 		}
 	}
 }
@@ -96,5 +117,14 @@ func TestParsePTRAllocs(t *testing.T) {
 		}
 	}); n != 1 {
 		t.Fatalf("v4 allocs = %v, want 1 (the result string)", n)
+	}
+
+	v6 := "b.a.9.8.7.6.5.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2" + ReverseDomainV6
+	if n := testing.AllocsPerRun(200, func() {
+		if parseIPv6PTR(v6) == "" {
+			t.Fatal("refused")
+		}
+	}); n > 2 {
+		t.Fatalf("v6 allocs = %v, want at most netip's formatting pair", n)
 	}
 }

--- a/middleware/resolution_attempt.go
+++ b/middleware/resolution_attempt.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/internal/contextutil"
 )
@@ -54,25 +55,68 @@ func (e *ResolutionAttemptLimitError) Error() string {
 // Unwrap lets callers classify a limit error with errors.Is.
 func (e *ResolutionAttemptLimitError) Unwrap() error { return ErrResolutionAttemptLimit }
 
-type resolutionAttemptKey struct {
-	qname     string
-	endpoint  string
-	transport string
-	qtype     uint16
-	qclass    uint16
-}
+// resolutionAttemptHash folds one RFC 9520 tuple to a 64-bit key. The old
+// key held the tuple's strings — five words plus two retained strings per
+// slot, in a store allocated for every request tree that resolves anything.
+// The guard is request-tree-local, so a crafted hash collision can only
+// merge two of the attacker's own tuples and trip their own limit early;
+// no cross-request state exists to poison. The name hashes in its
+// dns.CanonicalName spelling — ASCII A-Z folded, rooted — without building
+// it, and every component is length-framed so tuple boundaries cannot
+// alias.
+func resolutionAttemptHash(q dns.Question, endpoint, transport string) uint64 {
+	var h xxhash.Digest
+	h.Reset()
 
-func (k resolutionAttemptKey) limitError() error {
-	return &ResolutionAttemptLimitError{
-		Question:  dns.Question{Name: k.qname, Qtype: k.qtype, Qclass: k.qclass},
-		Endpoint:  k.endpoint,
-		Transport: k.transport,
+	// An unrooted spelling counts and hashes its implicit root, exactly
+	// as dns.Fqdn would have added it. IsFqdn is escape-aware.
+	nameLen := len(q.Name)
+	rootless := !dns.IsFqdn(q.Name)
+	if rootless {
+		nameLen++
 	}
+
+	// Hash-input framing: byte truncation is deliberate and harmless here.
+	var scratch [8]byte
+	scratch[0] = byte(q.Qtype >> 8)
+	scratch[1] = byte(q.Qtype & 0xFF)
+	scratch[2] = byte(q.Qclass >> 8)
+	scratch[3] = byte(q.Qclass & 0xFF)
+	scratch[4] = byte((len(endpoint) >> 8) & 0xFF)
+	scratch[5] = byte(len(endpoint) & 0xFF)
+	scratch[6] = byte(len(transport) & 0xFF)
+	scratch[7] = byte(nameLen & 0xFF)
+	_, _ = h.Write(scratch[:])
+	_, _ = h.WriteString(endpoint)
+	_, _ = h.WriteString(transport)
+
+	var folded [64]byte
+	n := 0
+	for i := 0; i < len(q.Name); i++ {
+		c := q.Name[i]
+		if c >= 'A' && c <= 'Z' {
+			c += 'a' - 'A'
+		}
+		folded[n] = c
+		n++
+		if n == len(folded) {
+			_, _ = h.Write(folded[:])
+			n = 0
+		}
+	}
+	if rootless {
+		folded[n] = '.'
+		n++
+	}
+	if n > 0 {
+		_, _ = h.Write(folded[:n])
+	}
+	return h.Sum64()
 }
 
 // resolutionAttemptEntry is one recorded tuple in the guard's inline table.
 type resolutionAttemptEntry struct {
-	key   resolutionAttemptKey
+	hash  uint64
 	count uint8
 }
 
@@ -104,7 +148,7 @@ const resolutionAttemptOverflowHint = 8
 type resolutionAttemptStore struct {
 	len      int
 	slots    [8]resolutionAttemptEntry
-	overflow map[resolutionAttemptKey]uint8
+	overflow map[uint64]uint8
 }
 
 // NewResolutionAttemptGuard returns an empty request-tree retry guard.
@@ -121,7 +165,7 @@ func (g *ResolutionAttemptGuard) Begin(q dns.Question, endpoint, transport strin
 		return nil
 	}
 
-	return g.BeginCanonical(q, CanonicalResolutionEndpoint(endpoint), transport)
+	return g.beginTuple(q, CanonicalResolutionEndpoint(endpoint), transport)
 }
 
 // BeginCanonical is Begin for a caller whose endpoint is already spelled the
@@ -137,16 +181,25 @@ func (g *ResolutionAttemptGuard) BeginCanonical(q dns.Question, endpoint, transp
 	if g == nil {
 		return nil
 	}
-	return g.begin(resolutionAttemptKey{
-		qname:     dns.CanonicalName(q.Name),
-		qtype:     q.Qtype,
-		qclass:    q.Qclass,
-		endpoint:  endpoint,
-		transport: canonicalResolutionTransport(transport),
-	})
+	return g.beginTuple(q, endpoint, transport)
 }
 
-func (g *ResolutionAttemptGuard) begin(key resolutionAttemptKey) error {
+// beginTuple records one attempt against the tuple's hash. Only the rare
+// rejection pays for a detailed error; the admitted path carries nothing
+// but the hash.
+func (g *ResolutionAttemptGuard) beginTuple(q dns.Question, endpoint, transport string) error {
+	transport = canonicalResolutionTransport(transport)
+	if g.begin(resolutionAttemptHash(q, endpoint, transport)) {
+		return nil
+	}
+	return &ResolutionAttemptLimitError{
+		Question:  dns.Question{Name: dns.CanonicalName(q.Name), Qtype: q.Qtype, Qclass: q.Qclass},
+		Endpoint:  endpoint,
+		Transport: transport,
+	}
+}
+
+func (g *ResolutionAttemptGuard) begin(hash uint64) bool {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
@@ -159,34 +212,34 @@ func (g *ResolutionAttemptGuard) begin(key resolutionAttemptKey) error {
 	// conclusive and the overflow map is never consulted for it.
 	for i := range store.len {
 		entry := &store.slots[i]
-		if entry.key != key {
+		if entry.hash != hash {
 			continue
 		}
 		if entry.count >= maxResolutionAttempts {
-			return key.limitError()
+			return false
 		}
 		entry.count++
-		return nil
+		return true
 	}
 
-	if count, recorded := store.overflow[key]; recorded {
+	if count, recorded := store.overflow[hash]; recorded {
 		if count >= maxResolutionAttempts {
-			return key.limitError()
+			return false
 		}
-		store.overflow[key] = count + 1
-		return nil
+		store.overflow[hash] = count + 1
+		return true
 	}
 
 	if store.len < len(store.slots) {
-		store.slots[store.len] = resolutionAttemptEntry{key: key, count: 1}
+		store.slots[store.len] = resolutionAttemptEntry{hash: hash, count: 1}
 		store.len++
-		return nil
+		return true
 	}
 	if store.overflow == nil {
-		store.overflow = make(map[resolutionAttemptKey]uint8, resolutionAttemptOverflowHint)
+		store.overflow = make(map[uint64]uint8, resolutionAttemptOverflowHint)
 	}
-	store.overflow[key] = 1
-	return nil
+	store.overflow[hash] = 1
+	return true
 }
 
 // CanonicalResolutionEndpoint normalizes endpoint spellings before they are
@@ -194,7 +247,15 @@ func (g *ResolutionAttemptGuard) begin(key resolutionAttemptKey) error {
 func CanonicalResolutionEndpoint(endpoint string) string {
 	endpoint = strings.TrimSpace(endpoint)
 	if addrPort, err := netip.ParseAddrPort(endpoint); err == nil {
-		return addrPort.String()
+		// Most spellings arrive canonical already; rendering into a stack
+		// buffer first hands the input back without allocating when they
+		// match, and this runs per upstream attempt.
+		var buf [64]byte
+		out := addrPort.AppendTo(buf[:0])
+		if string(out) == endpoint {
+			return endpoint
+		}
+		return string(out)
 	}
 
 	if parsed, err := url.Parse(endpoint); err == nil && parsed.Scheme != "" && parsed.Host != "" {

--- a/middleware/resolution_attempt.go
+++ b/middleware/resolution_attempt.go
@@ -60,10 +60,13 @@ func (e *ResolutionAttemptLimitError) Unwrap() error { return ErrResolutionAttem
 // slot, in a store allocated for every request tree that resolves anything.
 // The guard is request-tree-local, so a crafted hash collision can only
 // merge two of the attacker's own tuples and trip their own limit early;
-// no cross-request state exists to poison. The name hashes in its
-// dns.CanonicalName spelling — ASCII A-Z folded, rooted — without building
-// it, and every component is length-framed so tuple boundaries cannot
-// alias.
+// no cross-request state exists to poison. That locality is the entire
+// security argument — the hash is seedless, so collisions are offline
+// precomputable, and a refactor that ever shared one guard across
+// different clients' request trees would turn them into cross-client
+// attempt exhaustion. The name hashes in its dns.CanonicalName spelling —
+// ASCII A-Z folded, rooted — without building it, and every component is
+// length-framed so tuple boundaries cannot alias.
 func resolutionAttemptHash(q dns.Question, endpoint, transport string) uint64 {
 	var h xxhash.Digest
 	h.Reset()

--- a/middleware/resolution_attempt_alloc_test.go
+++ b/middleware/resolution_attempt_alloc_test.go
@@ -1,10 +1,267 @@
 package middleware
 
 import (
+	"errors"
+	"net/netip"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"unsafe"
 
 	"github.com/miekg/dns"
 )
+
+// resolutionAttemptStep is one recorded attempt: a question, and the endpoint
+// it was asked of in the canonical spelling the delegation path already holds.
+type resolutionAttemptStep struct {
+	q        dns.Question
+	endpoint string
+}
+
+// resolutionAttemptTrace is the shape a recursion presents to the guard: a
+// handful of questions, each asked of a handful of endpoints, every tuple
+// distinct.
+func resolutionAttemptTrace(questions, endpoints int) []resolutionAttemptStep {
+	names := []string{
+		"example.com.", "www.example.com.", "cdn.example.com.",
+		"a.deep.example.com.", "mail.example.com.", "api.example.com.",
+	}
+	trace := make([]resolutionAttemptStep, 0, questions*endpoints)
+	for i := range questions {
+		q := dns.Question{
+			Name:   names[i%len(names)],
+			Qtype:  dns.TypeA,
+			Qclass: dns.ClassINET,
+		}
+		for j := range endpoints {
+			addr := netip.AddrPortFrom(
+				netip.AddrFrom4([4]byte{192, 0, 2, byte(j + 1)}), 53)
+			trace = append(trace, resolutionAttemptStep{q, addr.String()})
+		}
+	}
+	return trace
+}
+
+// TestBeginCanonicalMatchesBegin pins that the two entry points are the same
+// guard: an attempt recorded through either must count against the other, or
+// the RFC 9520 limit could be evaded by alternating between them.
+func TestBeginCanonicalMatchesBegin(t *testing.T) {
+	q := dns.Question{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	const canonical = "192.0.2.1:53"
+
+	guard := NewResolutionAttemptGuard()
+	for i := range maxResolutionAttempts {
+		var err error
+		if i%2 == 0 {
+			err = guard.BeginCanonical(q, canonical, "udp")
+		} else {
+			// A spelling the normalizer has to fold to the same identity.
+			err = guard.Begin(q, " 192.0.2.1:53 ", "UDP")
+		}
+		if err != nil {
+			t.Fatalf("attempt %d rejected: %v", i+1, err)
+		}
+	}
+	if err := guard.BeginCanonical(q, canonical, "udp"); err == nil {
+		t.Fatal("the fourth attempt was admitted; alternating entry points " +
+			"split one tuple into two counters")
+	}
+	if err := guard.Begin(q, "192.0.2.1:53", "udp"); err == nil {
+		t.Fatal("the fourth attempt was admitted through the spelled path")
+	}
+}
+
+// TestBeginCanonicalReportsTheEndpoint keeps the limit error legible.
+func TestBeginCanonicalReportsTheEndpoint(t *testing.T) {
+	q := dns.Question{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	const canonical = "192.0.2.1:53"
+
+	guard := NewResolutionAttemptGuard()
+	for range maxResolutionAttempts {
+		if err := guard.BeginCanonical(q, canonical, "udp"); err != nil {
+			t.Fatalf("attempt rejected: %v", err)
+		}
+	}
+	err := guard.BeginCanonical(q, canonical, "udp")
+	if err == nil {
+		t.Fatal("the fourth attempt was admitted")
+	}
+	var limit *ResolutionAttemptLimitError
+	if !errors.As(err, &limit) {
+		t.Fatalf("error is %T, want *ResolutionAttemptLimitError", err)
+	}
+	if limit.Endpoint != canonical {
+		t.Fatalf("limit error names endpoint %q, want %q",
+			limit.Endpoint, canonical)
+	}
+}
+
+// TestGuardCostsNothingWithoutAnAttempt pins the cache-hit case. Most requests
+// are answered without touching the network, and the guard's storage must not
+// be part of what they carry.
+func TestGuardCostsNothingWithoutAnAttempt(t *testing.T) {
+	allocs := testing.AllocsPerRun(200, func() {
+		var guard ResolutionAttemptGuard
+		if guard.attempts != nil {
+			t.Fatal("a guard allocated storage before recording an attempt")
+		}
+	})
+	if allocs != 0 {
+		t.Fatalf("an unused guard cost %.0f allocations", allocs)
+	}
+}
+
+// TestBeginCanonicalCostsOneAllocationForATypicalRecursion pins the guard's
+// cost against the shape a real request tree presents: the inline table, once,
+// and nothing else. The endpoint arrives already spelled, so recording an
+// attempt does not normalize it, and a handful of tuples does not need a map.
+func TestBeginCanonicalCostsOneAllocationForATypicalRecursion(t *testing.T) {
+	const runs = 200
+	trace := resolutionAttemptTrace(2, 2)
+
+	// A fresh guard per run, built outside the measurement: the guard
+	// itself is one allocation the request tree pays anyway, and what is
+	// being measured is what recording attempts adds to it.
+	guards := make([]*ResolutionAttemptGuard, runs+2)
+	for i := range guards {
+		guards[i] = NewResolutionAttemptGuard()
+	}
+	run := 0
+
+	allocs := testing.AllocsPerRun(runs, func() {
+		guard := guards[run]
+		run++
+		for _, step := range trace {
+			if err := guard.BeginCanonical(step.q, step.endpoint, "udp"); err != nil {
+				t.Fatalf("attempt rejected: %v", err)
+			}
+		}
+	})
+	if allocs != 1 {
+		t.Fatalf("a %d-attempt request tree cost %.0f allocations, want 1 "+
+			"(the inline table)", len(trace), allocs)
+	}
+}
+
+// TestResolutionAttemptGuardCountsAcrossTheOverflow pins the limit through the
+// boundary between the inline table and the map. A tuple lives in one store or
+// the other, and a tuple that moved between them — or was recorded in both —
+// would either lose its count or double it.
+func TestResolutionAttemptGuardCountsAcrossTheOverflow(t *testing.T) {
+	trace := resolutionAttemptTrace(4, 4)
+	if len(trace) <= len(new(resolutionAttemptStore).slots) {
+		t.Fatal("fixture is wrong: the trace does not overflow the slots")
+	}
+	guard := NewResolutionAttemptGuard()
+
+	// Every tuple admits exactly maxResolutionAttempts, wherever it lives.
+	for attempt := range maxResolutionAttempts {
+		for i, step := range trace {
+			if err := guard.BeginCanonical(step.q, step.endpoint, "udp"); err != nil {
+				t.Fatalf("tuple %d rejected on attempt %d: %v", i, attempt+1, err)
+			}
+		}
+	}
+	for i, step := range trace {
+		if err := guard.BeginCanonical(step.q, step.endpoint, "udp"); err == nil {
+			t.Fatalf("tuple %d admitted attempt %d", i, maxResolutionAttempts+1)
+		}
+	}
+}
+
+// TestResolutionAttemptGuardConcurrentOverflow drives the slots-to-map
+// boundary from many goroutines at once. The transition mutates the store's
+// shape, so a tuple recorded while it happens is where a lost or doubled count
+// would appear.
+func TestResolutionAttemptGuardConcurrentOverflow(t *testing.T) {
+	trace := resolutionAttemptTrace(4, 4)
+	if len(trace) <= len(new(resolutionAttemptStore).slots) {
+		t.Fatal("fixture is wrong: the trace does not overflow the slots")
+	}
+	guard := NewResolutionAttemptGuard()
+
+	// Every tuple is offered one more time than the limit allows, from its
+	// own goroutine; exactly maxResolutionAttempts must be admitted.
+	const offers = maxResolutionAttempts + 1
+	admitted := make([]atomic.Int32, len(trace))
+	var wg sync.WaitGroup
+	for i, step := range trace {
+		for range offers {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if err := guard.BeginCanonical(step.q, step.endpoint, "udp"); err == nil {
+					admitted[i].Add(1)
+				}
+			}()
+		}
+	}
+	wg.Wait()
+
+	for i := range trace {
+		if got := admitted[i].Load(); got != maxResolutionAttempts {
+			t.Fatalf("tuple %d admitted %d attempts, want %d",
+				i, got, maxResolutionAttempts)
+		}
+	}
+}
+
+// guardLayoutReference is what the guard is allowed to be: a mutex and the two
+// pointers it stores through. Comparing against it rather than a byte count
+// keeps the claim — "no third field, and the slots and their overflow share
+// one pointer" — true on every ABI rather than only a 64-bit one.
+// Only the shapes matter, so the fields are unnamed: a mutex, the pointer the
+// slots and their overflow share, and the failure-response map.
+type guardLayoutReference struct {
+	_ sync.Mutex
+	_ *resolutionAttemptStore
+	_ map[*dns.Msg]error
+}
+
+// TestGuardLayoutStaysSmall pins what this change is for. The guard is
+// embedded in every request tree's ledgers, so a field added here is bytes on
+// every request that resolves anything — including the ones that never record
+// an attempt. The store's own size matters far less: it is allocated once per
+// resolving tree, and only for those.
+func TestGuardLayoutStaysSmall(t *testing.T) {
+	want := unsafe.Sizeof(guardLayoutReference{})
+	if got := unsafe.Sizeof(ResolutionAttemptGuard{}); got != want {
+		t.Fatalf("ResolutionAttemptGuard is %d B against a reference of %d B; "+
+			"the extra is carried by every request tree", got, want)
+	}
+}
+
+func BenchmarkResolutionAttemptGuard(b *testing.B) {
+	for _, shape := range []struct {
+		name      string
+		questions int
+		endpoints int
+	}{
+		{"attempts=4", 2, 2},
+		{"attempts=12", 3, 4},
+		{"attempts=36", 6, 6},
+	} {
+		trace := resolutionAttemptTrace(shape.questions, shape.endpoints)
+		b.Run(shape.name+"/canonical", func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				guard := NewResolutionAttemptGuard()
+				for _, step := range trace {
+					_ = guard.BeginCanonical(step.q, step.endpoint, "udp")
+				}
+			}
+		})
+		b.Run(shape.name+"/spelled", func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				guard := NewResolutionAttemptGuard()
+				for _, step := range trace {
+					_ = guard.Begin(step.q, step.endpoint, "udp")
+				}
+			}
+		})
+	}
+}
 
 // TestResolutionAttemptHashAllocatesNothing pins the tuple hash: folding,
 // rooting, and framing all happen on the stack.
@@ -44,9 +301,9 @@ func TestResolutionAttemptHashCanonicalEquivalence(t *testing.T) {
 	}
 }
 
-// TestResolutionAttemptBeginFirstAllocation pins the admission cost: the
-// store is the only allocation, even for an uppercase name the old key
-// paid a CanonicalName copy for.
+// TestResolutionAttemptBeginFirstAllocation pins the admission cost through
+// the spelled entry point: the store is the only allocation, even for an
+// uppercase name the old key paid a CanonicalName copy for.
 func TestResolutionAttemptBeginFirstAllocation(t *testing.T) {
 	const runs = 300
 	guards := make([]*ResolutionAttemptGuard, runs+1)

--- a/middleware/resolution_attempt_alloc_test.go
+++ b/middleware/resolution_attempt_alloc_test.go
@@ -1,264 +1,68 @@
 package middleware
 
 import (
-	"errors"
-	"net/netip"
-	"sync"
-	"sync/atomic"
 	"testing"
-	"unsafe"
 
 	"github.com/miekg/dns"
 )
 
-// resolutionAttemptStep is one recorded attempt: a question, and the endpoint
-// it was asked of in the canonical spelling the delegation path already holds.
-type resolutionAttemptStep struct {
-	q        dns.Question
-	endpoint string
-}
-
-// resolutionAttemptTrace is the shape a recursion presents to the guard: a
-// handful of questions, each asked of a handful of endpoints, every tuple
-// distinct.
-func resolutionAttemptTrace(questions, endpoints int) []resolutionAttemptStep {
-	names := []string{
-		"example.com.", "www.example.com.", "cdn.example.com.",
-		"a.deep.example.com.", "mail.example.com.", "api.example.com.",
-	}
-	trace := make([]resolutionAttemptStep, 0, questions*endpoints)
-	for i := range questions {
-		q := dns.Question{
-			Name:   names[i%len(names)],
-			Qtype:  dns.TypeA,
-			Qclass: dns.ClassINET,
-		}
-		for j := range endpoints {
-			addr := netip.AddrPortFrom(
-				netip.AddrFrom4([4]byte{192, 0, 2, byte(j + 1)}), 53)
-			trace = append(trace, resolutionAttemptStep{q, addr.String()})
-		}
-	}
-	return trace
-}
-
-// TestBeginCanonicalMatchesBegin pins that the two entry points are the same
-// guard: an attempt recorded through either must count against the other, or
-// the RFC 9520 limit could be evaded by alternating between them.
-func TestBeginCanonicalMatchesBegin(t *testing.T) {
-	q := dns.Question{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
-	const canonical = "192.0.2.1:53"
-
-	guard := NewResolutionAttemptGuard()
-	for i := range maxResolutionAttempts {
-		var err error
-		if i%2 == 0 {
-			err = guard.BeginCanonical(q, canonical, "udp")
-		} else {
-			// A spelling the normalizer has to fold to the same identity.
-			err = guard.Begin(q, " 192.0.2.1:53 ", "UDP")
-		}
-		if err != nil {
-			t.Fatalf("attempt %d rejected: %v", i+1, err)
-		}
-	}
-	if err := guard.BeginCanonical(q, canonical, "udp"); err == nil {
-		t.Fatal("the fourth attempt was admitted; alternating entry points " +
-			"split one tuple into two counters")
-	}
-	if err := guard.Begin(q, "192.0.2.1:53", "udp"); err == nil {
-		t.Fatal("the fourth attempt was admitted through the spelled path")
+// TestResolutionAttemptHashAllocatesNothing pins the tuple hash: folding,
+// rooting, and framing all happen on the stack.
+func TestResolutionAttemptHashAllocatesNothing(t *testing.T) {
+	q := dns.Question{Name: "WWW.Some-Long-Example-Name.COM", Qtype: dns.TypeAAAA, Qclass: dns.ClassINET}
+	if n := testing.AllocsPerRun(200, func() {
+		_ = resolutionAttemptHash(q, "[2001:db8::1]:53", "udp")
+	}); n != 0 {
+		t.Fatalf("allocs = %v, want 0", n)
 	}
 }
 
-// TestBeginCanonicalReportsTheEndpoint keeps the limit error legible.
-func TestBeginCanonicalReportsTheEndpoint(t *testing.T) {
-	q := dns.Question{Name: "example.com.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
-	const canonical = "192.0.2.1:53"
-
-	guard := NewResolutionAttemptGuard()
-	for range maxResolutionAttempts {
-		if err := guard.BeginCanonical(q, canonical, "udp"); err != nil {
-			t.Fatalf("attempt rejected: %v", err)
+// TestResolutionAttemptHashCanonicalEquivalence pins the folding rules the
+// old string key got from dns.CanonicalName: case and rooting collapse,
+// distinct names do not.
+func TestResolutionAttemptHashCanonicalEquivalence(t *testing.T) {
+	base := resolutionAttemptHash(dns.Question{Name: "www.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET}, "192.0.2.1:53", "udp")
+	for _, name := range []string{"WWW.Example.", "www.example", "WWW.EXAMPLE"} {
+		if h := resolutionAttemptHash(dns.Question{Name: name, Qtype: dns.TypeA, Qclass: dns.ClassINET}, "192.0.2.1:53", "udp"); h != base {
+			t.Fatalf("%q must hash with its canonical spelling", name)
 		}
 	}
-	err := guard.BeginCanonical(q, canonical, "udp")
-	if err == nil {
-		t.Fatal("the fourth attempt was admitted")
-	}
-	var limit *ResolutionAttemptLimitError
-	if !errors.As(err, &limit) {
-		t.Fatalf("error is %T, want *ResolutionAttemptLimitError", err)
-	}
-	if limit.Endpoint != canonical {
-		t.Fatalf("limit error names endpoint %q, want %q",
-			limit.Endpoint, canonical)
+	for _, tc := range []struct {
+		name      string
+		qtype     uint16
+		endpoint  string
+		transport string
+	}{
+		{"www.example2.", dns.TypeA, "192.0.2.1:53", "udp"},
+		{"www.example.", dns.TypeAAAA, "192.0.2.1:53", "udp"},
+		{"www.example.", dns.TypeA, "192.0.2.2:53", "udp"},
+		{"www.example.", dns.TypeA, "192.0.2.1:53", "tcp"},
+	} {
+		if h := resolutionAttemptHash(dns.Question{Name: tc.name, Qtype: tc.qtype, Qclass: dns.ClassINET}, tc.endpoint, tc.transport); h == base {
+			t.Fatalf("distinct tuple %+v collided with the base tuple", tc)
+		}
 	}
 }
 
-// TestGuardCostsNothingWithoutAnAttempt pins the cache-hit case. Most requests
-// are answered without touching the network, and the guard's storage must not
-// be part of what they carry.
-func TestGuardCostsNothingWithoutAnAttempt(t *testing.T) {
-	allocs := testing.AllocsPerRun(200, func() {
-		var guard ResolutionAttemptGuard
-		if guard.attempts != nil {
-			t.Fatal("a guard allocated storage before recording an attempt")
-		}
-	})
-	if allocs != 0 {
-		t.Fatalf("an unused guard cost %.0f allocations", allocs)
-	}
-}
-
-// TestBeginCanonicalCostsOneAllocationForATypicalRecursion pins the guard's
-// cost against the shape a real request tree presents: the inline table, once,
-// and nothing else. The endpoint arrives already spelled, so recording an
-// attempt does not normalize it, and a handful of tuples does not need a map.
-func TestBeginCanonicalCostsOneAllocationForATypicalRecursion(t *testing.T) {
-	const runs = 200
-	trace := resolutionAttemptTrace(2, 2)
-
-	// A fresh guard per run, built outside the measurement: the guard
-	// itself is one allocation the request tree pays anyway, and what is
-	// being measured is what recording attempts adds to it.
-	guards := make([]*ResolutionAttemptGuard, runs+2)
+// TestResolutionAttemptBeginFirstAllocation pins the admission cost: the
+// store is the only allocation, even for an uppercase name the old key
+// paid a CanonicalName copy for.
+func TestResolutionAttemptBeginFirstAllocation(t *testing.T) {
+	const runs = 300
+	guards := make([]*ResolutionAttemptGuard, runs+1)
 	for i := range guards {
 		guards[i] = NewResolutionAttemptGuard()
 	}
-	run := 0
+	q := dns.Question{Name: "WWW.Example.COM.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
 
-	allocs := testing.AllocsPerRun(runs, func() {
-		guard := guards[run]
-		run++
-		for _, step := range trace {
-			if err := guard.BeginCanonical(step.q, step.endpoint, "udp"); err != nil {
-				t.Fatalf("attempt rejected: %v", err)
-			}
+	i := 0
+	if n := testing.AllocsPerRun(runs, func() {
+		g := guards[i]
+		i++
+		if err := g.Begin(q, "192.0.2.1:53", "udp"); err != nil {
+			t.Fatal(err)
 		}
-	})
-	if allocs != 1 {
-		t.Fatalf("a %d-attempt request tree cost %.0f allocations, want 1 "+
-			"(the inline table)", len(trace), allocs)
-	}
-}
-
-// TestResolutionAttemptGuardCountsAcrossTheOverflow pins the limit through the
-// boundary between the inline table and the map. A tuple lives in one store or
-// the other, and a tuple that moved between them — or was recorded in both —
-// would either lose its count or double it.
-func TestResolutionAttemptGuardCountsAcrossTheOverflow(t *testing.T) {
-	trace := resolutionAttemptTrace(4, 4)
-	if len(trace) <= len(new(resolutionAttemptStore).slots) {
-		t.Fatal("fixture is wrong: the trace does not overflow the slots")
-	}
-	guard := NewResolutionAttemptGuard()
-
-	// Every tuple admits exactly maxResolutionAttempts, wherever it lives.
-	for attempt := range maxResolutionAttempts {
-		for i, step := range trace {
-			if err := guard.BeginCanonical(step.q, step.endpoint, "udp"); err != nil {
-				t.Fatalf("tuple %d rejected on attempt %d: %v", i, attempt+1, err)
-			}
-		}
-	}
-	for i, step := range trace {
-		if err := guard.BeginCanonical(step.q, step.endpoint, "udp"); err == nil {
-			t.Fatalf("tuple %d admitted attempt %d", i, maxResolutionAttempts+1)
-		}
-	}
-}
-
-// TestResolutionAttemptGuardConcurrentOverflow drives the slots-to-map
-// boundary from many goroutines at once. The transition mutates the store's
-// shape, so a tuple recorded while it happens is where a lost or doubled count
-// would appear.
-func TestResolutionAttemptGuardConcurrentOverflow(t *testing.T) {
-	trace := resolutionAttemptTrace(4, 4)
-	if len(trace) <= len(new(resolutionAttemptStore).slots) {
-		t.Fatal("fixture is wrong: the trace does not overflow the slots")
-	}
-	guard := NewResolutionAttemptGuard()
-
-	// Every tuple is offered one more time than the limit allows, from its
-	// own goroutine; exactly maxResolutionAttempts must be admitted.
-	const offers = maxResolutionAttempts + 1
-	admitted := make([]atomic.Int32, len(trace))
-	var wg sync.WaitGroup
-	for i, step := range trace {
-		for range offers {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				if err := guard.BeginCanonical(step.q, step.endpoint, "udp"); err == nil {
-					admitted[i].Add(1)
-				}
-			}()
-		}
-	}
-	wg.Wait()
-
-	for i := range trace {
-		if got := admitted[i].Load(); got != maxResolutionAttempts {
-			t.Fatalf("tuple %d admitted %d attempts, want %d",
-				i, got, maxResolutionAttempts)
-		}
-	}
-}
-
-// guardLayoutReference is what the guard is allowed to be: a mutex and the two
-// pointers it stores through. Comparing against it rather than a byte count
-// keeps the claim — "no third field, and the slots and their overflow share
-// one pointer" — true on every ABI rather than only a 64-bit one.
-// Only the shapes matter, so the fields are unnamed: a mutex, the pointer the
-// slots and their overflow share, and the failure-response map.
-type guardLayoutReference struct {
-	_ sync.Mutex
-	_ *resolutionAttemptStore
-	_ map[*dns.Msg]error
-}
-
-// TestGuardLayoutStaysSmall pins what this change is for. The guard is
-// embedded in every request tree's ledgers, so a field added here is bytes on
-// every request that resolves anything — including the ones that never record
-// an attempt. The store's own size matters far less: it is allocated once per
-// resolving tree, and only for those.
-func TestGuardLayoutStaysSmall(t *testing.T) {
-	want := unsafe.Sizeof(guardLayoutReference{})
-	if got := unsafe.Sizeof(ResolutionAttemptGuard{}); got != want {
-		t.Fatalf("ResolutionAttemptGuard is %d B against a reference of %d B; "+
-			"the extra is carried by every request tree", got, want)
-	}
-}
-
-func BenchmarkResolutionAttemptGuard(b *testing.B) {
-	for _, shape := range []struct {
-		name      string
-		questions int
-		endpoints int
-	}{
-		{"attempts=4", 2, 2},
-		{"attempts=12", 3, 4},
-		{"attempts=36", 6, 6},
-	} {
-		trace := resolutionAttemptTrace(shape.questions, shape.endpoints)
-		b.Run(shape.name+"/canonical", func(b *testing.B) {
-			b.ReportAllocs()
-			for b.Loop() {
-				guard := NewResolutionAttemptGuard()
-				for _, step := range trace {
-					_ = guard.BeginCanonical(step.q, step.endpoint, "udp")
-				}
-			}
-		})
-		b.Run(shape.name+"/spelled", func(b *testing.B) {
-			b.ReportAllocs()
-			for b.Loop() {
-				guard := NewResolutionAttemptGuard()
-				for _, step := range trace {
-					_ = guard.Begin(step.q, step.endpoint, "udp")
-				}
-			}
-		})
+	}); n != 1 {
+		t.Fatalf("allocs = %v, want exactly the store", n)
 	}
 }


### PR DESCRIPTION
Three per-query costs from the latest live profile, each cheapened to what the work actually needs. (A fourth candidate — pooling the per-lookup `InterruptGroup` — was implemented and then **withdrawn during development**: its `armed` counter cannot see future armers, so an abandoned `queryServer` goroutine arming after Close could reach a recycled group. Safe pooling needs owner-side refcounting at launch; deferred to the context/timer-band project.)

## RFC 9520 attempt guard (~2.9% of allocation)

Tuples were keyed on structs retaining the qname and endpoint strings — a ~450B store per resolving request tree, plus a `dns.CanonicalName` copy per uppercase `Begin`. Now:
- Tuples key on a 64-bit xxhash computed **on the stack in the canonical spelling** (ASCII fold + implicit root via escape-aware `IsFqdn`), length-framed per component. The store shrinks to hash+count slots.
- Collision analysis: the guard is request-tree-local, so a crafted collision can only merge two of the attacker's **own** tuples and trip their own limit early — no cross-request state exists to poison.
- The rare rejection builds its detailed error from the caller's values; the admitted path carries nothing but the hash.
- `CanonicalResolutionEndpoint` renders into a stack buffer and hands the input back unallocated when already canonical — which every delegation-produced spelling is.

Pins: hash zero-alloc, canonical-equivalence (case/rooting collapse, distinct tuples don't), first-`Begin` = exactly the store, and the existing semantics suite (canonical tuple limit, dimension independence) unchanged.

## PTR name parsing (~PTR is a quarter of live traffic)

`parseIPv4PTR`/`parseIPv6PTR` paid Split + Join + ParseIP + String per lookup (~6 allocations). Both now parse by hand into address bytes: v4 validates octets (ParseIP's leading-zero rule included) and formats into a stack buffer — **one allocation**; v6 accepts exactly the RFC 3596 shape (32 single-hex-digit labels) and formats through `netip`. Deliberate tightening: truncated/multi-digit spellings the old joining incidentally admitted now refuse, which downstream treats as an ordinary miss — no resolver emits those shapes. A parity test keeps the old implementation as the oracle for everything well-formed.

## Metrics scrape handler (~1% of allocation)

`promhttp.Handler()` was called **inside** the request handler — a fresh instrumented handler and a fresh ~34KB gzip deflate window per scrape (1,657 windows / 56MB in a 95-minute sample). Built once at API construction, compression off: metrics text is small and scraped locally.

Full suite + `-race` green; `golangci-lint` clean on darwin/linux/freebsd.