### PR TITLE
release: 1.8.0 — version marks, BENCHMARKS.md, README pointer

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,124 @@
+# Benchmarks
+
+Measured 2026-08-18 at commit `8b36b91` (the 1.8.0 serving-path work, PR #572).
+This document exists to make one set of claims precisely, with the method and
+configurations needed to check them — not to advertise a bigger number than the
+method supports.
+
+**What these numbers are:** the cached-answer serving ceiling of each resolver
+on one machine — how fast the server itself can answer once the answer is in
+its cache. **What they are not:** a prediction of production throughput. Real
+traffic mixes hits with misses, and a miss is bound by upstream latency, not by
+the serving engine. What a resolver's engine controls is the hit path; that is
+what this measures.
+
+## Environment
+
+| | |
+|---|---|
+| Host | 2× Intel Xeon E5-2620 v4 @ 2.10 GHz (32 logical cores), 64 GB RAM |
+| OS | Ubuntu 26.04 LTS, stock kernel and sysctls — no network tuning |
+| Load generator | dnsperf 2.15.0, on the same host over loopback |
+| sdns build | Go 1.26.5, `go build`, no build flags |
+
+Client and server share the machine, so every number includes the load
+generator's own CPU cost, identically for every contender.
+
+## Method
+
+- **Corpus:** 2,349 names pre-verified to be served from cache (plus separate
+  corpora: 1,143 names covered by cached negative answers, 63 names with
+  cached SERVFAIL). Warm-hit corpora decay as TTLs expire, so every
+  measurement is preceded by a fresh warm pass; numbers taken against a stale
+  cache measure recursion, not serving, and come out far lower.
+- **Protocol per contender:** start fresh → warm the corpus (parallel `dig`
+  pass) → one 10-second throwaway run → the measured runs, 20 seconds each.
+  Median and best of the series are reported.
+- **UDP load shape:** `dnsperf -c 128 -T 8 -l 20`. The flow count matters: with
+  only 20 flows (`-c 20`), kernel reuseport hashing leaves most of a 32-socket
+  receiver idle and the results measure hash luck. 128 flows approximates real
+  traffic, which carries thousands. (For reference, the 20-flow shape puts
+  sdns and PowerDNS at parity around 370–400k and does not change the ordering
+  of the others.)
+- **TCP load shape:** `dnsperf -m tcp -c 20 -T 4 -l 20`, pipelined persistent
+  connections.
+- **DNSSEC validation enabled in all four resolvers** (AD flag spot-checked
+  through each). IPv6 upstream disabled everywhere (the host has no v6
+  transit); irrelevant to cached serving.
+
+## Contenders
+
+| Resolver | Version | Serving configuration |
+|---|---|---|
+| sdns | 1.8.0 @ `8b36b91` | stock generated config (bind/API/paths only); full middleware chain runs per query |
+| PowerDNS Recursor | 5.4.1 | `threads=8`, `reuseport=yes`, `dnssec=validate`; warm hits served by the packet cache |
+| Unbound | 1.24.2 | `num-threads: 8`, `so-reuseport: yes`, cache slabs = 8, `msg-cache-size: 256m`, `rrset-cache-size: 512m`, `minimal-responses: yes` |
+| Knot Resolver | 6.2.0 | 8 `kresd` instances on one port (SO_REUSEPORT), shared 512 MB LMDB cache |
+
+Two fairness notes, one in each direction. PowerDNS's packet cache echoes a
+stored packet — deliberately less work per query than sdns's full chain, so
+its number represents its lightest possible path, as does ours. And each
+contender was given a reasonable performance configuration, not an exhaustive
+tuning pass; a specialist could likely move any of these numbers some percent.
+
+## Results
+
+### UDP, cached answers (`-c 128 -T 8`, 3×20 s)
+
+| Resolver | median qps | best qps |
+|---|---|---|
+| **sdns 1.8.0** | **424k** | **444k** |
+| PowerDNS Recursor 5.4.1 | 371k | 390k |
+| Unbound 1.24.2 | 343k | 346k |
+| Knot Resolver 6.2.0 | 191k | 192k |
+
+sdns with the untouched default configuration measures in the same band
+(median 406k over three runs) — the result does not depend on tuning knobs.
+Answer classes beyond plain hits, measured on sdns freshly warmed: negative
+answers (NXDOMAIN from cached denial) 409k, cached SERVFAIL 399k.
+
+### TCP, cached answers (`-c 20 -T 4`, 5×20 s)
+
+| Resolver | median qps | best qps |
+|---|---|---|
+| **sdns 1.8.0** | **226k** | **273k** |
+| Knot Resolver 6.2.0 | 142k | 146k |
+| Unbound 1.24.2 | 136k | 149k |
+| PowerDNS Recursor 5.4.1 | 56k | 57k |
+
+### Run-to-run spread
+
+20-second runs on a busy OS have real variance; the full series behind the
+medians spanned roughly ±7% for sdns UDP (423–444k), ±6% for PowerDNS
+(346–390k), ±3% for Unbound, ±2% for Knot, and ±15% for sdns TCP (195–273k).
+Single-run numbers from any resolver should be read with that in mind.
+
+## What changed in 1.8.0
+
+The same harness, applied to sdns itself across the 1.8.0 serving-path work
+(each row A/B-measured against its predecessor at the time; early rows used
+the 20-flow shape, so rows are comparable to their neighbors, not across the
+whole column):
+
+| build | UDP cached answers |
+|---|---|
+| 1.8.0 baseline before PR #572 | 268k |
+| + sharded slab caches | 287k |
+| + fetch-add lease admission | 306k |
+| + batch-slot persistence | ~330k |
+| + inline wire-hit serving on the reader | 424k median / 444k best |
+
+TCP moved from ~100k to the 226k median above in the same PR, by removing a
+per-connection query budget that forced a reconnect storm under pipelining.
+
+## Reproducing
+
+```sh
+# corpus: one name per line; verify each serves from cache before trusting it
+dnsperf -s <addr> -p <port> -d hits.txt -c 128 -T 8 -l 20          # UDP
+dnsperf -s <addr> -p <port> -m tcp -d hits.txt -c 20 -T 4 -l 20    # TCP
+```
+
+Warm first, discard a throwaway run, take at least three measurements, report
+the median, and state the flow count — it is the parameter that moves these
+numbers the most.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ docker run -d --name sdns -p 53:53 -p 53:53/udp ghcr.io/semihalev/sdns:latest
 Pin to a specific version (recommended for production):
 
 ```shell
-$ docker run -d --name sdns -p 53:53 -p 53:53/udp ghcr.io/semihalev/sdns:1.8.0-rc2
+$ docker run -d --name sdns -p 53:53 -p 53:53/udp ghcr.io/semihalev/sdns:1.8.0
 ```
 
 #### Docker Compose
@@ -572,39 +572,10 @@ This is useful when:
 
 ## Performance
 
-### Benchmark Environment
-
-*   **Server Specifications:**
-    *   Processor: Apple M1 Pro
-    *   Memory: 16GB
-
-### Benchmarking Tool
-
-*   **Tool:** [DNS-OARC dnsperf](https://www.dns-oarc.net/tools/dnsperf)
-*   **Configuration:**
-    *   Query volume: 50,000 sample queries
-    *   Test date: June 2025
-
-### Benchmark Comparisons
-
-Tests were performed on the following DNS resolvers: SDNS 1.6.5, PowerDNS Recursor 5.4.1, BIND 9.19.12, and Unbound 1.17.1.
-
-### Benchmark Results
-
-| Resolver | Version | QPS    | Avg Latency | Lost Queries | Runtime  | Response Codes                                      |
-| -------- | ------- | ------ | ----------- | ------------ | -------- | --------------------------------------------------- |
-| SDNS     | 1.6.5   | 708/s  | 134ms       | 1 (0.00%)    | 70.5s    | NOERROR: 66.87%, SERVFAIL: 1.71%, NXDOMAIN: 31.43% |
-| PowerDNS | 5.4.1   | 617/s  | 147ms       | 17 (0.03%)   | 80.9s    | NOERROR: 66.87%, SERVFAIL: 1.69%, NXDOMAIN: 31.44% |
-| BIND     | 9.19.12 | 405/s  | 200ms       | 156 (0.31%)  | 123.0s   | NOERROR: 67.84%, SERVFAIL: 1.62%, NXDOMAIN: 30.54% |
-| Unbound  | 1.17.1  | 338/s  | 237ms       | 263 (0.53%)  | 147.0s   | NOERROR: 68.20%, SERVFAIL: 1.20%, NXDOMAIN: 30.60% |
-
-### Performance Summary
-
-SDNS demonstrates superior performance across all key metrics:
-- **Highest throughput**: 708 queries per second (15% faster than PowerDNS, 75% faster than BIND, 109% faster than Unbound)
-- **Lowest latency**: 134ms average (9-43% lower than competitors)
-- **Best reliability**: Only 1 lost query out of 50,000 (99.998% success rate)
-- **Fastest completion**: 70.5 seconds total runtime
+Throughput measurements, methodology, resolver comparisons and their caveats
+live in [BENCHMARKS.md](BENCHMARKS.md) — measured with dnsperf against
+PowerDNS Recursor, Unbound and Knot Resolver under identical load, most
+recently for the 1.8.0 serving-path work.
 
 For Kubernetes DNS, the registry is the hot path:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,8 @@ Only the latest minor release line receives security updates:
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 1.7.x   | :white_check_mark: |
-| < 1.7   | :x:                |
+| 1.8.x   | :white_check_mark: |
+| < 1.8   | :x:                |
 
 ## Reporting a Vulnerability
 

--- a/sdns.go
+++ b/sdns.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const version = "1.8.0-rc2"
+const version = "1.8.0"
 
 var (
 	cfgPath    string


### PR DESCRIPTION
The 1.8.0 release preparation:

**Version marks.** `sdns.go` moves from `1.8.0-rc2` to `1.8.0`; the README docker pin example follows; `config/config.go`'s configver and the README Configuration header were already at 1.8.0. A repo-wide sweep for stale `1.7.x`/`rc` marks found one more — SECURITY.md's supported-versions table, now `1.8.x`. (Remaining "pre-1.7.0" mentions in the README are behavioral descriptions of ECS cache compatibility, not version marks, and stay.)

**BENCHMARKS.md.** A standalone benchmark document for the 1.8.0 serving-path results: what was measured (cached-answer serving ceiling), on what (32-core Xeon host, loopback, dnsperf 2.15.0), how (fresh-warm protocol, throwaway run, 3–5×20s, medians; 128-flow UDP shape with the rationale), against whom (PowerDNS Recursor 5.4.1, Unbound 1.24.2, Knot Resolver 6.2.0 — versions and serving configurations listed, DNSSEC validation on everywhere), and with the caveats stated plainly: loopback includes the load generator's cost, run-to-run spread bands are given, PowerDNS's packet cache does less per query than our full chain, and none of it predicts mixed-traffic production throughput.

**README.** The June-2025 benchmark section (Apple M1 Pro, SDNS 1.6.5 era) is deleted in favor of a pointer to BENCHMARKS.md. The Kubernetes registry performance notes stay.