### PR TITLE
cache/resolver: serve the answer's own TTL, not the oldest key consulted on the walk

### DIFF
--- a/internal/authority/cache.go
+++ b/internal/authority/cache.go
@@ -96,6 +96,46 @@ func (n *Cache) SetUntil(key uint64, dsSet []dns.RR, servers *Servers, expiresAt
 	n.store(key, dsSet, servers, expiresAt)
 }
 
+// (*Cache).SetUntilIfAbsent is SetUntil for provisional writers: it stores
+// only when the key holds no live delegation — absent, or present but past
+// its expiry. A live entry always wins, atomically: the absent case inserts
+// under the segment write lock (AddIfAbsent), and the expired case replaces
+// exactly the expired value it examined (CompareAndSwap), so a real lease
+// published by a concurrent walk can never be displaced by the provisional
+// one racing it.
+func (n *Cache) SetUntilIfAbsent(key uint64, dsSet []dns.RR, servers *Servers, expiresAt time.Time) {
+	now := n.now()
+	if !expiresAt.After(now) {
+		return
+	}
+	if ceiling := now.Add(maximumTTL); expiresAt.After(ceiling) {
+		expiresAt = ceiling
+	}
+
+	d := &Delegation{
+		Servers:   servers,
+		DSSet:     dsSet,
+		ExpiresAt: expiresAt,
+	}
+	for {
+		cur, ok := n.cache.Get(key)
+		if !ok {
+			if n.cache.AddIfAbsent(key, d) {
+				return
+			}
+			// Lost the insert race; re-examine what landed.
+			continue
+		}
+		if n.now().Before(cur.(*Delegation).ExpiresAt) {
+			return
+		}
+		if n.cache.CompareAndSwap(key, cur, d) {
+			return
+		}
+		// The expired value was replaced under us; re-examine the newer one.
+	}
+}
+
 func (n *Cache) store(key uint64, dsSet []dns.RR, servers *Servers, expiresAt time.Time) {
 	n.cache.Add(key, &Delegation{
 		Servers:   servers,

--- a/internal/authority/cache_test.go
+++ b/internal/authority/cache_test.go
@@ -179,3 +179,67 @@ func Test_CacheSetUntil(t *testing.T) {
 		t.Fatalf("ExpiresAt = %v, want ceiling %v", d.ExpiresAt, want)
 	}
 }
+
+// TestSetUntilIfAbsent pins the provisional writer's contract: a live lease
+// always survives it, an absent or expired slot accepts it. The concurrent
+// leg hammers provisional writes against a live lease — the guard runs under
+// the segment lock, so none of them may displace it.
+func TestSetUntilIfAbsent(t *testing.T) {
+	nscache := NewCache()
+	servers := &Servers{List: []*Server{NewServer("192.0.2.1:53", IPv4)}}
+	provisional := &Servers{List: []*Server{NewServer("192.0.2.2:53", IPv4)}}
+	const key = uint64(0x1234)
+
+	t.Run("absent slot accepts the provisional", func(t *testing.T) {
+		nscache.SetUntilIfAbsent(key, nil, provisional, time.Now().Add(time.Minute))
+		d, err := nscache.Get(key)
+		if err != nil {
+			t.Fatalf("provisional not stored: %v", err)
+		}
+		if d.Servers != provisional {
+			t.Fatal("stored someone else's servers")
+		}
+	})
+
+	t.Run("a live lease survives provisional writers", func(t *testing.T) {
+		lease := time.Now().Add(time.Hour)
+		nscache.SetUntil(key, nil, servers, lease)
+
+		done := make(chan struct{})
+		for i := 0; i < 8; i++ {
+			go func() {
+				defer func() { done <- struct{}{} }()
+				for j := 0; j < 200; j++ {
+					nscache.SetUntilIfAbsent(key, nil, provisional, time.Now().Add(time.Minute))
+				}
+			}()
+		}
+		for i := 0; i < 8; i++ {
+			<-done
+		}
+
+		d, err := nscache.Get(key)
+		if err != nil {
+			t.Fatalf("lease vanished: %v", err)
+		}
+		if d.Servers != servers || !d.ExpiresAt.Equal(lease) {
+			t.Fatalf("live lease displaced: servers=%v expires=%v", d.Servers == servers, d.ExpiresAt)
+		}
+	})
+
+	t.Run("an expired slot accepts the provisional", func(t *testing.T) {
+		past := time.Now().Add(-2 * time.Hour)
+		nscache.now = func() time.Time { return past }
+		nscache.SetUntil(key, nil, servers, past.Add(time.Minute))
+		nscache.now = time.Now
+
+		nscache.SetUntilIfAbsent(key, nil, provisional, time.Now().Add(time.Minute))
+		d, err := nscache.Get(key)
+		if err != nil {
+			t.Fatalf("expired slot not replaced: %v", err)
+		}
+		if d.Servers != provisional {
+			t.Fatal("the expired lease survived the provisional writer")
+		}
+	})
+}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -66,6 +66,15 @@ func (c *Cache) Remove(key uint64) {
 	c.data.Del(key)
 }
 
+// AddIfAbsent adds the item only if the key is not already present, paying
+// the same self-eviction toll as Add when the insert pushes the map over
+// capacity. The existence check and the insert run under the key's segment
+// write lock, so a concurrent Add cannot land between them. Returns whether
+// value was stored.
+func (c *Cache) AddIfAbsent(key uint64, value any) bool {
+	return c.data.data.PutIfNotExistsWithCap(key, value, c.maxSize)
+}
+
 // CompareAndSwap stores value under key only if the value currently
 // stored is identical (==, i.e. pointer identity for pointer-typed
 // values) to old. Returns false — storing nothing — when the key is

--- a/internal/cache/segment_uint64_map.go
+++ b/internal/cache/segment_uint64_map.go
@@ -133,15 +133,47 @@ func (m *SegmentUInt64Map[V]) SetWithCap(key uint64, value V, capacity int64) {
 	}
 	segment.rwlock.Unlock()
 
-	if deficit <= 0 {
-		return
-	}
+	m.collectRemainingToll(segIdx, offset, deficit, key, capacity)
+}
 
-	// The writer's own segment couldn't cover the toll — it happens when
-	// entries are sparse relative to the segment count (small caches).
-	// Collect the remainder from the following segments, one lock at a
-	// time and never nested, so two writers can never hold each other's
-	// segment. Stop as soon as the map is back under capacity.
+// PutIfNotExistsWithCap adds the key-value pair only if the key doesn't
+// already exist, paying the same self-eviction toll as SetWithCap when the
+// insert pushes the map over capacity. The existence check and the insert
+// run under the segment write lock, so a concurrent writer cannot land
+// between them. Returns whether value was inserted.
+func (m *SegmentUInt64Map[V]) PutIfNotExistsWithCap(key uint64, value V, capacity int64) bool {
+	segIdx := m.getSegmentIndex(key)
+	segment := m.segments[segIdx]
+	offset := int((key * 0xff51afd7ed558ccd) >> 40) //nolint:gosec // G115 - masked to bucket range by EvictKeysAt
+
+	segment.rwlock.Lock()
+	_, inserted := segment.data.PutIfNotExists(key, value)
+	if !inserted {
+		segment.rwlock.Unlock()
+		return false
+	}
+	m.count.Add(1)
+	deficit := 0
+	if m.count.Load() > capacity {
+		d := segment.data.EvictKeysAt(offset, 2, key)
+		if d > 0 {
+			m.count.Add(int64(-d))
+		}
+		deficit = 2 - d
+	}
+	segment.rwlock.Unlock()
+
+	m.collectRemainingToll(segIdx, offset, deficit, key, capacity)
+	return true
+}
+
+// collectRemainingToll finishes an over-capacity insert's eviction toll when
+// the writer's own segment couldn't cover it — it happens when entries are
+// sparse relative to the segment count (small caches). Collect the remainder
+// from the following segments, one lock at a time and never nested, so two
+// writers can never hold each other's segment. Stop as soon as the map is
+// back under capacity.
+func (m *SegmentUInt64Map[V]) collectRemainingToll(segIdx uint, offset, deficit int, key uint64, capacity int64) {
 	for i := uint(1); i < uint(len(m.segments)) && deficit > 0; i++ {
 		if m.count.Load() <= capacity {
 			return

--- a/middleware/cache/mixed_ttl_lineage_test.go
+++ b/middleware/cache/mixed_ttl_lineage_test.go
@@ -1,0 +1,157 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/middleware"
+)
+
+// TestMixedTTLRecordsServeTheAnswersOwnHorizon exercises the TTL lineage
+// with every record class carrying a different TTL: the A RRset at 3600, its
+// RRSIG at 1800 (validity weeks away), a consulted DNSKEY entry with only 30
+// seconds left, and a delegation cut of its own. The first query serves the
+// records as resolved; the second serves the cached entry, whose horizon must
+// be min(A, RRSIG) — the admission rule — and not the remaining life of
+// whatever the resolver consulted on the way. The delegation cut is the one
+// outside bound that still applies.
+func TestMixedTTLRecordsServeTheAnswersOwnHorizon(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, Expire: 600})
+	defer c.Stop()
+
+	now := time.Now()
+	signedAnswer := func(name string) []dns.RR {
+		return []dns.RR{
+			&dns.A{
+				Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 3600},
+				A:   []byte{192, 0, 2, 7},
+			},
+			&dns.RRSIG{
+				Hdr:         dns.RR_Header{Name: name, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 1800},
+				TypeCovered: dns.TypeA,
+				Algorithm:   8,
+				Labels:      2,
+				OrigTtl:     3600,
+				Expiration:  uint32(now.Add(14 * 24 * time.Hour).Unix()), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+				Inception:   uint32(now.Add(-time.Hour).Unix()),          //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+				KeyTag:      12345,
+				SignerName:  "example.",
+				Signature:   "MTIzNDU2Nzg5MGFiY2RlZg==",
+			},
+		}
+	}
+
+	query := func(name string, handlers ...middleware.Handler) *dns.Msg {
+		t.Helper()
+		req := new(dns.Msg)
+		req.SetQuestion(name, dns.TypeA)
+		req.RecursionDesired = true
+		w := mock.NewWriter("udp", "127.0.0.1:0")
+		ch := middleware.NewChain(append([]middleware.Handler{c}, handlers...))
+		ch.Reset(w, req)
+		ch.Next(context.Background())
+		if !w.Written() {
+			t.Fatal("no response written")
+		}
+		return w.Msg()
+	}
+
+	entryFor := func(name string) *CacheEntry {
+		t.Helper()
+		q := dns.Question{Name: name, Qtype: dns.TypeA, Qclass: dns.ClassINET}
+		entry, ok := c.store.LookupByKey(CacheKey{Question: q, CD: false}.Hash())
+		if !ok {
+			t.Fatal("the answer was not cached")
+		}
+		return entry
+	}
+
+	answerTTL := func(msg *dns.Msg) uint32 {
+		t.Helper()
+		if len(msg.Answer) == 0 {
+			t.Fatal("empty answer")
+		}
+		return msg.Answer[0].Header().Ttl
+	}
+
+	t.Run("a short-lived DNSKEY consult does not cap the answer", func(t *testing.T) {
+		// A DNSKEY entry with 30 seconds left, as after a long-lived key
+		// has almost aged out of the cache.
+		keyReq := new(dns.Msg)
+		keyReq.SetQuestion("example.", dns.TypeDNSKEY)
+		keyResp := new(dns.Msg)
+		keyResp.SetReply(keyReq)
+		keyResp.Answer = []dns.RR{&dns.DNSKEY{
+			Hdr:       dns.RR_Header{Name: "example.", Rrtype: dns.TypeDNSKEY, Class: dns.ClassINET, Ttl: 30},
+			Flags:     256,
+			Protocol:  3,
+			Algorithm: 8,
+			PublicKey: "MTIzNDU2Nzg5MGFiY2RlZg==",
+		}}
+		c.store.SetFromResponse(keyResp, false, time.Time{})
+
+		const name = "signed.mixed.example."
+		first := query(name, middleware.HandlerFunc(func(ctx context.Context, ch *middleware.Chain) {
+			// The validation consult, on the request's own context —
+			// exactly how subQuery reads keys mid-resolution.
+			if _, ok := c.store.GetWithContext(ctx, keyReq); !ok {
+				t.Error("the DNSKEY consult missed")
+			}
+			resp := new(dns.Msg)
+			resp.SetReply(ch.Request.Msg())
+			resp.Answer = signedAnswer(name)
+			_ = ch.Writer.WriteMsg(resp)
+			ch.Cancel()
+		}))
+		second := query(name, middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+			t.Error("second query missed the cache")
+			ch.Cancel()
+		}))
+
+		// First query: the records as resolved.
+		if got := answerTTL(first); got != 3600 {
+			t.Fatalf("first query A TTL = %d, want the authority's 3600", got)
+		}
+		// Second query: the entry's own horizon — min(A 3600, RRSIG 1800) —
+		// not the consulted key's 30 seconds.
+		if got := answerTTL(second); got < 1700 || got > 1800 {
+			t.Fatalf("second query A TTL = %d, want ~1800, not the key's 30", got)
+		}
+		if entry := entryFor(name); !entry.cutUntil.IsZero() {
+			t.Fatalf("the DNSKEY consult stamped cutUntil %v onto the answer", entry.cutUntil)
+		}
+	})
+
+	t.Run("the delegation cut is the bound that still applies", func(t *testing.T) {
+		const name = "signed.cut.example."
+		cut := time.Now().Add(45 * time.Second)
+		first := query(name, middleware.HandlerFunc(func(ctx context.Context, ch *middleware.Chain) {
+			// The walk's noteCut: the delegation this answer came
+			// through expires before the records do.
+			middleware.ResponseMetaFrom(ctx).BoundCutFor(cut, 0x77)
+			resp := new(dns.Msg)
+			resp.SetReply(ch.Request.Msg())
+			resp.Answer = signedAnswer(name)
+			_ = ch.Writer.WriteMsg(resp)
+			ch.Cancel()
+		}))
+		second := query(name, middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+			t.Error("second query missed the cache")
+			ch.Cancel()
+		}))
+
+		if got := answerTTL(first); got != 3600 {
+			t.Fatalf("first query A TTL = %d, want the authority's 3600", got)
+		}
+		if got := answerTTL(second); got > 45 || got < 30 {
+			t.Fatalf("second query A TTL = %d, want the 45s delegation lease", got)
+		}
+		if entry := entryFor(name); entry.cutUntil.IsZero() {
+			t.Fatal("the delegation cut did not reach the entry")
+		}
+	})
+}

