### PR TITLE
release prep: 1.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ docker run -d --name sdns -p 53:53 -p 53:53/udp ghcr.io/semihalev/sdns:latest
 Pin to a specific version (recommended for production):
 
 ```shell
-$ docker run -d --name sdns -p 53:53 -p 53:53/udp ghcr.io/semihalev/sdns:1.8.0
+$ docker run -d --name sdns -p 53:53 -p 53:53/udp ghcr.io/semihalev/sdns:1.8.1
 ```
 
 #### Docker Compose
@@ -136,7 +136,7 @@ example.com.		0	CH	HINFO	"Host" "IPv6:[2001:500:8f::53]:53 rtt:147ms health:[GOO
 example.com.		0	CH	HINFO	"Host" "IPv6:[2001:500:8d::53]:53 rtt:148ms health:[GOOD]"
 ```
 
-## Configuration (v1.8.0)
+## Configuration (v1.8.1)
 
 | Key                  | Description                                                                                                         |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------- |

--- a/config/config.go
+++ b/config/config.go
@@ -18,7 +18,7 @@ import (
 	"github.com/semihalev/zlog/v2"
 )
 
-const configver = "1.8.0"
+const configver = "1.8.1"
 
 // Config type.
 type Config struct {

--- a/contrib/linux/sdns.conf
+++ b/contrib/linux/sdns.conf
@@ -1,6 +1,6 @@
 
 # Configuration file version (not SDNS version)
-version = "1.8.0"
+version = "1.8.1"
 
 # ============================
 # Basic Server Configuration

--- a/doc.go
+++ b/doc.go
@@ -16,7 +16,7 @@ metrics and operational endpoints (blocklist management, cache purge).
   - Iterative recursive resolution with DNSSEC validation, NSEC/NSEC3
     denial-of-existence proofs, and RFC 5011 automatic root trust-anchor
     maintenance.
-  - QNAME minimization (RFC 7816) for query privacy.
+  - QNAME minimization (RFC 9156) for query privacy.
   - High-performance caching: positive and negative caches, prefetch of
     popular entries, and EDNS Client Subnet (ECS, RFC 7871) aware keying.
   - Forwarding to upstream resolvers over UDP, TCP, DoT, and DoH.

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -1815,10 +1815,7 @@ func clampTTLsToCut(res *dns.Msg, cutUntil time.Time) {
 	if cutUntil.IsZero() {
 		return
 	}
-	lease := time.Until(cutUntil)
-	if lease < 0 {
-		lease = 0
-	}
+	lease := max(time.Until(cutUntil), 0)
 	leaseSecs := uint32(lease.Seconds())
 	clamp := func(rrs []dns.RR) {
 		for _, rr := range rrs {

--- a/sdns.go
+++ b/sdns.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const version = "1.8.0"
+const version = "1.8.1"
 
 var (
 	cfgPath    string


### PR DESCRIPTION
Gathers the small items for cutting 1.8.1, whose substance is already on main (#579, #580 — the TTL collapse fixes and the lease-bounded client TTL):

- Version to **1.8.1** in `sdns.go`, `config/config.go` (configver), and the README docker/Configuration headers. The benchmark section stays at the last-measured release by policy.
- `contrib/linux/sdns.conf` regenerated — verified **byte-identical** to what the 1.8.1 binary writes for a missing config.
- `doc.go` cited RFC 7816 (obsoleted 2021); now RFC 9156, matching the config and README.
- One modernization in the TTL clamp (`max` over an if).

Checked and deliberately not included: the prefetch-claim release on failed refreshes is already correct — `processPrefetch` releases the claim on every exit path via `defer releasePrefetchClaim`, pinned by `TestPrefetchWorkerReleasesClaimOnError`.