### PR TITLE
bench: measure the miss path, not just the hit path

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -189,13 +189,18 @@ changed the answer by more than the result itself:
   time out adaptively from measured RTT and have no equivalent single knob;
   Unbound's starting point for an unmeasured server is 376 ms, so it is
   already the more aggressive of the two policies.
-- **QNAME minimisation off in all four.** Every one of them implements it, and
-  every one of them uses a different step policy — RFC 9156 requires the extra
-  queries to be bounded but does not say by how much, so the counts are not
-  comparable in common units. Turning it off removes the variable. **This is
-  therefore not a configuration anyone should run:** minimisation is the
-  recommended default and disabling it is a privacy regression. It is
-  disabled here to compare resolution engines, not to recommend a setting.
+- **QNAME minimisation off in all four.** All four implement it and each
+  bounds it differently. RFC 9156 §2.3 does require a bound — *"Resolvers
+  supporting QNAME minimisation MUST implement a mechanism to limit the
+  number of outgoing queries per user request"* — and it names values:
+  MAX_MINIMISE_COUNT with a RECOMMENDED value of 10, and MINIMISE_ONE_LAB
+  with "a good value is 4". What the implementations do not share is the
+  knob: sdns exposes a label depth (`qname_min_level`, default 3), the
+  others expose a boolean or their own parameters, so the recommended
+  values cannot simply be dialled in on all four. Turning it off removes
+  the variable instead. **This is not a configuration to run in
+  production** — it is a privacy regression, and it is off here to compare
+  resolution engines rather than to recommend a setting.
 
 ### Results
 
@@ -231,6 +236,10 @@ lost column are where that shows up.
   this network from this host, and should not be read as a portable ranking.
 - The minimisation caveat above is not a footnote: with each resolver's own
   minimisation policy enabled, the numbers and possibly the ordering differ.
+  Measuring that would mean establishing what each one actually sends —
+  observable on the wire, since the minimised queries are visible in a
+  capture — rather than trusting four differently-named settings to mean the
+  same thing.
 
 ## What changed in 1.8.0
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -156,7 +156,10 @@ cache. It is a different question, and the answer belongs to a different part
 of the code: how quickly the resolver walks root → TLD → zone, and which
 upstream it picks at each step.
 
-Measured 2026-08-22 at commit `676ac14`, on the same host as above.
+Measured 2026-08-23 at commit `42d06f3`, on the same host as above, in both
+minimisation modes: once with QNAME minimisation disabled in all four, which
+isolates the resolution engines, and once with every resolver on its shipped
+minimisation defaults, which is what a deployment actually runs.
 
 ### Method
 
@@ -189,46 +192,66 @@ changed the answer by more than the result itself:
   time out adaptively from measured RTT and have no equivalent single knob;
   Unbound's starting point for an unmeasured server is 376 ms, so it is
   already the more aggressive of the two policies.
-- **QNAME minimisation off in all four**, because their defaults do not
-  implement the same policy. RFC 9156 §2.3 requires a bound — *"Resolvers
-  supporting QNAME minimisation MUST implement a mechanism to limit the
-  number of outgoing queries per user request"* — and names values:
-  MAX_MINIMISE_COUNT with a RECOMMENDED value of 10, MINIMISE_ONE_LAB with
-  "a good value is 4". Read from the installed builds:
+- **Address family: every resolver on its shipped dual-stack default.** An
+  earlier revision of this section pinned PowerDNS to one IPv4 address,
+  switched Unbound's IPv6 off and bound Knot to IPv4 — none of which is that
+  resolver's default — while sdns ran dual-stack. On this host the root
+  answers in 1 ms over IPv4 and ~49 ms over IPv6, so those pins handed three
+  resolvers the fast path exclusively. The pins are gone; all four now run
+  the dual stack they ship with, and the numbers below replace the earlier
+  ones.
+- **QNAME minimisation: measured both ways.** RFC 9156 §2.3 requires a bound
+  — *"Resolvers supporting QNAME minimisation MUST implement a mechanism to
+  limit the number of outgoing queries per user request"* — and names
+  values: MAX_MINIMISE_COUNT with a RECOMMENDED value of 10,
+  MINIMISE_ONE_LAB with "a good value is 4". Read from the installed builds:
 
   | | default | step bound |
   |---|---|---|
