### PR TITLE
edns: truncate to the RFC 6891 minimal response

### DIFF
--- a/middleware/edns/edns.go
+++ b/middleware/edns/edns.go
@@ -373,13 +373,35 @@ func (w *ResponseWriter) WriteMsg(m *dns.Msg) error {
 	}
 
 	if w.Proto() == "udp" && udpOverflow(m, w.size) {
+		// A truncated response is a retry signal, not a partial answer
+		// (RFC 2181 §9): the client must discard the content and ask
+		// again over TCP, so everything but the question and the OPT
+		// goes. The OPT survives per RFC 6891 — the EDNS negotiation
+		// state stays visible. Extra in particular must not ride along:
+		// it can be the very section that overflowed, and keeping it
+		// used to send a TC=1 message still larger than the buffer the
+		// client advertised.
 		m.Truncated = true
 		m.Answer = []dns.RR{}
 		m.Ns = []dns.RR{}
+		m.Extra = keepOPTOnly(m.Extra)
 		m.AuthenticatedData = false
 	}
 
 	return w.ResponseWriter.WriteMsg(m)
+}
+
+// keepOPTOnly returns just the OPT record from extra, or nil without one —
+// the additional section a minimal truncated response is allowed to carry.
+// A fresh slice, not an in-place filter: the message's sections may still
+// be referenced by upstream writer layers.
+func keepOPTOnly(extra []dns.RR) []dns.RR {
+	for _, rr := range extra {
+		if opt, ok := rr.(*dns.OPT); ok {
+			return []dns.RR{opt}
+		}
+	}
+	return nil
 }
 
 // stripECS returns opts with every EDNS0_SUBNET entry removed.

--- a/middleware/edns/edns_truncate_test.go
+++ b/middleware/edns/edns_truncate_test.go
@@ -1,0 +1,156 @@
+package edns
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/middleware"
+)
+
+// bulkResponder writes a response with the requested section sizes, each
+// record ~44 wire bytes, so tests can steer exactly which section overflows
+// the client's buffer.
+type bulkResponder struct {
+	answer, ns, extra int
+}
+
+func (b *bulkResponder) Name() string { return "bulk" }
+
+func (b *bulkResponder) ServeDNS(ctx context.Context, ch *middleware.Chain) {
+	req := ch.Request.Msg()
+	resp := new(dns.Msg)
+	resp.SetReply(req)
+
+	rr := func(i int) dns.RR {
+		return &dns.A{
+			Hdr: dns.RR_Header{
+				Name:   fmt.Sprintf("padding-record-%03d.example.com.", i),
+				Rrtype: dns.TypeA,
+				Class:  dns.ClassINET,
+				Ttl:    60,
+			},
+			A: net.IPv4(192, 0, 2, byte(i%250+1)),
+		}
+	}
+	for i := 0; i < b.answer; i++ {
+		resp.Answer = append(resp.Answer, rr(i))
+	}
+	for i := 0; i < b.ns; i++ {
+		resp.Ns = append(resp.Ns, rr(1000+i))
+	}
+	for i := 0; i < b.extra; i++ {
+		resp.Extra = append(resp.Extra, rr(2000+i))
+	}
+
+	_ = ch.Writer.WriteMsg(resp)
+	ch.Cancel()
+}
+
+func truncateHarness(t *testing.T) *EDNS {
+	t.Helper()
+	middleware.Reset()
+	t.Cleanup(middleware.Reset)
+	middleware.Register("edns", func(cfg *config.Config) middleware.Handler { return New(cfg) })
+	middleware.Setup(new(config.Config))
+	return middleware.Get("edns").(*EDNS)
+}
+
+// serveBulk drives one UDP request with the given advertised size (0 =
+// no EDNS) through [edns, bulkResponder] and returns the written message.
+func serveBulk(t *testing.T, e *EDNS, udpSize uint16, b *bulkResponder) *dns.Msg {
+	t.Helper()
+
+	req := new(dns.Msg)
+	req.SetQuestion("truncate.example.com.", dns.TypeA)
+	if udpSize > 0 {
+		req.SetEdns0(udpSize, false)
+	}
+
+	w := mock.NewWriter("udp", "192.0.2.7:40000")
+	ch := middleware.NewChain([]middleware.Handler{e, b})
+	ch.Reset(w, req)
+	ch.Next(context.Background())
+
+	if !w.Written() {
+		t.Fatal("no response written")
+	}
+	return w.Msg()
+}
+
+// TestTruncatedResponseIsMinimal pins RFC 6891 §7: the truncated response
+// is the header, the question, and the OPT record — nothing else.
+func TestTruncatedResponseIsMinimal(t *testing.T) {
+	e := truncateHarness(t)
+
+	m := serveBulk(t, e, 512, &bulkResponder{answer: 60})
+	if !m.Truncated {
+		t.Fatal("an overflowing answer must truncate")
+	}
+	if len(m.Answer) != 0 || len(m.Ns) != 0 {
+		t.Fatalf("truncated response carries answer/authority: %d/%d", len(m.Answer), len(m.Ns))
+	}
+	if len(m.Extra) != 1 || m.IsEdns0() == nil {
+		t.Fatalf("truncated response must carry exactly the OPT (RFC 6891 §7): extra=%v", m.Extra)
+	}
+
+	packed, err := m.Pack()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(packed) > 512 {
+		t.Fatalf("truncated response is %d bytes, larger than the advertised 512", len(packed))
+	}
+}
+
+// TestTruncationDropsAnOverflowingExtra pins the defect this change fixes:
+// when the additional section itself is what overflows, the truncated
+// message used to keep it — TC=1 on a message still larger than the
+// client's buffer.
+func TestTruncationDropsAnOverflowingExtra(t *testing.T) {
+	e := truncateHarness(t)
+
+	m := serveBulk(t, e, 512, &bulkResponder{answer: 2, extra: 60})
+	if !m.Truncated {
+		t.Fatal("an overflowing additional section must truncate")
+	}
+	if len(m.Extra) != 1 || m.IsEdns0() == nil {
+		t.Fatalf("extra must reduce to the OPT: %d records", len(m.Extra))
+	}
+
+	packed, err := m.Pack()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(packed) > 512 {
+		t.Fatalf("truncated response is %d bytes, larger than the advertised 512", len(packed))
+	}
+}
+
+// TestTruncationWithoutEDNSCarriesNoOPT pins the other direction of
+// RFC 6891 §6: a requestor without an OPT record must not receive one,
+// truncation included.
+func TestTruncationWithoutEDNSCarriesNoOPT(t *testing.T) {
+	e := truncateHarness(t)
+
+	m := serveBulk(t, e, 0, &bulkResponder{answer: 60})
+	if !m.Truncated {
+		t.Fatal("an overflowing answer must truncate for a plain client too")
+	}
+	if len(m.Answer) != 0 || len(m.Ns) != 0 || len(m.Extra) != 0 {
+		t.Fatalf("plain client's truncated response must be header+question only: %d/%d/%d",
+			len(m.Answer), len(m.Ns), len(m.Extra))
+	}
+
+	packed, err := m.Pack()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(packed) > 512 {
+		t.Fatalf("truncated response is %d bytes, larger than the 512 minimum", len(packed))
+	}
+}

