### PR TITLE
authority: price an unmeasured upstream as a guess, not as instant

### DIFF
--- a/internal/authority/ranking_test.go
+++ b/internal/authority/ranking_test.go
@@ -2,6 +2,7 @@ package authority
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -158,6 +159,51 @@ func TestRotationLeavesTheOrderedServersAlone(t *testing.T) {
 
 	if got := addrsOf(list); got[0] != fast.Addr || got[1] != mid.Addr || got[2] != slow.Addr {
 		t.Fatalf("distinct scores were reordered: %v", got)
+	}
+}
+
+// The order behind the first two is not decoration: it is what the
+// resolver walks when the leader does not answer, waiting out an adaptive
+// timeout at every step. So exploration moves its candidate into the
+// second slot rather than trading places with whoever held it — a trade
+// would fling the genuine runner-up down to wherever the guess came from,
+// putting every other guess in the delegation ahead of a server already
+// known to be fast.
+func TestExplorationDoesNotDemoteTheRunnerUp(t *testing.T) {
+	leader := measured("192.0.2.1:53", 10*time.Millisecond)
+	runnerUp := measured("192.0.2.2:53", 20*time.Millisecond)
+	list := []*Server{leader, runnerUp}
+	for i := range 6 {
+		list = append(list, NewServer(fmt.Sprintf("192.0.2.9:%d", i+1), IPv4))
+	}
+	last := list[len(list)-1]
+
+	// Explore — the roll is randN(len) < staleCount, so zero always
+	// explores — and take the furthest candidate on offer.
+	withRand(t, func(n int) int {
+		if n == len(list) {
+			return 0
+		}
+		return n - 1
+	})
+	Sort(list)
+
+	if list[1] != last {
+		t.Fatalf("exploration did not reach the last unmeasured address: %v", addrsOf(list))
+	}
+	if list[0] != leader {
+		t.Fatalf("exploration displaced the leader: %v", addrsOf(list))
+	}
+	if list[2] != runnerUp {
+		t.Fatalf("the runner-up was demoted to position %d of %d; the resolver "+
+			"would time out on every guess before reaching it: %v",
+			slices.Index(list, runnerUp), len(list), addrsOf(list))
+	}
+	// And what the ranking sorted on still describes what it holds.
+	for i := 1; i < len(list); i++ {
+		if i > 2 && list[i].Score() < list[i-1].Score() {
+			t.Fatalf("the tail came out of order: %v", addrsOf(list))
+		}
 	}
 }
 

--- a/internal/authority/ranking_test.go
+++ b/internal/authority/ranking_test.go
@@ -207,6 +207,29 @@ func TestExplorationDoesNotDemoteTheRunnerUp(t *testing.T) {
 	}
 }
 
+// An exchange that completed faster than the clock can see is still an
+// exchange that completed. The estimate and "nothing has answered" are
+// told apart by the estimate being zero, so recording a zero makes a
+// measurement report itself as the absence of one: priced at the seed,
+// explored forever, and never allowed to lead however fast it is.
+// Windows' timer produces exactly this for a loopback exchange — it is
+// where CI found it — and a LAN authority on any platform is one clock
+// granularity away from it.
+func TestAnInstantAnswerIsStillAnAnswer(t *testing.T) {
+	s := NewServer("192.0.2.1:53", IPv4)
+	s.Observe(0)
+
+	if s.SmoothedRTT() == 0 {
+		t.Fatal("an exchange the clock could not resolve reads as never having happened")
+	}
+	if got := s.Score(); got >= time.Duration(rttUnknownSeed) {
+		t.Fatalf("the fastest possible answer is priced at %v, the price of a guess", got)
+	}
+	if !s.Answering() {
+		t.Fatal("an answer that arrived instantly is not counted as an answer")
+	}
+}
+
 // An operator reading a delegation has to be able to tell a slow
 // authority from one that is not replying, and the price cannot say it: a
 // server that does not answer is charged a timeout, and a timeout is also

--- a/internal/authority/ranking_test.go
+++ b/internal/authority/ranking_test.go
@@ -2,6 +2,7 @@ package authority
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -157,6 +158,38 @@ func TestRotationLeavesTheOrderedServersAlone(t *testing.T) {
 
 	if got := addrsOf(list); got[0] != fast.Addr || got[1] != mid.Addr || got[2] != slow.Addr {
 		t.Fatalf("distinct scores were reordered: %v", got)
+	}
+}
+
+// An operator reading a delegation has to be able to tell a slow
+// authority from one that is not replying, and the price cannot say it: a
+// server that does not answer is charged a timeout, and a timeout is also
+// what a very slow server costs. So the state carries whether the last
+// exchange came back, and the health line reports it. Nothing is ranked
+// on it.
+func TestHealthSeparatesSlowFromSilent(t *testing.T) {
+	slow := NewServer("192.0.2.1:53", IPv4)
+	slow.Observe(2 * time.Second)
+
+	silent := NewServer("192.0.2.2:53", IPv4)
+	silent.ObserveNoAnswer(2 * time.Second)
+
+	if got := slow.String(); !strings.Contains(got, "[POOR]") {
+		t.Fatalf("a slow but answering authority reports %q", got)
+	}
+	if got := silent.String(); !strings.Contains(got, "[FAILING]") {
+		t.Fatalf("an authority that did not reply reports %q", got)
+	}
+	// Both are priced the same, which is the whole reason the bit exists.
+	if slow.Score() != silent.Score() {
+		t.Fatalf("the two are ranked differently: %v against %v", slow.Score(), silent.Score())
+	}
+
+	// And one answer clears it, in the same write that folds in the
+	// latency.
+	silent.Observe(10 * time.Millisecond)
+	if !silent.Answering() {
+		t.Fatal("an authority that answered still reports as failing")
 	}
 }
 

--- a/internal/authority/ranking_test.go
+++ b/internal/authority/ranking_test.go
@@ -108,6 +108,58 @@ func TestStaleEvidenceDrifts(t *testing.T) {
 	}
 }
 
+// withRand pins the ranking's randomness so a test can state an order.
+func withRand(t *testing.T, f func(int) int) {
+	t.Helper()
+	old := randN
+	randN = f
+	t.Cleanup(func() { randN = old })
+}
+
+// The leader answers the query; the slot behind it goes to whichever
+// server is level with the runner-up, and the sort's stability meant that
+// was the same address on every lookup, forever. It matters most where
+// the tie is widest: a delegation's unmeasured addresses all carry the
+// same price, so one of them was queried on every cache miss and the
+// other seventeen were never tried at all.
+func TestTheSecondSlotRotatesAmongEquals(t *testing.T) {
+	fast := measured("192.0.2.1:53", 10*time.Millisecond)
+	list := []*Server{fast}
+	for i := range 8 {
+		list = append(list, NewServer(fmt.Sprintf("192.0.2.9:%d", i+1), IPv4))
+	}
+
+	seen := map[string]int{}
+	for range 2000 {
+		Sort(list)
+		if list[0] != fast {
+			t.Fatalf("the leader lost its slot to a guess: %v", addrsOf(list))
+		}
+		seen[list[1].Addr]++
+	}
+
+	if len(seen) != 8 {
+		t.Fatalf("the second slot reached %d of 8 unmeasured addresses: %v", len(seen), seen)
+	}
+}
+
+// Rotation may not touch the leader, and may not reach past the servers
+// that are actually level with the runner-up.
+func TestRotationLeavesTheOrderedServersAlone(t *testing.T) {
+	fast := measured("192.0.2.1:53", 10*time.Millisecond)
+	mid := measured("192.0.2.2:53", 50*time.Millisecond)
+	slow := measured("192.0.2.3:53", 90*time.Millisecond)
+	list := []*Server{slow, fast, mid}
+
+	// A source that would swap the furthest thing it is offered.
+	withRand(t, func(n int) int { return n - 1 })
+	Sort(list)
+
+	if got := addrsOf(list); got[0] != fast.Addr || got[1] != mid.Addr || got[2] != slow.Addr {
+		t.Fatalf("distinct scores were reordered: %v", got)
+	}
+}
+
 // The ranking runs once per cache miss, so an allocation here is an
 // allocation per miss on the path that already carries the resolver's
 // heaviest work. sort.Slice cost two, for the reflection it needs.
@@ -179,6 +231,25 @@ func benchmarkSort(b *testing.B, n int) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		copy(list, src) // restore the unordered set; copying pointers allocates nothing
+		Sort(list)
+	}
+}
+
+// A delegation the resolver has just read is entirely unmeasured, so
+// every address ties and the rotation has the widest set to scan and pick
+// from. This is that shape, against benchmarkSort's mostly-distinct one.
+func BenchmarkSortAllUnmeasured(b *testing.B) {
+	const n = 13
+	src := make([]*Server, 0, n)
+	for i := range n {
+		src = append(src, NewServer(fmt.Sprintf("192.0.2.9:%d", i+1), IPv4))
+	}
+	list := make([]*Server, n)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		copy(list, src)
 		Sort(list)
 	}
 }

--- a/internal/authority/ranking_test.go
+++ b/internal/authority/ranking_test.go
@@ -1,0 +1,198 @@
+package authority
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// The ranking runs on every cache miss, over every delegation's address
+// set, and it decides which upstream gets the query. These are the four
+// properties it is being changed for.
+
+func measured(addr string, rtt time.Duration) *Server {
+	s := NewServer(addr, IPv4)
+	s.Observe(rtt)
+	return s
+}
+
+func addrsOf(list []*Server) []string {
+	out := make([]string, len(list))
+	for i, s := range list {
+		out[i] = s.Addr
+	}
+	return out
+}
+
+// A server nothing is known about must not outrank one measured fast.
+// "No data" was worth zero, which is not slow but instant, so the head of
+// the list went to whichever address had never answered — and with the
+// resolver starting its top two in parallel, that is one of every miss's
+// two queries spent on the one server whose speed nobody has established.
+func TestUnmeasuredDoesNotOutrankMeasured(t *testing.T) {
+	fast := measured("192.0.2.1:53", 10*time.Millisecond)
+	unknown := NewServer("192.0.2.2:53", IPv4)
+
+	list := []*Server{unknown, fast}
+	Sort(list)
+
+	if list[0] != fast {
+		t.Fatalf("ranking put the unmeasured server first: %v", addrsOf(list))
+	}
+	// And it is priced as a guess worth trying, not as a server to avoid.
+	if got := unknown.Score(); got != time.Duration(rttUnknownSeed)+1 {
+		t.Fatalf("an unmeasured server is priced at %v, want the seed", got)
+	}
+}
+
+// Degradation has to be visible immediately. A running average over every
+// sample ever taken needed dozens of them to notice an authority going
+// bad, and kept sending queries into it in the meantime; the blend is half
+// and half so one bad sample lands in the ranking at once.
+func TestDegradationSinksOnOneSlowAnswer(t *testing.T) {
+	degrading := measured("192.0.2.1:53", 10*time.Millisecond)
+	steady := measured("192.0.2.2:53", 50*time.Millisecond)
+
+	list := []*Server{degrading, steady}
+	Sort(list)
+	if list[0] != degrading {
+		t.Fatal("the fast server should lead before it degrades")
+	}
+
+	degrading.Observe(2 * time.Second)
+	Sort(list)
+	if list[0] != steady {
+		t.Fatalf("a degraded server still leads after a slow answer: %v", addrsOf(list))
+	}
+}
+
+// The ranking must survive a long run. The old shape cleared every
+// server's statistics every thousandth sort, which is not aging but
+// amnesia: for the sorts that followed, the whole set read as unmeasured
+// — the state it ranked first — so the fastest server lost the lead
+// periodically for no reason anyone could see from the outside.
+func TestRankingSurvivesLongRuns(t *testing.T) {
+	fast := measured("192.0.2.1:53", 10*time.Millisecond)
+	slow := measured("192.0.2.2:53", 200*time.Millisecond)
+	list := []*Server{fast, slow}
+
+	for i := 1; i <= 2500; i++ {
+		fast.Observe(10 * time.Millisecond)
+		slow.Observe(200 * time.Millisecond)
+		Sort(list)
+
+		if list[0] != fast {
+			t.Fatalf("ranking lost the faster server at call %d: %v", i, addrsOf(list))
+		}
+	}
+}
+
+// Evidence expires. A server measured fast an hour ago drifts back toward
+// a guess rather than holding the lead on a path that may no longer
+// exist — per server, as its own measurement ages, which is what replaced
+// wiping the whole set at once.
+func TestStaleEvidenceDrifts(t *testing.T) {
+	s := measured("192.0.2.1:53", 10*time.Millisecond)
+	fresh := s.Score()
+
+	atomic.StoreInt64(&s.lastNs, time.Now().Add(-time.Hour).UnixNano())
+	stale := s.Score()
+
+	if stale <= fresh {
+		t.Fatalf("an hour-old measurement did not age: %v -> %v", fresh, stale)
+	}
+	if stale >= time.Duration(rttUnknownSeed) {
+		t.Fatalf("aging threw the evidence away entirely: %v", stale)
+	}
+}
+
+// The ranking runs once per cache miss, so an allocation here is an
+// allocation per miss on the path that already carries the resolver's
+// heaviest work. sort.Slice cost two, for the reflection it needs.
+func TestSortDoesNotAllocate(t *testing.T) {
+	list := benchServers(13)
+	if allocs := testing.AllocsPerRun(200, func() { Sort(list) }); allocs != 0 {
+		t.Fatalf("Sort allocated %.0f objects per call", allocs)
+	}
+}
+
+// One server is sampled by several lookups at once — a root address is in
+// flight from most of them, most of the time. Read, halve, write as
+// separate steps keeps only whichever store landed last, which is how an
+// estimate drifts away from what the network is doing under exactly the
+// load that makes ranking matter. Identical samples make the expectation
+// exact: each one halves the distance to its own value, so eight of them
+// must land within a two-hundred-and-fifty-sixth of it however they
+// interleave.
+func TestConcurrentSamplesAreNotLost(t *testing.T) {
+	const rounds, writers = 200, 8
+	const start, sample = 2 * time.Second, 10 * time.Millisecond
+	worst := int64(sample) + int64(start)/(1<<writers)
+
+	for range rounds {
+		s := measured("192.0.2.1:53", start)
+
+		var gate, done sync.WaitGroup
+		gate.Add(1)
+		for range writers {
+			done.Add(1)
+			go func() {
+				defer done.Done()
+				gate.Wait()
+				s.Observe(sample)
+			}()
+		}
+		gate.Done()
+		done.Wait()
+
+		if got := s.SmoothedRTT(); int64(got) > worst {
+			t.Fatalf("estimate settled at %v after %d identical samples, want %v or better — samples were dropped",
+				got, writers, time.Duration(worst))
+		}
+	}
+}
+
+// benchServers builds a deterministic address set shaped like a root or
+// TLD set: a few fast, a few far, one never measured. The port carries the
+// identity because past 254 a last-octet address stops being an address.
+func benchServers(n int) []*Server {
+	list := make([]*Server, 0, n)
+	for i := range n {
+		s := NewServer(fmt.Sprintf("192.0.2.1:%d", i+1), IPv4)
+		if i%7 != 0 {
+			s.Observe(time.Duration(10+i*7) * time.Millisecond)
+		}
+		list = append(list, s)
+	}
+	return list
+}
+
+// Every lookup hands over a fresh copy of the delegation, so this is a
+// sort of an arbitrary order rather than a re-sort of the last ranking.
+func benchmarkSort(b *testing.B, n int) {
+	src := benchServers(n)
+	list := make([]*Server, n)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		copy(list, src) // restore the unordered set; copying pointers allocates nothing
+		Sort(list)
+	}
+}
+
+func BenchmarkSort2(b *testing.B)  { benchmarkSort(b, 2) }
+func BenchmarkSort8(b *testing.B)  { benchmarkSort(b, 8) }
+func BenchmarkSort13(b *testing.B) { benchmarkSort(b, 13) }
+func BenchmarkSort26(b *testing.B) { benchmarkSort(b, 26) }
+
+// The record path runs once per upstream attempt, so it is priced too.
+func BenchmarkObserve(b *testing.B) {
+	s := NewServer("192.0.2.1:53", IPv4)
+	b.ReportAllocs()
+	for range b.N {
+		s.Observe(12 * time.Millisecond)
+	}
+}