-  | sdns 1.8.0 | on, `qname_min_level = 3` | 3 levels, then the full name |
+  | sdns 1.8.0 | on, `qname_max_minimize_count = 10`, `qname_minimize_one_label = 4` | RFC 9156's recommended values |
   | PowerDNS 5.4.1 | `qname_minimization: true` | `qname_max_minimize_count: 10`, `qname_minimize_one_label: 4` |
   | Unbound 1.24.2 | `qname-minimisation: yes`, strict `no` | the RFC's parameter names are Unbound's own: 10 and 4 |
   | Knot 6.2.0 | on | label by label |
 
-  PowerDNS and Unbound ship the values the RFC recommends. **sdns stops at
-  three**, so its default sends fewer minimised queries than the others' —
-  cheaper, and less private. Left on, that difference would show up in this
-  table as an engine result, which it is not. Turning it off in all four
-  removes it. **The result is not a configuration to run in production:**
-  disabling minimisation is a privacy regression, and it is off here to
-  compare resolution engines rather than to recommend a setting.
+  Three of the four ship the values the RFC recommends, which makes the
+  as-shipped comparison meaningful; Knot minimises label by label, the
+  deepest policy of the four, and its as-shipped number carries that choice.
+  The minimisation-off run isolates the engines from the policies. Disabled
+  minimisation is a privacy regression and not a configuration to run in
+  production; it is off in that run to compare resolution engines, not to
+  recommend a setting.
 
 ### Results
 
-Medians of three rounds:
+Medians of three rounds. First with minimisation disabled in all four — the
+engine comparison:
 
-| | queries/sec | avg latency | unanswered | lost | spread |
+| minimisation off | queries/sec | avg latency | unanswered | lost | spread |
 |---|---|---|---|---|---|
-| **sdns 1.8.0** | **868** | **0.111 s** | 869 (1.74%) | **0 / 0 / 0** | 3.2% |
-| PowerDNS Recursor 5.4.1 | 799 | 0.118 s | 882 (1.76%) | 1 / 0 / 0 | 2.0% |
-| Knot Resolver 6.2.0 | 583 | 0.121 s | 884 (1.77%) | 234 / 203 / 188 | 6.4% |
-| Unbound 1.24.2 | 447 | 0.127 s | 874 (1.75%) | 526 / 489 / 473 | 5.3% |
+| **sdns 1.8.0** | **905** | **0.107 s** | 883 (1.77%) | **0 / 0 / 0** | 1.9% |
+| PowerDNS Recursor 5.4.1 | 799 | 0.118 s | 860 (1.72%) | 0 / 0 / 0 | 1.5% |
+| Knot Resolver 6.2.0 | 534 | 0.135 s | 910 (1.82%) | 218 / 206 / 236 | 5.3% |
+| Unbound 1.24.2 | 399 | 0.137 s | 905 (1.81%) | 567 / 581 / 554 | 2.4% |
+
+And as shipped — every resolver on its own minimisation defaults:
+
+| as shipped | queries/sec | avg latency | unanswered | lost | spread |
+|---|---|---|---|---|---|
+| **sdns 1.8.0** | **658** | **0.145 s** | 898 (1.80%) | **2 / 1 / 1** | 3.9% |
+| PowerDNS Recursor 5.4.1 | 636 | 0.149 s | 912 (1.82%) | 0 / 0 / 0 | 5.0% |
+| Knot Resolver 6.2.0 | 436 | 0.173 s | 928 (1.86%) | 248 / 245 / 235 | 4.3% |
+| Unbound 1.24.2 | 243 | 0.188 s | 1424 (2.85%) | 1106 / 1067 / 1152 | 5.8% |
 
 **"Unanswered" counts SERVFAIL and lost queries together**, and it is the
 column that makes the rest readable. Counting SERVFAIL alone puts Unbound