--- a/middleware/cache/negative_lineage_test.go
+++ b/middleware/cache/negative_lineage_test.go
@@ -205,11 +205,12 @@ func TestDenialProofLookupReportsEarliestExpiry(t *testing.T) {
 	}
 }
 
-// TestStoreGetWithContextBindsEntryLifetime pins the lineage rule on the
-// resolver-private path. DS and DNSKEY lookups come through here, and what
-// they return is folded into whatever the resolver is validating — so the
-// answer's own lifetime has to bound the request tree.
-func TestStoreGetWithContextBindsEntryLifetime(t *testing.T) {
+// TestStoreGetWithContextLeavesPositiveUnbound pins the lineage line on the
+// resolver-private path. DS and DNSKEY lookups come through here; a denial
+// binds the request tree to its own lifetime, but a positive answer is a
+// validation input, not lineage — binding it collapsed every fresh answer's
+// served TTL to the oldest key consulted on the walk.
+func TestStoreGetWithContextLeavesPositiveUnbound(t *testing.T) {
 	c := New(&config.Config{CacheSize: 1024, Expire: 600})
 	defer c.Stop()
 
@@ -236,8 +237,7 @@ func TestStoreGetWithContextBindsEntryLifetime(t *testing.T) {
 	primeChain.Next(context.Background())
 
 	key := CacheKey{Question: primeReq.Question[0], CD: false}.Hash()
-	entry, ok := c.store.LookupByKey(key)
-	if !ok {
+	if _, ok := c.store.LookupByKey(key); !ok {
 		t.Fatal("the answer was not cached")
 	}
 
@@ -247,9 +247,8 @@ func TestStoreGetWithContextBindsEntryLifetime(t *testing.T) {
 		t.Fatal("the resolver-private lookup missed")
 	}
 
-	got, _ := meta.Cut()
-	if want := entryExpiry(entry); !got.Equal(want) {
-		t.Fatalf("request tree bound to %v, want the entry's expiry %v", got, want)
+	if got, _ := meta.Cut(); !got.IsZero() {
+		t.Fatalf("positive consult bound the request tree to %v", got)
 	}
 }
 

--- a/middleware/cache/store.go
+++ b/middleware/cache/store.go
@@ -221,16 +221,21 @@ func (s *Store) GetWithContext(ctx context.Context, req *dns.Msg) (*dns.Msg, boo
 	if req == nil {
 		return nil, false
 	}
-	// Every answer handed out here is consumed by the resolver — DS and
-	// DNSKEY lookups above all — and folded into whatever it is validating.
-	// So each one binds the request tree to its own lifetime, exactly as the
-	// middleware hit paths do: a delegation held insecure by a cached DS
-	// denial must not outlive the proof that said so.
+	// Answers handed out here are consumed by the resolver — DS and DNSKEY
+	// lookups above all. Only denial shapes bind the request tree to their
+	// lifetime: a delegation held insecure by a cached DS denial must not
+	// outlive the proof that said so. A positive consult is a validation
+	// input, not part of the answer's lineage — folding its remaining life
+	// into the tree collapsed every fresh answer's served TTL to the oldest
+	// key consulted on the walk, and signature validity already bounds
+	// validated answers at admission.
 	entry, ok := s.Lookup(req)
 	if ok {
 		msg := entry.ToMsg(req)
 		if msg != nil {
-			boundRequestToEntryLifetime(ctx, entry)
+			if msg.Rcode != dns.RcodeSuccess || len(msg.Answer) == 0 {
+				boundRequestToEntryLifetime(ctx, entry)
+			}
 			return msg, true
 		}
 	}

--- a/middleware/cache/subquery_fold_test.go
+++ b/middleware/cache/subquery_fold_test.go
@@ -1,0 +1,71 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/middleware"
+)
+
+// TestSubqueryPositiveHitDoesNotBindRequest reproduces the served-TTL
+// collapse: resolver subqueries (DNSKEY and DS lookups) consult the cache
+// through GetWithContext, and a positive hit used to fold its own remaining
+// lifetime into the shared request meta. The client answer then stamped that
+// bound as its cutUntil, so a fresh 3600-second answer was served with
+// whatever happened to remain on the oldest key consulted during the walk.
+// A positive consult is a validation input, not part of the answer's
+// lineage; it must leave the request tree unbounded.
+func TestSubqueryPositiveHitDoesNotBindRequest(t *testing.T) {
+	s := newTestStore(t)
+	const name = "dnskey.example."
+	s.SetFromResponse(newTestSuccessResp(name), false, time.Time{})
+
+	meta := &middleware.ResponseMeta{}
+	ctx := middleware.WithResponseMeta(context.Background(), meta)
+
+	req := new(dns.Msg)
+	req.SetQuestion(name, dns.TypeA)
+	if _, ok := s.GetWithContext(ctx, req); !ok {
+		t.Fatal("expected a positive hit")
+	}
+	if cut, _ := meta.Cut(); !cut.IsZero() {
+		t.Fatalf("positive consult bound the request tree to %v", cut)
+	}
+}
+
+// TestSubqueryNegativeHitStillBindsRequest pins the other side of the line:
+// a cached denial consulted mid-resolution — a DS NODATA holding a
+// delegation insecure — is validation state, and whatever is assembled from
+// it must not outlive the proof (GHSA-mqfw-f48p-2vc8).
+func TestSubqueryNegativeHitStillBindsRequest(t *testing.T) {
+	s := newTestStore(t)
+	const name = "insecure.example."
+
+	req := new(dns.Msg)
+	req.SetQuestion(name, dns.TypeDS)
+	resp := new(dns.Msg)
+	resp.SetReply(req)
+	resp.Ns = []dns.RR{&dns.SOA{
+		Hdr:     dns.RR_Header{Name: "example.", Rrtype: dns.TypeSOA, Class: dns.ClassINET, Ttl: 300},
+		Ns:      "ns.example.",
+		Mbox:    "hostmaster.example.",
+		Serial:  1,
+		Refresh: 60,
+		Retry:   60,
+		Expire:  60,
+		Minttl:  300,
+	}}
+	s.SetFromResponse(resp, false, time.Time{})
+
+	meta := &middleware.ResponseMeta{}
+	ctx := middleware.WithResponseMeta(context.Background(), meta)
+
+	if _, ok := s.GetWithContext(ctx, req); !ok {
+		t.Fatal("expected a NODATA hit")
+	}
+	if cut, _ := meta.Cut(); cut.IsZero() {
+		t.Fatal("denial consult no longer bounds the request tree")
+	}
+}

--- a/middleware/resolver/delegation_lease_test.go
+++ b/middleware/resolver/delegation_lease_test.go
@@ -1,0 +1,50 @@
+package resolver
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/authority"
+)
+
+// TestProvisionalStoreDoesNotClobberDelegationLease guards the lease against
+// the deferred enrichment lane. resolveV4Host stores a one-minute provisional
+// delegation before its address lookup so the lookup itself can find the
+// servers. Inline that entry is overwritten by the real lease as soon as the
+// walk stores it — but a queued enrichment job runs after that store, and its
+// provisional write used to replace an hours-long lease with the one-minute
+// cap, cutting the served TTL of every answer under the delegation to it.
+func TestProvisionalStoreDoesNotClobberDelegationLease(t *testing.T) {
+	cfg := makeTestConfig()
+	cfg.DNSSEC = "off"
+	r := newWiredTestResolver(cfg)
+
+	const host = "ns1.lease.example."
+	const key = uint64(0xBEEF)
+
+	authservers := &authority.Servers{Zone: "lease.example."}
+	authservers.List = append(authservers.List,
+		authority.NewServerFromAddrPort(netip.MustParseAddrPort("192.0.2.1:53")))
+
+	lease := time.Now().Add(time.Hour)
+	r.delegations.SetUntil(key, nil, authservers, lease)
+
+	r.addIPv4Cache(map[string]nsAddrs{host: {addrs: []netip.Addr{netip.MustParseAddr("192.0.2.2")}, ttl: 300}})
+
+	q := dns.Question{Name: "www.lease.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET}
+	if _, err := r.resolveV4Host(context.Background(), q, authservers, key, nil, host, false, time.Time{}); err != nil {
+		t.Fatalf("resolveV4Host: %v", err)
+	}
+
+	d, err := r.delegations.Get(key)
+	if err != nil {
+		t.Fatalf("delegation vanished: %v", err)
+	}
+	if d.ExpiresAt.Before(lease.Add(-time.Second)) {
+		t.Fatalf("lease clobbered: expires in %v, want the stored hour",
+			time.Until(d.ExpiresAt).Round(time.Second))
+	}
+}

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -3143,7 +3143,17 @@ func (r *Resolver) resolveV4Host(ctx context.Context, q dns.Question, authserver
 		// (GHSA-mqfw-f48p-2vc8). Cap it at one minute so a long-lived cut
 		// still refreshes the provisional set promptly. A past deadline
 		// is not cached (SetUntil skips it).
-		r.delegations.SetUntil(key, parentDS, authservers, minNonZero(cutDeadline, time.Now().Add(time.Minute)))
+		//
+		// Never displace a live entry with the provisional one: the walk
+		// stores the real lease once the NS set is filled, and a deferred
+		// enrichment job re-entering here after that would replace an
+		// hours-long lease with the one-minute cap — capping the served
+		// TTL of every answer under the delegation with it. A live entry
+		// already satisfies what this store is for: giving the address
+		// lookup a delegation to find.
+		if _, err := r.delegations.Get(key); err != nil {
+			r.delegations.SetUntil(key, parentDS, authservers, minNonZero(cutDeadline, time.Now().Add(time.Minute)))
+		}
 	}
 
 	addrs, ttl, fromCache, err := r.lookupNSAddrV4(ctx, name, cd)

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -3150,10 +3150,10 @@ func (r *Resolver) resolveV4Host(ctx context.Context, q dns.Question, authserver
 		// hours-long lease with the one-minute cap — capping the served
 		// TTL of every answer under the delegation with it. A live entry
 		// already satisfies what this store is for: giving the address
-		// lookup a delegation to find.
-		if _, err := r.delegations.Get(key); err != nil {
-			r.delegations.SetUntil(key, parentDS, authservers, minNonZero(cutDeadline, time.Now().Add(time.Minute)))
-		}
+		// lookup a delegation to find. The guard is atomic (a plain
+		// Get-then-SetUntil would let a real lease land in between and
+		// still be displaced).
+		r.delegations.SetUntilIfAbsent(key, parentDS, authservers, minNonZero(cutDeadline, time.Now().Add(time.Minute)))
 	}
 
 	addrs, ttl, fromCache, err := r.lookupNSAddrV4(ctx, name, cd)


### PR DESCRIPTION
Two fixes for the production TTL collapse (first query full TTL, second
query a fraction of it):

The resolver-private cache lookup folded every consulted entry's
remaining lifetime into the request tree, so a fresh answer's cutUntil —
and with it the served TTL — collapsed to whatever remained on the DS or
DNSKEY key consulted during validation. A positive consult is a
validation input, not part of the answer's lineage, and signature
validity already bounds validated answers at admission. Only denial
shapes bind the tree now: a delegation held insecure by a cached DS
denial still must not outlive that proof (GHSA-mqfw-f48p-2vc8).

The provisional one-minute delegation store in resolveV4Host could
displace the real lease when a deferred enrichment job re-entered it
after the walk had already stored the filled NS set, capping the served
TTL of every answer under that delegation to the provisional minute. A
live entry now stays: it already gives the address lookup the delegation
it needs.

Regression tests pin both directions of the fold, the lease against the
enrichment lane, and the client-visible first/second-query TTL sequence
with mixed A / RRSIG / DNSKEY TTLs and a separate delegation cut.

Field observation that triggered this: repeated queries against the new deploy served a fresh answer at its authority TTL, then the cached copy at 60 seconds or an arbitrary smaller number that varied by name — the remaining lifetime of whichever infrastructure key or provisional delegation the walk had consulted.