### PR TITLE
cache: the delegation lease caps the first response's TTL too

### DIFF
--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -601,8 +601,10 @@ func (c *Cache) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	// field load instead of a ctx.Value walk on every external
 	// client miss. middleware.IsInternal(ctx) remains the
 	// ctx-based successor for code paths without a writer in
-	// scope.
-	if !w.Internal() {
+	// scope. Read once and reused by the wrapping ResponseWriter:
+	// the answer cannot change within one request.
+	internal := w.Internal()
+	if !internal {
 		var (
 			previousGeneration   *waitgroup.Generation
 			failureProbeRegroups int
@@ -755,6 +757,7 @@ func (c *Cache) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	// may have been mutated by the edns wrapper on the response).
 	rw.clientScope = clientScope
 	rw.meta = meta
+	rw.internal = internal
 	ch.Writer = rw
 	defer func() {
 		ch.Writer = w
@@ -766,6 +769,7 @@ func (c *Cache) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		rw.requestTreeBypassesSharedDenial = false
 		rw.denialMissWitness = nil
 		rw.meta = nil
+		rw.internal = false
 		c.writerPool.Put(rw)
 	}()
 
@@ -1605,6 +1609,12 @@ type ResponseWriter struct {
 	// the insert bounds the entry with that deadline. Nil when the
 	// writer is used outside ServeDNS.
 	meta *middleware.ResponseMeta
+	// internal is the wrapped writer's Internal() flag, read once in
+	// ServeDNS. WriteMsg needs it to scope the client-TTL clamp to real
+	// client writes, and must not re-query the wrapped writer: the flag
+	// cannot change within a request, and one call per request is a
+	// contract test doubles rely on.
+	internal bool
 }
 
 // (*ResponseWriter).WriteMsg writeMsg implements the ResponseWriter interface.
@@ -1738,6 +1748,32 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 	// restart at the initial interval on a later failure.
 	w.cache.store.resetMatchingFailures(q, res.CheckingDisabled, w.clientScope)
 
+	// The delegation lease caps the TTL the client sees, on this uncached
+	// response exactly as remaining() caps it on every later hit. Without
+	// this the first response advertised the records' own TTL while hits
+	// advertised the lease remainder — two promises for the same records —
+	// and, worse than inconsistent, the first client's downstream cache
+	// could retain a withdrawn delegation's answer past the parent-granted
+	// lease the ghost fix (GHSA-mqfw-f48p-2vc8) bounds everything else to.
+	//
+	// Last, deliberately: every admission above must see the response as
+	// the resolver produced it. The negative-proof provenance fingerprint
+	// seals the authority section TTLs included, so clamping before
+	// ValidatedNegativeProofForResponse silently disqualified every
+	// NXDOMAIN/NODATA proof whose delegation lease ran shorter than its
+	// records — the entry stores are unaffected either way, since packing
+	// happens inside the Set calls and cutUntil bounds reads regardless.
+	//
+	// And external writers only: an internal write hands this same message
+	// back to a CNAME/DNAME caller that re-verifies the fingerprint before
+	// propagating the denial into the outer answer — mutating it here would
+	// lose short-lease provenance mid-chain. The outer response inherits
+	// the cut through the shared meta and is clamped at the real client
+	// write.
+	if !w.internal {
+		clampTTLsToCut(res, cutUntil)
+	}
+
 	return w.ResponseWriter.WriteMsg(res)
 }
 
@@ -1769,6 +1805,34 @@ func (w *ResponseWriter) recursionWorkFailure(fallback *dns.Msg) *dns.Msg {
 		edeCode,
 		edeText,
 	)
+}
+
+// clampTTLsToCut lowers every record TTL in res to the delegation lease's
+// remaining seconds. A zero cut leaves the response untouched; a past cut
+// clamps to zero — the answer is still delivered, but nothing downstream is
+// invited to keep it. OPT is hop metadata whose TTL field is not a TTL.
+func clampTTLsToCut(res *dns.Msg, cutUntil time.Time) {
+	if cutUntil.IsZero() {
+		return
+	}
+	lease := time.Until(cutUntil)
+	if lease < 0 {
+		lease = 0
+	}
+	leaseSecs := uint32(lease.Seconds())
+	clamp := func(rrs []dns.RR) {
+		for _, rr := range rrs {
+			if rr.Header().Rrtype == dns.TypeOPT {
+				continue
+			}
+			if rr.Header().Ttl > leaseSecs {
+				rr.Header().Ttl = leaseSecs
+			}
+		}
+	}
+	clamp(res.Answer)
+	clamp(res.Ns)
+	clamp(res.Extra)
 }
 
 // filterCacheableAnswer keeps only the records directly relevant to

--- a/middleware/cache/mixed_ttl_lineage_test.go
+++ b/middleware/cache/mixed_ttl_lineage_test.go
@@ -126,7 +126,7 @@ func TestMixedTTLRecordsServeTheAnswersOwnHorizon(t *testing.T) {
 		}
 	})
 