-first at 0.78% — but it left 489 queries with no answer at all, which from a
-client is worse than a SERVFAIL, not better. Summed, all four land between
-1.74% and 1.77%: they resolved the same corpus to the same outcomes, and the
-residue is names that genuinely do not resolve. That is what makes this a
-like-for-like comparison rather than four different amounts of work.
+first at 0.7% — but it left over five hundred queries with no answer at all,
+which from a client is worse than a SERVFAIL, not better. Summed, the
+minimisation-off run lands all four between 1.72% and 1.82%: they resolved
+the same corpus to the same outcomes, and the residue is names that genuinely
+do not resolve. That is what makes it a like-for-like comparison rather than
+four different amounts of work. In the as-shipped run three of the four hold
+that band; Unbound's unanswered rises to 2.85%, which is its own minimisation
+policy's cost on this corpus, reported rather than corrected.
 
 Average latency is reported for completed queries only, so a resolver that
 abandons a query improves its own average by doing so; the wall clock and the
@@ -243,12 +266,11 @@ lost column are where that shows up.
 - Cold-cache throughput is dominated by upstream latency, not by the local
   machine. These numbers describe how well each resolver walks the tree on
   this network from this host, and should not be read as a portable ranking.
-- The minimisation caveat above is not a footnote: with each resolver's own
-  minimisation policy enabled, the numbers and possibly the ordering differ.
-  Measuring that would mean establishing what each one actually sends —
-  observable on the wire, since the minimised queries are visible in a
-  capture — rather than trusting four differently-named settings to mean the
-  same thing.
+- The two tables answer different questions and neither replaces the other:
+  minimisation-off ranks the engines, as-shipped ranks the deployments. The
+  as-shipped gap between them is what each resolver's minimisation policy
+  costs on this corpus — visible on the wire, since minimised queries show
+  up in a capture, and stated per resolver in the defaults table above.
 
 ## What changed in 1.8.0
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -131,10 +131,8 @@ configuration, not an intrinsic constant — PowerDNS's echo does the least
 work per query of the four and earns the best per-core number for it.
 Third, sdns's own scaling curve bends: ~50k qps/core at 8 procs falling
 to ~30k at the runtime default of 32, and doubling the concurrency from
-8 to 16 buys only ~17% more throughput. What the measurements establish
-is precisely this: on this dual-socket, 32-logical-CPU host, bounding
-Go's parallelism below the runtime default materially improves throughput
-(418k median at the default vs 462k at `GOMAXPROCS=16`). The shape is
+8 to 16 buys only ~17% more throughput — on this host, bounding Go's
+parallelism below the runtime default is a material win. The shape is
 consistent with scheduler, shared-state and cache-coherence costs; an
 affinity-controlled check (the process bound to one NUMA node with
 `numactl`) measured no improvement over the unbound runs, so memory
@@ -200,26 +198,25 @@ changed the answer by more than the result itself:
   resolvers the fast path exclusively. The pins are gone; all four now run
   the dual stack they ship with, and the numbers below replace the earlier
   ones.
-- **QNAME minimisation: measured both ways.** RFC 9156 §2.3 requires a bound
-  — *"Resolvers supporting QNAME minimisation MUST implement a mechanism to
-  limit the number of outgoing queries per user request"* — and names
-  values: MAX_MINIMISE_COUNT with a RECOMMENDED value of 10,
-  MINIMISE_ONE_LAB with "a good value is 4". Read from the installed builds:
 
