### PR TITLE
server: uncontend the slabs, serve wire hits inline, unchain the TCP session

### DIFF
--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -406,6 +406,16 @@ func (c *Cache) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		return
 	}
 
+	// An inline serve runs on a transport reader that must not block.
+	// The wire ladder above was its whole budget: everything from here
+	// down materializes, may consult the Msg-path cache, and on a miss
+	// starts an upstream resolution — none of which a reader can wait
+	// out. Decline, unwritten; the transport replays on a worker.
+	if ch.InlineOnly() {
+		ch.MarkHandoff()
+		return
+	}
+
 	ctx, req := ch.Materialize(ctx)
 	if req == nil {
 		return

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -1160,7 +1160,10 @@ func entryMatchesWire(entry *CacheEntry, req *middleware.Request) bool {
 // and must not charge the same question twice. (A refresh replacing the
 // entry under the same key shares the limiter, so the memo survives it.)
 // Across the inline/replay boundary no local can carry the permit, which
-// is why every deterministic decline is checked before this charge.
+// is why both serve branches — the flat copy and the chase composition —
+// check every decline they can before this charge; what stays past it
+// are commit-time backstops, and an inline query dropped there pays a
+// second token on the replay, accepted as the rare case.
 func (c *Cache) chargeEntryLimiter(ch *middleware.Chain, entry *CacheEntry, spent **rate.Limiter) bool {
 	limiter := entry.GetRateLimiter()
 	if limiter == nil || *spent == limiter {
@@ -1220,11 +1223,9 @@ func (c *Cache) serveHitFromWire(
 		// An alias without its terminal: the one exact-entry shape whose
 		// reply is composed rather than copied. Fully cache-contained
 		// chains serve here; anything else declines to the Msg path,
-		// which runs the complete chase machinery.
-		if !c.chargeEntryLimiter(ch, entry, spent) {
-			return true
-		}
-		return c.serveChaseHit(ctx, ch, entry, capability, leaser)
+		// which runs the complete chase machinery. The limiter charge
+		// lives inside, past the chase's own decline gates.
+		return c.serveChaseHit(ctx, ch, entry, capability, leaser, spent)
 	}
 	if mismatch := entry.wireChainMismatch(capability); mismatch != nil {
 		mismatch.Inc()

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -263,6 +263,13 @@ func New(cfg *config.Config) *Cache {
 // (*Cache).Name name returns middleware name.
 func (c *Cache) Name() string { return name }
 
+// InlineBarrier declares that the cache honors Chain.InlineOnly: an
+// inline pass gets the wire ladder and nothing below it — everything
+// past the ladder can materialize, wait, or resolve, and a transport
+// reader can afford none of those. Its presence is what lets the server
+// turn the reader fast path on at all.
+func (c *Cache) InlineBarrier() bool { return true }
+
 // buildCacheECSPolicy parses [ecs] config the same way
 // middleware/edns does, so the cache and the forwarder agree on
 // who is in the allow-list, what the source-prefix ceiling is, and
@@ -401,8 +408,13 @@ func (c *Cache) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	// entry, because a refresh replacing the entry under the same key
 	// shares that same limiter — charging the replacement would drop a
 	// question that had already paid.
+	// The replay pass skips the ladder outright: the inline pass ran it
+	// microseconds ago and declined, the Msg body below carries the full
+	// capability set the decline fell back for, and a second ladder walk
+	// would double the decline diagnostics and the per-entry limiter
+	// charge for the same client question.
 	var spent *rate.Limiter
-	if ch.Request.Undecoded() && c.serveWire(ctx, ch, &spent) {
+	if ch.Request.Undecoded() && !ch.Replay() && c.serveWire(ctx, ch, &spent) {
 		return
 	}
 
@@ -1135,6 +1147,34 @@ func entryMatchesWire(entry *CacheEntry, req *middleware.Request) bool {
 	return entryMatchesWireQuestion(entry, req.WireName(), req.Qtype(), req.Qclass(), req.CD())
 }
 
+// chargeEntryLimiter pays the per-entry rate-limit token immediately
+// before a wire serve commits to answering. A false return means the
+// token was refused: the query is cancelled and counted as a hit — the
+// Msg path counts a rate-limited hit as a hit, and the byte path must
+// answer the same question the same way.
+//
+// The permit is remembered in spent, keyed by the limiter it was spent
+// on: the declines that remain past this point — a lease the writer
+// cannot grant, a body that fails to build, a transport fallback — fall
+// to the Msg body of the same call, which checks the same limiter again
+// and must not charge the same question twice. (A refresh replacing the
+// entry under the same key shares the limiter, so the memo survives it.)
+// Across the inline/replay boundary no local can carry the permit, which
+// is why every deterministic decline is checked before this charge.
+func (c *Cache) chargeEntryLimiter(ch *middleware.Chain, entry *CacheEntry, spent **rate.Limiter) bool {
+	limiter := entry.GetRateLimiter()
+	if limiter == nil || *spent == limiter {
+		return true
+	}
+	if !limiter.Allow() {
+		c.metrics.Hit()
+		ch.Cancel()
+		return false
+	}
+	*spent = limiter
+	return true
+}
+
 // serveHitFromWire serves one verified exact hit as bytes built in the
 // writer's lease. Anything the byte path cannot express declines to the
 // ordinary body rather than half-serving.
@@ -1145,29 +1185,13 @@ func (c *Cache) serveHitFromWire(
 	if w.Internal() {
 		return false
 	}
-	if limiter := entry.GetRateLimiter(); limiter != nil {
-		if !limiter.Allow() {
-			// The Msg path counts a rate-limited hit as a hit (the
-			// caller records it on every true return); the byte path
-			// answers the same question the same way, so the metric
-			// must not depend on which path the query took.
-			c.metrics.Hit()
-			ch.Cancel()
-			return true
-		}
-		// Spent, and remembered. Everything below this line can still
-		// decline to the Msg body — a prefetch-due entry, a writer
-		// without the lease, a body the capability cannot express — and
-		// that body checks the same limiter again. One question would
-		// then cost two tokens, and at a small limit the second check
-		// cancels a hit the client was entitled to. The permit rides a
-		// local through the one call that owns both paths, keyed by the
-		// limiter it was spent on: a refresh that replaces the entry
-		// under the same key shares this limiter and must not be charged
-		// again for the same question, while an entry answering to a
-		// different limiter still pays.
-		*spent = limiter
-	}
+	// The deterministic declines run before the limiter spends anything:
+	// a prefetch-due entry, an ineligible body, a writer without the
+	// lease all fall to the Msg path (or, inline, to the replay), and a
+	// token paid here would be paid again there — the exact double
+	// charge the spent memo below exists to prevent within one pass, and
+	// which no local can prevent across the inline/replay boundary.
+	//
 	// A prefetch-due hit needs a decoded request copy for the refresh
 	// queue; the ordinary body claims it.
 	if c.prefetchQueue != nil && entry.PrefetchEligible() && entry.ShouldPrefetch(c.config.Prefetch) {
@@ -1197,6 +1221,9 @@ func (c *Cache) serveHitFromWire(
 		// reply is composed rather than copied. Fully cache-contained
 		// chains serve here; anything else declines to the Msg path,
 		// which runs the complete chase machinery.
+		if !c.chargeEntryLimiter(ch, entry, spent) {
+			return true
+		}
 		return c.serveChaseHit(ctx, ch, entry, capability, leaser)
 	}
 	if mismatch := entry.wireChainMismatch(capability); mismatch != nil {
@@ -1207,6 +1234,9 @@ func (c *Cache) serveHitFromWire(
 	if stored == nil {
 		wireSkipDNSSEC.Inc()
 		return false
+	}
+	if !c.chargeEntryLimiter(ch, entry, spent) {
+		return true
 	}
 	dst := leaser.BeginWire(len(stored), capability.Reserve+entry.wireEDEReserve())
 	if dst == nil {

--- a/middleware/cache/entry_wire_chase.go
+++ b/middleware/cache/entry_wire_chase.go
@@ -10,6 +10,7 @@ import (
 	internalcache "github.com/semihalev/sdns/internal/cache"
 	"github.com/semihalev/sdns/internal/wire"
 	"github.com/semihalev/sdns/middleware"
+	"golang.org/x/time/rate"
 )
 
 // The cache-contained CNAME chase on the wire: an alias entry whose answer
@@ -51,13 +52,19 @@ type wireChaseSegment struct {
 }
 
 // serveChaseHit answers a chase-unsafe exact hit from cache-contained
-// state. A false return took nothing and wrote nothing.
+// state. A false return took nothing and wrote nothing — including the
+// per-entry rate-limit token: a chase declines routinely (an uncached or
+// expired hop, a non-recomposable rrtype, an oversized composition), and
+// every decline before the commit must leave the limiter untouched, or
+// the Msg path — or the replay after an inline handoff — would charge
+// the same question a second time.
 func (c *Cache) serveChaseHit(
 	ctx context.Context,
 	ch *middleware.Chain,
 	alias *CacheEntry,
 	capability middleware.WireCapability,
 	leaser middleware.WireBodyLeaser,
+	spent **rate.Limiter,
 ) bool {
 	var segs [maxWireChaseHops]wireChaseSegment
 	n, ok := c.collectWireChase(ch.Request, alias, capability.DO, segs[:])
@@ -87,6 +94,14 @@ func (c *Cache) serveChaseHit(
 		leaser.AbortWire()
 		wireSkipSize.Inc()
 		return false
+	}
+
+	// The last gate before the commit: a refusal here drops the query
+	// with Msg-path parity (counted as a hit, cancelled), and a granted
+	// token is spent on a serve that no longer declines.
+	if !c.chargeEntryLimiter(ch, alias, spent) {
+		leaser.AbortWire()
+		return true
 	}
 
 	switch err := leaser.CommitWire(body, info); {

--- a/middleware/cache/inline_charge_test.go
+++ b/middleware/cache/inline_charge_test.go
@@ -1,0 +1,52 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/middleware"
+	"golang.org/x/time/rate"
+)
+
+// A wire-ladder decline must not spend the per-entry rate-limit token:
+// the query falls to the Msg body — or, on an inline pass, to the replay
+// on a worker — and that path checks the same limiter. A token paid by a
+// serve that then declined billed one client question twice, and at
+// burst 1 the second check cancelled a hit the client had already paid
+// for. The charge therefore runs after every deterministic decline gate.
+func TestWireDeclineDoesNotChargeEntryLimiter(t *testing.T) {
+	c := New(&config.Config{Expire: 600, CacheSize: 1024, RateLimit: 1})
+
+	resp := new(dns.Msg)
+	resp.SetQuestion("charge.zone.test.", dns.TypeA)
+	resp.Response = true
+	resp.Answer = []dns.RR{&dns.A{
+		Hdr: dns.RR_Header{Name: "charge.zone.test.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+		A:   []byte{192, 0, 2, 8},
+	}}
+	entry := NewCacheEntryWithKey(resp, time.Minute, 1, 42)
+	if entry.GetRateLimiter() == nil {
+		t.Fatal("test needs a rate-limited entry")
+	}
+
+	req, _ := wireTestRequest(t, "charge.zone.test.", dns.TypeA, false)
+	ch := middleware.NewChain(nil)
+	// A mock writer has no wire capability, so the ladder must decline
+	// this serve to the Msg path — before the limiter spends anything.
+	ch.ResetWire(mock.NewWriter("udp", "203.0.113.50:4242"), req)
+
+	var spent *rate.Limiter
+	if c.serveHitFromWire(context.Background(), ch, entry, &spent) {
+		t.Fatal("expected the incapable writer to decline to the Msg path")
+	}
+	if spent != nil {
+		t.Fatal("declined wire serve recorded a spent limiter")
+	}
+	if !entry.GetRateLimiter().Allow() {
+		t.Fatal("declined wire serve consumed the entry's only token")
+	}
+}

--- a/middleware/cache/inline_charge_test.go
+++ b/middleware/cache/inline_charge_test.go
@@ -50,3 +50,63 @@ func TestWireDeclineDoesNotChargeEntryLimiter(t *testing.T) {
 		t.Fatal("declined wire serve consumed the entry's only token")
 	}
 }
+
+// leaseTransport is a mock transport with the wire body lease, so the
+// ladder reaches the branches behind the writer-capability gates.
+type leaseTransport struct {
+	*mock.Writer
+	buf [4096]byte
+}
+
+func (l *leaseTransport) LeaseWire(capacity int) []byte {
+	if capacity > len(l.buf) {
+		return nil
+	}
+	return l.buf[:0]
+}
+
+// The chase branch declines routinely — an uncached hop is the everyday
+// case — and none of its declines may spend the per-entry token: the
+// query falls to the Msg path (or the replay after an inline handoff),
+// which checks the same limiter, and a pre-spent token there drops a
+// paid-for hit at burst 1.
+func TestChaseDeclineDoesNotChargeEntryLimiter(t *testing.T) {
+	c := New(&config.Config{Expire: 600, CacheSize: 1024, RateLimit: 1})
+
+	// A bare alias: the CNAME without its terminal. Chase-unsafe by
+	// shape, and the target is not cached, so collectWireChase declines.
+	resp := new(dns.Msg)
+	resp.SetQuestion("alias.zone.test.", dns.TypeA)
+	resp.Response = true
+	resp.Answer = []dns.RR{&dns.CNAME{
+		Hdr:    dns.RR_Header{Name: "alias.zone.test.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+		Target: "target.zone.test.",
+	}}
+	entry := NewCacheEntryWithKey(resp, time.Minute, 1, 43)
+	if entry.wireServe&wireEligible == 0 {
+		t.Fatal("fixture must be wire-eligible")
+	}
+	if entry.wireServe&wireChaseSafe != 0 {
+		t.Fatal("fixture must be chase-unsafe")
+	}
+	if entry.GetRateLimiter() == nil {
+		t.Fatal("test needs a rate-limited entry")
+	}
+
+	req, _ := wireTestRequest(t, "alias.zone.test.", dns.TypeA, false)
+	ch := middleware.NewChain(nil)
+	tr := &leaseTransport{Writer: mock.NewWriter("udp", "203.0.113.51:4242")}
+	ch.ResetWire(tr, req)
+	ch.AllowDirectPack()
+
+	var spent *rate.Limiter
+	if c.serveHitFromWire(context.Background(), ch, entry, &spent) {
+		t.Fatal("expected the uncachable chase to decline to the Msg path")
+	}
+	if spent != nil {
+		t.Fatal("declined chase recorded a spent limiter")
+	}
+	if !entry.GetRateLimiter().Allow() {
+		t.Fatal("declined chase consumed the entry's only token")
+	}
+}

--- a/middleware/chain.go
+++ b/middleware/chain.go
@@ -782,6 +782,12 @@ type Chain struct {
 	// lazy deadline. Established by Materialize, run exactly once after the
 	// serve completes (PutChain, or the next rebind as a backstop).
 	detachCleanup func()
+
+	// inlineOnly marks a serve running on a transport reader that must
+	// not block; handoff records that a handler declined blocking work.
+	// Both reset with the chain.
+	inlineOnly bool
+	handoff    bool
 }
 
 // NewChain returns a Chain bound to the given handler pipeline. The slice
@@ -995,6 +1001,8 @@ func (ch *Chain) Reset(w Transport, r *dns.Msg) {
 	ch.Meta.Reset()
 	ch.pos = 0
 	ch.count = len(ch.handlers)
+	ch.inlineOnly = false
+	ch.handoff = false
 }
 
 // rebindWriter points the chain's pooled base writer at the next
@@ -1022,7 +1030,25 @@ func (ch *Chain) ResetWire(w Transport, r *Request) {
 	ch.Meta.Reset()
 	ch.pos = 0
 	ch.count = len(ch.handlers)
+	ch.inlineOnly = false
+	ch.handoff = false
 }
+
+// SetInlineOnly declares that this serve runs on a transport reader that
+// must not block: a handler that would start an upstream resolution marks
+// the chain for handoff instead and returns unwritten. The transport then
+// replays the query on a worker.
+func (ch *Chain) SetInlineOnly() { ch.inlineOnly = true }
+
+// InlineOnly reports whether the current serve refuses to block.
+func (ch *Chain) InlineOnly() bool { return ch.inlineOnly }
+
+// MarkHandoff records that the serve stopped short of blocking work and
+// the query needs a full pass on a worker.
+func (ch *Chain) MarkHandoff() { ch.handoff = true }
+
+// Handoff reports whether a handler declined blocking work this serve.
+func (ch *Chain) Handoff() bool { return ch.handoff }
 
 // AllowDirectPack declares that the transport beneath this chain's writer is
 // an SDNS-owned UDP, TCP or DoT sink whose Write sends raw wire bytes

--- a/middleware/chain.go
+++ b/middleware/chain.go
@@ -784,10 +784,14 @@ type Chain struct {
 	detachCleanup func()
 
 	// inlineOnly marks a serve running on a transport reader that must
-	// not block; handoff records that a handler declined blocking work.
-	// Both reset with the chain.
+	// not block; handoff records that a handler declined blocking work;
+	// replay marks the worker pass that finishes a handed-off query, so
+	// a handler whose entry effect already fired on the inline pass can
+	// skip it while still installing its response-side observers. All
+	// three reset with the chain.
 	inlineOnly bool
 	handoff    bool
+	replay     bool
 }
 
 // NewChain returns a Chain bound to the given handler pipeline. The slice
@@ -1003,6 +1007,7 @@ func (ch *Chain) Reset(w Transport, r *dns.Msg) {
 	ch.count = len(ch.handlers)
 	ch.inlineOnly = false
 	ch.handoff = false
+	ch.replay = false
 }
 
 // rebindWriter points the chain's pooled base writer at the next
@@ -1032,6 +1037,7 @@ func (ch *Chain) ResetWire(w Transport, r *Request) {
 	ch.count = len(ch.handlers)
 	ch.inlineOnly = false
 	ch.handoff = false
+	ch.replay = false
 }
 
 // SetInlineOnly declares that this serve runs on a transport reader that
@@ -1049,6 +1055,19 @@ func (ch *Chain) MarkHandoff() { ch.handoff = true }
 
 // Handoff reports whether a handler declined blocking work this serve.
 func (ch *Chain) Handoff() bool { return ch.handoff }
+
+// SetReplay declares that this serve finishes a query an inline pass
+// handed off: the full pipeline ran once on the transport reader up to
+// the handoff point, so every entry effect — a limiter token, a scored
+// query, a tap's query frame, a per-query statistic — has already
+// happened. A handler with such an effect checks Replay and skips it;
+// its response-side observers (writer wrappers) install as always,
+// because this pass is the one that writes.
+func (ch *Chain) SetReplay() { ch.replay = true }
+
+// Replay reports whether this serve is the worker pass after an inline
+// handoff.
+func (ch *Chain) Replay() bool { return ch.replay }
 
 // AllowDirectPack declares that the transport beneath this chain's writer is
 // an SDNS-owned UDP, TCP or DoT sink whose Write sends raw wire bytes

--- a/middleware/chaos/chaos.go
+++ b/middleware/chaos/chaos.go
@@ -85,10 +85,13 @@ func (c *Chaos) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		return
 	}
 
-	// Increment query counter
-	c.mu.Lock()
-	c.queryCount++
-	c.mu.Unlock()
+	// Increment query counter — once per query: the replay pass after an
+	// inline handoff walks this handler again for the same question.
+	if !ch.Replay() {
+		c.mu.Lock()
+		c.queryCount++
+		c.mu.Unlock()
+	}
 
 	var answer *dns.TXT
 

--- a/middleware/dns64/dns64.go
+++ b/middleware/dns64/dns64.go
@@ -154,8 +154,13 @@ func (d *DNS64) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		ch.Next(ctx)
 		return
 	}
+	// The passthrough diagnostics count once per query: the replay pass
+	// after an inline handoff walks this handler again.
+	firstPass := !ch.Replay()
 	if w.Internal() {
-		passthroughInternal.Inc()
+		if firstPass {
+			passthroughInternal.Inc()
+		}
 		ch.Next(ctx)
 		return
 	}
@@ -168,7 +173,9 @@ func (d *DNS64) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		// DNS64 would interpret that SERVFAIL as "no AAAA",
 		// firing a recursive A query that bypasses the
 		// non-recursion intent.
-		passthroughNoRD.Inc()
+		if firstPass {
+			passthroughNoRD.Inc()
+		}
 		ch.Next(ctx)
 		return
 	}
@@ -177,12 +184,16 @@ func (d *DNS64) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		// itself; do not synthesise. Symmetric for PTR: the
 		// CNAME we'd synthesise points at an unsigned name we
 		// fabricated, so respect the bit.
-		passthroughCDBit.Inc()
+		if firstPass {
+			passthroughCDBit.Inc()
+		}
 		ch.Next(ctx)
 		return
 	}
 	if !d.cfg.clientEligible(w.RemoteIP()) {
-		passthroughClientExcluded.Inc()
+		if firstPass {
+			passthroughClientExcluded.Inc()
+		}
 		ch.Next(ctx)
 		return
 	}

--- a/middleware/dnstap/dnstap.go
+++ b/middleware/dnstap/dnstap.go
@@ -100,32 +100,45 @@ func (d *Dnstap) Name() string {
 // dnstap streams reflect real client queries only.
 func (d *Dnstap) ClientOnly() bool { return true }
 
-// (*Dnstap).OncePerQuery: the query frame is emitted at entry, so the
-// serve replay after an inline handoff must not tap the query twice.
-func (d *Dnstap) OncePerQuery() bool { return true }
-
 // (*Dnstap).ServeDNS serveDNS logs DNS messages in dnstap format.
 // Disconnected dnstap is a read-lock check and a wire-born request passes
-// undecoded; a connected tap packs the request and materializes (enabling
-// it is documented as disabling the zero guarantee).
+// undecoded. A connected tap stays on the byte path too: a dnstap frame
+// carries wire bytes, and a wire-born request already is wire bytes — an
+// owned copy taps it without decoding, so the cache's wire ladder (and
+// the inline fast path behind it) keeps working with the tap on. Only a
+// request that arrived decoded (DoH, internal entries) packs.
 func (d *Dnstap) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	if !d.isEnabled() {
 		ch.Next(ctx)
 		return
 	}
 
-	ctx, req := ch.Materialize(ctx)
-	if req == nil {
-		return
-	}
 	w := ch.Writer
 
 	// Capture query time
 	queryTime := time.Now()
 
-	// Log query if enabled
-	if d.logQueries {
-		d.logMessage(w, req, nil, queryTime, true)
+	// The copy is the ownership rule, not an optimization: the raw view
+	// is transport job storage, rewritten by the next packet, while the
+	// frame travels to a queue another goroutine drains later.
+	var query *dns.Msg
+	var queryWire []byte
+	if ch.Request.Undecoded() && ch.Request.Raw() != nil {
+		queryWire = append([]byte(nil), ch.Request.Raw()...)
+	} else {
+		var req *dns.Msg
+		ctx, req = ch.Materialize(ctx)
+		if req == nil {
+			return
+		}
+		query = req
+	}
+
+	// The replay pass finishes a query the inline pass already tapped; a
+	// second query frame would double it. The response wrapper below
+	// still installs, because this pass is the one that writes.
+	if d.logQueries && !ch.Replay() {
+		d.logMessage(w, query, queryWire, nil, queryTime, true)
 	}
 
 	// Create response writer wrapper to capture response.
@@ -137,7 +150,8 @@ func (d *Dnstap) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		orig := ch.Writer
 		ch.Writer = &responseWriter{
 			ResponseWriter: w,
-			query:          req,
+			query:          query,
+			queryWire:      queryWire,
 			queryTime:      queryTime,
 			dnstap:         d,
 		}
@@ -306,20 +320,31 @@ func (d *Dnstap) encodeMessage(msg *DnstapMessage) []byte {
 	return buf
 }
 
-func (d *Dnstap) logMessage(w middleware.ResponseWriter, query, response *dns.Msg, timestamp time.Time, isQuery bool) {
+func (d *Dnstap) logMessage(w middleware.ResponseWriter, query *dns.Msg, queryWire []byte, response *dns.Msg, timestamp time.Time, isQuery bool) {
 	msg := d.newTapMessage(w, timestamp, isQuery)
 
-	// Set message data
-	if query != nil {
-		data, _ := query.Pack()
-		msg.QueryMessage = data
-	}
+	fillQuery(msg, query, queryWire)
 	if response != nil {
 		data, _ := response.Pack()
 		msg.ResponseMsg = data
 	}
 
 	d.enqueue(msg)
+}
+
+// fillQuery sets the frame's query bytes from whichever form the request
+// had: an owned wire copy verbatim, or a pack of the decoded message. The
+// wire copy is shared between the query frame and the response wrapper —
+// both only read it, and the frame encoder copies on write.
+func fillQuery(msg *DnstapMessage, query *dns.Msg, queryWire []byte) {
+	if queryWire != nil {
+		msg.QueryMessage = queryWire
+		return
+	}
+	if query != nil {
+		data, _ := query.Pack()
+		msg.QueryMessage = data
+	}
 }
 
 // prepareWireTap is logMessage's assembly for a response that already exists
@@ -334,15 +359,13 @@ func (d *Dnstap) logMessage(w middleware.ResponseWriter, query, response *dns.Ms
 func (d *Dnstap) prepareWireTap(
 	w middleware.ResponseWriter,
 	query *dns.Msg,
+	queryWire []byte,
 	body []byte,
 	timestamp time.Time,
 ) *DnstapMessage {
 	msg := d.newTapMessage(w, timestamp, false)
 
-	if query != nil {
-		data, _ := query.Pack()
-		msg.QueryMessage = data
-	}
+	fillQuery(msg, query, queryWire)
 	msg.ResponseMsg = append([]byte(nil), body...)
 	return msg
 }
@@ -397,6 +420,7 @@ func (d *Dnstap) Close() error {
 type responseWriter struct {
 	middleware.ResponseWriter
 	query     *dns.Msg
+	queryWire []byte
 	queryTime time.Time
 	dnstap    *Dnstap
 }
@@ -409,7 +433,7 @@ func (w *responseWriter) Size() int {
 }
 
 func (rw *responseWriter) WriteMsg(res *dns.Msg) error {
-	rw.dnstap.logMessage(rw.ResponseWriter, rw.query, res, time.Now(), false)
+	rw.dnstap.logMessage(rw.ResponseWriter, rw.query, rw.queryWire, res, time.Now(), false)
 	return rw.ResponseWriter.WriteMsg(res)
 }
 
@@ -455,7 +479,7 @@ func (rw *responseWriter) WriteWire(body []byte, info middleware.WireInfo) error
 	if !ok {
 		return middleware.ErrWireFallback
 	}
-	tap := rw.dnstap.prepareWireTap(rw.ResponseWriter, rw.query, body, time.Now())
+	tap := rw.dnstap.prepareWireTap(rw.ResponseWriter, rw.query, rw.queryWire, body, time.Now())
 	err := next.WriteWire(body, info)
 	if !errors.Is(err, middleware.ErrWireFallback) {
 		rw.dnstap.enqueue(tap)

--- a/middleware/dnstap/dnstap.go
+++ b/middleware/dnstap/dnstap.go
@@ -100,6 +100,10 @@ func (d *Dnstap) Name() string {
 // dnstap streams reflect real client queries only.
 func (d *Dnstap) ClientOnly() bool { return true }
 
+// (*Dnstap).OncePerQuery: the query frame is emitted at entry, so the
+// serve replay after an inline handoff must not tap the query twice.
+func (d *Dnstap) OncePerQuery() bool { return true }
+
 // (*Dnstap).ServeDNS serveDNS logs DNS messages in dnstap format.
 // Disconnected dnstap is a read-lock check and a wire-born request passes
 // undecoded; a connected tap packs the request and materializes (enabling

--- a/middleware/dnstap/dnstap_test.go
+++ b/middleware/dnstap/dnstap_test.go
@@ -321,7 +321,7 @@ func TestLogMessage(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			w := mock.NewWriter(tt.proto, tt.addr)
 
-			d.logMessage(w, tt.query, tt.response, time.Now(), tt.isQuery)
+			d.logMessage(w, tt.query, nil, tt.response, time.Now(), tt.isQuery)
 
 			select {
 			case msg := <-d.messageQueue:
@@ -358,7 +358,7 @@ func TestLogMessage_QueueFull(t *testing.T) {
 	w := mock.NewWriter("udp", "127.0.0.1:53")
 
 	// This should not block
-	d.logMessage(w, req, nil, time.Now(), true)
+	d.logMessage(w, req, nil, nil, time.Now(), true)
 
 	// Verify queue still has only 1 message
 	if len(d.messageQueue) != 1 {

--- a/middleware/dnstap/replay_test.go
+++ b/middleware/dnstap/replay_test.go
@@ -1,0 +1,130 @@
+package dnstap
+
+import (
+	"bytes"
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/middleware"
+)
+
+func newTapForFrames(t *testing.T) *Dnstap {
+	t.Helper()
+	d := &Dnstap{
+		identity:     []byte("test"),
+		version:      []byte("test"),
+		logQueries:   true,
+		logResponses: true,
+		messageQueue: make(chan *DnstapMessage, 16),
+	}
+	r, w := net.Pipe()
+	t.Cleanup(func() { _ = r.Close(); _ = w.Close() })
+	d.mu.Lock()
+	d.conn = w
+	d.mu.Unlock()
+	return d
+}
+
+func wireBornChain(t *testing.T, next middleware.Handler) (*middleware.Chain, []byte) {
+	t.Helper()
+	q := new(dns.Msg)
+	q.SetQuestion("tap.example.", dns.TypeA)
+	q.SetEdns0(1232, false)
+	raw, err := q.Pack()
+	if err != nil {
+		t.Fatalf("pack: %v", err)
+	}
+	req := new(middleware.Request)
+	if !req.ParseWire(raw, time.Now(), nil) {
+		t.Fatal("eligible query refused")
+	}
+	ch := middleware.NewChain([]middleware.Handler{next})
+	ch.ResetWire(mock.NewWriter("udp", "203.0.113.70:5353"), req)
+	return ch, raw
+}
+
+func drainFrames(d *Dnstap) []*DnstapMessage {
+	var out []*DnstapMessage
+	for {
+		select {
+		case m := <-d.messageQueue:
+			out = append(out, m)
+		default:
+			return out
+		}
+	}
+}
+
+// A connected tap must stay on the byte path: the query frame comes from
+// an owned copy of the wire bytes, the request stays undecoded for the
+// handlers below (the cache's wire ladder among them), and the response
+// frame comes from the writer wrapper.
+func TestDnstapWireBornStaysUndecoded(t *testing.T) {
+	d := newTapForFrames(t)
+
+	undecodedBelow := false
+	next := middleware.HandlerFunc(func(ctx context.Context, ch *middleware.Chain) {
+		undecodedBelow = ch.Request.Undecoded()
+		ctx, req := ch.Materialize(ctx)
+		if req == nil {
+			return
+		}
+		_ = ctx
+		resp := new(dns.Msg)
+		resp.SetReply(req)
+		_ = ch.Writer.WriteMsg(resp)
+		ch.Cancel()
+	})
+
+	ch, raw := wireBornChain(t, next)
+	d.ServeDNS(context.Background(), ch)
+
+	if !undecodedBelow {
+		t.Fatal("connected tap materialized a wire-born request")
+	}
+	frames := drainFrames(d)
+	if len(frames) != 2 {
+		t.Fatalf("got %d frames, want query + response", len(frames))
+	}
+	if frames[0].Type != MessageTypeQuery || !bytes.Equal(frames[0].QueryMessage, raw) {
+		t.Fatal("query frame does not carry the verbatim wire bytes")
+	}
+	if frames[1].Type != MessageTypeResponse || len(frames[1].ResponseMsg) == 0 {
+		t.Fatal("response frame missing or empty")
+	}
+}
+
+// The replay pass finishes a query the inline pass already tapped: no
+// second query frame — but the response wrapper still installs, because
+// the replay is the pass that writes.
+func TestDnstapReplayEmitsOnlyResponseFrame(t *testing.T) {
+	d := newTapForFrames(t)
+
+	next := middleware.HandlerFunc(func(ctx context.Context, ch *middleware.Chain) {
+		ctx, req := ch.Materialize(ctx)
+		if req == nil {
+			return
+		}
+		_ = ctx
+		resp := new(dns.Msg)
+		resp.SetReply(req)
+		_ = ch.Writer.WriteMsg(resp)
+		ch.Cancel()
+	})
+
+	ch, _ := wireBornChain(t, next)
+	ch.SetReplay()
+	d.ServeDNS(context.Background(), ch)
+
+	frames := drainFrames(d)
+	if len(frames) != 1 {
+		t.Fatalf("got %d frames on the replay pass, want the response alone", len(frames))
+	}
+	if frames[0].Type != MessageTypeResponse {
+		t.Fatalf("replay pass emitted a %v frame, want response", frames[0].Type)
+	}
+}

--- a/middleware/hostsfile/hostsfile.go
+++ b/middleware/hostsfile/hostsfile.go
@@ -146,9 +146,12 @@ func (h *Hostsfile) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	q := req.Question[0]
 	db := h.getDB()
 
-	// Increment lookup counter
-	atomic.AddUint64(&db.stats.lookups, 1)
-	hostsfileLookups.Inc()
+	// Increment lookup counter — once per query: the replay pass after an
+	// inline handoff walks this handler again for the same question.
+	if !ch.Replay() {
+		atomic.AddUint64(&db.stats.lookups, 1)
+		hostsfileLookups.Inc()
+	}
 
 	answer, found := h.lookup(db, q.Name, q.Qtype)
 
@@ -211,8 +214,10 @@ func (h *Hostsfile) serveWire(ctx context.Context, ch *middleware.Chain) {
 		}
 		qname = string(pres)
 
-		atomic.AddUint64(&db.stats.lookups, 1)
-		hostsfileLookups.Inc()
+		if !ch.Replay() {
+			atomic.AddUint64(&db.stats.lookups, 1)
+			hostsfileLookups.Inc()
+		}
 
 		answer, found = h.lookupPTR(db, qname)
 	} else {
@@ -222,8 +227,10 @@ func (h *Hostsfile) serveWire(ctx context.Context, ch *middleware.Chain) {
 			return
 		}
 
-		atomic.AddUint64(&db.stats.lookups, 1)
-		hostsfileLookups.Inc()
+		if !ch.Replay() {
+			atomic.AddUint64(&db.stats.lookups, 1)
+			hostsfileLookups.Inc()
+		}
 
 		answer, found = lookupKeyed(h, db, key, req.Qtype())
 	}

--- a/middleware/kubernetes/kubernetes.go
+++ b/middleware/kubernetes/kubernetes.go
@@ -124,8 +124,12 @@ func (k *Kubernetes) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	}
 	w := ch.Writer
 
-	atomic.AddUint64(&k.queries, 1)
-	kubernetesQueries.Inc()
+	// Once per query: the replay pass after an inline handoff walks this
+	// handler again for the same question.
+	if !ch.Replay() {
+		atomic.AddUint64(&k.queries, 1)
+		kubernetesQueries.Inc()
+	}
 
 	if len(req.Question) == 0 {
 		ch.Next(ctx)

--- a/middleware/ratelimit/ratelimit.go
+++ b/middleware/ratelimit/ratelimit.go
@@ -68,6 +68,10 @@ func (r *RateLimit) Name() string { return name }
 // limiter bucket attributed to its outer client.
 func (r *RateLimit) ClientOnly() bool { return true }
 
+// (*RateLimit).OncePerQuery: a token is consumed at entry, so the serve
+// replay after an inline handoff must not run the limiter again.
+func (r *RateLimit) OncePerQuery() bool { return true }
+
 // (*RateLimit).ServeDNS serveDNS implements the Handle interface.
 func (r *RateLimit) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	w := ch.Writer

--- a/middleware/ratelimit/ratelimit.go
+++ b/middleware/ratelimit/ratelimit.go
@@ -68,12 +68,18 @@ func (r *RateLimit) Name() string { return name }
 // limiter bucket attributed to its outer client.
 func (r *RateLimit) ClientOnly() bool { return true }
 
-// (*RateLimit).OncePerQuery: a token is consumed at entry, so the serve
-// replay after an inline handoff must not run the limiter again.
-func (r *RateLimit) OncePerQuery() bool { return true }
-
 // (*RateLimit).ServeDNS serveDNS implements the Handle interface.
 func (r *RateLimit) ServeDNS(ctx context.Context, ch *middleware.Chain) {
+	// The replay pass finishes a query the inline pass admitted: its
+	// token was consumed and its cookie checked there, and a second
+	// charge would bill one question twice. The limiter is pure entry
+	// effect — nothing here observes the response — so the replay just
+	// passes through.
+	if ch.Replay() {
+		ch.Next(ctx)
+		return
+	}
+
 	w := ch.Writer
 
 	if w.Internal() {

--- a/middleware/ratelimit/replay_test.go
+++ b/middleware/ratelimit/replay_test.go
@@ -1,0 +1,47 @@
+package ratelimit
+
+import (
+	"context"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/middleware"
+)
+
+// The replay pass finishes a query whose token was already consumed on
+// the inline pass; running the limiter again would bill one question
+// twice. Ten replay passes must leave the bucket untouched — if any of
+// them consumed, the normal pass at the end would find it empty.
+func TestRateLimitReplayPassesThrough(t *testing.T) {
+	cfg := &config.Config{ClientRateLimit: 1, CookieSecret: "6c6f6f6b61686172646c6f6f6b6168617264"} //nolint:gosec // test fixture
+	r := New(cfg)
+
+	q := new(dns.Msg)
+	q.SetQuestion("replay.example.", dns.TypeA)
+
+	reached := 0
+	next := middleware.HandlerFunc(func(ctx context.Context, ch *middleware.Chain) {
+		reached++
+		ch.Cancel()
+	})
+
+	for range 10 {
+		ch := middleware.NewChain([]middleware.Handler{next})
+		ch.Reset(mock.NewWriter("udp", "203.0.113.61:5353"), q)
+		ch.SetReplay()
+		r.ServeDNS(context.Background(), ch)
+	}
+	if reached != 10 {
+		t.Fatalf("replay passes reached the next handler %d times, want 10", reached)
+	}
+
+	// The bucket is still full: a normal first pass gets through.
+	ch := middleware.NewChain([]middleware.Handler{next})
+	ch.Reset(mock.NewWriter("udp", "203.0.113.61:5353"), q)
+	r.ServeDNS(context.Background(), ch)
+	if reached != 11 {
+		t.Fatal("normal pass was limited: a replay pass consumed a token it must not touch")
+	}
+}

--- a/middleware/reflex/reflex.go
+++ b/middleware/reflex/reflex.go
@@ -100,10 +100,6 @@ func (r *Reflex) Name() string {
 // internal sub-queries don't trip detection heuristics.
 func (r *Reflex) ClientOnly() bool { return true }
 
-// (*Reflex).OncePerQuery: scoring happens at entry, so the serve replay
-// after an inline handoff must not score the query twice.
-func (r *Reflex) OncePerQuery() bool { return true }
-
 // ServeDNS processes queries for amplification attack detection. The
 // scoring facts — qtype and request wire length — come from the parsed
 // request, so a wire-born query is scored without decoding; only the
@@ -114,6 +110,20 @@ func (r *Reflex) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 
 	// Skip internal/loopback/TCP (can't spoof TCP)
 	if w.Internal() || w.RemoteIP() == nil || w.RemoteIP().IsLoopback() {
+		ch.Next(ctx)
+		return
+	}
+
+	// The replay pass finishes a query the inline pass already scored;
+	// recording it again would double its contribution and could tip a
+	// legitimate client over the threshold. What this pass owns is the
+	// response — the inline pass handed off unwritten — so only the
+	// response-size wrapper installs, and the tracker still learns the
+	// amplification the resolution actually achieved.
+	if ch.Replay() {
+		if qtype, reqLen, ok := requestFacts(ch.Request); ok && getAmpFactor(qtype) > 1.0 {
+			defer r.wrapAmpTracking(ch, w.RemoteIP().String(), reqLen)()
+		}
 		ch.Next(ctx)
 		return
 	}
@@ -153,21 +163,26 @@ func (r *Reflex) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 
 	// Only wrap response writer for high-amp queries to track amplification.
 	// Normal queries (ampFactor <= 1.0) skip wrapping for better performance.
-	// Chains come from a sync.Pool, so the wrapper must be removed before
-	// returning — otherwise a later request starts with a stale reflex
-	// wrapper that tracks responses against an unrelated source IP.
 	if ampFactor > 1.0 {
-		orig := ch.Writer
-		ch.Writer = &responseWriter{
-			ResponseWriter: w,
-			reqLen:         reqLen,
-			tracker:        r.tracker,
-			ip:             ip,
-		}
-		defer func() { ch.Writer = orig }()
+		defer r.wrapAmpTracking(ch, ip, reqLen)()
 	}
 
 	ch.Next(ctx)
+}
+
+// wrapAmpTracking installs the response-size wrapper and returns the
+// restore. Chains come from a sync.Pool, so the wrapper must be removed
+// before returning — otherwise a later request starts with a stale reflex
+// wrapper that tracks responses against an unrelated source IP.
+func (r *Reflex) wrapAmpTracking(ch *middleware.Chain, ip string, reqLen int) func() {
+	orig := ch.Writer
+	ch.Writer = &responseWriter{
+		ResponseWriter: orig,
+		reqLen:         reqLen,
+		tracker:        r.tracker,
+		ip:             ip,
+	}
+	return func() { ch.Writer = orig }
 }
 
 // requestFacts returns the question type and the request's wire length —

--- a/middleware/reflex/reflex.go
+++ b/middleware/reflex/reflex.go
@@ -100,6 +100,10 @@ func (r *Reflex) Name() string {
 // internal sub-queries don't trip detection heuristics.
 func (r *Reflex) ClientOnly() bool { return true }
 
+// (*Reflex).OncePerQuery: scoring happens at entry, so the serve replay
+// after an inline handoff must not score the query twice.
+func (r *Reflex) OncePerQuery() bool { return true }
+
 // ServeDNS processes queries for amplification attack detection. The
 // scoring facts — qtype and request wire length — come from the parsed
 // request, so a wire-born query is scored without decoding; only the

--- a/middleware/reflex/replay_test.go
+++ b/middleware/reflex/replay_test.go
@@ -1,0 +1,49 @@
+package reflex
+
+import (
+	"context"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/middleware"
+)
+
+// The replay pass finishes a query the inline pass already scored:
+// recording it again would double its contribution, but the response
+// wrapper must still install — the replay is the pass that writes, and
+// the tracker's amplification feedback comes from that wrapper.
+func TestReflexReplayWrapsWithoutScoring(t *testing.T) {
+	cfg := &config.Config{ReflexEnabled: true, ReflexThreshold: 0.99}
+	r := New(cfg)
+
+	q := new(dns.Msg)
+	q.SetQuestion("amp.example.", dns.TypeTXT)
+
+	wrapped := false
+	next := middleware.HandlerFunc(func(ctx context.Context, ch *middleware.Chain) {
+		_, wrapped = ch.Writer.(*responseWriter)
+		ch.Cancel()
+	})
+
+	ch := middleware.NewChain([]middleware.Handler{next})
+	ch.Reset(mock.NewWriter("udp", "203.0.113.62:5353"), q)
+	ch.SetReplay()
+	r.ServeDNS(context.Background(), ch)
+
+	if !wrapped {
+		t.Fatal("replay pass did not install the response-size wrapper for a high-amp qtype")
+	}
+
+	// The replay must not have recorded the query: after one manual
+	// record, the replayed IP's score equals a fresh IP's single-record
+	// score. A doubled entry would sit above it.
+	qtype, reqLen := dns.TypeTXT, 40
+	amp := getAmpFactor(qtype)
+	replayed := r.tracker.RecordQuery("203.0.113.62", qtype, amp, reqLen)
+	fresh := r.tracker.RecordQuery("203.0.113.63", qtype, amp, reqLen)
+	if replayed != fresh {
+		t.Fatalf("replay pass scored the query: replayed IP score %v, fresh IP score %v", replayed, fresh)
+	}
+}

--- a/middleware/wiring.go
+++ b/middleware/wiring.go
@@ -23,6 +23,19 @@ type ClientOnly interface {
 	ClientOnly() bool
 }
 
+// OncePerQuery marks a Handler whose ServeDNS entry has side effects that
+// must happen exactly once per client query — a rate-limit token, a
+// per-query score, an emitted tap frame. The server's inline fast path
+// runs the full chain on the transport reader and replays the query on a
+// worker when the cache cannot answer without blocking; handlers carrying
+// this marker are excluded from the replay so their entry effect is not
+// doubled. Handlers whose effects key off the response — metrics and
+// accesslog gate on Written() — need no marker: the inline pass leaves a
+// handed-off query unwritten, so they fire exactly once, on the replay.
+type OncePerQuery interface {
+	OncePerQuery() bool
+}
+
 // Store is the minimum cache facade a resolver sub-query needs.
 // Satisfied by cache.Store; declared here so middleware.Setup can
 // wire it from one handler into another without either importing

--- a/middleware/wiring.go
+++ b/middleware/wiring.go
@@ -23,17 +23,24 @@ type ClientOnly interface {
 	ClientOnly() bool
 }
 
-// OncePerQuery marks a Handler whose ServeDNS entry has side effects that
-// must happen exactly once per client query — a rate-limit token, a
-// per-query score, an emitted tap frame. The server's inline fast path
-// runs the full chain on the transport reader and replays the query on a
-// worker when the cache cannot answer without blocking; handlers carrying
-// this marker are excluded from the replay so their entry effect is not
-// doubled. Handlers whose effects key off the response — metrics and
-// accesslog gate on Written() — need no marker: the inline pass leaves a
-// handed-off query unwritten, so they fire exactly once, on the replay.
-type OncePerQuery interface {
-	OncePerQuery() bool
+// InlineBarrier marks the Handler that makes a pipeline safe to run on a
+// transport reader: it honors Chain.InlineOnly by declining blocking work
+// — an upstream resolution, a queue wait — with MarkHandoff instead of
+// running it. The cache is the barrier in the standard pipeline. The
+// server enables the inline fast path only when some handler declares
+// this; a pipeline without a barrier would carry a reader all the way
+// into the resolver, and a reader that blocks for a resolution stalls
+// every packet behind it on that socket.
+//
+// Handlers whose ServeDNS entry has side effects that must happen exactly
+// once per client query — a rate-limit token, a scored query, a tap's
+// query frame, a per-query statistic — check Chain.Replay and skip the
+// effect on the worker pass that finishes a handed-off query; their
+// response-side writer wrappers install on both passes, because only the
+// pass that writes will trip them. Handlers keying purely off the
+// response — metrics and accesslog gate on Written() — need no check.
+type InlineBarrier interface {
+	InlineBarrier() bool
 }
 
 // Store is the minimum cache facade a resolver sub-query needs.

--- a/server/inline_serve_test.go
+++ b/server/inline_serve_test.go
@@ -1,0 +1,150 @@
+package server
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/middleware"
+	"github.com/semihalev/sdns/middleware/defaults"
+)
+
+// The inline serve contract: ServeRawInline finishes a warm wire hit on
+// the caller's goroutine, hands off what needs a worker unwritten, and
+// ServeRawReplay finishes the handoff with the replay mark visible to
+// every handler that runs.
+
+// replayWitness stands at the pipeline tail in the resolver's place. The
+// inline pass hands off at the cache, so every invocation this handler
+// sees must carry the replay mark — a call without it means the inline
+// pass ran past the barrier.
+type replayWitness struct {
+	calls        int
+	replayCalls  int
+	inlineOnlyAt int
+	respond      func(req *dns.Msg) *dns.Msg
+}
+
+func (rw *replayWitness) Name() string { return "replay-witness" }
+
+func (rw *replayWitness) ServeDNS(ctx context.Context, ch *middleware.Chain) {
+	rw.calls++
+	if ch.Replay() {
+		rw.replayCalls++
+	}
+	if ch.InlineOnly() {
+		rw.inlineOnlyAt++
+	}
+	ctx, req := ch.Materialize(ctx)
+	if req == nil {
+		return
+	}
+	_ = ctx
+	_ = ch.Writer.WriteMsg(rw.respond(req))
+	ch.Cancel()
+}
+
+func newInlineTestServer(t *testing.T, witness *replayWitness) *Server {
+	t.Helper()
+	middleware.Reset()
+	t.Cleanup(middleware.Reset)
+	defaults.RegisterUpTo("resolver")
+	middleware.Register("replay-witness", func(*config.Config) middleware.Handler { return witness })
+
+	cfg := &config.Config{ //nolint:gosec // G101 — the cookie secret is a test fixture, not a credential
+		Bind:         "127.0.0.1:0",
+		Expire:       600,
+		CacheSize:    10240,
+		CookieSecret: "6c6f6f6b61686172646c6f6f6b6168617264",
+	}
+	cfg.QueryTimeout.Duration = 10 * time.Second
+	middleware.Setup(cfg)
+	return New(cfg)
+}
+
+func stubAnswer(req *dns.Msg) *dns.Msg {
+	resp := new(dns.Msg)
+	resp.SetReply(req)
+	resp.RecursionAvailable = true
+	resp.Answer = []dns.RR{&dns.A{
+		Hdr: dns.RR_Header{Name: req.Question[0].Name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+		A:   net.IPv4(192, 0, 2, 77),
+	}}
+	return resp
+}
+
+func TestServeRawInlineContract(t *testing.T) {
+	witness := &replayWitness{respond: stubAnswer}
+	s := newInlineTestServer(t, witness)
+
+	if !s.InlineReady() {
+		t.Fatal("pipeline with the cache must report inline-ready")
+	}
+
+	job := &strictTestJob{remote: net.UDPAddr{IP: net.IPv4(203, 0, 113, 40), Port: 4242}}
+
+	// Cold query: the inline pass must stop at the cache — unwritten,
+	// handed off, and the resolver stand-in untouched.
+	raw := packRawQuery(t, "inline.zero.test.", true)
+	if s.ServeRawInline(job, raw, time.Now()) {
+		t.Fatal("cold query claimed handled on the inline pass")
+	}
+	if len(job.wrote) != 0 {
+		t.Fatalf("inline handoff left %d written bytes", len(job.wrote))
+	}
+	if witness.calls != 0 {
+		t.Fatalf("inline pass ran past the cache barrier: %d resolver calls", witness.calls)
+	}
+
+	// The replay finishes it, and the tail handler sees the replay mark.
+	if !s.ServeRawReplay(job, raw, time.Now()) {
+		t.Fatal("replay did not handle the handed-off query")
+	}
+	if witness.calls != 1 || witness.replayCalls != 1 {
+		t.Fatalf("replay pass reached the tail %d times, %d with the mark; want 1 and 1",
+			witness.calls, witness.replayCalls)
+	}
+	if witness.inlineOnlyAt != 0 {
+		t.Fatal("replay pass still carried the inline-only mark")
+	}
+	reply := new(dns.Msg)
+	if err := reply.Unpack(job.wrote); err != nil {
+		t.Fatalf("replay reply unpack: %v", err)
+	}
+	if reply.Rcode != dns.RcodeSuccess || len(reply.Answer) == 0 {
+		t.Fatalf("replay reply wrong: rcode=%d answers=%d", reply.Rcode, len(reply.Answer))
+	}
+
+	// Warm now: the inline pass serves the wire hit itself, no handoff,
+	// no resolver call.
+	job.wrote = job.wrote[:0]
+	if !s.ServeRawInline(job, raw, time.Now()) {
+		t.Fatal("warm hit not served on the inline pass")
+	}
+	if witness.calls != 1 {
+		t.Fatalf("warm inline serve reached the resolver: %d calls", witness.calls)
+	}
+	hit := new(dns.Msg)
+	if err := hit.Unpack(job.wrote); err != nil {
+		t.Fatalf("inline hit unpack: %v", err)
+	}
+	if hit.Rcode != dns.RcodeSuccess || len(hit.Answer) == 0 {
+		t.Fatalf("inline hit wrong: rcode=%d answers=%d", hit.Rcode, len(hit.Answer))
+	}
+	if hit.Id != reply.Id {
+		t.Fatalf("inline hit ID %d does not echo the query ID %d", hit.Id, reply.Id)
+	}
+}
+
+// A pipeline without an inline barrier (no cache) must refuse the fast
+// path outright: nothing in it can stop the reader short of blocking
+// work, and the engines consult InlineReady before wiring serveInline.
+func TestInlineReadyRequiresBarrier(t *testing.T) {
+	s := newRawTestServer(t)
+	if s.InlineReady() {
+		t.Fatal("pipeline without an inline barrier reported inline-ready")
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -24,12 +24,11 @@ import (
 type Server struct {
 	cfg      *config.Config
 	pipeline *middleware.Pipeline
-	// replay is the pipeline minus every OncePerQuery handler: the chain
-	// a worker runs for a query the inline pass admitted, guarded, and
-	// then handed off unwritten. Entry-effect middlewares already fired
-	// on the inline pass; response-keyed ones fire here, once, when the
-	// replay writes.
-	replay *middleware.Pipeline
+	// inlineReady records that some handler in the pipeline declares
+	// middleware.InlineBarrier: it will stop an inline pass before
+	// blocking work. Without one, ServeRawInline would carry a transport
+	// reader into the resolver, so the engines leave the fast path off.
+	inlineReady bool
 
 	certManager *CertManager
 	certMu      sync.Mutex
@@ -76,13 +75,12 @@ func New(cfg *config.Config) *Server {
 
 	s := &Server{cfg: cfg, pipeline: middleware.GlobalPipeline(), trimEnabled: cfg.MemoryTrim}
 	if s.pipeline != nil {
-		var once []string
 		for _, h := range s.pipeline.Handlers() {
-			if o, ok := h.(middleware.OncePerQuery); ok && o.OncePerQuery() {
-				once = append(once, h.Name())
+			if b, ok := h.(middleware.InlineBarrier); ok && b.InlineBarrier() {
+				s.inlineReady = true
+				break
 			}
 		}
-		s.replay = s.pipeline.SubPipeline(once...)
 	}
 
 	// One resource plan for every listener, derived before any exists:

--- a/server/server.go
+++ b/server/server.go
@@ -24,6 +24,12 @@ import (
 type Server struct {
 	cfg      *config.Config
 	pipeline *middleware.Pipeline
+	// replay is the pipeline minus every OncePerQuery handler: the chain
+	// a worker runs for a query the inline pass admitted, guarded, and
+	// then handed off unwritten. Entry-effect middlewares already fired
+	// on the inline pass; response-keyed ones fire here, once, when the
+	// replay writes.
+	replay *middleware.Pipeline
 
 	certManager *CertManager
 	certMu      sync.Mutex
@@ -69,6 +75,15 @@ func New(cfg *config.Config) *Server {
 	}
 
 	s := &Server{cfg: cfg, pipeline: middleware.GlobalPipeline(), trimEnabled: cfg.MemoryTrim}
+	if s.pipeline != nil {
+		var once []string
+		for _, h := range s.pipeline.Handlers() {
+			if o, ok := h.(middleware.OncePerQuery); ok && o.OncePerQuery() {
+				once = append(once, h.Name())
+			}
+		}
+		s.replay = s.pipeline.SubPipeline(once...)
+	}
 
 	// One resource plan for every listener, derived before any exists:
 	// the stream engines share a budget, so the plan has to know how

--- a/server/slab_cache.go
+++ b/server/slab_cache.go
@@ -20,49 +20,82 @@ import "sync"
 // counter; this is only where the slabs those tokens paid for wait
 // between requests. It never blocks: a miss means "allocate", trim means
 // the next requests allocate again, and both are correctness-neutral.
+//
+// The idle set is sharded. A single mutex here was measured as the UDP
+// engine's throughput ceiling: every request is one get and one put, so
+// at wire speed the readers and all the workers convoyed on one lock —
+// lock and scheduler overhead were a quarter of the CPU while the actual
+// serving was single digits. Callers address a shard by hint (the reader
+// or socket index); a job returns to the shard it was taken from, so
+// steady-state traffic spreads as wide as the socket fan-out.
 type slabCache[T any] struct {
-	mu   sync.Mutex
-	idle []*T
+	shards [slabShardCount]slabShard[T]
 }
 
-// get pops an idle slab, or returns nil when the caller should allocate.
-func (c *slabCache[T]) get() *T {
-	c.mu.Lock()
-	n := len(c.idle)
+// slabShardCount is a power of two so the hint folds with a mask. Sized
+// to the socket fan-out scale: contention drops by the shard count, and
+// sixteen slices of idle slabs cost nothing over one.
+const slabShardCount = 16
+
+// slabShard pads to a cache line so neighboring shards' mutexes do not
+// false-share under exactly the load the sharding exists for.
+type slabShard[T any] struct {
+	mu   sync.Mutex
+	idle []*T
+	_    [32]byte
+}
+
+// get pops an idle slab from the hinted shard, or returns nil when the
+// caller should allocate. A miss does not search other shards: allocation
+// is cheap, bounded by the engine's lease cap, and the put side refills
+// this shard on the very next completion of its own traffic.
+func (c *slabCache[T]) get(shard int) *T {
+	s := &c.shards[shard&(slabShardCount-1)]
+	s.mu.Lock()
+	n := len(s.idle)
 	if n == 0 {
-		c.mu.Unlock()
+		s.mu.Unlock()
 		return nil
 	}
-	x := c.idle[n-1]
-	c.idle[n-1] = nil
-	c.idle = c.idle[:n-1]
-	c.mu.Unlock()
+	x := s.idle[n-1]
+	s.idle[n-1] = nil
+	s.idle = s.idle[:n-1]
+	s.mu.Unlock()
 	return x
 }
 
-// put parks a scrubbed slab for reuse.
-func (c *slabCache[T]) put(x *T) {
-	c.mu.Lock()
-	c.idle = append(c.idle, x)
-	c.mu.Unlock()
+// put parks a scrubbed slab for reuse on the hinted shard.
+func (c *slabCache[T]) put(shard int, x *T) {
+	s := &c.shards[shard&(slabShardCount-1)]
+	s.mu.Lock()
+	s.idle = append(s.idle, x)
+	s.mu.Unlock()
 }
 
-// trim drops every idle slab — backing array included, so nothing here
+// trim drops every idle slab — backing arrays included, so nothing here
 // keeps the burst alive — and reports how many went. The caller decides
 // when trimming is worth a collection; this only makes the memory
 // collectable.
 func (c *slabCache[T]) trim() int {
-	c.mu.Lock()
-	n := len(c.idle)
-	c.idle = nil
-	c.mu.Unlock()
-	return n
+	total := 0
+	for i := range c.shards {
+		s := &c.shards[i]
+		s.mu.Lock()
+		total += len(s.idle)
+		s.idle = nil
+		s.mu.Unlock()
+	}
+	return total
 }
 
 // size reports how many slabs are parked, for observability.
 func (c *slabCache[T]) size() int {
-	c.mu.Lock()
-	n := len(c.idle)
-	c.mu.Unlock()
-	return n
+	total := 0
+	for i := range c.shards {
+		s := &c.shards[i]
+		s.mu.Lock()
+		total += len(s.idle)
+		s.mu.Unlock()
+	}
+	return total
 }

--- a/server/slab_cache.go
+++ b/server/slab_cache.go
@@ -29,6 +29,10 @@ import "sync"
 // or socket index); a job returns to the shard it was taken from, so
 // steady-state traffic spreads as wide as the socket fan-out.
 type slabCache[T any] struct {
+	// Leading pad: shard zero's mutex must not share a cache line with
+	// whatever hot field the embedding struct keeps just before the
+	// cache — the UDP engine's lease counter sits exactly there.
+	_      [64]byte
 	shards [slabShardCount]slabShard[T]
 }
 
@@ -45,12 +49,25 @@ type slabShard[T any] struct {
 	_    [32]byte
 }
 
-// get pops an idle slab from the hinted shard, or returns nil when the
-// caller should allocate. A miss does not search other shards: allocation
-// is cheap, bounded by the engine's lease cap, and the put side refills
-// this shard on the very next completion of its own traffic.
+// get pops an idle slab for the hinted shard, or returns nil when the
+// caller should allocate. A dry hinted shard sweeps the others before
+// giving up: the slab design's memory contract is that live slabs never
+// exceed the admission cap, and allocating while a neighbor parks idle
+// slabs would break that bound the moment traffic skews across shards —
+// a reuseport flow-hash concentrating on one socket, or the TCP rotor
+// walking sequentially. The sweep costs spare-shard locks only on the
+// path that was about to allocate anyway.
 func (c *slabCache[T]) get(shard int) *T {
-	s := &c.shards[shard&(slabShardCount-1)]
+	for i := 0; i < slabShardCount; i++ {
+		if x := c.shards[(shard+i)&(slabShardCount-1)].pop(); x != nil {
+			return x
+		}
+	}
+	return nil
+}
+
+// pop takes one idle slab, or nil.
+func (s *slabShard[T]) pop() *T {
 	s.mu.Lock()
 	n := len(s.idle)
 	if n == 0 {

--- a/server/strict.go
+++ b/server/strict.go
@@ -156,6 +156,16 @@ type rawHandler interface {
 	ServeRaw(w middleware.Transport, raw []byte, readTime time.Time) bool
 }
 
+// inlineRawHandler is the optional fast-path contract: a handler that can
+// run a query on the transport reader without blocking, handing off what
+// needs a worker. Engines type-assert it once at construction; a handler
+// without it (test stubs) simply keeps every query on the ring.
+type inlineRawHandler interface {
+	rawHandler
+	ServeRawInline(w middleware.Transport, raw []byte, readTime time.Time) bool
+	ServeRawReplay(w middleware.Transport, raw []byte, readTime time.Time) bool
+}
+
 // strictSlots is what an SDNS-owned transport job offers ServeRaw:
 // job-owned storage for the request, the context carrier, and the edns
 // writer wrapper.
@@ -199,6 +209,78 @@ func (s *Server) ServeRaw(w middleware.Transport, raw []byte, readTime time.Time
 	// reason a strict materialization flushes applies from the first
 	// instruction here: replies already staged on this transport must
 	// not wait out this query's resolution.
+	if f, ok := w.(middleware.StagedFlusher); ok {
+		f.FlushStaged()
+	}
+	s.serveMsgBy(context.Background(), w, m, true, readTime.Add(s.queryTimeout()))
+	return true
+}
+
+// ServeRawInline is ServeRaw for a transport reader that must not block:
+// the full chain runs with the inline-only mark, and the cache — the one
+// handler whose downstream can block on the network — declines a query it
+// cannot answer from its wire ladder, unwritten. handled reports whether
+// the query reached a terminal here; a false return with handoff true
+// means the caller owns an admitted, guarded, unanswered job it must
+// replay on a worker with ServeRawReplay. A packet the strict path cannot
+// carry is a handoff outright: the decoded fallback resolves, and
+// resolving blocks.
+func (s *Server) ServeRawInline(w middleware.Transport, raw []byte, readTime time.Time) (handled bool) {
+	if job, ok := w.(strictSlots); ok {
+		req, chain, carrier, ednsSlot := job.StrictSlots()
+		if req.ParseWire(raw, readTime, ednsSlot) {
+			if s.trimEnabled {
+				s.served.Add(1)
+			}
+			carrier.reset(readTime.Add(s.queryTimeout()))
+			if s.pipeline == nil || contextutil.EffectiveError(carrier) != nil {
+				return true
+			}
+			s.pipeline.BindChain(chain)
+			defer chain.Finish()
+			chain.ResetWire(w, req)
+			chain.AllowDirectPack()
+			chain.SetInlineOnly()
+			chain.Next(carrier)
+			return !chain.Handoff()
+		}
+	}
+	return false
+}
+
+// ServeRawReplay finishes a query the inline pass handed off. The chain
+// is the pipeline minus every OncePerQuery handler: entry effects fired
+// on the inline pass, and the middlewares that key off the response fire
+// here, once, when this pass writes.
+func (s *Server) ServeRawReplay(w middleware.Transport, raw []byte, readTime time.Time) bool {
+	// No served count here for the strict branch: the inline pass already
+	// counted this query. The decoded fallback below never ran inline.
+	if job, ok := w.(strictSlots); ok {
+		req, chain, carrier, ednsSlot := job.StrictSlots()
+		if req.ParseWire(raw, readTime, ednsSlot) {
+			carrier.reset(readTime.Add(s.queryTimeout()))
+			if s.replay == nil {
+				return true
+			}
+			if contextutil.EffectiveError(carrier) != nil {
+				return true
+			}
+			s.replay.BindChain(chain)
+			defer chain.Finish()
+			chain.ResetWire(w, req)
+			chain.AllowDirectPack()
+			chain.Next(carrier)
+			return true
+		}
+	}
+
+	if s.trimEnabled {
+		s.served.Add(1)
+	}
+	m := new(dns.Msg)
+	if err := m.Unpack(raw); err != nil {
+		return false
+	}
 	if f, ok := w.(middleware.StagedFlusher); ok {
 		f.FlushStaged()
 	}

--- a/server/strict.go
+++ b/server/strict.go
@@ -158,10 +158,14 @@ type rawHandler interface {
 
 // inlineRawHandler is the optional fast-path contract: a handler that can
 // run a query on the transport reader without blocking, handing off what
-// needs a worker. Engines type-assert it once at construction; a handler
-// without it (test stubs) simply keeps every query on the ring.
+// needs a worker. Engines type-assert it once at construction and consult
+// InlineReady — a handler whose pipeline carries no middleware.InlineBarrier
+// must not serve inline, or the reader would block in the resolver. A
+// handler without the interface (test stubs) simply keeps every query on
+// the ring.
 type inlineRawHandler interface {
 	rawHandler
+	InlineReady() bool
 	ServeRawInline(w middleware.Transport, raw []byte, readTime time.Time) bool
 	ServeRawReplay(w middleware.Transport, raw []byte, readTime time.Time) bool
 }
@@ -248,10 +252,14 @@ func (s *Server) ServeRawInline(w middleware.Transport, raw []byte, readTime tim
 	return false
 }
 
-// ServeRawReplay finishes a query the inline pass handed off. The chain
-// is the pipeline minus every OncePerQuery handler: entry effects fired
-// on the inline pass, and the middlewares that key off the response fire
-// here, once, when this pass writes.
+// InlineReady reports whether the pipeline carries an inline barrier; the
+// engines enable the reader fast path only when it does.
+func (s *Server) InlineReady() bool { return s.inlineReady }
+
+// ServeRawReplay finishes a query the inline pass handed off. The full
+// pipeline runs with the replay mark: handlers whose entry effects fired
+// on the inline pass skip them, and the middlewares that key off the
+// response fire here, once, when this pass writes.
 func (s *Server) ServeRawReplay(w middleware.Transport, raw []byte, readTime time.Time) bool {
 	// No served count here for the strict branch: the inline pass already
 	// counted this query. The decoded fallback below never ran inline.
@@ -259,16 +267,17 @@ func (s *Server) ServeRawReplay(w middleware.Transport, raw []byte, readTime tim
 		req, chain, carrier, ednsSlot := job.StrictSlots()
 		if req.ParseWire(raw, readTime, ednsSlot) {
 			carrier.reset(readTime.Add(s.queryTimeout()))
-			if s.replay == nil {
+			if s.pipeline == nil {
 				return true
 			}
 			if contextutil.EffectiveError(carrier) != nil {
 				return true
 			}
-			s.replay.BindChain(chain)
+			s.pipeline.BindChain(chain)
 			defer chain.Finish()
 			chain.ResetWire(w, req)
 			chain.AllowDirectPack()
+			chain.SetReplay()
 			chain.Next(carrier)
 			return true
 		}

--- a/server/tcp_engine.go
+++ b/server/tcp_engine.go
@@ -63,8 +63,7 @@ const (
 	// time than announcing it did, which is why this is the first-read
 	// allowance and not the idle timeout — staying silent is a client's
 	// right, holding a shared slab while it does so is not.
-	tcpQueryWait   = tcpFirstReadWait
-	tcpQueryBudget = 2048
+	tcpQueryWait = tcpFirstReadWait
 	// defaultTCPLargeJobs bounds the big class. Large frames are rare, so
 	// this exists to serve them without letting them define the ring's
 	// memory: the small class is what a busy server actually runs on.
@@ -445,8 +444,16 @@ func (e *tcpEngine) serveConn(conn net.Conn) {
 	// the life of the process.
 	defer release()
 
+	// A session serves until its client leaves. There is deliberately no
+	// per-connection query cap here: fairness is enforced where slabs are
+	// admitted (a token per announced frame), session count where
+	// connections are (the engine's conncap), and RFC 7766 tells clients
+	// to hold their connections open. A cap did exist once, and a busy
+	// pipelined client burned through it in under a second — every expiry
+	// a server-forced reconnect, and the reconnect storm cost the stream
+	// path half its throughput.
 	wait := tcpFirstReadWait
-	for served := 0; served < tcpQueryBudget; served++ {
+	for {
 		// Shutdown between frames, before any buffered prefix keeps the
 		// burst alive: a connection with pipelined frames in its fill
 		// buffer never blocks on the socket, so the closed socket alone

--- a/server/tcp_engine.go
+++ b/server/tcp_engine.go
@@ -82,6 +82,9 @@ type tcpJob struct {
 	engine *tcpEngine
 	conn   net.Conn
 	stream *tcpStream
+	// slabShard is where this job's slab returns on release; TCP has no
+	// per-slot reader, so acquisition deals shards out round-robin.
+	slabShard uint8
 	// rx and tx are sized by the slab's class and never resized. A
 	// connection takes the class its announced frame needs, which the
 	// length prefix has already told it — prefix-first acquisition was
@@ -181,6 +184,10 @@ type tcpEngine struct {
 	handler  rawHandler
 	proto    string // "tcp" or "tls", for metrics
 	maxConns int64
+
+	// slabRotor deals slab shards to acquisitions; connections have no
+	// stable index the way the UDP readers do.
+	slabRotor atomic.Uint32
 
 	// Two classes by frame size, each with its own admission tokens and
 	// its own idle cache. The tokens are the authority — how many frames
@@ -297,11 +304,11 @@ func (e *tcpEngine) put(j *tcpJob) {
 		panic("server: tcp job released twice")
 	}
 	if j.large {
-		e.largeCache.put(j)
+		e.largeCache.put(int(j.slabShard), j)
 		e.largeTokens <- struct{}{}
 		return
 	}
-	e.smallCache.put(j)
+	e.smallCache.put(int(j.slabShard), j)
 	e.smallTokens <- struct{}{}
 }
 
@@ -562,10 +569,12 @@ func (e *tcpEngine) acquire(s *tcpStream, deadline time.Time, length int) *tcpJo
 	if large {
 		cache = &e.largeCache
 	}
-	j := cache.get()
+	shard := int(e.slabRotor.Add(1))
+	j := cache.get(shard)
 	if j == nil {
 		j = newTCPJob(e, large)
 	}
+	j.slabShard = uint8(shard & (slabShardCount - 1))
 	j.leased.Store(true)
 	return j
 }

--- a/server/trim_test.go
+++ b/server/trim_test.go
@@ -95,7 +95,7 @@ func TestTrimGateNeedsARealIdleWindow(t *testing.T) {
 // trim costs the next queries an allocation, never an answer.
 func TestTrimDropsParkedSlabsOnly(t *testing.T) {
 	e := newUDPEngine(echoHandler(), nil, false, 1, 1, defaultResourcePlan(1))
-	j := e.take()
+	j := e.take(0)
 	if j == nil {
 		t.Fatal("lease refused")
 	}
@@ -104,7 +104,7 @@ func TestTrimDropsParkedSlabsOnly(t *testing.T) {
 	if got := e.trimIdle(); got != 1 {
 		t.Fatalf("trim dropped %d slabs, want the parked one", got)
 	}
-	if j2 := e.take(); j2 == nil {
+	if j2 := e.take(0); j2 == nil {
 		t.Fatal("a lease was refused after trim; trim must only cost an allocation")
 	} else {
 		j2.state = udpJobReading

--- a/server/udp_batch_fallback_test.go
+++ b/server/udp_batch_fallback_test.go
@@ -64,14 +64,14 @@ func TestUDPPortableFallbackReplyAddressing(t *testing.T) {
 	}
 	copy(poisoned.rawSA[:], sa[:])
 	poisoned.rawSALen = uint32(len(sa))
-	e.cache.put(poisoned)
+	e.cache.put(0, poisoned)
 
 	// The fallback shape: workers plus a portable reader on a socket the
 	// batch TX map still knows.
 	e.workerG.Add(1)
 	go e.worker(0)
 	e.readers.Add(1)
-	go e.reader(server)
+	go e.reader(0, server)
 	t.Cleanup(func() {
 		server.Close() //nolint:gosec // G104 - test socket teardown
 		_ = e.stopAndDrain(time.Now().Add(2 * time.Second))

--- a/server/udp_batch_linux.go
+++ b/server/udp_batch_linux.go
@@ -127,7 +127,25 @@ func newUDPBatchReader(e *udpEngine, idx int, pc *net.UDPConn, rc syscall.RawCon
 
 func (r *udpBatchReader) run() {
 	e := r.engine
-	defer e.readers.Done()
+	// held counts the armed jobs that persist across cycles. A batch
+	// rarely fills: the kernel hands back what the queue holds, and the
+	// old shape released every unfilled slot just to take it again on
+	// the next spin — a full take/release round trip (lease atomics,
+	// shard traffic, state transitions) per slot per cycle, priced at
+	// wire speed. A job the kernel did not fill stays armed; only what
+	// was consumed is re-taken, and every exit path below releases the
+	// holdover before returning.
+	held := 0
+	releaseHeld := func() {
+		for i := range held {
+			r.jobs[i].release(udpJobReading)
+		}
+		held = 0
+	}
+	defer func() {
+		releaseHeld()
+		e.readers.Done()
+	}()
 
 	for {
 		// The lease cap reserves a batch per reader. When it is reached
@@ -139,32 +157,26 @@ func (r *udpBatchReader) run() {
 		// receive queue are the oldest ones, whose clients have often
 		// stopped waiting. Shedding keeps the loss ours to report and
 		// keeps what is served fresh.
-		j0 := e.take(r.idx)
-		if j0 == nil {
-			if !r.shed() {
-				return
-			}
-			continue
-		}
-		j0.transition(udpJobFree, udpJobReading)
-		r.arm(j0, 0)
-		k := 1
-		for k < udpBatchSize {
+		for held < udpBatchSize {
 			j := e.take(r.idx)
 			if j == nil {
 				break
 			}
 			j.transition(udpJobFree, udpJobReading)
-			r.arm(j, k)
-			k++
+			r.arm(j, held)
+			held++
+		}
+		if held == 0 {
+			if !r.shed() {
+				return
+			}
+			continue
 		}
 
-		r.armed = k
+		r.armed = held
 		err := r.rc.Read(r.readFn)
 		if err != nil || r.rerr != nil {
-			for i := range k {
-				r.jobs[i].release(udpJobReading)
-			}
+			releaseHeld()
 			// A reader is the only consumer of its socket: it exits when
 			// the socket is gone and for nothing else. A transient errno
 			// drops the cycle, and a poller error that is not a closed
@@ -177,7 +189,7 @@ func (r *udpBatchReader) run() {
 				}
 				udpReaderPollErr.Inc()
 				zlog.Error("UDP batch reader poll failed",
-					"error", err.Error(), "armed", k)
+					"error", err.Error(), "armed", r.armed)
 				continue
 			}
 			if r.rerr == unix.EBADF {
@@ -196,9 +208,15 @@ func (r *udpBatchReader) run() {
 		for i := range n {
 			r.finishRecv(i, now)
 		}
-		for i := n; i < k; i++ {
-			r.jobs[i].release(udpJobReading)
+		// The kernel filled slots 0..n-1; the survivors compact to the
+		// front and stay armed for the next cycle. arm rebinds the slot's
+		// descriptors; the job itself is untouched.
+		m := 0
+		for i := n; i < held; i++ {
+			r.arm(r.jobs[i], m)
+			m++
 		}
+		held = m
 	}
 }
 

--- a/server/udp_batch_linux.go
+++ b/server/udp_batch_linux.go
@@ -100,6 +100,10 @@ type udpBatchReader struct {
 	armed    int
 	received int
 	rerr     error
+
+	// pending gathers a cycle's admitted jobs so the ring gets one send —
+	// one worker wake — per cycle instead of one per packet.
+	pending udpJobBatch
 }
 
 func newUDPBatchReader(e *udpEngine, idx int, pc *net.UDPConn, rc syscall.RawConn) *udpBatchReader {
@@ -205,8 +209,12 @@ func (r *udpBatchReader) run() {
 
 		n := r.received
 		now := time.Now()
+		r.pending.n = 0
 		for i := range n {
 			r.finishRecv(i, now)
+		}
+		if r.pending.n > 0 {
+			e.enqueueBatch(&r.pending)
 		}
 		// The kernel filled slots 0..n-1; the survivors compact to the
 		// front and stay armed for the next cycle. arm rebinds the slot's
@@ -341,7 +349,8 @@ func (r *udpBatchReader) finishRecv(i int, now time.Time) {
 		}
 	}
 
-	r.engine.enqueue(j)
+	r.pending.jobs[r.pending.n] = j
+	r.pending.n++
 }
 
 // setRemoteRaw rewrites the cached classic views from a kernel sockaddr.

--- a/server/udp_batch_linux.go
+++ b/server/udp_batch_linux.go
@@ -58,12 +58,12 @@ func (e *udpEngine) startBatched() bool {
 	if e.txConns == nil {
 		return false
 	}
-	for _, pc := range e.pcs {
+	for i, pc := range e.pcs {
 		rc := e.txConns[pc]
 		if rc == nil {
 			return false
 		}
-		r := newUDPBatchReader(e, pc, rc)
+		r := newUDPBatchReader(e, i, pc, rc)
 		e.readers.Add(1)
 		go r.run()
 	}
@@ -74,8 +74,10 @@ func (e *udpEngine) startBatched() bool {
 
 type udpBatchReader struct {
 	engine *udpEngine
-	pc     *net.UDPConn
-	rc     syscall.RawConn
+	// idx is this socket's slab shard hint.
+	idx int
+	pc  *net.UDPConn
+	rc  syscall.RawConn
 
 	// permanentErrs counts consecutive errnos that no retry will fix. A
 	// seccomp profile that filters recvmmsg answers EPERM or ENOSYS on
@@ -100,8 +102,8 @@ type udpBatchReader struct {
 	rerr     error
 }
 
-func newUDPBatchReader(e *udpEngine, pc *net.UDPConn, rc syscall.RawConn) *udpBatchReader {
-	r := &udpBatchReader{engine: e, pc: pc, rc: rc}
+func newUDPBatchReader(e *udpEngine, idx int, pc *net.UDPConn, rc syscall.RawConn) *udpBatchReader {
+	r := &udpBatchReader{engine: e, idx: idx, pc: pc, rc: rc}
 	r.readFn = func(fd uintptr) bool {
 		n, _, errno := unix.Syscall6(
 			unix.SYS_RECVMMSG,
@@ -137,7 +139,7 @@ func (r *udpBatchReader) run() {
 		// receive queue are the oldest ones, whose clients have often
 		// stopped waiting. Shedding keeps the loss ours to report and
 		// keeps what is served fresh.
-		j0 := e.take()
+		j0 := e.take(r.idx)
 		if j0 == nil {
 			if !r.shed() {
 				return
@@ -148,7 +150,7 @@ func (r *udpBatchReader) run() {
 		r.arm(j0, 0)
 		k := 1
 		for k < udpBatchSize {
-			j := e.take()
+			j := e.take(r.idx)
 			if j == nil {
 				break
 			}
@@ -265,7 +267,7 @@ func (r *udpBatchReader) permanentRerr() bool {
 		"errno", r.rerr.Error())
 	e := r.engine
 	e.readers.Add(1)
-	go e.reader(r.pc)
+	go e.reader(r.idx, r.pc)
 	return true
 }
 

--- a/server/udp_batch_linux.go
+++ b/server/udp_batch_linux.go
@@ -357,13 +357,13 @@ func (r *udpBatchReader) finishRecv(i int, now time.Time) {
 
 	// The inline pass first: a hit finishes here and its reply rides the
 	// cycle's transmit batch — no ring, no worker wake, no lone send. A
-	// handoff (or a handler without the fast path) takes the ring.
+	// handoff continues on the ring with its in-flight count carried; a
+	// handler without the fast path takes the counted enqueue.
 	if e := r.engine; e.inline != nil {
-		if e.serveInline(j, &r.txBurst) {
-			udpInlineServed.Inc()
-			return
+		if !e.serveInline(j, &r.txBurst) {
+			e.enqueueCounted(j)
 		}
-		udpInlineHandoff.Inc()
+		return
 	}
 	r.engine.enqueue(j)
 }

--- a/server/udp_batch_linux.go
+++ b/server/udp_batch_linux.go
@@ -100,10 +100,6 @@ type udpBatchReader struct {
 	armed    int
 	received int
 	rerr     error
-
-	// pending gathers a cycle's admitted jobs so the ring gets one send —
-	// one worker wake — per cycle instead of one per packet.
-	pending udpJobBatch
 }
 
 func newUDPBatchReader(e *udpEngine, idx int, pc *net.UDPConn, rc syscall.RawConn) *udpBatchReader {
@@ -209,12 +205,8 @@ func (r *udpBatchReader) run() {
 
 		n := r.received
 		now := time.Now()
-		r.pending.n = 0
 		for i := range n {
 			r.finishRecv(i, now)
-		}
-		if r.pending.n > 0 {
-			e.enqueueBatch(&r.pending)
 		}
 		// The kernel filled slots 0..n-1; the survivors compact to the
 		// front and stay armed for the next cycle. arm rebinds the slot's
@@ -349,8 +341,7 @@ func (r *udpBatchReader) finishRecv(i int, now time.Time) {
 		}
 	}
 
-	r.pending.jobs[r.pending.n] = j
-	r.pending.n++
+	r.engine.enqueue(j)
 }
 
 // setRemoteRaw rewrites the cached classic views from a kernel sockaddr.

--- a/server/udp_batch_linux.go
+++ b/server/udp_batch_linux.go
@@ -100,10 +100,16 @@ type udpBatchReader struct {
 	armed    int
 	received int
 	rerr     error
+
+	// txBurst stages the replies of inline-served jobs; the receive
+	// batch flushes back as one transmit batch at the end of the cycle.
+	// Its sender slot lives past the workers' range.
+	txBurst udpTXBurst
 }
 
 func newUDPBatchReader(e *udpEngine, idx int, pc *net.UDPConn, rc syscall.RawConn) *udpBatchReader {
 	r := &udpBatchReader{engine: e, idx: idx, pc: pc, rc: rc}
+	r.txBurst.slot = e.workers + idx
 	r.readFn = func(fd uintptr) bool {
 		n, _, errno := unix.Syscall6(
 			unix.SYS_RECVMMSG,
@@ -143,6 +149,9 @@ func (r *udpBatchReader) run() {
 		held = 0
 	}
 	defer func() {
+		// Staged inline replies leave before the holdover is released;
+		// the burst releases its jobs on send.
+		e.flushTX(&r.txBurst)
 		releaseHeld()
 		e.readers.Done()
 	}()
@@ -207,6 +216,11 @@ func (r *udpBatchReader) run() {
 		now := time.Now()
 		for i := range n {
 			r.finishRecv(i, now)
+		}
+		// The receive batch goes back out as one transmit batch: every
+		// inline-served reply of this cycle in a single send.
+		if r.txBurst.n > 0 {
+			e.flushTX(&r.txBurst)
 		}
 		// The kernel filled slots 0..n-1; the survivors compact to the
 		// front and stay armed for the next cycle. arm rebinds the slot's
@@ -341,6 +355,16 @@ func (r *udpBatchReader) finishRecv(i int, now time.Time) {
 		}
 	}
 
+	// The inline pass first: a hit finishes here and its reply rides the
+	// cycle's transmit batch — no ring, no worker wake, no lone send. A
+	// handoff (or a handler without the fast path) takes the ring.
+	if e := r.engine; e.inline != nil {
+		if e.serveInline(j, &r.txBurst) {
+			udpInlineServed.Inc()
+			return
+		}
+		udpInlineHandoff.Inc()
+	}
 	r.engine.enqueue(j)
 }
 

--- a/server/udp_engine.go
+++ b/server/udp_engine.go
@@ -234,7 +234,7 @@ type udpEngine struct {
 	pcs      []*net.UDPConn
 	wildcard bool
 
-	ready chan *udpJob
+	ready chan udpJobBatch
 
 	// inFlight counts the slabs between the ready queue and their
 	// release: queued, being served, or staged for a send. Slabs parked
@@ -337,7 +337,14 @@ func newUDPEngine(handler rawHandler, pcs []*net.UDPConn, wildcard bool, workers
 	// in the cache between requests.
 	e.slabCap = int64(queue + workers + len(pcs)*udpReaderReserve)
 	e.slabCap += plan.udpSpareSlabs
-	e.ready = make(chan *udpJob, queue)
+	// The ring carries reader cycles, not jobs: its depth is kept
+	// job-equivalent so the overflow threshold — the memory bound the
+	// design states — means what it always meant.
+	batches := queue / udpBatchSize
+	if batches < 1 {
+		batches = 1
+	}
+	e.ready = make(chan udpJobBatch, batches)
 	return e
 }
 
@@ -485,20 +492,41 @@ func (e *udpEngine) reader(idx int, pc *net.UDPConn) {
 //
 // The state write must precede the send: the channel gives the worker its
 // happens-before for every job field.
+// udpJobBatch is one reader cycle's admitted jobs, carried through the
+// ready ring as a single unit. The channel copies the value — no heap —
+// and one send wakes one worker for the whole cycle where the per-job
+// ring paid a scheduler wake per packet: at wire speed those wakes and
+// the runqueue churn behind them were the largest cost left in the
+// profile after the slab locks fell.
+type udpJobBatch struct {
+	jobs [udpBatchSize]*udpJob
+	n    int
+}
+
+// enqueue hands a single job to the workers — the portable reader's unit.
 func (e *udpEngine) enqueue(j *udpJob) {
+	var b udpJobBatch
+	b.jobs[0] = j
+	b.n = 1
+	e.enqueueBatch(&b)
+}
+
+func (e *udpEngine) enqueueBatch(b *udpJobBatch) {
 	// Counted from here rather than from the read: a slab parked in a
 	// reader waiting for a packet is idle, not outstanding, and a
 	// quiescence check that could not tell the two apart would never see
 	// an idle server settle.
-	e.inFlight.Add(1)
-	j.state = udpJobQueued
+	e.inFlight.Add(int64(b.n))
+	for i := 0; i < b.n; i++ {
+		b.jobs[i].state = udpJobQueued
+	}
 
 	// The pool first, while it can keep up. A served hit is microseconds,
 	// so the queue is empty in the ordinary case and the reply rides the
 	// worker's send burst — which is what keeps the hit path free of both
 	// syscalls and allocations.
 	select {
-	case e.ready <- j:
+	case e.ready <- *b:
 		return
 	default:
 	}
@@ -512,11 +540,13 @@ func (e *udpEngine) enqueue(j *udpJob) {
 	// gives one to the packets the pool cannot take, which restores the
 	// ceiling without giving up the burst on the path that has one.
 	//
-	// It is still bounded — by the ring, which this job came out of and
+	// It is still bounded — by the ring, which these jobs came out of and
 	// which is the memory bound the design already states.
-	udpOverflowServed.Inc()
-	e.overflowG.Add(1)
-	go e.serveOverflow(j)
+	for i := 0; i < b.n; i++ {
+		udpOverflowServed.Inc()
+		e.overflowG.Add(1)
+		go e.serveOverflow(b.jobs[i])
+	}
 }
 
 // serveOverflow runs one overflow job and leaves the drain barrier when
@@ -587,22 +617,30 @@ func (e *udpEngine) worker(slot int) {
 	burst := udpTXBurst{slot: slot}
 	for {
 		select {
-		case j, ok := <-e.ready:
+		case b, ok := <-e.ready:
 			if !ok {
 				e.flushTX(&burst)
 				return
 			}
-			e.serve(j, &burst)
-			if burst.full() {
-				e.flushTX(&burst)
-			}
+			e.serveBatch(&b, &burst)
 		default:
 			e.flushTX(&burst)
-			j, ok := <-e.ready
+			b, ok := <-e.ready
 			if !ok {
 				return
 			}
-			e.serve(j, &burst)
+			e.serveBatch(&b, &burst)
+		}
+	}
+}
+
+// serveBatch runs one reader cycle's jobs back to back; the burst flushes
+// whenever it fills, so a cycle larger than the TX window still sends.
+func (e *udpEngine) serveBatch(b *udpJobBatch, burst *udpTXBurst) {
+	for i := 0; i < b.n; i++ {
+		e.serve(b.jobs[i], burst)
+		if burst.full() {
+			e.flushTX(burst)
 		}
 	}
 }

--- a/server/udp_engine.go
+++ b/server/udp_engine.go
@@ -53,6 +53,11 @@ type udpJob struct {
 	engine *udpEngine
 	pc     *net.UDPConn
 
+	// slabShard is where this job's slab goes back when released — the
+	// shard of the reader that took it, so slab traffic spreads with the
+	// socket fan-out instead of convoying on one lock.
+	slabShard uint8
+
 	rx       [udpJobBufSize]byte
 	rxLen    int
 	tx       [udpJobBufSize]byte
@@ -339,7 +344,7 @@ func newUDPEngine(handler rawHandler, pcs []*net.UDPConn, wildcard bool, workers
 // take leases a slab to read into. A nil return is the shedding case:
 // the admission cap is reached, and the cap — not the cache, not the
 // collector — is the memory authority here.
-func (e *udpEngine) take() *udpJob {
+func (e *udpEngine) take(shard int) *udpJob {
 	for {
 		n := e.leased.Load()
 		if n >= e.slabCap {
@@ -349,10 +354,11 @@ func (e *udpEngine) take() *udpJob {
 			break
 		}
 	}
-	if j := e.cache.get(); j != nil {
+	if j := e.cache.get(shard); j != nil {
+		j.slabShard = uint8(shard & (slabShardCount - 1))
 		return j
 	}
-	return &udpJob{engine: e}
+	return &udpJob{engine: e, slabShard: uint8(shard & (slabShardCount - 1))}
 }
 
 // start launches the fixed workers and one reader per socket.
@@ -367,9 +373,9 @@ func (e *udpEngine) start() {
 	if e.startBatched() {
 		return
 	}
-	for _, pc := range e.pcs {
+	for i, pc := range e.pcs {
 		e.readers.Add(1)
-		go e.reader(pc)
+		go e.reader(i, pc)
 	}
 }
 
@@ -405,7 +411,7 @@ func (e *udpEngine) stopAndDrain(deadline time.Time) error {
 	}
 }
 
-func (e *udpEngine) reader(pc *net.UDPConn) {
+func (e *udpEngine) reader(idx int, pc *net.UDPConn) {
 	defer e.readers.Done()
 	var discard [udpJobBufSize]byte
 	var oob [pktinfoSpace]byte
@@ -414,7 +420,7 @@ func (e *udpEngine) reader(pc *net.UDPConn) {
 		oobBuf = nil
 	}
 	for {
-		j := e.take()
+		j := e.take(idx)
 		if j == nil {
 			// Ring empty and the stretch at its bound: consume and shed.
 			// The reader never blocks for a slab — a deep queue only
@@ -550,7 +556,7 @@ func (j *udpJob) release(from uint8) {
 	// lease is released after the slab is parked — count down earlier
 	// and the cap could admit a query the cache cannot yet serve.
 	e := j.engine
-	e.cache.put(j)
+	e.cache.put(int(j.slabShard), j)
 	e.leased.Add(-1)
 
 	// Counted down last, after the slab is scrubbed and parked.

--- a/server/udp_engine.go
+++ b/server/udp_engine.go
@@ -97,7 +97,11 @@ type udpJob struct {
 	burst    *udpTXBurst
 
 	written bool
-	state   uint8 // udpJobFree → udpJobReading → udpJobQueued → udpJobServing → free
+	// replay marks a job the inline pass admitted and handed off: the
+	// worker finishes it on the replay pipeline, whose entry-effect
+	// middlewares already fired inline.
+	replay bool
+	state  uint8 // udpJobFree → udpJobReading → udpJobQueued → udpJobServing → free
 }
 
 const (
@@ -230,7 +234,10 @@ func (j *udpJob) LeaseWire(capacity int) []byte {
 // udpEngine owns the sockets' read loops, the slab lease, and the
 // worker pool for one listener.
 type udpEngine struct {
-	handler  rawHandler
+	handler rawHandler
+	// inline is handler's fast-path contract when it offers one; nil
+	// keeps every query on the ring, which is what test stubs get.
+	inline   inlineRawHandler
 	pcs      []*net.UDPConn
 	wildcard bool
 
@@ -311,7 +318,13 @@ func newUDPEngine(handler rawHandler, pcs []*net.UDPConn, wildcard bool, workers
 		workers:  workers,
 		txConns:  make(map[*net.UDPConn]syscall.RawConn, len(pcs)),
 	}
-	e.txSenders = make([]udpTXSender, workers)
+	// The fast path is optional on the handler; without it every query
+	// keeps to the ring exactly as before.
+	e.inline, _ = handler.(inlineRawHandler)
+	// One send-state slot per worker, plus one per reader: an inline
+	// serve stages its replies on the reader's own burst and sends the
+	// receive batch back as one transmit batch.
+	e.txSenders = make([]udpTXSender, workers+len(pcs))
 	for i := range e.txSenders {
 		newUDPTXSender(&e.txSenders[i])
 	}
@@ -551,6 +564,7 @@ func (j *udpJob) release(from uint8) {
 	// ignored opcode, a panic — with the previous client's bytes, to the
 	// new client's address.
 	j.txLen = 0
+	j.replay = false
 	// Read before the slab leaves: once it is in the cache it belongs to
 	// whoever takes it next, and nothing here may touch it again. The
 	// lease is released after the slab is parked — count down earlier
@@ -647,10 +661,65 @@ func (e *udpEngine) serve(j *udpJob, burst *udpTXBurst) {
 
 	// The one ingress: the server decides eligibility, decode, and
 	// context. A false return means the accepted header hid an
-	// undecodable body — FORMERR, library parity.
+	// undecodable body — FORMERR, library parity. A replayed job
+	// finishes on the replay contract: its entry-effect middlewares
+	// already fired on the inline pass.
+	if j.replay {
+		if !e.inline.ServeRawReplay(j, j.rx[:j.rxLen], j.readTime) {
+			j.rejectInPlace(acceptFormatError)
+		}
+		return
+	}
 	if !e.handler.ServeRaw(j, j.rx[:j.rxLen], j.readTime) {
 		j.rejectInPlace(acceptFormatError)
 	}
+}
+
+// serveInline runs one job on its reader, refusing to block: the chain
+// carries the inline-only mark, and a query it cannot finish comes back
+// unserved for the ring. done reports whether the job reached a terminal
+// here; false hands ownership back to the caller with the job returned to
+// the reading state and marked for replay.
+//
+//nolint:unused // Linux batch path (udp_batch_linux.go)
+func (e *udpEngine) serveInline(j *udpJob, burst *udpTXBurst) (done bool) {
+	j.transition(udpJobReading, udpJobServing)
+	j.burst = burst
+	done = true
+	defer func() {
+		if r := recover(); r != nil {
+			udpDropPanic.Inc()
+			done = true
+		}
+		j.burst = nil
+		if !done {
+			j.replay = true
+			j.transition(udpJobServing, udpJobReading)
+			return
+		}
+		if j.txLen > 0 {
+			burst.add(j)
+			return
+		}
+		j.release(udpJobServing)
+	}()
+
+	header, ok := wire.ParseHeader(j.rx[:j.rxLen])
+	if !ok {
+		udpDropMalformed.Inc()
+		return true
+	}
+	switch verdict := acceptHeader(header); verdict {
+	case acceptOK:
+	case acceptIgnore:
+		udpDropIgnored.Inc()
+		return true
+	case acceptNotImplemented, acceptFormatError:
+		j.rejectInPlace(verdict)
+		return true
+	}
+
+	return e.inline.ServeRawInline(j, j.rx[:j.rxLen], j.readTime)
 }
 
 // Header-level accept verdicts, mirroring the library's default accept

--- a/server/udp_engine.go
+++ b/server/udp_engine.go
@@ -234,7 +234,7 @@ type udpEngine struct {
 	pcs      []*net.UDPConn
 	wildcard bool
 
-	ready chan udpJobBatch
+	ready chan *udpJob
 
 	// inFlight counts the slabs between the ready queue and their
 	// release: queued, being served, or staged for a send. Slabs parked
@@ -337,14 +337,7 @@ func newUDPEngine(handler rawHandler, pcs []*net.UDPConn, wildcard bool, workers
 	// in the cache between requests.
 	e.slabCap = int64(queue + workers + len(pcs)*udpReaderReserve)
 	e.slabCap += plan.udpSpareSlabs
-	// The ring carries reader cycles, not jobs: its depth is kept
-	// job-equivalent so the overflow threshold — the memory bound the
-	// design states — means what it always meant.
-	batches := queue / udpBatchSize
-	if batches < 1 {
-		batches = 1
-	}
-	e.ready = make(chan udpJobBatch, batches)
+	e.ready = make(chan *udpJob, queue)
 	return e
 }
 
@@ -492,41 +485,20 @@ func (e *udpEngine) reader(idx int, pc *net.UDPConn) {
 //
 // The state write must precede the send: the channel gives the worker its
 // happens-before for every job field.
-// udpJobBatch is one reader cycle's admitted jobs, carried through the
-// ready ring as a single unit. The channel copies the value — no heap —
-// and one send wakes one worker for the whole cycle where the per-job
-// ring paid a scheduler wake per packet: at wire speed those wakes and
-// the runqueue churn behind them were the largest cost left in the
-// profile after the slab locks fell.
-type udpJobBatch struct {
-	jobs [udpBatchSize]*udpJob
-	n    int
-}
-
-// enqueue hands a single job to the workers — the portable reader's unit.
 func (e *udpEngine) enqueue(j *udpJob) {
-	var b udpJobBatch
-	b.jobs[0] = j
-	b.n = 1
-	e.enqueueBatch(&b)
-}
-
-func (e *udpEngine) enqueueBatch(b *udpJobBatch) {
 	// Counted from here rather than from the read: a slab parked in a
 	// reader waiting for a packet is idle, not outstanding, and a
 	// quiescence check that could not tell the two apart would never see
 	// an idle server settle.
-	e.inFlight.Add(int64(b.n))
-	for i := 0; i < b.n; i++ {
-		b.jobs[i].state = udpJobQueued
-	}
+	e.inFlight.Add(1)
+	j.state = udpJobQueued
 
 	// The pool first, while it can keep up. A served hit is microseconds,
 	// so the queue is empty in the ordinary case and the reply rides the
 	// worker's send burst — which is what keeps the hit path free of both
 	// syscalls and allocations.
 	select {
-	case e.ready <- *b:
+	case e.ready <- j:
 		return
 	default:
 	}
@@ -540,13 +512,11 @@ func (e *udpEngine) enqueueBatch(b *udpJobBatch) {
 	// gives one to the packets the pool cannot take, which restores the
 	// ceiling without giving up the burst on the path that has one.
 	//
-	// It is still bounded — by the ring, which these jobs came out of and
+	// It is still bounded — by the ring, which this job came out of and
 	// which is the memory bound the design already states.
-	for i := 0; i < b.n; i++ {
-		udpOverflowServed.Inc()
-		e.overflowG.Add(1)
-		go e.serveOverflow(b.jobs[i])
-	}
+	udpOverflowServed.Inc()
+	e.overflowG.Add(1)
+	go e.serveOverflow(j)
 }
 
 // serveOverflow runs one overflow job and leaves the drain barrier when
@@ -617,30 +587,22 @@ func (e *udpEngine) worker(slot int) {
 	burst := udpTXBurst{slot: slot}
 	for {
 		select {
-		case b, ok := <-e.ready:
+		case j, ok := <-e.ready:
 			if !ok {
 				e.flushTX(&burst)
 				return
 			}
-			e.serveBatch(&b, &burst)
+			e.serve(j, &burst)
+			if burst.full() {
+				e.flushTX(&burst)
+			}
 		default:
 			e.flushTX(&burst)
-			b, ok := <-e.ready
+			j, ok := <-e.ready
 			if !ok {
 				return
 			}
-			e.serveBatch(&b, &burst)
-		}
-	}
-}
-
-// serveBatch runs one reader cycle's jobs back to back; the burst flushes
-// whenever it fills, so a cycle larger than the TX window still sends.
-func (e *udpEngine) serveBatch(b *udpJobBatch, burst *udpTXBurst) {
-	for i := 0; i < b.n; i++ {
-		e.serve(b.jobs[i], burst)
-		if burst.full() {
-			e.flushTX(burst)
+			e.serve(j, &burst)
 		}
 	}
 }

--- a/server/udp_engine.go
+++ b/server/udp_engine.go
@@ -319,8 +319,13 @@ func newUDPEngine(handler rawHandler, pcs []*net.UDPConn, wildcard bool, workers
 		txConns:  make(map[*net.UDPConn]syscall.RawConn, len(pcs)),
 	}
 	// The fast path is optional on the handler; without it every query
-	// keeps to the ring exactly as before.
-	e.inline, _ = handler.(inlineRawHandler)
+	// keeps to the ring exactly as before. InlineReady gates on the
+	// pipeline: a handler whose chain has no inline barrier would carry
+	// the reader into the resolver, so it declines the fast path even
+	// though it implements the interface.
+	if ih, ok := handler.(inlineRawHandler); ok && ih.InlineReady() {
+		e.inline = ih
+	}
 	// One send-state slot per worker, plus one per reader: an inline
 	// serve stages its replies on the reader's own burst and sends the
 	// receive batch back as one transmit batch.
@@ -504,6 +509,15 @@ func (e *udpEngine) enqueue(j *udpJob) {
 	// quiescence check that could not tell the two apart would never see
 	// an idle server settle.
 	e.inFlight.Add(1)
+	e.enqueueCounted(j)
+}
+
+// enqueueCounted is enqueue for a job whose in-flight count is already
+// carried: serveInline counts a job when it takes it into serving, and a
+// handoff keeps that count — decrementing across the hand-back would let
+// the counter dip through zero with the job still owned, and a quiescence
+// barrier could close over it.
+func (e *udpEngine) enqueueCounted(j *udpJob) {
 	j.state = udpJobQueued
 
 	// The pool first, while it can keep up. A served hit is microseconds,
@@ -679,11 +693,16 @@ func (e *udpEngine) serve(j *udpJob, burst *udpTXBurst) {
 // carries the inline-only mark, and a query it cannot finish comes back
 // unserved for the ring. done reports whether the job reached a terminal
 // here; false hands ownership back to the caller with the job returned to
-// the reading state and marked for replay.
+// the reading state, marked for replay, and its in-flight count carried —
+// the caller continues with enqueueCounted.
 //
 //nolint:unused // Linux batch path (udp_batch_linux.go)
 func (e *udpEngine) serveInline(j *udpJob, burst *udpTXBurst) (done bool) {
 	j.transition(udpJobReading, udpJobServing)
+	// Outstanding from here: the ring path counts a job at enqueue, and
+	// this is the inline path's equivalent moment. Every terminal below
+	// releases from Serving, which is what counts it back down.
+	e.inFlight.Add(1)
 	j.burst = burst
 	done = true
 	defer func() {
@@ -692,13 +711,24 @@ func (e *udpEngine) serveInline(j *udpJob, burst *udpTXBurst) (done bool) {
 			done = true
 		}
 		j.burst = nil
-		if !done {
-			j.replay = true
-			j.transition(udpJobServing, udpJobReading)
+		if j.txLen > 0 {
+			// A staged reply is terminal even when a handler also marked
+			// handoff: these bytes answer this query, and a replay after
+			// them could only resolve a question the client already has
+			// an answer to — or transmit a stale reply if the replay
+			// declined to write.
+			done = true
+			udpInlineServed.Inc()
+			if burst.full() {
+				e.flushTX(burst)
+			}
+			burst.add(j)
 			return
 		}
-		if j.txLen > 0 {
-			burst.add(j)
+		if !done {
+			udpInlineHandoff.Inc()
+			j.replay = true
+			j.transition(udpJobServing, udpJobReading)
 			return
 		}
 		j.release(udpJobServing)

--- a/server/udp_engine.go
+++ b/server/udp_engine.go
@@ -345,14 +345,14 @@ func newUDPEngine(handler rawHandler, pcs []*net.UDPConn, wildcard bool, workers
 // the admission cap is reached, and the cap — not the cache, not the
 // collector — is the memory authority here.
 func (e *udpEngine) take(shard int) *udpJob {
-	for {
-		n := e.leased.Load()
-		if n >= e.slabCap {
-			return nil
-		}
-		if e.leased.CompareAndSwap(n, n+1) {
-			break
-		}
+	// Add-then-rollback instead of a CAS loop: under wire-speed load
+	// sixteen readers spinning Load+CAS on one cache line burned more
+	// CPU retrying than serving. A fetch-add never retries; the counter
+	// may momentarily overshoot the cap by the number of concurrent
+	// takers, every one of which rolls back before returning.
+	if e.leased.Add(1) > e.slabCap {
+		e.leased.Add(-1)
+		return nil
 	}
 	if j := e.cache.get(shard); j != nil {
 		j.slabShard = uint8(shard & (slabShardCount - 1))

--- a/server/udp_inline_linux_test.go
+++ b/server/udp_inline_linux_test.go
@@ -1,0 +1,184 @@
+//go:build linux
+
+package server
+
+import (
+	"context"
+	"net"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/middleware"
+)
+
+// The batch reader's inline path, end to end over real sockets: hits
+// finish on the reader and ride the cycle's transmit burst, handoffs
+// travel the ring and finish on a worker via ServeRawReplay, a panicking
+// inline serve is dropped without killing the reader — and through all of
+// it the in-flight accounting balances, which the quiescence barrier at
+// the end proves. The pre-fix engine failed exactly there: every inline
+// terminal decremented a count enqueue never incremented, so Quiesced()
+// was false forever after the first inline serve.
+
+type inlineStubHandler struct {
+	inlineServed atomic.Int64
+	replayServed atomic.Int64
+}
+
+func (h *inlineStubHandler) InlineReady() bool { return true }
+
+func (h *inlineStubHandler) answer(w middleware.Transport, raw []byte) bool {
+	r := new(dns.Msg)
+	if err := r.Unpack(raw); err != nil {
+		return false
+	}
+	m := new(dns.Msg)
+	m.SetReply(r)
+	m.Answer = append(m.Answer, &dns.A{
+		Hdr: dns.RR_Header{Name: r.Question[0].Name, Rrtype: dns.TypeA,
+			Class: dns.ClassINET, Ttl: 60},
+		A: net.IPv4(192, 0, 2, 2),
+	})
+	_ = w.WriteMsg(m)
+	return true
+}
+
+func (h *inlineStubHandler) ServeRaw(w middleware.Transport, raw []byte, _ time.Time) bool {
+	return h.answer(w, raw)
+}
+
+func (h *inlineStubHandler) ServeRawInline(w middleware.Transport, raw []byte, _ time.Time) bool {
+	r := new(dns.Msg)
+	if err := r.Unpack(raw); err != nil {
+		return true
+	}
+	name := r.Question[0].Name
+	switch {
+	case strings.HasPrefix(name, "panic."):
+		panic("inline stub panic")
+	case strings.HasPrefix(name, "miss."):
+		return false
+	}
+	if h.answer(w, raw) {
+		h.inlineServed.Add(1)
+	}
+	return true
+}
+
+func (h *inlineStubHandler) ServeRawReplay(w middleware.Transport, raw []byte, _ time.Time) bool {
+	if h.answer(w, raw) {
+		h.replayServed.Add(1)
+	}
+	return true
+}
+
+func TestUDPInlineServeEndToEnd(t *testing.T) {
+	stub := &inlineStubHandler{}
+	l := newUDPListener("127.0.0.1:0", stub, time.Second, 4, 64, defaultResourcePlan(1))
+	if err := l.Bind(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	served := make(chan error, 1)
+	go func() { served <- l.Serve(context.Background()) }()
+	deadline := time.Now().Add(2 * time.Second)
+	for !l.Serving() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !l.Serving() {
+		t.Fatal("engine did not start serving")
+	}
+	defer func() {
+		if err := l.Shutdown(context.Background()); err != nil {
+			t.Errorf("shutdown: %v", err)
+		}
+		select {
+		case err := <-served:
+			if err != nil {
+				t.Errorf("serve returned: %v", err)
+			}
+		case <-time.After(3 * time.Second):
+			t.Error("serve did not return after shutdown")
+		}
+	}()
+
+	addr := l.pcs[0].LocalAddr().String()
+	conn, err := net.Dial("udp", addr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	exchange := func(name string, id uint16) (*dns.Msg, error) {
+		q := new(dns.Msg)
+		q.SetQuestion(name, dns.TypeA)
+		q.Id = id
+		wire, _ := q.Pack()
+		if _, err := conn.Write(wire); err != nil {
+			return nil, err
+		}
+		buf := make([]byte, 512)
+		_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+		n, err := conn.Read(buf)
+		if err != nil {
+			return nil, err
+		}
+		m := new(dns.Msg)
+		if err := m.Unpack(buf[:n]); err != nil {
+			return nil, err
+		}
+		return m, nil
+	}
+
+	// Inline hits and ring handoffs, interleaved.
+	for i := 0; i < 50; i++ {
+		name := "hit.example."
+		if i%2 == 1 {
+			name = "miss.example."
+		}
+		m, err := exchange(name, uint16(1000+i)) //nolint:gosec // bounded test loop
+		if err != nil {
+			t.Fatalf("query %d (%s): %v", i, name, err)
+		}
+		if m.Id != uint16(1000+i) || len(m.Answer) != 1 { //nolint:gosec // bounded test loop
+			t.Fatalf("query %d (%s): bad reply %v", i, name, m)
+		}
+	}
+	if stub.inlineServed.Load() == 0 {
+		t.Fatal("no query served on the inline path")
+	}
+	if stub.replayServed.Load() == 0 {
+		t.Fatal("no handoff finished on the replay path")
+	}
+
+	// A panicking inline serve drops the query and nothing else: no
+	// reply for it, and the reader keeps serving.
+	q := new(dns.Msg)
+	q.SetQuestion("panic.example.", dns.TypeA)
+	q.Id = 9999
+	wire, _ := q.Pack()
+	if _, err := conn.Write(wire); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 512)
+	_ = conn.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+	if _, err := conn.Read(buf); err == nil {
+		t.Fatal("panicked inline serve produced a reply")
+	}
+	if m, err := exchange("hit.example.", 424); err != nil || m.Id != 424 {
+		t.Fatalf("reader did not survive the inline panic: %v", err)
+	}
+
+	// The balance proof: with the load stopped, every slab must return
+	// to the ring. An inline terminal that decrements what enqueue never
+	// incremented keeps this false forever.
+	settle := time.Now().Add(2 * time.Second)
+	for !l.Quiesced() && time.Now().Before(settle) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !l.Quiesced() {
+		t.Fatal("engine did not quiesce after inline traffic: the in-flight accounting leaked")
+	}
+}

--- a/server/udp_stretch_test.go
+++ b/server/udp_stretch_test.go
@@ -112,7 +112,7 @@ func TestUDPSlabsParkInTheCache(t *testing.T) {
 		t.Fatalf("a fresh engine parked %d slabs before any query", got)
 	}
 
-	j := e.take()
+	j := e.take(0)
 	if j == nil {
 		t.Fatal("an idle engine refused a lease")
 	}
@@ -130,7 +130,7 @@ func TestUDPSlabsParkInTheCache(t *testing.T) {
 	}
 
 	// The next lease reuses the parked slab rather than allocating.
-	j2 := e.take()
+	j2 := e.take(0)
 	if j2 != j {
 		t.Fatal("a parked slab was not reused")
 	}
@@ -144,7 +144,7 @@ func TestUDPSlabsParkInTheCache(t *testing.T) {
 	if got := e.cache.size(); got != 0 {
 		t.Fatalf("cache holds %d slabs after trim", got)
 	}
-	j3 := e.take()
+	j3 := e.take(0)
 	if j3 == nil {
 		t.Fatal("a lease was refused after trim; trim must only cost an allocation")
 	}

--- a/server/udp_stretch_test.go
+++ b/server/udp_stretch_test.go
@@ -96,8 +96,11 @@ func TestUDPAdmissionOutlivesTheSteadyState(t *testing.T) {
 		t.Fatalf("%d queries in flight with a steady-state formula of %d; "+
 			"admission must not be capped at the formula", got, steady)
 	}
-	if leased := e.leased.Load(); leased > e.slabCap {
-		t.Fatalf("leased %d slabs past the cap %d", leased, e.slabCap)
+	// Fetch-add admission may transiently overshoot by the number of
+	// concurrent takers — each rolls back before returning — so the
+	// at-rest bound only holds with the reader slack added.
+	if leased, slack := e.leased.Load(), int64(len(e.pcs)); leased > e.slabCap+slack {
+		t.Fatalf("leased %d slabs past the cap %d (+%d reader slack)", leased, e.slabCap, slack)
 	}
 }
 

--- a/server/udp_support.go
+++ b/server/udp_support.go
@@ -44,6 +44,17 @@ var (
 	}, []string{"kind"})
 	udpOverflowServed = udpOverflow.Register("served")
 
+	// udpInline splits the reader fast path from the ring: "served" is a
+	// query that finished on its reader — reply on the cycle's transmit
+	// batch, no worker wake — and "handoff" is one the inline pass
+	// admitted and guarded but a worker had to finish.
+	udpInline = metric.NewCounterVec(nil, prometheus.CounterOpts{ //nolint:unused // Linux batch path
+		Name: "dns_udp_inline_total",
+		Help: "UDP queries attempted on the reader's inline fast path, by outcome",
+	}, []string{"outcome"})
+	udpInlineServed  = udpInline.Register("served")  //nolint:unused // Linux batch path
+	udpInlineHandoff = udpInline.Register("handoff") //nolint:unused // Linux batch path
+
 	udpDropFull      = udpIngressDrops.Register("full")
 	udpDropTrunc     = udpIngressDrops.Register("trunc")
 	udpDropCtrunc    = udpIngressDrops.Register("ctrunc")


### PR DESCRIPTION
## The investigation

A head-to-head against another resolver on the bench host showed our UDP warm-hit ceiling well below what the box can push, and a CPU profile under wire-speed load explained it: **the serving itself was single digits while lock and scheduler overhead consumed a quarter of the CPU.** Three structural fixes came out of the profile trail, each verified on the box before the next was attempted.

## The fixes

**1. Shard the slab caches (16 ways).** The convoy was the engines' slab management — one `sync.Mutex` fronting each idle-slab list, taking one get and one put per request from sixteen readers and 512 workers (~540k lock ops/s on one lock). UDP jobs remember the shard of the reader that took them and return there, so steady-state slab traffic spreads exactly as wide as the socket fan-out; TCP acquisitions deal shards out round-robin off an atomic rotor. Trim/size walk the shards; the admission authority (lease and token counters) is untouched. After this, `Mutex.lockSlow` — 11.7% cum before — left the profile entirely.

**2. Fetch-add lease admission.** Sharding moved the convoy to the lease counter: sixteen readers spinning Load+CAS on one cache line (CAS alone 5.6% flat). `Add(1)` then rollback on overshoot never retries; the cap semantics are unchanged (momentary overshoot bounded by the number of concurrent takers, all of whom roll back before returning nil).

**3. Batch-slot persistence, then inline serving.** With the locks gone the profile turned into wake cost: replies left one at a time, so `sendmmsg` ran at wire speed with ~1-reply bursts (78% of syscall time) and every query paid a reader→ring→worker wake. Keeping received-but-unserved slots armed across cycles fixed the take/release churn; a first attempt at batching the ring hand-off itself (one ring send per reader cycle) is in the history as ca4a038 and its revert — it serialized a batch's cache hits behind a single worker and the admission stretch test caught the head-of-line blocking.

The structural answer is that a wire-servable hit should never cross the ring at all. The reader now runs the full middleware chain on each received packet with an **inline-only** mark; the cache — the one handler whose downstream can block — answers from its wire ladder or marks the chain for hand-off, unwritten. Replies collect in a per-reader transmit burst and leave in **one `sendmmsg` per receive cycle**, so the receive batch and the transmit batch are the same size by construction. Misses travel the ring as before and finish on a worker through a **replay pipeline** — the pipeline minus every handler declaring `OncePerQuery()` (ratelimit, reflex, dnstap), whose entry effects already ran on the inline pass. Response-keyed middlewares (metrics, accesslog) need no marker: they fire wherever the response is written, once. Handlers without the inline contract (tests, non-batch platforms) keep the old per-job path bit for bit.

## The review, and what it caught

An independent three-way adversarial review (engine state machine, middleware contract, attack surface) ran against the inline commit and found real defects; a follow-up independent review verified the fixes and caught one more. All closed in the two hardening commits:

- **In-flight accounting**: inline terminals decremented a count enqueue never incremented — the quiescence barrier broke and the opt-in memory trim silently died. The inline path now counts a job when it takes it, and a hand-off carries the count to the ring.
- **The replay contract**: excluding whole handlers from the replay lost dnstap response frames and reflex's observed-amplification feedback (both are entry-effect *and* response-wrapper handlers). The exclusion list is gone; the full pipeline replays with a chain-level replay mark and ratelimit/reflex/dnstap skip their own entry effects.
- **dnstap wire transparency**: a connected tap materialized every request, which killed the wire ladder outright. The tap now copies a wire-born request's bytes for its frames — the fast path survives with the tap on.
- **Per-entry rate-limit double charge**: both wire-serve branches (flat and chase) charged the token before gates that could still decline; across the inline/replay boundary one question could cost two tokens and a burst-1 limit dropped a paid-for hit. Every deterministic decline now precedes the charge.
- **Guard rails**: the fast path wires only when a handler declares `middleware.InlineBarrier` (a pipeline without the cache never puts a resolver on a reader); the inline counter counts staged replies alone; a written reply is terminal; per-query statistics gate on the replay mark.

The contract is under test: server-level inline/replay passes, a Linux end-to-end whose quiescence assertion fails on the broken accounting, the single-charge ladder in both branches, and the three entry-skipping middlewares.

## Measured (same corpus/harness as the #560 measurement session, 32-core host)

| | UDP warm hits | avg latency |
|---|---|---|
| baseline (0b68076) | 268k qps | 0.33 ms |
| + shards | 287k | 0.27 ms |
| + shards + fetch-add | 306k | 0.27 ms |
| + batch-slot persistence | ~330k | 0.26 ms |
| + inline serve, hardened | **424k median / 444k best** | 0.22 ms |

Under the hit hammer the inline path carries ~97.5% of queries (2.5% hand-off), zero drops, zero loss; the post-change profile shows the futex/wake bucket collapsed to ~3% with actual chain work as the top consumer. Freshly warmed NX serves at 409k and cached-SERVFAIL at 399k. The default configuration reaches the same band as the tuned one — no knob required.

Head-to-head on the same host, same warmed corpus, identical load (`-c 128 -T 8` for UDP — a realistic flow count; 20 flows leaves most of 32 reuseport readers idle — and `-c 20 -T 4` for TCP), DNSSEC validation on everywhere, 3 runs each:

| resolver | UDP median | UDP best | TCP median | TCP best |
|---|---|---|---|---|
| **sdns (this branch)** | **424k** | **444k** | **226k** | **273k** |
| PowerDNS Recursor 5.4.1 (packet-cache echo) | 371k | 390k | 56k | 57k |
| Unbound 1.24.2 | 343k | 346k | 136k | 149k |
| Knot Resolver 6.2.0 (8 workers) | 191k | 192k | 142k | 146k |

sdns runs its full middleware chain per query in those numbers.

The TCP row is this PR's last fix. The first comparison had sdns third at ~102k with a wild 80–117k band, and the profile said latency-bound, not CPU-bound: the per-connection query budget (2048) was forcing a server-side close every half second of warm-hit pipelining — a reconnect storm, confirmed by ~1,500 TIME_WAITs per minute of load. The cap defended nothing the engine does not already bound elsewhere (slab fairness is a token per announced frame, session count is the conncap, an idle connection pins no slab), so it is gone: a session now serves until its client leaves, per RFC 7766. Same harness, the storm's TIME_WAIT churn is gone and TCP more than doubled.

Known inline-architecture costs, documented not fixed here: a miss-heavy flood pays a discarded chain walk on the reader before queueing, and a pre-cache middleware that materializes — blocklist with entries, accesslog to a file, views — still bypasses the wire ladder and degrades to 100% hand-off, which `dns_udp_inline_total` makes visible (dnstap got its byte path in this PR; the rest is Track B).

## Verification

Full suite + `-race` green on darwin and linux (including the trim/stretch/fallback engine tests and the admission stretch test that killed the reverted design); `golangci-lint` clean on darwin/linux/freebsd; allocation gates green.