--- a/internal/authority/server.go
+++ b/internal/authority/server.go
@@ -13,8 +13,17 @@ import (
 // Server type.
 type Server struct {
 	// place atomic members at the start to fix alignment for ARM32
-	Rtt       int64
-	Count     int64
+	//
+	// state is the smoothed latency and the fact that an exchange has
+	// completed, in one word: [estimate ns : 63][measured : 1]. They are
+	// packed because they have to change together — a sample that lands
+	// between reading one and writing the other could otherwise replace a
+	// measurement instead of folding into it.
+	state int64
+	// lastNs is when state was last refreshed, in Unix nanoseconds. It is
+	// what ages a measurement per server, replacing a periodic wipe that
+	// aged the whole set at once.
+	lastNs    int64
 	Addr      string
 	IPVersion IPVersion
 
@@ -118,26 +127,30 @@ func (v IPVersion) String() string {
 }
 
 func (a *Server) String() string {
-	count := atomic.LoadInt64(&a.Count)
-	rn := atomic.LoadInt64(&a.Rtt)
-
-	if count == 0 {
-		count = 1
-	}
+	measured := a.SmoothedRTT()
 
 	var health string
 	switch {
-	case rn >= int64(time.Second):
-		health = "POOR"
-	case rn > 0:
-		health = "GOOD"
-	default:
+	case measured == 0:
 		health = "UNKNOWN"
+	case measured >= time.Second:
+		health = "POOR"
+	default:
+		health = "GOOD"
 	}
 
-	rtt := (time.Duration(rn) / time.Duration(count)).Round(time.Millisecond)
+	rtt := "unknown"
+	if measured != 0 {
+		rtt = measured.Round(time.Millisecond).String()
+	}
 
-	return a.IPVersion.String() + ":" + a.Addr + " rtt:" + rtt.String() + " health:[" + health + "]"
+	// The score is what the ranking actually sorts on, and it is not the
+	// latency: an unmeasured server is priced at the seed, and an old
+	// measurement drifts back toward it. Printing both is what makes the
+	// order this reports explicable.
+	return a.IPVersion.String() + ":" + a.Addr + " rtt:" + rtt +
+		" rank:" + a.Score().Round(time.Millisecond).String() +
+		" health:[" + health + "]"
 }
 
 // fpEntry caches a Fingerprint() result along with the generation
@@ -221,27 +234,119 @@ func (a *Servers) InvalidateFingerprint() {
 	a.gen.Add(1)
 }
 
-// Sort sort servers by rtt.
-func Sort(serversList []*Server, called uint64) {
-	for _, s := range serversList {
-		// clear stats and re-start again
-		if called%1e3 == 0 {
-			atomic.StoreInt64(&s.Rtt, 0)
-			atomic.StoreInt64(&s.Count, 0)
+const (
+	// rttUnknownSeed is what "no data" is worth. Zero — the value a fresh
+	// Server carries — ranked no-data as instant, which handed the head of
+	// the list to whichever address had never answered; with the resolver
+	// starting its top two in parallel, that spent one of every miss's two
+	// queries on the one server whose speed nobody had established. The
+	// seed sits above a healthy authority and below a sick one: an
+	// unmeasured server is worth trying, never worth preferring.
+	rttUnknownSeed = int64(300 * time.Millisecond)
 
-			continue
+	// staleAfter is when a measurement stops counting as fresh evidence.
+	// It replaces clearing every server's statistics every thousandth
+	// sort, which aged the whole set at once and returned all of them to
+	// the unmeasured state the ranking treated as fastest.
+	staleAfter = int64(5 * time.Minute)
+
+	// sortStackServers is the largest address set ranked without touching
+	// the heap. The root names thirteen; a delegation past this is rare
+	// enough to pay for a slice.
+	sortStackServers = 32
+)
+
+// Observe records a completed exchange: how long this server took to
+// answer. The estimate is blended half and half with each new sample, so
+// one bad sample is visible in the ranking immediately — which is what a
+// resolver needs when an authority starts to degrade. A running average
+// over every sample ever taken needed dozens of them to notice.
+//
+// The loop is there because a root address is in flight from several
+// lookups at once. Read, decide, write as separate steps kept only
+// whichever store landed last; the compare-and-swap carries the estimate
+// and its measured bit together, so a sample that is counted is a sample
+// that moved the estimate.
+func (s *Server) Observe(d time.Duration) {
+	sample := int64(d)
+	if sample < 0 {
+		sample = 0
+	}
+	for {
+		w := atomic.LoadInt64(&s.state)
+		next := sample
+		if w&1 == 1 {
+			next = (w>>1 + sample) / 2
 		}
-
-		rtt := atomic.LoadInt64(&s.Rtt)
-		count := atomic.LoadInt64(&s.Count)
-
-		if count > 0 {
-			// average rtt
-			atomic.StoreInt64(&s.Rtt, rtt/count)
-			atomic.StoreInt64(&s.Count, 1)
+		if atomic.CompareAndSwapInt64(&s.state, w, next<<1|1) {
+			break
 		}
 	}
-	sort.Slice(serversList, func(i, j int) bool {
-		return atomic.LoadInt64(&serversList[i].Rtt) < atomic.LoadInt64(&serversList[j].Rtt)
-	})
+	atomic.StoreInt64(&s.lastNs, time.Now().UnixNano())
+}
+
+// SmoothedRTT is the measured latency, or zero when nothing has answered.
+// The adaptive per-server timeout reads this rather than the ranking
+// score: a timeout should follow how fast the server is, not how far the
+// ranking has priced it down.
+func (s *Server) SmoothedRTT() time.Duration {
+	w := atomic.LoadInt64(&s.state)
+	if w&1 == 0 {
+		return 0
+	}
+	return time.Duration(w >> 1)
+}
+
+// Score is what the ranking sorts on, at this instant.
+func (s *Server) Score() time.Duration { return time.Duration(s.score(time.Now().UnixNano())) }
+
+func (s *Server) score(nowNs int64) int64 {
+	w := atomic.LoadInt64(&s.state)
+	base := w >> 1
+	if w&1 == 0 {
+		// Nothing has answered: a guess is priced at the seed. The extra
+		// nanosecond is the tie-break, so a server measured at exactly
+		// that price still outranks the guess.
+		base = rttUnknownSeed + 1
+	} else if last := atomic.LoadInt64(&s.lastNs); last != 0 && nowNs-last > staleAfter {
+		// Halfway back toward a guess: old evidence is weakened, not
+		// discarded, so a server that was fast an hour ago still outranks
+		// one that was slow an hour ago.
+		base = (base + rttUnknownSeed) / 2
+	}
+	return base
+}
+
+// Sort ranks a delegation's addresses in place, fastest first. It runs on
+// every cache miss, so it allocates nothing for the sets a resolver
+// actually meets: the scores are read once into a small array and the
+// pass over them is insertion, which is the cheapest thing for a handful
+// of addresses and does not need a closure the way sort.Slice does.
+func Sort(serversList []*Server) {
+	n := len(serversList)
+	if n < 2 {
+		return
+	}
+	now := time.Now().UnixNano()
+	if n <= sortStackServers {
+		var scores [sortStackServers]int64
+		rank(serversList, scores[:n], now)
+		return
+	}
+	rank(serversList, make([]int64, n), now)
+}
+
+func rank(list []*Server, scores []int64, now int64) {
+	for i, s := range list {
+		scores[i] = s.score(now)
+	}
+	for i := 1; i < len(list); i++ {
+		score, server := scores[i], list[i]
+		j := i - 1
+		for j >= 0 && scores[j] > score {
+			scores[j+1], list[j+1] = scores[j], list[j]
+			j--
+		}
+		scores[j+1], list[j+1] = score, server
+	}
 }

--- a/internal/authority/server.go
+++ b/internal/authority/server.go
@@ -379,21 +379,28 @@ func (s *Server) score(nowNs int64) (int64, bool) {
 // actually meets: the scores are read once into a small array and the
 // pass over them is insertion, which is the cheapest thing for a handful
 // of addresses and does not need a closure the way sort.Slice does.
-func Sort(serversList []*Server) {
+//
+// It returns the server the second slot is spending on an exploration
+// probe, or nil when that slot is an ordinary hedge. The caller has to
+// treat the two differently: a hedge is a spare answer, worth nothing
+// once the leader has answered, and cancelling it is right. A probe is
+// worth only the measurement it brings back, and cancelling it brings
+// none — which is what happens by default, every time, because the leader
+// is by construction the fastest server in the list.
+func Sort(serversList []*Server) *Server {
 	n := len(serversList)
 	if n < 2 {
-		return
+		return nil
 	}
 	now := time.Now().UnixNano()
 	if n <= sortStackServers {
 		var scores [sortStackServers]int64
-		rank(serversList, scores[:n], now)
-		return
+		return rank(serversList, scores[:n], now)
 	}
-	rank(serversList, make([]int64, n), now)
+	return rank(serversList, make([]int64, n), now)
 }
 
-func rank(list []*Server, scores []int64, now int64) {
+func rank(list []*Server, scores []int64, now int64) *Server {
 	// How much of this delegation is out of date falls out of the scoring
 	// pass, which has already read what it takes to know. The count is
 	// what sets the exploration rate: how much of the hedge is worth
@@ -416,7 +423,7 @@ func rank(list []*Server, scores []int64, now int64) {
 		}
 		scores[j+1], list[j+1] = score, server
 	}
-	hedge(list, scores, now, stale)
+	return hedge(list, scores, now, stale)
 }
 
 // randN is the ranking's only source of randomness, replaceable so a test
@@ -461,10 +468,10 @@ var randN = rand.IntN
 // five hundred misses to reach a given address of com., which on a real
 // delegation is hours, while the same rate on a zone with one unknown
 // left would spend every thirty-second hedge on that one address forever.
-func hedge(list []*Server, scores []int64, now int64, stale int) {
+func hedge(list []*Server, scores []int64, now int64, stale int) *Server {
 	n := len(list)
 	if n < 3 {
-		return
+		return nil
 	}
 
 	if stale > 0 && randN(n) < stale {
@@ -499,7 +506,7 @@ func hedge(list []*Server, scores []int64, now int64, stale int) {
 					copy(list[2:i+1], list[1:i])
 					copy(scores[2:i+1], scores[1:i])
 					list[1], scores[1] = probe, score
-					return
+					return probe
 				}
 				pick--
 			}
@@ -514,4 +521,5 @@ func hedge(list []*Server, scores []int64, now int64, stale int) {
 		j := 1 + randN(k-1)
 		list[1], list[j] = list[j], list[1]
 	}
+	return nil
 }

--- a/internal/authority/server.go
+++ b/internal/authority/server.go
@@ -15,10 +15,10 @@ import (
 type Server struct {
 	// place atomic members at the start to fix alignment for ARM32
 	//
-	// state is the smoothed latency and the fact that an exchange has
-	// completed, in one word: [estimate ns : 63][measured : 1]. They are
-	// packed because they have to change together — a sample that lands
-	// between reading one and writing the other could otherwise replace a
+	// state is what one exchange says about this server, in one word:
+	// [estimate ns : 62][answered : 1][measured : 1]. They are packed
+	// because they have to change together — a sample that lands between
+	// reading one and writing the other could otherwise replace a
 	// measurement instead of folding into it.
 	state int64
 	// lastNs is when state was last refreshed, in Unix nanoseconds. It is
@@ -175,7 +175,6 @@ type fpEntry struct {
 type Servers struct {
 	sync.RWMutex
 	// place atomic members at the start to fix alignment for ARM32
-	Called     uint64
 	ErrorCount uint32
 
 	// gen is bumped on every List mutation by InvalidateFingerprint.
@@ -339,23 +338,40 @@ func (s *Server) SmoothedRTT() time.Duration {
 }
 
 // Score is what the ranking sorts on, at this instant.
-func (s *Server) Score() time.Duration { return time.Duration(s.score(time.Now().UnixNano())) }
+func (s *Server) Score() time.Duration {
+	score, _ := s.score(time.Now().UnixNano())
+	return time.Duration(score)
+}
 
-func (s *Server) score(nowNs int64) int64 {
+// score also reports whether what is known about this server is out of
+// date — nothing has answered, or what did answer is old enough that it
+// no longer describes the path. It comes back from here because the
+// scoring pass has already paid for both loads, and the ranking needs the
+// count to decide how much of the hedge to spend on finding out.
+func (s *Server) score(nowNs int64) (int64, bool) {
 	w := atomic.LoadInt64(&s.state)
 	base := w >> stateRTTShift
 	if w&stateMeasured == 0 {
 		// Nothing has answered: a guess is priced at the seed. The extra
 		// nanosecond is the tie-break, so a server measured at exactly
 		// that price still outranks the guess.
-		base = rttUnknownSeed + 1
-	} else if last := atomic.LoadInt64(&s.lastNs); last != 0 && nowNs-last > staleAfter {
+		return rttUnknownSeed + 1, true
+	}
+	if last := atomic.LoadInt64(&s.lastNs); last != 0 && nowNs-last > staleAfter {
 		// Halfway back toward a guess: old evidence is weakened, not
 		// discarded, so a server that was fast an hour ago still outranks
 		// one that was slow an hour ago.
-		base = (base + rttUnknownSeed) / 2
+		//
+		// And it is worth asking about again. A first impression can be
+		// very wrong — an address that timed out once while the resolver
+		// was walking a cold delegation carries that timeout for a long
+		// time, and it is priced below the guesses, so nothing would ever
+		// query it again. Measured on a production resolver: five of com.'s
+		// addresses sitting at 535ms, all of them answering in under 60ms
+		// when finally asked.
+		return (base + rttUnknownSeed) / 2, true
 	}
-	return base
+	return base, false
 }
 
 // Sort ranks a delegation's addresses in place, fastest first. It runs on
@@ -378,14 +394,18 @@ func Sort(serversList []*Server) {
 }
 
 func rank(list []*Server, scores []int64, now int64) {
-	// Whether anything here is unmeasured falls out of the scoring pass:
-	// a guess is priced at exactly the seed. Knowing it costs a comparison
-	// per server and saves the exploration roll on every delegation that
-	// has none — which, once a zone has settled, is most of them.
-	unknown := false
+	// How much of this delegation is out of date falls out of the scoring
+	// pass, which has already read what it takes to know. The count is
+	// what sets the exploration rate: how much of the hedge is worth
+	// spending on finding out is exactly how much there is left to find
+	// out.
+	stale := 0
 	for i, s := range list {
-		scores[i] = s.score(now)
-		unknown = unknown || scores[i] == rttUnknownSeed+1
+		var old bool
+		scores[i], old = s.score(now)
+		if old {
+			stale++
+		}
 	}
 	for i := 1; i < len(list); i++ {
 		score, server := scores[i], list[i]
@@ -396,7 +416,7 @@ func rank(list []*Server, scores []int64, now int64) {
 		}
 		scores[j+1], list[j+1] = score, server
 	}
-	hedge(list, scores, unknown)
+	hedge(list, scores, now, stale)
 }
 
 // randN is the ranking's only source of randomness, replaceable so a test
@@ -428,38 +448,57 @@ var randN = rand.IntN
 // addresses of a TLD are never contacted again. Measured on a production
 // resolver: two of thirteen in use for com., net. and org. alike.
 //
-// So the slot is occasionally spent on an address nothing is known about,
-// which is the only way one can stop being unknown. One lookup in
-// exploreOdds is enough to work through a delegation within a few hundred
-// misses, and it costs nothing the hedge was not already spending — the
-// query goes out either way; this only decides where.
-const exploreOdds = 32
-
-func hedge(list []*Server, scores []int64, unknown bool) {
+// So the slot goes to an address whose worth is out of date, which is the
+// only way one can stop being out of date. It costs nothing the hedge was
+// not already spending: the second query goes out either way, and this
+// only decides where.
+//
+// How often is set by how much there is left to learn — the share of the
+// delegation that is unmeasured or stale. A zone the resolver has just
+// met explores on most lookups, because most of what it could know it
+// does not; a settled one barely explores at all, because there is
+// nothing to find. A fixed rate cannot be both: one in thirty-two took
+// five hundred misses to reach a given address of com., which on a real
+// delegation is hours, while the same rate on a zone with one unknown
+// left would spend every thirty-second hedge on that one address forever.
+func hedge(list []*Server, scores []int64, now int64, stale int) {
 	n := len(list)
 	if n < 3 {
 		return
 	}
 
-	if unknown && randN(exploreOdds) == 0 {
+	if stale > 0 && randN(n) < stale {
 		// Any of them, not the first of them: the unmeasured all carry the
 		// same price, so taking the first would probe one address forever
 		// and leave the rest of the delegation permanently unknown — which
 		// is the shape this exists to break.
 		candidates := 0
 		for i := 1; i < n; i++ {
-			if list[i].SmoothedRTT() == 0 {
+			if _, old := list[i].score(now); old {
 				candidates++
 			}
 		}
 		if candidates > 0 {
 			pick := randN(candidates)
 			for i := 1; i < n; i++ {
-				if list[i].SmoothedRTT() != 0 {
+				if _, old := list[i].score(now); !old {
 					continue
 				}
 				if pick == 0 {
-					list[1], list[i] = list[i], list[1]
+					// Moved into the slot, not traded for it. A swap would
+					// fling the genuine runner-up down to wherever the
+					// guess came from, and the order behind the first two
+					// is not decoration: it is what the resolver walks when
+					// the leader does not answer, waiting out an adaptive
+					// timeout at each step. Trading a known-good second for
+					// a guess would put every other guess in the delegation
+					// ahead of it, which on a twenty-six address zone is
+					// seconds of waiting before reaching a server already
+					// known to be fast.
+					probe, score := list[i], scores[i]
+					copy(list[2:i+1], list[1:i])
+					copy(scores[2:i+1], scores[1:i])
+					list[1], scores[1] = probe, score
 					return
 				}
 				pick--

--- a/internal/authority/server.go
+++ b/internal/authority/server.go
@@ -130,10 +130,16 @@ func (v IPVersion) String() string {
 func (a *Server) String() string {
 	measured := a.SmoothedRTT()
 
+	// FAILING comes before POOR because it says something the latency
+	// cannot: a server that does not reply is charged a timeout, and a
+	// timeout is also what a very slow server costs, so priced alone the
+	// two are indistinguishable to whoever is reading this.
 	var health string
 	switch {
 	case measured == 0:
 		health = "UNKNOWN"
+	case !a.Answering():
+		health = "FAILING"
 	case measured >= time.Second:
 		health = "POOR"
 	default:
@@ -257,18 +263,41 @@ const (
 	sortStackServers = 32
 )
 
+// The state word: [ estimate ns : 62 ][ answered : 1 ][ measured : 1 ].
+//
+// measured says an exchange has completed, which is what separates an
+// estimate from the seed. answered says the last one came back with an
+// answer, and nothing is decided on it — it is there so an operator
+// reading the delegation can tell a slow authority from one that is not
+// replying at all. Priced by the ranking the two look alike, because a
+// server that does not answer is charged a timeout, and a timeout is
+// also what a very slow server costs.
+const (
+	stateMeasured = 1
+	stateAnswered = 2
+	stateRTTShift = 2
+)
+
 // Observe records a completed exchange: how long this server took to
 // answer. The estimate is blended half and half with each new sample, so
 // one bad sample is visible in the ranking immediately — which is what a
 // resolver needs when an authority starts to degrade. A running average
 // over every sample ever taken needed dozens of them to notice.
+func (s *Server) Observe(d time.Duration) { s.record(d, true) }
+
+// ObserveNoAnswer records an exchange that came back with no answer — a
+// timeout, a transport error, a refusal. The caller prices it, and prices
+// it as a timeout; this only adds that the authority did not reply.
+func (s *Server) ObserveNoAnswer(d time.Duration) { s.record(d, false) }
+
+// record folds a sample into the estimate.
 //
 // The loop is there because a root address is in flight from several
 // lookups at once. Read, decide, write as separate steps kept only
 // whichever store landed last; the compare-and-swap carries the estimate
-// and its measured bit together, so a sample that is counted is a sample
+// and both its bits together, so a sample that is counted is a sample
 // that moved the estimate.
-func (s *Server) Observe(d time.Duration) {
+func (s *Server) record(d time.Duration, answered bool) {
 	sample := int64(d)
 	if sample < 0 {
 		sample = 0
@@ -276,14 +305,25 @@ func (s *Server) Observe(d time.Duration) {
 	for {
 		w := atomic.LoadInt64(&s.state)
 		next := sample
-		if w&1 == 1 {
-			next = (w>>1 + sample) / 2
+		if w&stateMeasured != 0 {
+			next = (w>>stateRTTShift + sample) / 2
 		}
-		if atomic.CompareAndSwapInt64(&s.state, w, next<<1|1) {
+		packed := next<<stateRTTShift | stateMeasured
+		if answered {
+			packed |= stateAnswered
+		}
+		if atomic.CompareAndSwapInt64(&s.state, w, packed) {
 			break
 		}
 	}
 	atomic.StoreInt64(&s.lastNs, time.Now().UnixNano())
+}
+
+// Answering reports whether the last completed exchange came back with an
+// answer. Unmeasured servers report true: nothing has failed yet.
+func (s *Server) Answering() bool {
+	w := atomic.LoadInt64(&s.state)
+	return w&stateMeasured == 0 || w&stateAnswered != 0
 }
 
 // SmoothedRTT is the measured latency, or zero when nothing has answered.
@@ -292,10 +332,10 @@ func (s *Server) Observe(d time.Duration) {
 // ranking has priced it down.
 func (s *Server) SmoothedRTT() time.Duration {
 	w := atomic.LoadInt64(&s.state)
-	if w&1 == 0 {
+	if w&stateMeasured == 0 {
 		return 0
 	}
-	return time.Duration(w >> 1)
+	return time.Duration(w >> stateRTTShift)
 }
 
 // Score is what the ranking sorts on, at this instant.
@@ -303,8 +343,8 @@ func (s *Server) Score() time.Duration { return time.Duration(s.score(time.Now()
 
 func (s *Server) score(nowNs int64) int64 {
 	w := atomic.LoadInt64(&s.state)
-	base := w >> 1
-	if w&1 == 0 {
+	base := w >> stateRTTShift
+	if w&stateMeasured == 0 {
 		// Nothing has answered: a guess is priced at the seed. The extra
 		// nanosecond is the tie-break, so a server measured at exactly
 		// that price still outranks the guess.
@@ -338,8 +378,14 @@ func Sort(serversList []*Server) {
 }
 
 func rank(list []*Server, scores []int64, now int64) {
+	// Whether anything here is unmeasured falls out of the scoring pass:
+	// a guess is priced at exactly the seed. Knowing it costs a comparison
+	// per server and saves the exploration roll on every delegation that
+	// has none — which, once a zone has settled, is most of them.
+	unknown := false
 	for i, s := range list {
 		scores[i] = s.score(now)
+		unknown = unknown || scores[i] == rttUnknownSeed+1
 	}
 	for i := 1; i < len(list); i++ {
 		score, server := scores[i], list[i]
@@ -350,7 +396,7 @@ func rank(list []*Server, scores []int64, now int64) {
 		}
 		scores[j+1], list[j+1] = score, server
 	}
-	hedge(list, scores)
+	hedge(list, scores, unknown)
 }
 
 // randN is the ranking's only source of randomness, replaceable so a test
@@ -375,11 +421,52 @@ var randN = rand.IntN
 // measurable — only an attempt that outlives the winner can do that — but
 // it does give every tied candidate its turn at the one thing that can
 // measure it, which is winning the race outright.
-func hedge(list []*Server, scores []int64) {
+// A delegation settles on two measured addresses and stops there without
+// this. The parallel head is two, so two addresses get measured and rank
+// ahead of the seed; from then on nothing else is level with the second
+// slot, rotation has nothing to rotate, and the remaining ten or eleven
+// addresses of a TLD are never contacted again. Measured on a production
+// resolver: two of thirteen in use for com., net. and org. alike.
+//
+// So the slot is occasionally spent on an address nothing is known about,
+// which is the only way one can stop being unknown. One lookup in
+// exploreOdds is enough to work through a delegation within a few hundred
+// misses, and it costs nothing the hedge was not already spending — the
+// query goes out either way; this only decides where.
+const exploreOdds = 32
+
+func hedge(list []*Server, scores []int64, unknown bool) {
 	n := len(list)
 	if n < 3 {
 		return
 	}
+
+	if unknown && randN(exploreOdds) == 0 {
+		// Any of them, not the first of them: the unmeasured all carry the
+		// same price, so taking the first would probe one address forever
+		// and leave the rest of the delegation permanently unknown — which
+		// is the shape this exists to break.
+		candidates := 0
+		for i := 1; i < n; i++ {
+			if list[i].SmoothedRTT() == 0 {
+				candidates++
+			}
+		}
+		if candidates > 0 {
+			pick := randN(candidates)
+			for i := 1; i < n; i++ {
+				if list[i].SmoothedRTT() != 0 {
+					continue
+				}
+				if pick == 0 {
+					list[1], list[i] = list[i], list[1]
+					return
+				}
+				pick--
+			}
+		}
+	}
+
 	k := 2
 	for k < n && scores[k] == scores[1] {
 		k++

--- a/internal/authority/server.go
+++ b/internal/authority/server.go
@@ -2,6 +2,7 @@ package authority
 
 import (
 	"hash/fnv"
+	"math/rand/v2"
 	"net"
 	"net/netip"
 	"sort"
@@ -348,5 +349,43 @@ func rank(list []*Server, scores []int64, now int64) {
 			j--
 		}
 		scores[j+1], list[j+1] = score, server
+	}
+	hedge(list, scores)
+}
+
+// randN is the ranking's only source of randomness, replaceable so a test
+// can pin an order rather than chase one.
+var randN = rand.IntN
+
+// hedge decides which of the servers tied for second place takes the
+// second slot. The leader is left alone — the fastest server answers the
+// query — but everything level with the runner-up is, by definition,
+// something the ranking has no reason to choose between.
+//
+// Leaving that to the sort's stability meant the same address took the
+// slot on every single lookup, forever. That matters most where the tie
+// is widest: a delegation's unmeasured addresses all carry the same
+// price, so one of them was queried on every cache miss and the rest were
+// never tried at all — and since the query is cancelled the moment the
+// leader answers, the one that was tried never came back measured
+// either. Eighteen unmeasured addresses, one of them getting all of the
+// chances and none of them getting measured.
+//
+// Rotating the slot does not make a server slower than the leader
+// measurable — only an attempt that outlives the winner can do that — but
+// it does give every tied candidate its turn at the one thing that can
+// measure it, which is winning the race outright.
+func hedge(list []*Server, scores []int64) {
+	n := len(list)
+	if n < 3 {
+		return
+	}
+	k := 2
+	for k < n && scores[k] == scores[1] {
+		k++
+	}
+	if k > 2 {
+		j := 1 + randN(k-1)
+		list[1], list[j] = list[j], list[1]
 	}
 }

--- a/internal/authority/server.go
+++ b/internal/authority/server.go
@@ -297,9 +297,17 @@ func (s *Server) ObserveNoAnswer(d time.Duration) { s.record(d, false) }
 // and both its bits together, so a sample that is counted is a sample
 // that moved the estimate.
 func (s *Server) record(d time.Duration, answered bool) {
+	// A completed exchange took some time, whatever the clock managed to
+	// see. Recording a zero would make it unreadable: the estimate and
+	// "nothing has answered" are told apart by the estimate being zero, so
+	// a sample of zero is a measurement that reports itself as the absence
+	// of one — priced at the seed, explored forever, and never allowed to
+	// lead however fast it actually is. Windows' coarse timer produces it
+	// for a loopback exchange; a LAN authority on any platform is one
+	// clock granularity away from it.
 	sample := int64(d)
-	if sample < 0 {
-		sample = 0
+	if sample < 1 {
+		sample = 1
 	}
 	for {
 		w := atomic.LoadInt64(&s.state)

--- a/internal/authority/server_test.go
+++ b/internal/authority/server_test.go
@@ -17,8 +17,8 @@ import (
 // the claim being made is "the marker is free" rather than a byte count that
 // is only true on one ABI.
 type serverWithoutCanonical struct {
-	Rtt       int64
-	Count     int64
+	State     int64
+	LastNs    int64
 	Addr      string
 	IPVersion IPVersion
 	UDPAddr   *net.UDPAddr
@@ -50,14 +50,21 @@ func Test_TrySort(t *testing.T) {
 	r := rand.New(rand.NewSource(time.Now().UnixNano())) //nolint:gosec // G404 - test file, not used for crypto
 	for i := 0; i < 2000; i++ {
 		for j := range s.List {
-			s.List[j].Count++
-			s.List[j].Rtt += (time.Duration(r.Intn(2000-0)+0) * time.Millisecond).Nanoseconds()
-			Sort(s.List, uint64(i))
+			s.List[j].Observe(time.Duration(r.Intn(2000)) * time.Millisecond)
+			Sort(s.List)
 		}
 	}
 
-	if !reflect.DeepEqual(int64(1), s.List[0].Count) {
-		t.Errorf("s.List[0].Count = %v, want %v", s.List[0].Count, int64(1))
+	// However the samples fell, the head of the list is the cheapest
+	// server in it. The old shape could not promise this: every thousandth
+	// sort wiped every server's statistics, and for the sorts that
+	// followed the whole set read as unmeasured — which it ranked first.
+	lead := s.List[0].Score()
+	for _, srv := range s.List[1:] {
+		if srv.Score() < lead {
+			t.Fatalf("%s scores %v, ahead of the leader %s at %v",
+				srv.Addr, srv.Score(), s.List[0].Addr, lead)
+		}
 	}
 }
 
@@ -150,17 +157,16 @@ func Test_ServerString(t *testing.T) {
 		t.Errorf("%q does not contain %q", str, "UNKNOWN")
 	}
 
-	// Test GOOD health (0 < Rtt < 1 second)
-	s.Rtt = int64(100 * time.Millisecond)
-	s.Count = 1
+	// Test GOOD health (a measured, sub-second latency)
+	s.Observe(100 * time.Millisecond)
 	str = s.String()
 	if !strings.Contains(str, "GOOD") {
 		t.Errorf("%q does not contain %q", str, "GOOD")
 	}
 
-	// Test POOR health (Rtt >= 1 second)
-	s.Rtt = int64(2 * time.Second)
-	s.Count = 1
+	// Test POOR health (a measured latency past a second). The blend is
+	// half and half, so this lands at 2.05s.
+	s.Observe(4 * time.Second)
 	str = s.String()
 	if !strings.Contains(str, "POOR") {
 		t.Errorf("%q does not contain %q", str, "POOR")

--- a/middleware/ratelimit/rate_limit_complete_test.go
+++ b/middleware/ratelimit/rate_limit_complete_test.go
@@ -307,12 +307,15 @@ func TestRateLimitPerformanceUnderAttack(t *testing.T) {
 
 	elapsed := time.Since(start)
 
-	// Should handle 100k requests quickly even under attack
-	if elapsed >= 5*time.Second {
-		t.Errorf("%s: elapsed = %v, want < %v", "Should handle 100k requests in < 5 seconds", elapsed, 5*time.Second)
-	}
-
-	// Cache should not exceed limit
+	// The property under test is the bound, not the clock. What an attack
+	// threatens here is unbounded growth — a limiter kept per source
+	// address, a hundred thousand addresses — and the cache size is what
+	// says whether that holds. How long the loop took says more about the
+	// machine that ran it than about this code: most of it is the harness
+	// building a writer and a chain per iteration, and the shared Windows
+	// runner walks past a five-second budget while the limiter is fine.
+	// Throughput belongs to BenchmarkRateLimitRandomIPAttack, which
+	// measures it without a threshold nobody can hold.
 	if rl.store.Len() > cacheSize {
 		t.Errorf("%s: rl.store.Len() = %v, want <= %v", "Cache should not exceed size limit", rl.store.Len(), cacheSize)
 	}

--- a/middleware/ratelimit/ratelimit_bench_test.go
+++ b/middleware/ratelimit/ratelimit_bench_test.go
@@ -130,12 +130,11 @@ func TestRateLimitEvictionPerformance(t *testing.T) {
 	}
 	elapsed := time.Since(start)
 
-	// Should handle 51,200 IPs (2x cache size) quickly
-	if elapsed > 1*time.Second {
-		t.Errorf("Eviction too slow: %v for %d IPs", elapsed, cacheSize*2)
-	}
-
-	// Cache should be at max size
+	// Eviction is checked by what it leaves behind, not by a stopwatch:
+	// twice the cache size went in, and no more than the cache size may
+	// remain. A one-second budget for that loop is a statement about the
+	// runner, and a shared one misses it while the eviction works exactly
+	// as intended.
 	if rl.store.Len() > cacheSize {
 		t.Errorf("Cache size exceeded: %d > %d", rl.store.Len(), cacheSize)
 	}

--- a/middleware/resolver/dnssec/signature.go
+++ b/middleware/resolver/dnssec/signature.go
@@ -177,18 +177,37 @@ func verifyECDSASignature(k *dns.DNSKEY, algorithm uint8, signed, signature []by
 		return dns.ErrSig
 	}
 
-	x := new(big.Int).SetBytes(public[:size])
-	y := new(big.Int).SetBytes(public[size:])
+	// RFC 6605 §4 carries the two coordinates bare; the parser wants them
+	// behind the uncompressed-point marker. Built on the stack because the
+	// largest curve here is P-384, so the point is 97 bytes and this runs
+	// once per signature.
+	//
+	// Parsing rather than assembling a PublicKey from its coordinates is
+	// what crypto/ecdsa now asks for, and it is stricter in a way that
+	// suits a validator: a point that is not on the curve is rejected here
+	// rather than carried into the verification.
+	var point [1 + 2*ecdsaMaxCoordinate]byte
+	point[0] = 4
+	copy(point[1:], public)
+	pub, err := ecdsa.ParseUncompressedPublicKey(curve, point[:1+len(public)])
+	if err != nil {
+		return ErrMissingDNSKEY
+	}
+
 	hasher.Write(signed)
 	hashed := hasher.Sum(nil)
 
 	r := new(big.Int).SetBytes(signature[:size])
 	s := new(big.Int).SetBytes(signature[size:])
-	if !ecdsa.Verify(&ecdsa.PublicKey{Curve: curve, X: x, Y: y}, hashed, r, s) {
+	if !ecdsa.Verify(pub, hashed, r, s) {
 		return dns.ErrSig
 	}
 	return nil
 }
+
+// ecdsaMaxCoordinate is one coordinate of the widest curve this validator
+// accepts, which is P-384.
+const ecdsaMaxCoordinate = 48
 
 func verifyEd25519Signature(k *dns.DNSKEY, signed, signature []byte) error {
 	// RFC 8080 §2: Ed25519 signs the message itself, not a digest of it.

--- a/middleware/resolver/exchange_cancel_test.go
+++ b/middleware/resolver/exchange_cancel_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -57,8 +56,8 @@ func TestExchangeCancellationInterruptsInFlightUDPRead(t *testing.T) {
 	case <-time.After(300 * time.Millisecond):
 		t.Fatal("resolver UDP read ignored context cancellation")
 	}
-	if got := atomic.LoadInt64(&server.Count); got != 0 {
-		t.Fatalf("canceled exchange updated RTT sample count to %d", got)
+	if got := server.SmoothedRTT(); got != 0 {
+		t.Fatalf("canceled exchange measured the server at %v", got)
 	}
 }
 
@@ -111,7 +110,7 @@ func TestExchangeCancellationInterruptsThroughGroup(t *testing.T) {
 	case <-time.After(300 * time.Millisecond):
 		t.Fatal("group-armed resolver UDP read ignored context cancellation")
 	}
-	if got := atomic.LoadInt64(&server.Count); got != 0 {
-		t.Fatalf("canceled exchange updated RTT sample count to %d", got)
+	if got := server.SmoothedRTT(); got != 0 {
+		t.Fatalf("canceled exchange measured the server at %v", got)
 	}
 }

--- a/middleware/resolver/exchange_observe_test.go
+++ b/middleware/resolver/exchange_observe_test.go
@@ -1,0 +1,143 @@
+package resolver
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/authority"
+)
+
+// A server that does not answer must never be scored by how quickly it
+// failed to. The exchange reports the elapsed time whatever the outcome,
+// and a refused connection comes back in microseconds — faster than any
+// authority on earth — so recording it as a latency made the one address
+// in the delegation that serves nothing into its permanent leader: ranked
+// first, queried first, refused again, and re-recorded as instant.
+//
+// A stale glue record pointing at a host that is up but not serving DNS
+// is all it takes, and the ranking has no way back out on its own.
+func TestAServerThatRefusesIsNotTheFastest(t *testing.T) {
+	// A closed port on loopback: the write lands, the kernel answers with
+	// ICMP port-unreachable, and the read fails in microseconds.
+	packet, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := packet.LocalAddr().String()
+	_ = packet.Close()
+
+	r := &Resolver{cfg: new(config.Config), netTimeout: time.Second}
+	server := authority.NewServer(addr, authority.IPv4)
+	req := new(dns.Msg)
+	req.SetQuestion("refused.example.", dns.TypeA)
+
+	if _, err := r.exchange(context.Background(), &resolveState{}, nil, "udp", req, server, 0); err == nil {
+		t.Skip("the platform accepted a query to a closed port; nothing to measure here")
+	}
+
+	got := server.SmoothedRTT()
+	if got != 0 && got < 500*time.Millisecond {
+		t.Fatalf("a server that refused the query is measured at %v — it now leads the delegation", got)
+	}
+}
+
+// The same rule from the other side: a server that answers is measured by
+// what it actually took.
+func TestAServerThatAnswersIsMeasuredByItsLatency(t *testing.T) {
+	addr := answeringUpstream(t, dns.RcodeSuccess)
+
+	r := &Resolver{cfg: new(config.Config), netTimeout: time.Second}
+	server := authority.NewServer(addr, authority.IPv4)
+	req := new(dns.Msg)
+	req.SetQuestion("answer.example.", dns.TypeA)
+
+	if _, err := r.exchange(context.Background(), &resolveState{}, nil, "udp", req, server, 0); err != nil {
+		t.Fatalf("exchange: %v", err)
+	}
+	if got := server.SmoothedRTT(); got == 0 || got > 100*time.Millisecond {
+		t.Fatalf("a loopback answer measured %v", got)
+	}
+}
+
+// answeringUpstream starts a UDP server that replies to every query with
+// the given rcode, and returns its address.
+func answeringUpstream(t *testing.T, rcode int) string {
+	t.Helper()
+	packet, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = packet.Close() })
+	go func() {
+		buf := make([]byte, 1024)
+		for {
+			n, addr, readErr := packet.ReadFrom(buf)
+			if readErr != nil {
+				return
+			}
+			req := new(dns.Msg)
+			if req.Unpack(buf[:n]) != nil {
+				continue
+			}
+			reply := new(dns.Msg)
+			reply.SetRcode(req, rcode)
+			out, packErr := reply.Pack()
+			if packErr != nil {
+				continue
+			}
+			_, _ = packet.WriteTo(out, addr)
+		}
+	}()
+	return packet.LocalAddr().String()
+}
+
+// A refusal is the fastest answer an authority can give, so scoring it by
+// the clock taught the ranking to prefer the servers that turn us away.
+// What counts is whether the question was answered — while a negative
+// answer is still an answer, and a zone that mostly says no must not cost
+// its authorities their standing.
+func TestRcodeDecidesWhetherAnAnswerCounts(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		rcode   int
+		counted bool
+	}{
+		{"refused", dns.RcodeRefused, false},
+		{"servfail", dns.RcodeServerFailure, false},
+		{"not authoritative", dns.RcodeNotAuth, false},
+		{"not implemented", dns.RcodeNotImplemented, false},
+		{"format error", dns.RcodeFormatError, false},
+		{"not zone", dns.RcodeNotZone, false},
+		{"nxdomain", dns.RcodeNameError, true},
+		{"noerror", dns.RcodeSuccess, true},
+		// RFC 6672 §2.2: a DNAME substitution past 255 octets is answered
+		// YXDOMAIN. It reads like an UPDATE prerequisite failure and is not
+		// one — the authority answered, and the answer is that the question
+		// cannot have one.
+		{"yxdomain", dns.RcodeYXDomain, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			addr := answeringUpstream(t, tc.rcode)
+			r := &Resolver{cfg: new(config.Config), netTimeout: time.Second}
+			server := authority.NewServer(addr, authority.IPv4)
+			req := new(dns.Msg)
+			req.SetQuestion("rcode.example.", dns.TypeA)
+
+			if _, err := r.exchange(context.Background(), &resolveState{}, nil, "udp", req, server, 0); err != nil {
+				t.Fatalf("exchange: %v", err)
+			}
+
+			// Counted means "measured by what it took"; the rest are priced
+			// at the timeout, which is what not answering is worth.
+			fast := server.SmoothedRTT() < 100*time.Millisecond
+			if fast != tc.counted {
+				t.Fatalf("%s: measured %v, counted as an answer = %v, want %v",
+					tc.name, server.SmoothedRTT(), fast, tc.counted)
+			}
+		})
+	}
+}

--- a/middleware/resolver/exchange_observe_test.go
+++ b/middleware/resolver/exchange_observe_test.go
@@ -63,6 +63,70 @@ func TestAServerThatAnswersIsMeasuredByItsLatency(t *testing.T) {
 	}
 }
 
+// A retry recurses into exchange, so the frame that failed returns after
+// the frame that succeeded. Leaving both outcomes to the defer delivered
+// them backwards: the timeout was recorded last, and a blend that halves
+// with each sample left a server that had just answered priced near the
+// timeout it had already recovered from.
+func TestASuccessfulRetryIsNotPricedAsATimeout(t *testing.T) {
+	packet, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer packet.Close()
+
+	// An upstream that swallows the first query and answers the second.
+	go func() {
+		buf := make([]byte, 1024)
+		for attempt := 0; ; attempt++ {
+			n, addr, readErr := packet.ReadFrom(buf)
+			if readErr != nil {
+				return
+			}
+			if attempt == 0 {
+				continue
+			}
+			req := new(dns.Msg)
+			if req.Unpack(buf[:n]) != nil {
+				continue
+			}
+			reply := new(dns.Msg)
+			reply.SetReply(req)
+			out, packErr := reply.Pack()
+			if packErr != nil {
+				continue
+			}
+			_, _ = packet.WriteTo(out, addr)
+		}
+	}()
+
+	r := &Resolver{cfg: new(config.Config), netTimeout: 200 * time.Millisecond}
+	server := authority.NewServer(packet.LocalAddr().String(), authority.IPv4)
+	// A server with a history, which is what makes the order visible: on a
+	// fresh one the first sample replaces and the second blends half and
+	// half, so two samples land on the same number either way round.
+	server.Observe(10 * time.Millisecond)
+
+	req := new(dns.Msg)
+	req.SetQuestion("retry.example.", dns.TypeA)
+
+	resp, err := r.exchange(context.Background(), &resolveState{}, nil, "udp", req, server, 0)
+	if err != nil || resp == nil {
+		t.Fatalf("the retry never succeeded: resp=%v err=%v", resp, err)
+	}
+
+	// Both attempts are on the record — the timeout happened and cost what
+	// it cost — but the answer came last, so it is what the estimate leans
+	// toward: (10ms, 200ms) blends to 105ms and the answer halves it to
+	// ~52ms. Delivered backwards the answer is absorbed first and the
+	// timeout lands on top, which leaves ~102ms: twice the price, for a
+	// server that is answering.
+	if got := server.SmoothedRTT(); got > 75*time.Millisecond {
+		t.Fatalf("a server that answered on the retry is estimated at %v, "+
+			"as though the timeout were the last thing it did", got)
+	}
+}
+
 // answeringUpstream starts a UDP server that replies to every query with
 // the given rcode, and returns its address.
 func answeringUpstream(t *testing.T, rcode int) string {

--- a/middleware/resolver/exchange_probe_test.go
+++ b/middleware/resolver/exchange_probe_test.go
@@ -1,0 +1,182 @@
+package resolver
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/authority"
+)
+
+// slowUpstream answers every query after delay, and reports its address.
+func slowUpstream(t *testing.T, delay time.Duration) string {
+	t.Helper()
+	packet, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = packet.Close() })
+	go func() {
+		buf := make([]byte, 1024)
+		for {
+			n, addr, readErr := packet.ReadFrom(buf)
+			if readErr != nil {
+				return
+			}
+			req := new(dns.Msg)
+			if req.Unpack(buf[:n]) != nil {
+				continue
+			}
+			reply := new(dns.Msg)
+			reply.SetReply(req)
+			go func() {
+				time.Sleep(delay)
+				out, packErr := reply.Pack()
+				if packErr != nil {
+					return
+				}
+				_, _ = packet.WriteTo(out, addr)
+			}()
+		}
+	}()
+	return packet.LocalAddr().String()
+}
+
+// probeResolver builds the minimum queryServer needs, with room for the
+// given number of probes.
+func probeResolver(probeCap int) *Resolver {
+	return &Resolver{
+		cfg:            new(config.Config),
+		netTimeout:     time.Second,
+		circuitBreaker: newCircuitBreaker(),
+		maxConcurrent:  make(chan struct{}, 1),
+		probeSlots:     make(chan struct{}, probeCap),
+	}
+}
+
+// runAttempt drives one upstream attempt the way lookup does, and cancels
+// the moment a leader would have answered.
+func runAttempt(t *testing.T, r *Resolver, server *authority.Server, probing bool, leaderAnswersIn time.Duration) {
+	t.Helper()
+
+	req := new(dns.Msg)
+	req.SetQuestion("probe.example.", dns.TypeA)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	interrupts := NewInterruptGroup(ctx)
+	defer interrupts.Close()
+
+	results := make(chan lookupResult)
+	done := make(chan struct{})
+
+	r.maxConcurrent <- struct{}{}
+	go func() {
+		defer close(done)
+		r.queryServer(ctx, &resolveState{}, interrupts, req.Id, req.Copy(), server, results, probing)
+	}()
+
+	// The leader answers and lookup returns, which cancels everything it
+	// started.
+	time.Sleep(leaderAnswersIn)
+	cancel()
+	interrupts.Close()
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("the attempt never finished")
+	}
+}
+
+// Exploring is worth only what it brings back, and until now it brought
+// back nothing. The ranking picked an address whose worth was out of
+// date, the resolver sent it the second query, the leader answered first
+// — as it must, being the fastest server in the list — and the lookup
+// returned and cancelled it before it could reply. So an address was only
+// ever measured by winning the race outright, which on a production
+// delegation meant one new address a minute with seventeen waiting, and
+// the ones slower than the leader waiting forever.
+func TestAProbeOutlivesTheWinnerAndBringsBackAMeasurement(t *testing.T) {
+	addr := slowUpstream(t, 120*time.Millisecond)
+
+	// What the field showed: the leader answers in a few milliseconds
+	// while the probed address is an order of magnitude further away.
+	const leaderAnswersIn = 10 * time.Millisecond
+
+	t.Run("as an ordinary hedge it learns nothing", func(t *testing.T) {
+		server := authority.NewServer(addr, authority.IPv4)
+		runAttempt(t, probeResolver(1), server, false, leaderAnswersIn)
+
+		if got := server.SmoothedRTT(); got != 0 {
+			t.Fatalf("a cancelled hedge measured %v", got)
+		}
+	})
+
+	t.Run("as a probe it comes back with the latency", func(t *testing.T) {
+		server := authority.NewServer(addr, authority.IPv4)
+		runAttempt(t, probeResolver(1), server, true, leaderAnswersIn)
+
+		got := server.SmoothedRTT()
+		if got < 100*time.Millisecond {
+			t.Fatalf("the probe measured %v, want the upstream's real latency", got)
+		}
+		if !server.Answering() {
+			t.Fatal("a server that answered the probe is marked as failing")
+		}
+	})
+}
+
+// The probe pool is what keeps a detached job from growing with arrival
+// rate. When it is empty the measurement is given up, not queued: the
+// attempt goes ahead as the hedge it would have been, and the lookup
+// behaves exactly as it did before.
+func TestAProbeIsShedWhenThePoolIsFull(t *testing.T) {
+	addr := slowUpstream(t, 120*time.Millisecond)
+	r := probeResolver(1)
+
+	// Hold the only slot, as an in-flight probe elsewhere would.
+	r.probeSlots <- struct{}{}
+
+	server := authority.NewServer(addr, authority.IPv4)
+	runAttempt(t, r, server, true, 10*time.Millisecond)
+
+	if got := server.SmoothedRTT(); got != 0 {
+		t.Fatalf("a shed probe measured %v — it outlived its lookup without a slot", got)
+	}
+}
+
+// A probe to something silent has to end as a failure rather than as a
+// cancellation, which is what the grace on its deadline buys: the socket
+// deadline fires first, so the address is recorded as not answering
+// instead of leaving no trace at all.
+func TestAProbeToASilentServerRecordsTheFailure(t *testing.T) {
+	packet, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer packet.Close()
+	go func() {
+		buf := make([]byte, 1024)
+		for {
+			if _, _, readErr := packet.ReadFrom(buf); readErr != nil {
+				return
+			}
+		}
+	}()
+
+	r := probeResolver(1)
+	r.netTimeout = 150 * time.Millisecond
+	server := authority.NewServer(packet.LocalAddr().String(), authority.IPv4)
+	runAttempt(t, r, server, true, 10*time.Millisecond)
+
+	if server.Answering() {
+		t.Fatal("a server that never replied to the probe is not marked as failing")
+	}
+	if got := server.SmoothedRTT(); got == 0 {
+		t.Fatal("a probe that timed out recorded nothing at all")
+	}
+}

--- a/middleware/resolver/exchange_probe_test.go
+++ b/middleware/resolver/exchange_probe_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/config"
 	"github.com/semihalev/sdns/internal/authority"
+	"github.com/semihalev/sdns/internal/dnsutil"
 )
 
 // slowUpstream answers every query after delay, and reports its address.
@@ -61,9 +62,20 @@ func probeResolver(probeCap int) *Resolver {
 // the moment a leader would have answered.
 func runAttempt(t *testing.T, r *Resolver, server *authority.Server, probing bool, leaderAnswersIn time.Duration) {
 	t.Helper()
+	runAttemptWith(t, r, server, probing, leaderAnswersIn, false)
+}
+
+// runAttemptWith is runAttempt with a say in whether the query carries
+// EDNS, which is what decides whether a FORMERR reaches the fallback that
+// strips it.
+func runAttemptWith(t *testing.T, r *Resolver, server *authority.Server, probing bool, leaderAnswersIn time.Duration, edns bool) {
+	t.Helper()
 
 	req := new(dns.Msg)
 	req.SetQuestion("probe.example.", dns.TypeA)
+	if edns {
+		req.SetEdns0(dnsutil.DefaultMsgSize, false)
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -146,6 +158,84 @@ func TestAProbeIsShedWhenThePoolIsFull(t *testing.T) {
 
 	if got := server.SmoothedRTT(); got != 0 {
 		t.Fatalf("a shed probe measured %v — it outlived its lookup without a slot", got)
+	}
+}
+
+// rcodeUpstream answers every query with the given rcode, optionally
+// truncated, and reports its address.
+func rcodeUpstream(t *testing.T, rcode int, truncated bool) string {
+	t.Helper()
+	packet, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = packet.Close() })
+	go func() {
+		buf := make([]byte, 1024)
+		for {
+			n, addr, readErr := packet.ReadFrom(buf)
+			if readErr != nil {
+				return
+			}
+			req := new(dns.Msg)
+			if req.Unpack(buf[:n]) != nil {
+				continue
+			}
+			reply := new(dns.Msg)
+			reply.SetRcode(req, rcode)
+			reply.Truncated = truncated
+			out, packErr := reply.Pack()
+			if packErr != nil {
+				continue
+			}
+			_, _ = packet.WriteTo(out, addr)
+		}
+	}()
+	return packet.LocalAddr().String()
+}
+
+// A probe stops before the fallbacks, so whatever it leaves behind is the
+// whole record of that address until the next one. Leaving nothing is the
+// case to watch: the address stays exactly as out of date as it was, so
+// it is a candidate again, so it is probed again, and the loop has no end
+// while the server keeps giving the same reply.
+//
+// FORMERR is where that bites. The lookup path answers it by asking again
+// without EDNS and prices the first attempt at nothing, which is right
+// there and wrong here.
+func TestAProbeAlwaysLeavesAMeasurement(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		rcode     int
+		truncated bool
+		fast      bool
+	}{
+		// It answered, and the answer says to come back over TCP. What the
+		// probe measured is the round trip it made.
+		{"truncated", dns.RcodeSuccess, true, true},
+		// It answered, and the answer says it dislikes our EDNS. Also a
+		// round trip, and not the authority's failing.
+		{"format error", dns.RcodeFormatError, false, true},
+		// It did not answer the question, and no fallback would have
+		// helped. That is worth a timeout.
+		{"refused", dns.RcodeRefused, false, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			addr := rcodeUpstream(t, tc.rcode, tc.truncated)
+			server := authority.NewServer(addr, authority.IPv4)
+			// With EDNS on the query, so a FORMERR reaches the fallback
+			// that would otherwise strip it and ask again.
+			runAttemptWith(t, probeResolver(1), server, true, 10*time.Millisecond, true)
+
+			got := server.SmoothedRTT()
+			if got == 0 {
+				t.Fatal("the probe recorded nothing; this address will be probed again forever")
+			}
+			if fast := got < 100*time.Millisecond; fast != tc.fast {
+				t.Fatalf("%s measured %v, which reads as %s", tc.name, got,
+					map[bool]string{true: "a prompt answer", false: "a timeout"}[fast])
+			}
+		})
 	}
 }
 

--- a/middleware/resolver/handler.go
+++ b/middleware/resolver/handler.go
@@ -261,7 +261,7 @@ func (h *DNSHandler) nsStats(req *dns.Msg) *dns.Msg {
 	copy(serversList, servers.List)
 	servers.RUnlock()
 
-	authority.Sort(serversList, 1)
+	authority.Sort(serversList)
 
 	rrHeader := dns.RR_Header{
 		Name:   name,

--- a/middleware/resolver/lookup_benchmark_test.go
+++ b/middleware/resolver/lookup_benchmark_test.go
@@ -26,14 +26,22 @@ func BenchmarkLookupPerformance(b *testing.B) {
 	req.SetQuestion("example.com.", dns.TypeA)
 	req.RecursionDesired = true
 
-	// Create mock servers with different RTTs
-	servers := &authority.Servers{
-		Zone: "com.",
-		List: []*authority.Server{
-			{Addr: "192.0.2.1:53", Rtt: int64(20 * time.Millisecond)},  // Fast server
-			{Addr: "192.0.2.2:53", Rtt: int64(100 * time.Millisecond)}, // Medium server
-			{Addr: "192.0.2.3:53", Rtt: int64(200 * time.Millisecond)}, // Slow server
-		},
+	// Mock servers with different RTTs, recorded the way the resolver
+	// records them rather than written into the fields: a fixture that
+	// sets state directly tests the shape of the fields instead of the
+	// behaviour of the model.
+	servers := &authority.Servers{Zone: "com."}
+	for _, m := range []struct {
+		addr string
+		rtt  time.Duration
+	}{
+		{"192.0.2.1:53", 20 * time.Millisecond},  // Fast server
+		{"192.0.2.2:53", 100 * time.Millisecond}, // Medium server
+		{"192.0.2.3:53", 200 * time.Millisecond}, // Slow server
+	} {
+		s := authority.NewServer(m.addr, authority.IPv4)
+		s.Observe(m.rtt)
+		servers.List = append(servers.List, s)
 	}
 
 	b.ResetTimer()

--- a/middleware/resolver/lookup_rotation_test.go
+++ b/middleware/resolver/lookup_rotation_test.go
@@ -12,6 +12,16 @@ import (
 	"github.com/semihalev/sdns/internal/authority"
 )
 
+// allMeasured reports whether every one of these has a latency on record.
+func allMeasured(list []*authority.Server) bool {
+	for _, s := range list {
+		if s.SmoothedRTT() == 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // countingUpstream is a loopback authority that records how many queries
 // reached it. When answer is false it reads and drops, which is what an
 // address slower than the leader looks like from here: the lookup returns
@@ -153,9 +163,12 @@ func TestUnknownsAreExploredOnceTheDelegationHasSettled(t *testing.T) {
 	const answering, silentCount, lookups = 2, 8, 100
 
 	servers := &authority.Servers{Zone: "example."}
+	answered := make([]*authority.Server, 0, answering)
 	for range answering {
 		addr, _ := countingUpstream(t, true)
-		servers.List = append(servers.List, authority.NewServer(addr, authority.IPv4))
+		s := authority.NewServer(addr, authority.IPv4)
+		answered = append(answered, s)
+		servers.List = append(servers.List, s)
 	}
 	silent := make(map[string]*atomic.Int64, silentCount)
 	for range silentCount {
@@ -180,18 +193,21 @@ func TestUnknownsAreExploredOnceTheDelegationHasSettled(t *testing.T) {
 		}
 	}
 
-	// Let it settle the way production settles, then measure from there.
-	for range 20 {
+	// Settle the delegation the way production settles it: both of the
+	// authorities that answer are measured, so the second slot is no
+	// longer level with anything and the rotation has nothing to rotate.
+	// That is the state this test is about.
+	//
+	// Waited for rather than counted out in lookups. Which of the two
+	// answering addresses takes the second slot is a random choice, so a
+	// fixed warm-up leaves the other one unmeasured about one run in
+	// seven — a coin this test has no reason to be flipping.
+	settled := time.Now().Add(5 * time.Second)
+	for !allMeasured(answered) && time.Now().Before(settled) {
 		runLookup()
 	}
-	measured := 0
-	for _, s := range servers.List {
-		if s.SmoothedRTT() != 0 {
-			measured++
-		}
-	}
-	if measured != answering {
-		t.Fatalf("the delegation settled on %d measured addresses, want the %d that answer", measured, answering)
+	if !allMeasured(answered) {
+		t.Fatal("the authorities that answer never got measured")
 	}
 	for _, hits := range silent {
 		hits.Store(0)

--- a/middleware/resolver/lookup_rotation_test.go
+++ b/middleware/resolver/lookup_rotation_test.go
@@ -1,0 +1,162 @@
+package resolver
+
+import (
+	"context"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/authority"
+)
+
+// countingUpstream is a loopback authority that records how many queries
+// reached it. When answer is false it reads and drops, which is what an
+// address slower than the leader looks like from here: the lookup returns
+// on the leader's answer and cancels this attempt before it could reply.
+func countingUpstream(t *testing.T, answer bool) (string, *atomic.Int64) {
+	t.Helper()
+	packet, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = packet.Close() })
+
+	hits := new(atomic.Int64)
+	go func() {
+		buf := make([]byte, 1024)
+		for {
+			n, addr, readErr := packet.ReadFrom(buf)
+			if readErr != nil {
+				return
+			}
+			hits.Add(1)
+			if !answer {
+				continue
+			}
+			req := new(dns.Msg)
+			if req.Unpack(buf[:n]) != nil {
+				continue
+			}
+			reply := new(dns.Msg)
+			reply.SetReply(req)
+			reply.Answer = append(reply.Answer, &dns.A{
+				Hdr: dns.RR_Header{Name: req.Question[0].Name, Rrtype: dns.TypeA,
+					Class: dns.ClassINET, Ttl: 5},
+				A: net.IPv4(192, 0, 2, 1),
+			})
+			out, packErr := reply.Pack()
+			if packErr != nil {
+				continue
+			}
+			_, _ = packet.WriteTo(out, addr)
+		}
+	}()
+	return packet.LocalAddr().String(), hits
+}
+
+// The ranking's decision has to reach the wire, and this is the shape it
+// reaches it in: a delegation of ten addresses where one answers and the
+// rest are unmeasured. The resolver starts the top two of every lookup in
+// parallel, so each miss sends exactly one query to an unmeasured address
+// — and that query is cancelled the moment the leader answers, so the
+// address never comes back measured and stays tied with its peers.
+//
+// Which is the whole point. Nine addresses sharing one price is nine
+// addresses the ranking has no reason to choose between, and the sort's
+// stability chose the same one anyway: it took every one of those queries
+// and the other eight were never contacted at all, for the life of the
+// process. This drives real lookups against real sockets and counts what
+// each address actually received.
+func TestEveryUnmeasuredAuthorityIsEventuallyQueried(t *testing.T) {
+	const unmeasured = 9
+	const lookups = 200
+
+	leaderAddr, leaderHits := countingUpstream(t, true)
+
+	servers := &authority.Servers{Zone: "example."}
+	silent := make(map[string]*atomic.Int64, unmeasured)
+	for range unmeasured {
+		addr, hits := countingUpstream(t, false)
+		silent[addr] = hits
+		servers.List = append(servers.List, authority.NewServer(addr, authority.IPv4))
+	}
+	// The leader goes in last, so the order it ends up in is the ranking's
+	// doing rather than the order it was handed.
+	servers.List = append(servers.List, authority.NewServer(leaderAddr, authority.IPv4))
+
+	cfg := &config.Config{
+		// Roots this test never reaches, but a resolver built without any
+		// treats an empty list as a fatal misconfiguration and takes the
+		// process down with it.
+		RootServers:          []string{"198.41.0.4:53"},
+		Timeout:              config.Duration{Duration: 2 * time.Second},
+		MaxConcurrentQueries: 100,
+	}
+	r := newWiredTestResolver(cfg)
+
+	req := new(dns.Msg)
+	req.SetQuestion("rotate.example.", dns.TypeA)
+
+	runLookup := func() {
+		t.Helper()
+		resp, err := r.lookup(context.Background(), &resolveState{requestID: req.Id}, req, servers)
+		if err != nil {
+			t.Fatalf("lookup: %v", err)
+		}
+		if resp == nil || len(resp.Answer) == 0 {
+			t.Fatal("lookup returned no answer")
+		}
+	}
+
+	// One lookup to establish a leader. On the first one nothing is
+	// measured, so the whole delegation is tied and the resolver walks
+	// down it until something answers — which contacts every address once
+	// and says nothing about how the slot behind the leader is chosen.
+	runLookup()
+	for _, hits := range silent {
+		hits.Store(0)
+	}
+	leaderHits.Store(0)
+
+	for range lookups {
+		runLookup()
+	}
+
+	// The measured server leads every lookup, so it takes one query each.
+	if got := leaderHits.Load(); got < lookups {
+		t.Fatalf("the measured leader received %d of %d lookups", got, lookups)
+	}
+
+	// And the second slot has to have reached all of its equals. Without
+	// rotation exactly one of these is at ~200 and the other eight are at
+	// zero.
+	untried := 0
+	counts := make([]int64, 0, unmeasured)
+	for _, hits := range silent {
+		got := hits.Load()
+		counts = append(counts, got)
+		if got == 0 {
+			untried++
+		}
+	}
+	t.Logf("second-slot queries across %d unmeasured addresses: %v", unmeasured, counts)
+	if untried > 0 {
+		t.Fatalf("%d of %d unmeasured addresses were never queried across %d lookups: %v",
+			untried, unmeasured, lookups, counts)
+	}
+
+	// None of them may be measured either — every one of those attempts
+	// was cancelled when the leader answered, and what an attempt took to
+	// be cancelled is not what the server is worth.
+	for _, s := range servers.List {
+		if s.Addr == leaderAddr {
+			continue
+		}
+		if got := s.SmoothedRTT(); got != 0 {
+			t.Fatalf("a cancelled attempt measured %s at %v", s.Addr, got)
+		}
+	}
+}

--- a/middleware/resolver/lookup_rotation_test.go
+++ b/middleware/resolver/lookup_rotation_test.go
@@ -69,11 +69,11 @@ func countingUpstream(t *testing.T, answer bool) (string, *atomic.Int64) {
 // case the exploration exists for. Without it, all eight take zero
 // queries across two hundred lookups.
 func TestUnknownsAreExploredOnceTheDelegationHasSettled(t *testing.T) {
-	// The lookup count is set by the odds, not by taste: exploration fires
-	// on one lookup in thirty-two and then picks among the eight, so this
-	// is about fifteen turns each. Enough that a zero is not something
-	// this test will ever see by luck.
-	const answering, silentCount, lookups = 2, 8, 4000
+	// Eight of ten addresses are unmeasured, so exploration fires on about
+	// eight lookups in ten and picks among those eight: roughly one turn
+	// each per ten lookups. A hundred is about eighty turns apiece, which
+	// is not a number this test will ever see a zero under.
+	const answering, silentCount, lookups = 2, 8, 100
 
 	servers := &authority.Servers{Zone: "example."}
 	for range answering {

--- a/middleware/resolver/lookup_rotation_test.go
+++ b/middleware/resolver/lookup_rotation_test.go
@@ -57,6 +57,89 @@ func countingUpstream(t *testing.T, answer bool) (string, *atomic.Int64) {
 	return packet.LocalAddr().String(), hits
 }
 
+// The shape a delegation actually settles into, which is not the one
+// above: the parallel head is two, so two addresses get measured and
+// every other address in the zone is left behind the seed. Nothing is
+// then level with the second slot, so rotation has nothing to rotate, and
+// a TLD's remaining ten or eleven authorities are never contacted again.
+//
+// Measured on a production resolver running this branch: two of thirteen
+// in use for com., net. and org. alike. This is that, in a fixture — two
+// authorities answering at similar speeds, eight silent — and it is the
+// case the exploration exists for. Without it, all eight take zero
+// queries across two hundred lookups.
+func TestUnknownsAreExploredOnceTheDelegationHasSettled(t *testing.T) {
+	// The lookup count is set by the odds, not by taste: exploration fires
+	// on one lookup in thirty-two and then picks among the eight, so this
+	// is about fifteen turns each. Enough that a zero is not something
+	// this test will ever see by luck.
+	const answering, silentCount, lookups = 2, 8, 4000
+
+	servers := &authority.Servers{Zone: "example."}
+	for range answering {
+		addr, _ := countingUpstream(t, true)
+		servers.List = append(servers.List, authority.NewServer(addr, authority.IPv4))
+	}
+	silent := make(map[string]*atomic.Int64, silentCount)
+	for range silentCount {
+		addr, hits := countingUpstream(t, false)
+		silent[addr] = hits
+		servers.List = append(servers.List, authority.NewServer(addr, authority.IPv4))
+	}
+
+	cfg := &config.Config{
+		RootServers:          []string{"198.41.0.4:53"},
+		Timeout:              config.Duration{Duration: 2 * time.Second},
+		MaxConcurrentQueries: 100,
+	}
+	r := newWiredTestResolver(cfg)
+	req := new(dns.Msg)
+	req.SetQuestion("settled.example.", dns.TypeA)
+
+	runLookup := func() {
+		t.Helper()
+		if _, err := r.lookup(context.Background(), &resolveState{requestID: req.Id}, req, servers); err != nil {
+			t.Fatalf("lookup: %v", err)
+		}
+	}
+
+	// Let it settle the way production settles, then measure from there.
+	for range 20 {
+		runLookup()
+	}
+	measured := 0
+	for _, s := range servers.List {
+		if s.SmoothedRTT() != 0 {
+			measured++
+		}
+	}
+	if measured != answering {
+		t.Fatalf("the delegation settled on %d measured addresses, want the %d that answer", measured, answering)
+	}
+	for _, hits := range silent {
+		hits.Store(0)
+	}
+
+	for range lookups {
+		runLookup()
+	}
+
+	untried, counts := 0, make([]int64, 0, silentCount)
+	for _, hits := range silent {
+		got := hits.Load()
+		counts = append(counts, got)
+		if got == 0 {
+			untried++
+		}
+	}
+	t.Logf("exploration queries across %d unmeasured addresses in %d lookups: %v",
+		silentCount, lookups, counts)
+	if untried > 0 {
+		t.Fatalf("%d of %d addresses behind a settled delegation were never explored: %v",
+			untried, silentCount, counts)
+	}
+}
+
 // The ranking's decision has to reach the wire, and this is the shape it
 // reaches it in: a delegation of ten addresses where one answers and the
 // rest are unmeasured. The resolver starts the top two of every lookup in

--- a/middleware/resolver/lookup_rotation_test.go
+++ b/middleware/resolver/lookup_rotation_test.go
@@ -57,6 +57,83 @@ func countingUpstream(t *testing.T, answer bool) (string, *atomic.Int64) {
 	return packet.LocalAddr().String(), hits
 }
 
+// The end of the arc, over real sockets: a delegation where every
+// address but the leader is slower than the leader. Those are the ones
+// exploring could never measure, because an explored address only ever
+// came back measured by winning its race — so the field showed a
+// delegation gaining one address a minute with seventeen waiting, and the
+// genuinely slower ones waiting for good.
+func TestSlowerAuthoritiesAreMeasuredNotJustExplored(t *testing.T) {
+	const slower, lookups = 6, 200
+
+	// A lookup against loopback costs a fraction of a millisecond and a
+	// probe to these costs eighty, so an unpaced loop starts probes
+	// hundreds of times faster than the pool can retire them and the pool
+	// sheds nearly all of them — correctly, that being what it is for.
+	// Real misses do not arrive at that rate. The pause keeps the test out
+	// of a regime it is not trying to measure.
+	const pace = 3 * time.Millisecond
+
+	fastAddr, _ := countingUpstream(t, true)
+	servers := &authority.Servers{Zone: "example."}
+	servers.List = append(servers.List, authority.NewServer(fastAddr, authority.IPv4))
+
+	slow := make([]*authority.Server, 0, slower)
+	for range slower {
+		// Far enough behind the leader that it never wins the race.
+		s := authority.NewServer(slowUpstream(t, 80*time.Millisecond), authority.IPv4)
+		slow = append(slow, s)
+		servers.List = append(servers.List, s)
+	}
+
+	cfg := &config.Config{
+		RootServers:          []string{"198.41.0.4:53"},
+		Timeout:              config.Duration{Duration: 2 * time.Second},
+		MaxConcurrentQueries: 100,
+	}
+	r := newWiredTestResolver(cfg)
+	req := new(dns.Msg)
+	req.SetQuestion("slower.example.", dns.TypeA)
+
+	for range lookups {
+		if _, err := r.lookup(context.Background(), &resolveState{requestID: req.Id}, req, servers); err != nil {
+			t.Fatalf("lookup: %v", err)
+		}
+		time.Sleep(pace)
+	}
+
+	// A probe outlives the lookup that sent it, which is the whole point,
+	// so the last ones are still in flight when the loop ends.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		done := true
+		for _, s := range slow {
+			if s.SmoothedRTT() == 0 {
+				done = false
+				break
+			}
+		}
+		if done {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	unmeasured, rtts := 0, make([]time.Duration, 0, slower)
+	for _, s := range slow {
+		got := s.SmoothedRTT()
+		rtts = append(rtts, got.Round(time.Millisecond))
+		if got == 0 {
+			unmeasured++
+		}
+	}
+	t.Logf("latencies learned for addresses that never win a race: %v", rtts)
+	if unmeasured > 0 {
+		t.Fatalf("%d of %d addresses slower than the leader are still unmeasured after %d lookups: %v",
+			unmeasured, slower, lookups, rtts)
+	}
+}
+
 // The shape a delegation actually settles into, which is not the one
 // above: the parallel head is two, so two addresses get measured and
 // every other address in the zone is left behind the seed. Nothing is

--- a/middleware/resolver/resolution_attempt_test.go
+++ b/middleware/resolver/resolution_attempt_test.go
@@ -937,7 +937,9 @@ func TestLookupRejectsBadReferralAndKeepsHealthyAuthority(t *testing.T) {
 				case got := <-done:
 					t.Fatalf("lookup accepted bad referral before healthy response: resp:%#v err:%v", got.resp, got.err)
 				case <-ticker.C:
-					if atomic.LoadInt64(&badServer.Count) >= 2 {
+					// The penalty is a two-second sample, so the estimate
+					// crossing a second is the mark landing.
+					if badServer.SmoothedRTT() >= time.Second {
 						break waitForPenalty
 					}
 				case <-deadline.C:

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -1751,7 +1751,13 @@ func (r *Resolver) queryServer(ctx context.Context, rs *resolveState, interrupts
 	switch {
 	case !r.circuitBreaker.canQuery(server.Addr):
 		res.err = fatalError(errConnectionFailed)
-	case contextutil.EffectiveError(ctx) != nil:
+	case contextutil.EffectiveError(exchangeCtx) != nil:
+		// The context this attempt would run under, which for a probe is
+		// not the lookup's. Reading the lookup's here undid the admission
+		// that had just been granted: a probe took a slot and retained the
+		// ledger, and then returned without reaching the wire because a
+		// fast leader had cancelled in the meantime — which is precisely
+		// the case it exists for.
 		return
 	default:
 		reqCopy.Id = dns.Id() // anti-spoofing
@@ -1931,19 +1937,35 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, interrupts *I
 			return
 		}
 		observed = true
-		if err != nil || resp == nil || !answeredTheQuestion(resp.Rcode) {
-			// Only an answer is worth what it took. Everything else here
-			// is fast for the wrong reason: a refusal is the quickest
-			// reply an authority can send, and a refused connection comes
-			// back in microseconds — quicker than any authority on earth.
-			// The exchange reports elapsed time whatever the outcome, so
-			// scoring these by the clock made the one address in a
-			// delegation that serves nothing into its permanent leader.
-			// Not answering is worth a timeout.
+		switch {
+		case err != nil || resp == nil:
+			// Nothing came back. Only an answer is worth what it took, and
+			// the ways of not answering are fast for the wrong reason: a
+			// refused connection comes back in microseconds, quicker than
+			// any authority on earth. The exchange reports elapsed time
+			// whatever the outcome, so scoring these by the clock made the
+			// one address in a delegation that serves nothing into its
+			// permanent leader. Not answering is worth a timeout.
 			server.ObserveNoAnswer(r.netTimeout)
-			return
+
+		case answeredTheQuestion(resp.Rcode):
+			server.Observe(rtt)
+
+		case isProbe(ctx) && resp.Rcode == dns.RcodeFormatError:
+			// The one rcode a probe reads differently. It says the server
+			// dislikes the shape of our query, not that it failed to
+			// answer — the lookup path replies to it by asking again
+			// without EDNS, and prices the attempt at nothing. A probe
+			// cannot price it at nothing: recording nothing leaves the
+			// address as out of date as it was, so it is a candidate
+			// again, so it is probed again, for as long as the server
+			// keeps saying it. The round trip is what a probe went to find
+			// out, and this server did make one.
+			server.Observe(rtt)
+
+		default:
+			server.ObserveNoAnswer(r.netTimeout)
 		}
-		server.Observe(rtt)
 	}
 	defer record()
 
@@ -2063,10 +2085,22 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, interrupts *I
 
 	ReleaseConn(co)
 
-	// A probe stops here on every one of these. The fallbacks exist to get
-	// an answer, and by the time a probe has one the lookup it was born in
-	// has returned and nobody is left to read it; the UDP exchange it just
-	// completed is the measurement it was sent for.
+	// A probe stops here on both of these, and what it records is the UDP
+	// round trip it completed — deliberately, not by omission. The
+	// fallbacks exist to get an answer, and by the time a probe has one
+	// the lookup it was born in has returned and nobody is left to read
+	// it.
+	//
+	// That does understate an authority whose TCP is slow or broken:
+	// truncation sends the real lookup to TCP, and the probe's number
+	// covers only the UDP leg. The alternative is worse. Pricing a
+	// truncated reply as a failure would mark a server that answered
+	// promptly and correctly, and truncation is a property of the answer's
+	// size rather than of the server, so it would fall on whichever
+	// addresses happened to be probed with a large question. A server
+	// whose TCP is genuinely broken is caught where the evidence actually
+	// exists: the first real lookup that needs TCP records a failure
+	// against it, and the estimate halves toward the timeout at once.
 	if resp != nil && resp.Truncated && proto == "udp" && !isProbe(ctx) {
 		record()
 		return r.exchange(ctx, rs, interrupts, "tcp", req, server, retried)
@@ -2081,16 +2115,20 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, interrupts *I
 	}
 
 	if resp != nil && resp.Rcode == dns.RcodeFormatError && req.IsEdns0() != nil {
+		if isProbe(ctx) {
+			// A probe stops here, and it has to leave a measurement behind.
+			// Recording nothing left the address exactly as it was — out of
+			// date, so a candidate again, so probed again, for as long as
+			// the server keeps refusing our EDNS. The round trip is what a
+			// probe went to find out and the server did make it; that it
+			// dislikes the shape of the query is a fact about the query.
+			return resp, nil
+		}
 		// A server that cannot parse EDNS is not a server that failed to
 		// answer: this attempt is being replaced, not scored. Marking it
 		// observed keeps the defer from pricing our own choice of query
-		// shape as the authority's fault — which is as true for a probe,
-		// which stops here rather than asking again, as for a lookup that
-		// goes on to.
+		// shape as the authority's fault.
 		observed = true
-		if isProbe(ctx) {
-			return resp, nil
-		}
 		// try again without edns tags, some weird servers didn't implement that
 		req = dnsutil.ClearOPT(req)
 		return r.exchange(ctx, rs, interrupts, proto, req, server, retried)

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -1794,11 +1794,15 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, interrupts *I
 			return
 		}
 		sample := rtt
-		if resp != nil && !answeredTheQuestion(resp.Rcode) {
-			// A refusal is the fastest answer an authority can give, so
-			// scoring it by the clock teaches the ranking to prefer the
-			// servers that turn us away. It did not answer the question;
-			// price it as if it had not answered at all.
+		if err != nil || resp == nil || !answeredTheQuestion(resp.Rcode) {
+			// Only an answer is worth what it took. Everything else here
+			// is fast for the wrong reason: a refusal is the quickest
+			// reply an authority can send, and a refused connection comes
+			// back in microseconds — quicker than any authority on earth.
+			// The exchange reports elapsed time whatever the outcome, so
+			// scoring these by the clock made the one address in a
+			// delegation that serves nothing into its permanent leader.
+			// Not answering is worth a timeout.
 			sample = r.netTimeout
 		}
 		server.Observe(sample)

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -1635,6 +1635,39 @@ type lookupResult struct {
 // launching the goroutine, and the pooled reqCopy buffer; both are
 // released before the result send so the main loop can keep launching
 // workers while we queue.
+// probeMode marks an attempt as a measurement probe, and rides on the
+// probe's own detached context — the one thing already scoped to a single
+// attempt, so it cannot reach another one. What it turns off is the retry
+// and the fallbacks to TCP: those exist to get an answer, and a probe's
+// answer has no reader once the lookup it was born in has returned. One
+// exchange is what a probe is for, and one exchange is what it costs.
+type probeMode struct{}
+
+func withProbeMode(ctx context.Context) context.Context {
+	return context.WithValue(ctx, probeMode{}, true)
+}
+
+func isProbe(ctx context.Context) bool {
+	on, _ := ctx.Value(probeMode{}).(bool)
+	return on
+}
+
+// retainForProbe holds the request tree's work ledger open across an
+// attempt that outlives the lookup, the same way the detached IPv6
+// enrichment holds it. Detaching the context carries the ledger through
+// but does not keep it alive: once the tree completes, a debit against it
+// comes back as an error, and this path would read that as the authority
+// failing and trip its circuit breaker for the resolver's own bookkeeping.
+//
+// It reports false when the tree is already finished, which is when
+// starting detached work would escape the tree's aggregate cap.
+func retainForProbe(rs *resolveState) (release func(), ok bool) {
+	if rs == nil || rs.work == nil {
+		return func() {}, true
+	}
+	return rs.work.Retain()
+}
+
 // queryServer runs one upstream attempt and reports it back to lookup.
 //
 // probing marks the attempt the ranking chose to spend on a server whose
@@ -1659,36 +1692,40 @@ func (r *Resolver) queryServer(ctx context.Context, rs *resolveState, interrupts
 	// read it.
 	exchangeCtx := ctx
 	if probing {
-		select {
-		case r.probeSlots <- struct{}{}:
-			defer func() { <-r.probeSlots }()
+		if releaseWork, retained := retainForProbe(rs); retained {
+			select {
+			case r.probeSlots <- struct{}{}:
+				defer func() { <-r.probeSlots }()
+				defer releaseWork()
 
-			// Detached, so the winner's cancellation does not reach it.
-			// Values are carried through, so the request tree still meters
-			// this query as its own.
-			//
-			// The deadline is one exchange window and a grace, because one
-			// exchange is all a probe is for: nobody will read its answer,
-			// so the retry and the fallback to TCP an ordinary attempt is
-			// entitled to would be work for a reply with no reader. The
-			// grace is there so the socket deadline is what ends a silent
-			// server, which is the difference between recording a failure
-			// and recording nothing. A probe therefore lives no longer than
-			// any other attempt.
-			var release context.CancelFunc
-			exchangeCtx, release = context.WithTimeout(context.WithoutCancel(ctx), r.netTimeout+probeGrace)
-			defer release()
+				// Detached, so the winner's cancellation does not reach it.
+				// Values are carried through, so the request tree still
+				// meters this query as its own — and the retain above is
+				// what keeps that ledger open long enough to be metered
+				// against.
+				//
+				// The deadline is one exchange window and a grace. The
+				// grace is there so the socket deadline is what ends a
+				// silent server, which is the difference between recording
+				// a failure and recording nothing. A probe therefore lives
+				// no longer than any other attempt.
+				var release context.CancelFunc
+				exchangeCtx, release = context.WithTimeout(context.WithoutCancel(ctx), r.netTimeout+probeGrace)
+				defer release()
+				exchangeCtx = withProbeMode(exchangeCtx)
 
-			// The interrupt group belongs to the lookup and fires with it,
-			// so a probe registered there would be cut down anyway. Nil
-			// leaves the exchange on its own context, which is the detached
-			// one.
-			interrupts = nil
-		default:
-			// The probe pool is full. Shedding a measurement is free, and
-			// the attempt goes ahead as the hedge it would have been:
-			// exchangeCtx is still the lookup's, so the winner cancels it
-			// like any other.
+				// The interrupt group belongs to the lookup and fires with
+				// it, so a probe registered there would be cut down anyway.
+				// Nil leaves the exchange on its own context, which is the
+				// detached one.
+				interrupts = nil
+			default:
+				// The probe pool is full. Shedding a measurement is free,
+				// and the attempt goes ahead as the hedge it would have
+				// been: exchangeCtx is still the lookup's, so the winner
+				// cancels it like any other.
+				releaseWork()
+			}
 		}
 	}
 
@@ -2002,7 +2039,7 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, interrupts *I
 		if contextutil.EffectiveError(ctx) != nil {
 			return nil, err
 		}
-		if retried < 2 {
+		if retried < 2 && !isProbe(ctx) {
 			if retried == 1 && proto == "udp" {
 				proto = "tcp"
 			}
@@ -2026,12 +2063,16 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, interrupts *I
 
 	ReleaseConn(co)
 
-	if resp != nil && resp.Truncated && proto == "udp" {
+	// A probe stops here on every one of these. The fallbacks exist to get
+	// an answer, and by the time a probe has one the lookup it was born in
+	// has returned and nobody is left to read it; the UDP exchange it just
+	// completed is the measurement it was sent for.
+	if resp != nil && resp.Truncated && proto == "udp" && !isProbe(ctx) {
 		record()
 		return r.exchange(ctx, rs, interrupts, "tcp", req, server, retried)
 	}
 
-	if resp != nil && !resp.Truncated && proto == "udp" && resp.Len() > dnsutil.DefaultMsgSize {
+	if resp != nil && !resp.Truncated && proto == "udp" && resp.Len() > dnsutil.DefaultMsgSize && !isProbe(ctx) {
 		// If response is too large, switch to TCP
 		zlog.Debug("Response too large, switching to TCP", "query", dnsutil.FormatQuestion(q), "upstream", server.Addr,
 			"size", resp.Len(), "maxSize", dnsutil.DefaultMsgSize, "retried", retried)
@@ -2040,13 +2081,18 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, interrupts *I
 	}
 
 	if resp != nil && resp.Rcode == dns.RcodeFormatError && req.IsEdns0() != nil {
-		// try again without edns tags, some weird servers didn't implement that
-		req = dnsutil.ClearOPT(req)
 		// A server that cannot parse EDNS is not a server that failed to
 		// answer: this attempt is being replaced, not scored. Marking it
 		// observed keeps the defer from pricing our own choice of query
-		// shape as the authority's fault.
+		// shape as the authority's fault — which is as true for a probe,
+		// which stops here rather than asking again, as for a lookup that
+		// goes on to.
 		observed = true
+		if isProbe(ctx) {
+			return resp, nil
+		}
+		// try again without edns tags, some weird servers didn't implement that
+		req = dnsutil.ClearOPT(req)
 		return r.exchange(ctx, rs, interrupts, proto, req, server, retried)
 	}
 

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -1364,7 +1364,7 @@ func (r *Resolver) lookup(ctx context.Context, rs *resolveState, req *dns.Msg, s
 	level := dns.CountLabel(servers.Zone)
 	servers.RUnlock()
 
-	authority.Sort(serversList, atomic.AddUint64(&servers.Called, 1)) // sort by RTT and failure rate
+	authority.Sort(serversList) // fastest first
 	serversList = dedupeAuthorityServers(serversList)
 
 	responseErrors := []*dns.Msg{}
@@ -1496,8 +1496,7 @@ mainloop:
 						// bogus delegation, not the current loop index —
 						// results arrive out of order from parallel
 						// goroutines, so `server` can be a later peer.
-						atomic.AddInt64(&res.server.Rtt, 2*time.Second.Nanoseconds())
-						atomic.AddInt64(&res.server.Count, 1)
+						res.server.Observe(2 * time.Second)
 
 						if left > 0 && len(serversList)-1 == index {
 							continue fallbackloop
@@ -1678,12 +1677,27 @@ func (r *Resolver) queryServer(ctx context.Context, rs *resolveState, interrupts
 	}
 }
 
+// answeredTheQuestion reports the rcodes that mean the authority did the
+// job it was asked to do: the name exists and here it is, the name does
+// not exist, or — RFC 6672 §2.2, a DNAME substitution that would exceed
+// 255 octets — the question can have no answer at all. Everything else is
+// a server that did not answer, however quickly it said so.
+//
+// A list of what counts rather than a list of what does not, because the
+// failure mode is asymmetric: a rcode nobody thought about lands in the
+// default, and the safe default is "this did not answer my question".
+func answeredTheQuestion(rcode int) bool {
+	return rcode == dns.RcodeSuccess ||
+		rcode == dns.RcodeNameError ||
+		rcode == dns.RcodeYXDomain
+}
+
 // adaptiveServerTimeout picks how long lookup waits on a single server
 // before racing the next candidate. With no RTT samples the result is a
 // conservative 100ms; otherwise it is 2× the observed RTT clamped to
 // [25ms, 300ms] so a single slow outlier can't stall the whole fan-out.
 func adaptiveServerTimeout(server *authority.Server) time.Duration {
-	rtt := time.Duration(atomic.LoadInt64(&server.Rtt))
+	rtt := server.SmoothedRTT()
 	if rtt <= 0 {
 		return 100 * time.Millisecond
 	}
@@ -1773,10 +1787,21 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, interrupts *I
 	var rtt = r.netTimeout
 	defer func() {
 		if contextutil.EffectiveError(ctx) != nil {
+			// This attempt was cancelled because a peer answered first.
+			// What it took to get cancelled is not what this server is
+			// worth, and recording it would make a server nobody has heard
+			// from look like the fastest in the delegation.
 			return
 		}
-		atomic.AddInt64(&server.Rtt, rtt.Nanoseconds())
-		atomic.AddInt64(&server.Count, 1)
+		sample := rtt
+		if resp != nil && !answeredTheQuestion(resp.Rcode) {
+			// A refusal is the fastest answer an authority can give, so
+			// scoring it by the clock teaches the ranking to prefer the
+			// servers that turn us away. It did not answer the question;
+			// price it as if it had not answered at all.
+			sample = r.netTimeout
+		}
+		server.Observe(sample)
 	}()
 
 	// Check if we should use TCP connection pooling

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -82,6 +82,7 @@ type Resolver struct {
 	circuitBreaker  *circuitBreaker
 	maxConcurrent   chan struct{} // Semaphore for limiting concurrent queries
 	v6LookupSlots   chan struct{} // Global cap on detached IPv6 NS enrichment jobs
+	probeSlots      chan struct{} // Global cap on exploration probes outliving their lookup
 	resolutionSlots chan struct{} // Hard ceiling on in-flight zone lookups; full → fail fast
 	zoneInflight    *zoneInflightLimiter
 	cryptoLimiter   *dnssec.CryptoLimiter
@@ -212,6 +213,25 @@ const (
 	maxUint16        = 1 << 16
 	defaultCacheSize = 1024 * 256
 	defaultTimeout   = 2 * time.Second
+
+	// maxInflightProbes caps the exploration probes allowed to outlive the
+	// lookup that started them.
+	//
+	// Sixteen is chosen from what the slots turn over rather than from what
+	// a machine could carry: a probe to a server that answers is done in
+	// the time that server takes, so these sustain a hundred-odd
+	// measurements a second against a delegation that needs a few dozen in
+	// its lifetime. Only a probe to something silent holds a slot for a
+	// whole timeout, and sixteen of those is a number nobody has to think
+	// about. What it must not do is grow with arrival rate, which is how a
+	// detached pool in this file once reached 1.4M goroutines.
+	maxInflightProbes = 16
+
+	// probeGrace is how much longer than one upstream timeout a probe's
+	// context lives, so a silent server is ended by the socket deadline —
+	// which records a failure — rather than by the context, which would
+	// only record a cancellation.
+	probeGrace = 250 * time.Millisecond
 )
 
 // NewResolver return a resolver.
@@ -258,6 +278,8 @@ func NewResolver(cfg *config.Config) *Resolver {
 		// goroutines). Full slots shed the job instead of queueing it.
 		r.v6LookupSlots = make(chan struct{}, maxConcurrent)
 	}
+
+	r.probeSlots = make(chan struct{}, maxInflightProbes)
 
 	if r.cfg.Timeout.Duration > 0 {
 		r.netTimeout = r.cfg.Timeout.Duration
@@ -1364,7 +1386,10 @@ func (r *Resolver) lookup(ctx context.Context, rs *resolveState, req *dns.Msg, s
 	level := dns.CountLabel(servers.Zone)
 	servers.RUnlock()
 
-	authority.Sort(serversList) // fastest first
+	// probing is the server the second slot is spending on an exploration
+	// probe, if it is spending it on one. It is carried as the server
+	// rather than the position because dedupe runs next and can move it.
+	probing := authority.Sort(serversList) // fastest first
 	serversList = dedupeAuthorityServers(serversList)
 
 	responseErrors := []*dns.Msg{}
@@ -1421,7 +1446,7 @@ mainloop:
 		select {
 		case r.maxConcurrent <- struct{}{}:
 			// Got a slot, start the query
-			go r.queryServer(ctx, rs, interrupts, originalID, serverReq, server, results)
+			go r.queryServer(ctx, rs, interrupts, originalID, serverReq, server, results, server == probing)
 		case <-ctx.Done():
 			// Context cancelled while waiting for slot —
 			// return the pre-copied pooled message before
@@ -1610,8 +1635,62 @@ type lookupResult struct {
 // launching the goroutine, and the pooled reqCopy buffer; both are
 // released before the result send so the main loop can keep launching
 // workers while we queue.
-func (r *Resolver) queryServer(ctx context.Context, rs *resolveState, interrupts *InterruptGroup, originalID uint16, reqCopy *dns.Msg, server *authority.Server, results chan<- lookupResult) {
+// queryServer runs one upstream attempt and reports it back to lookup.
+//
+// probing marks the attempt the ranking chose to spend on a server whose
+// worth is out of date. It is the same query as any other, but what it is
+// worth is the opposite: an ordinary attempt is worth the answer it may
+// bring and nothing once the leader has answered, while a probe is worth
+// only the measurement, and there is no measurement until the server
+// replies. Cancelling it the moment the leader answers — which is what
+// happens to every other attempt — cancels it before it can say anything,
+// every time, because the leader is by construction the fastest server in
+// the list. Exploring at any rate then measures only the addresses quick
+// enough to win outright, which on a production delegation was one new
+// address a minute against seventeen waiting.
+//
+// So a probe runs on a context detached from the lookup's. The query
+// itself is one that was being sent anyway.
+func (r *Resolver) queryServer(ctx context.Context, rs *resolveState, interrupts *InterruptGroup, originalID uint16, reqCopy *dns.Msg, server *authority.Server, results chan<- lookupResult, probing bool) {
 	defer ReleaseMsg(reqCopy)
+
+	// exchangeCtx is what the attempt runs under; ctx stays the lookup's,
+	// because the result is only wanted while the lookup is still there to
+	// read it.
+	exchangeCtx := ctx
+	if probing {
+		select {
+		case r.probeSlots <- struct{}{}:
+			defer func() { <-r.probeSlots }()
+
+			// Detached, so the winner's cancellation does not reach it.
+			// Values are carried through, so the request tree still meters
+			// this query as its own.
+			//
+			// The deadline is one exchange window and a grace, because one
+			// exchange is all a probe is for: nobody will read its answer,
+			// so the retry and the fallback to TCP an ordinary attempt is
+			// entitled to would be work for a reply with no reader. The
+			// grace is there so the socket deadline is what ends a silent
+			// server, which is the difference between recording a failure
+			// and recording nothing. A probe therefore lives no longer than
+			// any other attempt.
+			var release context.CancelFunc
+			exchangeCtx, release = context.WithTimeout(context.WithoutCancel(ctx), r.netTimeout+probeGrace)
+			defer release()
+
+			// The interrupt group belongs to the lookup and fires with it,
+			// so a probe registered there would be cut down anyway. Nil
+			// leaves the exchange on its own context, which is the detached
+			// one.
+			interrupts = nil
+		default:
+			// The probe pool is full. Shedding a measurement is free, and
+			// the attempt goes ahead as the hedge it would have been:
+			// exchangeCtx is still the lookup's, so the winner cancels it
+			// like any other.
+		}
+	}
 
 	// releaseSlot frees the semaphore slot acquired by the main
 	// loop before this goroutine was launched. We must release
@@ -1639,7 +1718,7 @@ func (r *Resolver) queryServer(ctx context.Context, rs *resolveState, interrupts
 		return
 	default:
 		reqCopy.Id = dns.Id() // anti-spoofing
-		resp, err := r.exchange(ctx, rs, interrupts, "udp", reqCopy, server, 0)
+		resp, err := r.exchange(exchangeCtx, rs, interrupts, "udp", reqCopy, server, 0)
 		if resp != nil {
 			resp.Id = originalID
 		}
@@ -1648,7 +1727,11 @@ func (r *Resolver) queryServer(ctx context.Context, rs *resolveState, interrupts
 			errors.Is(err, middleware.ErrResolutionAttemptLimit),
 			errors.Is(err, middleware.ErrFailureProbeLimit),
 			errors.Is(err, middleware.ErrMaxRecursion),
-			contextutil.EffectiveError(ctx) != nil:
+			// The context the attempt ran under, which for a probe is not
+			// the lookup's: by the time a probe finishes the lookup has
+			// usually returned and cancelled its own, and reading that one
+			// would throw away the health evidence the probe went to get.
+			contextutil.EffectiveError(exchangeCtx) != nil:
 			// Local policy exhaustion says nothing about the
 			// authority's health; neither does cancellation of this request
 			// tree. Do not use errors.Is(err, context.DeadlineExceeded) here:

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -1785,7 +1785,21 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, interrupts *I
 
 	// Track RTT for adaptive timeouts
 	var rtt = r.netTimeout
-	defer func() {
+
+	// record files this attempt's outcome with the ranking, once.
+	//
+	// It is called explicitly before this frame hands its work to a retry
+	// or a fallback, because those recurse: the frame that answered
+	// returns before the frame that failed, so leaving both to the defer
+	// delivered them backwards. A server that timed out and then answered
+	// on the retry had the timeout recorded last, and a blend that halves
+	// with each sample put it near the timeout — a server that had just
+	// answered, priced as one that had not.
+	observed := false
+	record := func() {
+		if observed {
+			return
+		}
 		if contextutil.EffectiveError(ctx) != nil {
 			// This attempt was cancelled because a peer answered first.
 			// What it took to get cancelled is not what this server is
@@ -1793,6 +1807,7 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, interrupts *I
 			// from look like the fastest in the delegation.
 			return
 		}
+		observed = true
 		sample := rtt
 		if err != nil || resp == nil || !answeredTheQuestion(resp.Rcode) {
 			// Only an answer is worth what it took. Everything else here
@@ -1806,7 +1821,8 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, interrupts *I
 			sample = r.netTimeout
 		}
 		server.Observe(sample)
-	}()
+	}
+	defer record()
 
 	// Check if we should use TCP connection pooling
 	var pooledConn *dns.Conn
@@ -1906,6 +1922,7 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, interrupts *I
 			}
 			// retry
 			retried++
+			record()
 			return r.exchange(ctx, rs, interrupts, proto, req, server, retried)
 		}
 
@@ -1924,6 +1941,7 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, interrupts *I
 	ReleaseConn(co)
 
 	if resp != nil && resp.Truncated && proto == "udp" {
+		record()
 		return r.exchange(ctx, rs, interrupts, "tcp", req, server, retried)
 	}
 
@@ -1931,12 +1949,18 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, interrupts *I
 		// If response is too large, switch to TCP
 		zlog.Debug("Response too large, switching to TCP", "query", dnsutil.FormatQuestion(q), "upstream", server.Addr,
 			"size", resp.Len(), "maxSize", dnsutil.DefaultMsgSize, "retried", retried)
+		record()
 		return r.exchange(ctx, rs, interrupts, "tcp", req, server, retried)
 	}
 
 	if resp != nil && resp.Rcode == dns.RcodeFormatError && req.IsEdns0() != nil {
 		// try again without edns tags, some weird servers didn't implement that
 		req = dnsutil.ClearOPT(req)
+		// A server that cannot parse EDNS is not a server that failed to
+		// answer: this attempt is being replaced, not scored. Marking it
+		// observed keeps the defer from pricing our own choice of query
+		// shape as the authority's fault.
+		observed = true
 		return r.exchange(ctx, rs, interrupts, proto, req, server, retried)
 	}
 

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -1496,7 +1496,10 @@ mainloop:
 						// bogus delegation, not the current loop index —
 						// results arrive out of order from parallel
 						// goroutines, so `server` can be a later peer.
-						res.server.Observe(2 * time.Second)
+						// It replied, but with a delegation it had no
+						// business sending, which is not an answer to the
+						// question we asked.
+						res.server.ObserveNoAnswer(2 * time.Second)
 
 						if left > 0 && len(serversList)-1 == index {
 							continue fallbackloop
@@ -1808,7 +1811,6 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, interrupts *I
 			return
 		}
 		observed = true
-		sample := rtt
 		if err != nil || resp == nil || !answeredTheQuestion(resp.Rcode) {
 			// Only an answer is worth what it took. Everything else here
 			// is fast for the wrong reason: a refusal is the quickest
@@ -1818,9 +1820,10 @@ func (r *Resolver) exchange(ctx context.Context, rs *resolveState, interrupts *I
 			// scoring these by the clock made the one address in a
 			// delegation that serves nothing into its permanent leader.
 			// Not answering is worth a timeout.
-			sample = r.netTimeout
+			server.ObserveNoAnswer(r.netTimeout)
+			return
 		}
-		server.Observe(sample)
+		server.Observe(rtt)
 	}
 	defer record()
 

--- a/middleware/resolver/utils.go
+++ b/middleware/resolver/utils.go
@@ -1,7 +1,6 @@
 package resolver
 
 import (
-	"math/rand/v2"
 	"net"
 	"net/netip"
 	"slices"
@@ -32,14 +31,6 @@ func init() {
 // first; rare paths (dial failures, loop detection) are not worth the noise.
 func debugLogEnabled() bool {
 	return zlog.Default().GetLevel() <= zlog.LevelDebug
-}
-
-func shuffleStr(vals []string) []string {
-	ret := slices.Clone(vals)
-	rand.Shuffle(len(ret), func(i, j int) {
-		ret[i], ret[j] = ret[j], ret[i]
-	})
-	return ret
 }
 
 // searchAddrs collects usable NS addresses from an answer as heap-free

--- a/middleware/resolver/utils_test.go
+++ b/middleware/resolver/utils_test.go
@@ -13,17 +13,6 @@ import (
 	"github.com/semihalev/zlog/v2"
 )
 
-func Test_shuffleStr(t *testing.T) {
-
-	vals := make([]string, 1)
-
-	rr := shuffleStr(vals)
-
-	if len(rr) != 1 {
-		t.Error("invalid array length")
-	}
-}
-
 func Test_searchAddr(t *testing.T) {
 	testDomain := "google.com."
 

--- a/server/listener_doq.go
+++ b/server/listener_doq.go
@@ -77,8 +77,12 @@ func (d *doqListener) Serve(_ context.Context) error {
 	zlog.Info("DNS server listening", "net", "doq", "addr", d.addr)
 	d.serving.Store(true)
 	defer d.serving.Store(false)
+	// Serve returns only by failing — it either cannot listen or its accept
+	// loop breaks — so there is no nil to check for. Shutting down is one
+	// of those failures, and the two errors it arrives as are the ones this
+	// swallows.
 	err := srv.Serve(pc, tlsConfig)
-	if err != nil && !errors.Is(err, net.ErrClosed) && !errors.Is(err, quic.ErrServerClosed) {
+	if !errors.Is(err, net.ErrClosed) && !errors.Is(err, quic.ErrServerClosed) {
 		return err
 	}
 	return nil


### PR DESCRIPTION
`dig ch hinfo com.` on a production resolver showed the delegation ranked with an address nobody had ever reached at the head of the list. The resolver starts the top two in parallel, so the query it depends on went to the one server whose speed nobody had established.

The cause is one line: the ranking sorted on an accumulated RTT, and an unmeasured server carries zero. Zero is not slow, it is instant.

Chasing it turned out to be worth more than a tidier `hinfo` output — cold-cache resolution got materially faster. **A throughput comparison first published here has been withdrawn**: it was measured against another resolver on the same host, but the two were not given equal conditions. The file-descriptor limit was 1024 for both, which silently caps how many upstream queries a resolver can have in flight and penalises them unequally; the per-upstream timeouts differed; and QNAME minimisation was on with a different step policy on each side. Re-measured with the descriptor limit raised, the timeouts matched and minimisation off on both, the gap is a fraction of what was claimed. The corrected figures belong in `BENCHMARKS.md` alongside the method, not here, and are being measured now.

What is not in doubt is the mechanism, which is visible without a benchmark: a cold miss walks root → TLD → zone, and at every step the primary query went to an address nobody had measured.

## What the ranking does now

**An unmeasured server is priced at 300ms.** It loses to any authority measured faster than that and beats one measured slower, which is what makes the price work in both directions: a guess is worth trying ahead of a server measured at 400ms, and a server measured at 8 seconds falls behind the guesses instead of holding the delegation forever. The number is chosen against what authorities cost in practice — a production `com.` set measures 28 to 60ms.

**Evidence ages per server** instead of being wiped for all of them. Every thousandth sort cleared every server's statistics, which is not aging but amnesia: for the sorts that followed, the whole set read as unmeasured, the state the ranking put first. A measurement nobody has refreshed in five minutes now drifts halfway back toward a guess.

**The estimate is blended half and half with each sample** instead of averaged over every sample ever taken. An average needed dozens of samples to notice an authority going bad and kept sending queries into it meanwhile.

**Only an answer is scored by what it took.** Both ways an attempt fails without a reply are fast for the wrong reason: a refusal is the quickest reply an authority can send, and a refused connection comes back in microseconds. A stale glue record pointing at a host that is up but not serving DNS measured 250ms across its retries — inside the price of a guess — so it took the head of the delegation, was queried first, refused again, and re-recorded as fast, with no way out. Anything but NOERROR, NXDOMAIN and the YXDOMAIN that RFC 6672 §2.2 requires is now priced at the timeout.

**An attempt is recorded before it hands its work to a retry or a fallback.** Those recurse, so the frame that answered returns before the frame that failed and the defer delivered them backwards: a server with a history at 10ms that timed out once and answered on the retry ended at 102ms instead of 52ms.

**Sorting allocates nothing, and is faster.** `sort.Slice` needs a closure and a swapper — two allocations and 56 bytes on every cache miss, on the path that already carries the resolver's heaviest work. The scores are read once into a small array and passed over by insertion, which beats a general sort outright at delegation sizes (1.8× at thirteen addresses, 2.2× at twenty-six).

## How an address stops being unknown

The ranking above is worth nothing if the delegation never learns. Three things had to be true, and each was found by watching production rather than by reasoning:

**The second slot rotates among the servers tied for it.** Leaving that to the sort's stability meant the same address took the slot on every lookup forever — and unmeasured addresses all carry the same price, so one of them was queried on every miss and the rest were never tried at all.

**Exploration runs as hard as there is something to learn.** A delegation settles on two measured addresses and stops: the parallel head is two, so nothing is level with the second slot any more and the rotation has nothing to rotate. Measured in production, `com.`, `net.` and `org.` each had two of their addresses in use and the rest idle. The second slot now goes to an address whose worth is out of date, at a rate set by the share of the delegation that is — most lookups on a zone just met, almost none on a settled one. A fixed rate cannot be both: one in thirty-two took five hundred misses to reach a given address, which is hours.

**A probe outlives the winner's cancellation.** Exploring taught nothing without this. The probe was sent, the leader answered first as it must, and the lookup returned and cancelled it before it could reply — so an address was only ever measured by winning its race outright, and one genuinely slower than the leader waited forever. A probe now runs on a context detached from the lookup's, out of a pool capped at sixteen, with a deadline of one exchange and a grace so a silent server is ended by the socket deadline. Retries and the TCP fallbacks are off for it: those exist to get an answer, and a probe's answer has no reader. The query itself is one that was being sent anyway.

Field result, same resolver, three builds in sequence:

| | fixed 1/32 rate | rate ∝ what is unknown | + probe survives |
|---|---|---|---|
| `com.` | 8 → 10 in ten minutes | 9 → 23 in twenty | **26 / 26** |
| `net.` | pinned at 2 for fifteen minutes | 16 → 20 | **26 / 26** |
| `org.` | 3 | stuck at 8 for twenty minutes | **12 / 12** |
| `tr.` | 5 | 7 → 9 | **12 / 12** |

Held at full coverage across the following half hour. One of `org.`'s new addresses came back at 133ms against a 48ms leader — an address that could not have won a race in any amount of time.

**Health is readable again.** Pricing a server that does not reply at the timeout is right for the ranking and useless for reading it, because a very slow server costs a timeout too. The state carries one more bit for whether the last exchange came back and the health line reports FAILING when it did not. Nothing is ranked on it. Observed in the field: two authorities flagged for four minutes and cleared the moment they answered again.

**An exchange the clock cannot resolve still happened.** The estimate and "nothing has answered" are told apart by the estimate being zero, so recording a zero made a measurement report itself as the absence of one — priced at the seed, explored forever, never allowed to lead however fast it is. Windows CI found it on a loopback exchange; a LAN authority on any platform is one clock granularity away.

## Also here

`Rtt` and `Count` are gone from `Server`, replaced by one packed word and a timestamp — the same two words, so the struct does not grow. A cancelled attempt still records nothing: what it took to be cancelled is not what that server is worth.

Three lint findings the current analyzers report are cleared rather than annotated: DNSSEC signature verification parses the ECDSA point instead of building a key from coordinates (deprecated in Go 1.26, and stricter — a point off the curve is rejected at the parse), the DoQ listener drops a nil check on a `Serve` that only returns by failing, and `shuffleStr` is deleted, having had no caller but its own test.

Two ratelimit tests lose their stopwatches. They asserted a wall-clock budget for a flood of source addresses next to the assertion that matters — that the cache stays within its size — and the same loop takes 59ms on a laptop and six seconds on the shared Windows runner.

## Verification

Full suite, `-race` on `internal/authority` and `middleware/resolver`, the probe and wire tests at `-count=50`, `golangci-lint run ./...` on darwin, linux, freebsd and windows, `gofmt -l`, `git diff --check`. CI green on all three platforms.

Supersedes #575, which answered the same question with a failure-penalty model, ticket-ordered verdicts, a backoff schedule and a packed multi-field state word — roughly five hundred lines of machinery that existed to keep other machinery consistent under concurrency. That branch stays for the record.