-  | | default | step bound |
-  |---|---|---|
-  | sdns 1.8.0 | on, `qname_max_minimize_count = 10`, `qname_minimize_one_label = 4` | RFC 9156's recommended values |
-  | PowerDNS 5.4.1 | `qname_minimization: true` | `qname_max_minimize_count: 10`, `qname_minimize_one_label: 4` |
-  | Unbound 1.24.2 | `qname-minimisation: yes`, strict `no` | the RFC's parameter names are Unbound's own: 10 and 4 |
-  | Knot 6.2.0 | on | label by label |
+QNAME minimisation was not equalised — it was measured both ways. RFC 9156
+§2.3 requires a bound — *"Resolvers supporting QNAME minimisation MUST
+implement a mechanism to limit the number of outgoing queries per user
+request"* — and names values: MAX_MINIMISE_COUNT with a RECOMMENDED value of
+10, MINIMISE_ONE_LAB with "a good value is 4". Read from the installed builds:
 
-  Three of the four ship the values the RFC recommends, which makes the
-  as-shipped comparison meaningful; Knot minimises label by label, the
-  deepest policy of the four, and its as-shipped number carries that choice.
-  The minimisation-off run isolates the engines from the policies. Disabled
-  minimisation is a privacy regression and not a configuration to run in
-  production; it is off in that run to compare resolution engines, not to
-  recommend a setting.
+| | default | step bound |
+|---|---|---|
+| sdns 1.8.0 | on, `qname_max_minimize_count = 10`, `qname_minimize_one_label = 4` | RFC 9156's recommended values |
+| PowerDNS 5.4.1 | `qname_minimization: true` | `qname_max_minimize_count: 10`, `qname_minimize_one_label: 4` |
+| Unbound 1.24.2 | `qname-minimisation: yes`, strict `no` | the RFC's parameter names are Unbound's own: 10 and 4 |
+| Knot 6.2.0 | on | label by label |
+
+Three of the four ship the values the RFC recommends, which makes the
+as-shipped comparison meaningful; Knot minimises label by label, the deepest
+policy of the four, and its as-shipped number carries that choice. Disabled
+minimisation is a privacy regression, not a recommended configuration; it is
+off in one run only to compare engines.
 
 ### Results
 

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,6 +1,6 @@
 # Benchmarks
 