-	t.Run("the delegation cut is the bound that still applies", func(t *testing.T) {
+	t.Run("the delegation cut bounds every response, the first included", func(t *testing.T) {
 		const name = "signed.cut.example."
 		cut := time.Now().Add(45 * time.Second)
 		first := query(name, middleware.HandlerFunc(func(ctx context.Context, ch *middleware.Chain) {
@@ -144,8 +144,12 @@ func TestMixedTTLRecordsServeTheAnswersOwnHorizon(t *testing.T) {
 			ch.Cancel()
 		}))
 
-		if got := answerTTL(first); got != 3600 {
-			t.Fatalf("first query A TTL = %d, want the authority's 3600", got)
+		// The ghost bound (GHSA-mqfw-f48p-2vc8) reaches the client on both
+		// responses: a downstream cache must never be invited to keep the
+		// answer past the parent-granted lease, and the uncached response
+		// must make the same promise the hits do.
+		if got := answerTTL(first); got > 45 || got < 40 {
+			t.Fatalf("first query A TTL = %d, want the 45s delegation lease", got)
 		}
 		if got := answerTTL(second); got > 45 || got < 30 {
 			t.Fatalf("second query A TTL = %d, want the 45s delegation lease", got)

--- a/middleware/cache/nxdomain_cut_integration_test.go
+++ b/middleware/cache/nxdomain_cut_integration_test.go
@@ -721,3 +721,98 @@ func TestNXDomainCutIntegrationCNAMETransfersTerminalProvenance(t *testing.T) {
 		t.Fatalf("alias-child miss unexpectedly queried terminal target; queries = %d", targetQueryer.calls)
 	}
 }
+
+// TestNXDomainCutIntegrationShortCutClampsClientNotProof pins the ordering of
+// the client-TTL clamp against proof admission. The provenance fingerprint
+// seals the authority section TTLs included, so clamping the response before
+// ValidatedNegativeProofForResponse ran silently disqualified every validated
+// denial whose delegation lease was shorter than its records — the RFC
+// 8020/8198 stores stayed empty exactly when the lease said to be careful.
+// Admission sees the resolver's response untouched; the clamp applies to the
+// client write alone.
+func TestNXDomainCutIntegrationShortCutClampsClientNotProof(t *testing.T) {
+	cache := New(&config.Config{CacheSize: 1024, Expire: 300})
+	defer cache.Stop()
+
+	calls := 0
+	cut := time.Now().Add(30 * time.Second)
+	downstream := middleware.HandlerFunc(func(ctx context.Context, ch *middleware.Chain) {
+		calls++
+		resp := nxCutValidatedResponse(ch.Request.Msg(), nxCutDeniedName, nxCutZone)
+		nxCutMark(ctx, resp, nxCutDeniedName, nxCutZone)
+		middleware.ResponseMetaFrom(ctx).BoundCutFor(cut, 0x99)
+		_ = ch.Writer.WriteMsg(resp)
+		ch.Cancel()
+	})
+
+	seed := nxCutRequest(nxCutDeniedName, dns.TypeA)
+	seed.Id = 700
+	got := nxCutExchange(t, cache, downstream, seed, "192.0.2.9:53000")
+	if got.Rcode != dns.RcodeNameError {
+		t.Fatalf("seed rcode = %s, want NXDOMAIN", dns.RcodeToString[got.Rcode])
+	}
+	for _, rr := range got.Ns {
+		if ttl := rr.Header().Ttl; ttl > 30 {
+			t.Fatalf("client-visible %s TTL = %d, want clamped to the 30s lease",
+				dns.TypeToString[rr.Header().Rrtype], ttl)
+		}
+	}
+	if cache.store.NXDomainCutLen() != 1 {
+		t.Fatalf("cut entries = %d, want 1 — the clamp must not disqualify the proof",
+			cache.store.NXDomainCutLen())
+	}
+
+	descendant := nxCutRequest("deep."+nxCutDeniedName, dns.TypeMX)
+	descendant.Id = 701
+	assertNXCutResponse(t, nxCutExchange(t, cache, downstream, descendant, "192.0.2.9:53000"), descendant)
+	if calls != 1 {
+		t.Fatalf("descendant reached downstream past the admitted cut; calls = %d, want 1", calls)
+	}
+}
+
+// TestNXDomainCutIntegrationInternalWriteKeepsProvenance pins the internal
+// half of the clamp's placement: a sub-pipeline write (CNAME/DNAME target
+// resolution) hands the same dns.Msg back to its caller, which re-verifies
+// the provenance fingerprint before propagating the denial into the outer
+// answer. Clamping that message would break the fingerprint and lose
+// short-lease provenance mid-chain — the clamp belongs to the real client
+// write alone, and the outer response inherits the cut through the shared
+// meta.
+func TestNXDomainCutIntegrationInternalWriteKeepsProvenance(t *testing.T) {
+	cache := New(&config.Config{CacheSize: 1024, Expire: 300})
+	defer cache.Stop()
+
+	cut := time.Now().Add(30 * time.Second)
+	var meta middleware.ResponseMeta
+	ctx := middleware.WithResponseMeta(context.Background(), &meta)
+
+	downstream := middleware.HandlerFunc(func(ctx context.Context, ch *middleware.Chain) {
+		resp := nxCutValidatedResponse(ch.Request.Msg(), nxCutDeniedName, nxCutZone)
+		nxCutMark(ctx, resp, nxCutDeniedName, nxCutZone)
+		middleware.ResponseMetaFrom(ctx).BoundCutFor(cut, 0x9A)
+		_ = ch.Writer.WriteMsg(resp)
+		ch.Cancel()
+	})
+
+	// The sentinel internal address: this is how subquery writers are
+	// tagged, and what w.Internal() reports true for.
+	writer := mock.NewWriter("udp", "127.0.0.255:0")
+	req := nxCutRequest(nxCutDeniedName, dns.TypeA)
+	ch := middleware.NewChain([]middleware.Handler{cache, downstream})
+	ch.Reset(writer, req)
+	ch.Next(ctx)
+	if !writer.Written() {
+		t.Fatal("internal pipeline wrote no response")
+	}
+	resp := writer.Msg()
+
+	for _, rr := range resp.Ns {
+		if ttl := rr.Header().Ttl; ttl != 300 {
+			t.Fatalf("internal %s TTL = %d, want the untouched 300 — the clamp leaked into the sub-pipeline",
+				dns.TypeToString[rr.Header().Rrtype], ttl)
+		}
+	}
+	if _, ok := middleware.ValidatedNegativeProofForResponse(ctx, resp); !ok {
+		t.Fatal("provenance fingerprint no longer matches the internally returned response")
+	}
+}


### PR DESCRIPTION
The first response (served straight from resolution) advertised the records' own TTL while every later hit advertised the lease remainder — 3600, then 1798 for a zone whose parent publishes its DS at 1800. Two promises for the same records, and the first one leaked past the ghost bound: a downstream cache could retain a withdrawn delegation's answer for the full record TTL when everything else is bounded by the parent-granted lease (GHSA-mqfw-f48p-2vc8).

The bound now reaches the client on the uncached response as well: the cache writer clamps record TTLs to the delegation cut before admission and before the write, so the first answer and every hit make the same promise — **min(record TTL, lease remaining)**. `remaining()` stays the served TTL on all hit paths, unchanged from main.

An earlier revision of this branch equalized in the other direction — serving the uncapped record TTL on hits. Review caught that it handed downstream caches exactly the retention the ghost fix exists to prevent; that revision is gone from the branch.

Field observation that triggered this: `sdns.dev` answered 3600 on resolution and 1798 on the next query. After this change both answer ~1798 — the .dev registry publishes the zone's DS at TTL 1800, and that lease is now the consistent, advertised bound.