--- a/middleware/edns/edns_truncate_test.go
+++ b/middleware/edns/edns_truncate_test.go
@@ -34,7 +34,7 @@ func (b *bulkResponder) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 				Class:  dns.ClassINET,
 				Ttl:    60,
 			},
-			A: net.IPv4(192, 0, 2, byte(i%250+1)),
+			A: net.IPv4(192, 0, 2, byte(i%250+1)), //nolint:gosec // G115 - bounded by the modulo
 		}
 	}
 	for i := 0; i < b.answer; i++ {


### PR DESCRIPTION
## Problem

The UDP overflow path cleared Answer and Ns but left **Extra** in place. When the additional section was the very thing that overflowed, the response went out with TC=1 while **still larger than the buffer the client advertised** — the exact condition truncation exists to prevent. Found in the #559 full-PR review, parked then as pre-existing (byte-identical to v1.7.4), scheduled for rc3.

## Fix

A truncated response is a retry signal, not a partial answer (RFC 2181 §9). The overflow branch now reduces the message to exactly what RFC 6891 §7 mandates, verified against the RFC text:

> "The minimal response MUST be the DNS header, question section, and an OPT record. **This MUST also occur when a truncated response (using the DNS header's TC bit) is returned.**"

- EDNS client → header + question + OPT (the OPT survives via `keepOPTOnly`, a fresh one-element slice — no in-place mutation of sections upstream layers may reference).
- Plain client → header + question only, per §6's "the responder MUST NOT include an OPT record in its response".

## Tests

Three shapes pinned, each also asserting the **packed size fits the advertised buffer**:
- Answer-driven overflow → minimal response with OPT.
- **Extra-driven overflow** — the reproducing case: fails on main (TC=1 while still over the 512-byte advertisement), passes with the fix. Red/green verified by stashing the fix against the new tests.
- Overflow for a plain (no-EDNS) client → header + question only.

Full suite green; `golangci-lint` clean on darwin/linux/freebsd.