-Measured 2026-08-18 at commit `8b36b91` (the 1.8.0 serving-path work, PR #572).
+Measured at commit `8b36b91` (the 1.8.0 serving-path work, PR #572).
 This document exists to make one set of claims precisely, with the method and
 configurations needed to check them — not to advertise a bigger number than the
 method supports.
@@ -12,9 +12,9 @@ traffic mixes hits with misses, and a miss is bound by upstream latency, not by
 the serving engine. What a resolver's engine controls is the hit path; that is
 what this measures.
 
-The miss path is measured separately in [Cold cache](#cold-cache-resolution-rather-than-serving),
-added 2026-08-22. The two sections answer different questions and their numbers
-are not comparable to each other.
+The miss path is measured separately in [Cold cache](#cold-cache-resolution-rather-than-serving).
+The two sections answer different questions and their numbers are not
+comparable to each other.
 
 ## Environment
 
@@ -154,7 +154,7 @@ cache. It is a different question, and the answer belongs to a different part
 of the code: how quickly the resolver walks root → TLD → zone, and which
 upstream it picks at each step.
 
-Measured 2026-08-23 at commit `42d06f3`, on the same host as above, in both
+Measured at commit `42d06f3`, on the same host as above, in both
 minimisation modes: once with QNAME minimisation disabled in all four, which
 isolates the resolution engines, and once with every resolver on its shipped
 minimisation defaults, which is what a deployment actually runs.

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -12,6 +12,10 @@ traffic mixes hits with misses, and a miss is bound by upstream latency, not by
 the serving engine. What a resolver's engine controls is the hit path; that is
 what this measures.
 
+The miss path is measured separately in [Cold cache](#cold-cache-resolution-rather-than-serving),
+added 2026-08-22. The two sections answer different questions and their numbers
+are not comparable to each other.
+
 ## Environment
 
 | | |
@@ -144,6 +148,90 @@ medians spanned roughly ±7% for sdns UDP (423–444k), ±6% for PowerDNS
 (346–390k), ±3% for Unbound, ±2% for Knot, and ±15% for sdns TCP (195–273k).
 Single-run numbers from any resolver should be read with that in mind.
 
+## Cold cache: resolution rather than serving
+
+Everything above measures the hit path. This measures the other half — what a
+miss costs — by running a corpus the resolver has never seen against an empty
+cache. It is a different question, and the answer belongs to a different part
+of the code: how quickly the resolver walks root → TLD → zone, and which
+upstream it picks at each step.
+
+Measured 2026-08-22 at commit `676ac14`, on the same host as above.
+
+### Method
+
+- **Corpus:** `queryfile-50000`, 50,000 names, one full pass per run. It
+  resolves to roughly 67% NOERROR, 32% NXDOMAIN and 1.7% unresolvable. A
+  corpus that is largely dead names is the wrong instrument for the serving
+  benchmark and the right one here, because dead names still cost a full
+  delegation walk.
+- **Cold start per run:** every resolver is restarted before every run. Knot
+  keeps its cache in LMDB on disk, so that file is deleted too; without that
+  its second run would start warm.
+- **Alternating, three rounds:** `sdns → PowerDNS → Unbound → Knot`, repeated
+  three times, 45 s between runs. Upstream latency varies with the hour, so
+  running one resolver's three runs back to back would charge that hour to
+  that resolver. Medians are reported.
+- **Load:** `dnsperf -S 1 -T 100 -t 10 -c 1000`, identical for all four.
+- **Readiness gate:** a run is only recorded if the resolver answered a probe
+  query first, so a failed start cannot be recorded as a slow one.
+
+Three things had to be equalised, and getting them wrong the first time
+changed the answer by more than the result itself:
+
+- **File-descriptor limit, 65536 for all four**, verified per run by reading
+  `/proc/<pid>/limits` and printed alongside each result. At the shell default
+  of 1024 the resolvers are not equally handicapped — a cold run's concurrency
+  is bound by outgoing sockets, and a resolver configured for more of them
+  than the limit allows is silently clamped. Under that limit PowerDNS
+  measured 529 qps; with it raised, 799.
+- **Per-upstream timeout, 750 ms for both sdns and PowerDNS.** Unbound and Knot
+  time out adaptively from measured RTT and have no equivalent single knob;
+  Unbound's starting point for an unmeasured server is 376 ms, so it is
+  already the more aggressive of the two policies.
+- **QNAME minimisation off in all four.** Every one of them implements it, and
+  every one of them uses a different step policy — RFC 9156 requires the extra
+  queries to be bounded but does not say by how much, so the counts are not
+  comparable in common units. Turning it off removes the variable. **This is
+  therefore not a configuration anyone should run:** minimisation is the
+  recommended default and disabling it is a privacy regression. It is
+  disabled here to compare resolution engines, not to recommend a setting.
+
+### Results
+
+Medians of three rounds:
+
+| | queries/sec | avg latency | unanswered | lost | spread |
+|---|---|---|---|---|---|
+| **sdns 1.8.0** | **868** | **0.111 s** | 869 (1.74%) | **0 / 0 / 0** | 3.2% |
+| PowerDNS Recursor 5.4.1 | 799 | 0.118 s | 882 (1.76%) | 1 / 0 / 0 | 2.0% |
+| Knot Resolver 6.2.0 | 583 | 0.121 s | 884 (1.77%) | 234 / 203 / 188 | 6.4% |
+| Unbound 1.24.2 | 447 | 0.127 s | 874 (1.75%) | 526 / 489 / 473 | 5.3% |
+
+**"Unanswered" counts SERVFAIL and lost queries together**, and it is the
+column that makes the rest readable. Counting SERVFAIL alone puts Unbound
+first at 0.78% — but it left 489 queries with no answer at all, which from a
+client is worse than a SERVFAIL, not better. Summed, all four land between
+1.74% and 1.77%: they resolved the same corpus to the same outcomes, and the
+residue is names that genuinely do not resolve. That is what makes this a
+like-for-like comparison rather than four different amounts of work.
+
+Average latency is reported for completed queries only, so a resolver that
+abandons a query improves its own average by doing so; the wall clock and the
+lost column are where that shows up.
+
+### Caveats
+
+- One pass per resolver per round, not a repeated measurement within a round.
+  A cold run cannot be repeated quickly — the cache has to be emptied and the
+  upstreams re-walked — so the spread column is across rounds, which also
+  carries the hour's drift.
+- Cold-cache throughput is dominated by upstream latency, not by the local
+  machine. These numbers describe how well each resolver walks the tree on
+  this network from this host, and should not be read as a portable ranking.
+- The minimisation caveat above is not a footnote: with each resolver's own
+  minimisation policy enabled, the numbers and possibly the ordering differ.
+
 ## What changed in 1.8.0
 
 The same harness, applied to sdns itself across the 1.8.0 serving-path work
@@ -173,3 +261,18 @@ dnsperf -s <addr> -p <port> -m tcp -d hits.txt -c 20 -T 4 -l 20    # TCP
 Warm first, discard a throwaway run, take at least three measurements, report
 the median, and state the flow count — it is the parameter that moves these
 numbers the most.
+
+For the cold-cache section, the shape is different: no warm pass, one full
+pass over a corpus the resolver has never seen, and a restart before every
+run.
+
+```sh
+ulimit -n 65536                       # or the comparison measures this, not the resolver
+# restart the resolver here; delete its on-disk cache if it keeps one
+dnsperf -s <addr> -p <port> -S 1 -T 100 -t 10 -c 1000 -d queryfile-50000
+```
+
+Alternate the resolvers rather than blocking them, record queries lost
+alongside SERVFAIL, and check that the two summed agree across contenders
+before comparing throughput — if they do not, the resolvers are not doing the
+same work and the throughput numbers do not mean what they appear to.

--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -189,18 +189,27 @@ changed the answer by more than the result itself:
   time out adaptively from measured RTT and have no equivalent single knob;
   Unbound's starting point for an unmeasured server is 376 ms, so it is
   already the more aggressive of the two policies.
-- **QNAME minimisation off in all four.** All four implement it and each
-  bounds it differently. RFC 9156 §2.3 does require a bound — *"Resolvers
+- **QNAME minimisation off in all four**, because their defaults do not
+  implement the same policy. RFC 9156 §2.3 requires a bound — *"Resolvers
   supporting QNAME minimisation MUST implement a mechanism to limit the
-  number of outgoing queries per user request"* — and it names values:
-  MAX_MINIMISE_COUNT with a RECOMMENDED value of 10, and MINIMISE_ONE_LAB
-  with "a good value is 4". What the implementations do not share is the
-  knob: sdns exposes a label depth (`qname_min_level`, default 3), the
-  others expose a boolean or their own parameters, so the recommended
-  values cannot simply be dialled in on all four. Turning it off removes
-  the variable instead. **This is not a configuration to run in
-  production** — it is a privacy regression, and it is off here to compare
-  resolution engines rather than to recommend a setting.
+  number of outgoing queries per user request"* — and names values:
+  MAX_MINIMISE_COUNT with a RECOMMENDED value of 10, MINIMISE_ONE_LAB with
+  "a good value is 4". Read from the installed builds:
+
+  | | default | step bound |
+  |---|---|---|
+  | sdns 1.8.0 | on, `qname_min_level = 3` | 3 levels, then the full name |
+  | PowerDNS 5.4.1 | `qname_minimization: true` | `qname_max_minimize_count: 10`, `qname_minimize_one_label: 4` |
+  | Unbound 1.24.2 | `qname-minimisation: yes`, strict `no` | the RFC's parameter names are Unbound's own: 10 and 4 |
+  | Knot 6.2.0 | on | label by label |
+
+  PowerDNS and Unbound ship the values the RFC recommends. **sdns stops at
+  three**, so its default sends fewer minimised queries than the others' —
+  cheaper, and less private. Left on, that difference would show up in this
+  table as an engine result, which it is not. Turning it off in all four
+  removes it. **The result is not a configuration to run in production:**
+  disabling minimisation is a privacy regression, and it is off here to
+  compare resolution engines rather than to recommend a setting.
 
 ### Results
 


### PR DESCRIPTION
`BENCHMARKS.md` measured the cached-answer serving ceiling and said, in its own preamble, that this was not a prediction of production throughput — because a miss is bound by upstream latency rather than by the serving engine. It never measured that half. This adds it, and after two methodology corrections found during review, measures it fairly.

50,000 names against an empty cache, one full pass per run, four resolvers alternating over three rounds on the same host, re-measured at `42d06f3`. Two tables, because two questions:

**Minimisation off — the engine comparison.** Medians:

| | queries/sec | avg latency | unanswered | lost |
|---|---|---|---|---|
| **sdns 1.8.0** | **905** | **0.107 s** | 883 (1.77%) | **0 / 0 / 0** |
| PowerDNS Recursor 5.4.1 | 799 | 0.118 s | 860 (1.72%) | 0 / 0 / 0 |
| Knot Resolver 6.2.0 | 534 | 0.135 s | 910 (1.82%) | 218 / 206 / 236 |
| Unbound 1.24.2 | 399 | 0.137 s | 905 (1.81%) | 567 / 581 / 554 |

**As shipped — every resolver on its own minimisation defaults.** Meaningful for the first time, because sdns now ships RFC 9156's recommended 10/4, the same values PowerDNS and Unbound ship. Medians:

| | queries/sec | avg latency | unanswered | lost |
|---|---|---|---|---|
| **sdns 1.8.0** | **658** | **0.145 s** | 898 (1.80%) | **2 / 1 / 1** |
| PowerDNS Recursor 5.4.1 | 636 | 0.149 s | 912 (1.82%) | 0 / 0 / 0 |
| Knot Resolver 6.2.0 | 436 | 0.173 s | 928 (1.86%) | 248 / 245 / 235 |
| Unbound 1.24.2 | 243 | 0.188 s | 1424 (2.85%) | 1106 / 1067 / 1152 |

**The unanswered column (SERVFAIL + lost) is what makes the throughput column readable.** Counting SERVFAIL alone is misleading: a resolver that abandons a query improves its own SERVFAIL rate and its own average latency by doing so. Summed, the engine run lands all four between 1.72% and 1.82% — the same corpus resolved to the same outcomes, with the residue being names that genuinely do not resolve.

### The two corrections, and why they are written down

- **Address family.** The first version of this comparison pinned PowerDNS to one IPv4 address, switched Unbound's IPv6 off and bound Knot to IPv4 — none of which is that resolver's default — while sdns ran dual-stack, on a host where the root answers in 1 ms over IPv4 and ~49 ms over IPv6. The pins handed three resolvers the fast path exclusively. All four now run the dual stack they ship with, and the document says so.
- **File descriptors**, 65536 for all four, verified per run from `/proc/<pid>/limits`. At the shell default of 1024 a cold run's outgoing-socket concurrency is silently clamped, and not equally; the gap it hides is larger than the gaps being measured.

Also equalised: per-upstream timeout matched at 750 ms where the knob exists (Unbound and Knot time out adaptively and start more aggressively), a readiness gate before every recorded run, cold start with on-disk caches deleted, and 45-second cool-downs between runs.

The document also states each resolver's shipped minimisation policy, read from the installed builds rather than from documentation, and keeps the minimisation-off run explicitly labelled as an engine comparison — disabling minimisation is a privacy regression, not a recommended configuration.

The reproduction section gains the cold-cache shape alongside the warm one, including the `ulimit` line and the instruction to check that SERVFAIL-plus-lost agrees across contenders before comparing throughput.
