### PR TITLE
resolver: hyperlocal root — serve the root zone from a verified local copy (RFC 8806)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ example.com.		0	CH	HINFO	"Host" "IPv6:[2001:500:8d::53]:53 rtt:148ms health:[GOO
 | **qname_max_minimize_count** | QNAME minimization (RFC 9156): minimized queries one lookup may spend before the full name goes out. 0 disables. Default: 10 |
 | **qname_minimize_one_label** | How many of those queries add a single label before the rest are grouped. 0 selects the RFC's suggested 4. Default: 4 |
 | **qname_min_level**  | Deprecated. Counted delegation depth instead of queries spent; still read when **qname_max_minimize_count** is unset |
+| **hyperlocal_root**  | Serve the root zone from a local copy (RFC 8806): AXFR from the root servers, ZONEMD-verified (RFC 8976) against the trust anchors, refreshed on the zone's SOA schedule. Root referrals and junk-TLD NXDOMAINs cost no upstream query. Default: false |
+| **hyperlocal_root_sources** | Transfer sources (host:port) for the local root copy. Empty selects the RFC 8806 appendix set |
 | **emptyzones**       | Enable local authoritative responses for RFC 1918 zones. See http://as112.net/ for details                         |
 | **tcpkeepalive**     | Enable TCP connection pooling for root and TLD servers. Improves performance by reusing connections. Default: false |
 | **roottcptimeout**   | TCP idle timeout for root server connections. Default: "5s"                                                          |

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ example.com.		0	CH	HINFO	"Host" "IPv6:[2001:500:8d::53]:53 rtt:148ms health:[GOO
 | **qname_max_minimize_count** | QNAME minimization (RFC 9156): minimized queries one lookup may spend before the full name goes out. 0 disables. Default: 10 |
 | **qname_minimize_one_label** | How many of those queries add a single label before the rest are grouped. 0 selects the RFC's suggested 4. Default: 4 |
 | **qname_min_level**  | Deprecated. Counted delegation depth instead of queries spent; still read when **qname_max_minimize_count** is unset |
-| **hyperlocal_root**  | Serve the root zone from a local copy (RFC 8806): AXFR from the root servers, ZONEMD-verified (RFC 8976) against the trust anchors, refreshed on the zone's SOA schedule. Root referrals and junk-TLD NXDOMAINs cost no upstream query. Default: false |
+| **hyperlocal_root**  | Serve the root zone from a local copy (RFC 8806): AXFR from the root servers, ZONEMD-verified (RFC 8976) against the trust anchors, refreshed on the zone's SOA schedule. Root referrals, junk-TLD NXDOMAINs and questions at the root itself (`. NS`, `. SOA`, `. DNSKEY`) cost no upstream query. Default: false |
 | **hyperlocal_root_sources** | Transfer sources (host:port) for the local root copy. Empty selects the RFC 8806 appendix set |
 | **emptyzones**       | Enable local authoritative responses for RFC 1918 zones. See http://as112.net/ for details                         |
 | **tcpkeepalive**     | Enable TCP connection pooling for root and TLD servers. Improves performance by reusing connections. Default: false |

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ $ docker run -d --name sdns -p 53:53 -p 53:53/udp ghcr.io/semihalev/sdns:latest
 Pin to a specific version (recommended for production):
 
 ```shell
-$ docker run -d --name sdns -p 53:53 -p 53:53/udp ghcr.io/semihalev/sdns:1.8.1
+$ docker run -d --name sdns -p 53:53 -p 53:53/udp ghcr.io/semihalev/sdns:1.8.2
 ```
 
 #### Docker Compose
@@ -136,7 +136,7 @@ example.com.		0	CH	HINFO	"Host" "IPv6:[2001:500:8f::53]:53 rtt:147ms health:[GOO
 example.com.		0	CH	HINFO	"Host" "IPv6:[2001:500:8d::53]:53 rtt:148ms health:[GOOD]"
 ```
 
-## Configuration (v1.8.1)
+## Configuration (v1.8.2)
 
 | Key                  | Description                                                                                                         |
 | -------------------- | ------------------------------------------------------------------------------------------------------------------- |

--- a/config/config.go
+++ b/config/config.go
@@ -830,7 +830,8 @@ qname_minimize_one_label = 4
 # Serve the root zone from a local copy: transferred over AXFR from the root
 # servers that publish it, verified against the zone's ZONEMD digest
 # (RFC 8976) chained to the root trust anchors, and refreshed on the zone's
-# own SOA schedule. Root referrals and junk-TLD NXDOMAINs then cost no
+# own SOA schedule. Root referrals, junk-TLD NXDOMAINs and questions asked
+# at the root itself then cost no
 # upstream query and leak nothing to the root servers. A copy that cannot be
 # refreshed is withdrawn at its SOA expire and resolution falls back to the
 # real root servers unchanged.

--- a/config/config.go
+++ b/config/config.go
@@ -18,7 +18,7 @@ import (
 	"github.com/semihalev/zlog/v2"
 )
 
-const configver = "1.8.1"
+const configver = "1.8.2"
 
 // Config type.
 type Config struct {

--- a/config/config.go
+++ b/config/config.go
@@ -831,10 +831,9 @@ qname_minimize_one_label = 4
 # servers that publish it, verified against the zone's ZONEMD digest
 # (RFC 8976) chained to the root trust anchors, and refreshed on the zone's
 # own SOA schedule. Root referrals, junk-TLD NXDOMAINs and questions asked
-# at the root itself then cost no
-# upstream query and leak nothing to the root servers. A copy that cannot be
-# refreshed is withdrawn at its SOA expire and resolution falls back to the
-# real root servers unchanged.
+# at the root itself then cost no upstream query and leak nothing to the
+# root servers. A copy that cannot be refreshed is withdrawn at its SOA
+# expire and resolution falls back to the real root servers unchanged.
 # hyperlocal_root_sources overrides the built-in transfer hosts (host:port).
 hyperlocal_root = false
 # hyperlocal_root_sources = ["b.root-servers.net:53", "k.root-servers.net:53"]

--- a/config/config.go
+++ b/config/config.go
@@ -82,7 +82,19 @@ type Config struct {
 	// grouping from the first query would expose a deep name almost at
 	// once, so it is not an available setting.
 	QnameMinimizeOneLabel int `toml:"qname_minimize_one_label"`
-	EmptyZones            []string
+
+	// HyperlocalRoot serves the root zone from a local copy (RFC 8806):
+	// transferred over AXFR from the root servers that publish it,
+	// verified against the ZONEMD digest (RFC 8976) chained to the root
+	// trust anchors, refreshed on the zone's own SOA schedule, and
+	// withdrawn past its SOA expire — the resolver then walks to the real
+	// root servers as if the copy never existed.
+	HyperlocalRoot bool `toml:"hyperlocal_root"`
+	// HyperlocalRootSources overrides the built-in transfer sources
+	// (host:port). Empty selects the RFC 8806 appendix set.
+	HyperlocalRootSources []string `toml:"hyperlocal_root_sources"`
+
+	EmptyZones []string
 
 	// Views are per-client static answers, evaluated in order. A
 	// query whose source IP falls in a view's Sources gets that
@@ -813,6 +825,18 @@ chaos = true
 # queries; it is still read when qname_max_minimize_count is unset.
 qname_max_minimize_count = 10
 qname_minimize_one_label = 4
+
+# Hyperlocal root (RFC 8806)
+# Serve the root zone from a local copy: transferred over AXFR from the root
+# servers that publish it, verified against the zone's ZONEMD digest
+# (RFC 8976) chained to the root trust anchors, and refreshed on the zone's
+# own SOA schedule. Root referrals and junk-TLD NXDOMAINs then cost no
+# upstream query and leak nothing to the root servers. A copy that cannot be
+# refreshed is withdrawn at its SOA expire and resolution falls back to the
+# real root servers unchanged.
+# hyperlocal_root_sources overrides the built-in transfer hosts (host:port).
+hyperlocal_root = false
+# hyperlocal_root_sources = ["b.root-servers.net:53", "k.root-servers.net:53"]
 
 # Empty zones (AS112 - RFC 7534)
 # Prevents queries for private IP reverse zones from leaking

--- a/contrib/linux/sdns.conf
+++ b/contrib/linux/sdns.conf
@@ -357,6 +357,18 @@ chaos = true
 qname_max_minimize_count = 10
 qname_minimize_one_label = 4
 
+# Hyperlocal root (RFC 8806)
+# Serve the root zone from a local copy: transferred over AXFR from the root
+# servers that publish it, verified against the zone's ZONEMD digest
+# (RFC 8976) chained to the root trust anchors, and refreshed on the zone's
+# own SOA schedule. Root referrals and junk-TLD NXDOMAINs then cost no
+# upstream query and leak nothing to the root servers. A copy that cannot be
+# refreshed is withdrawn at its SOA expire and resolution falls back to the
+# real root servers unchanged.
+# hyperlocal_root_sources overrides the built-in transfer hosts (host:port).
+hyperlocal_root = false
+# hyperlocal_root_sources = ["b.root-servers.net:53", "k.root-servers.net:53"]
+
 # Empty zones (AS112 - RFC 7534)
 # Prevents queries for private IP reverse zones from leaking
 # Default list used if empty

--- a/contrib/linux/sdns.conf
+++ b/contrib/linux/sdns.conf
@@ -362,10 +362,9 @@ qname_minimize_one_label = 4
 # servers that publish it, verified against the zone's ZONEMD digest
 # (RFC 8976) chained to the root trust anchors, and refreshed on the zone's
 # own SOA schedule. Root referrals, junk-TLD NXDOMAINs and questions asked
-# at the root itself then cost no
-# upstream query and leak nothing to the root servers. A copy that cannot be
-# refreshed is withdrawn at its SOA expire and resolution falls back to the
-# real root servers unchanged.
+# at the root itself then cost no upstream query and leak nothing to the
+# root servers. A copy that cannot be refreshed is withdrawn at its SOA
+# expire and resolution falls back to the real root servers unchanged.
 # hyperlocal_root_sources overrides the built-in transfer hosts (host:port).
 hyperlocal_root = false
 # hyperlocal_root_sources = ["b.root-servers.net:53", "k.root-servers.net:53"]

--- a/contrib/linux/sdns.conf
+++ b/contrib/linux/sdns.conf
@@ -1,6 +1,6 @@
 
 # Configuration file version (not SDNS version)
-version = "1.8.1"
+version = "1.8.2"
 
 # ============================
 # Basic Server Configuration

--- a/contrib/linux/sdns.conf
+++ b/contrib/linux/sdns.conf
@@ -361,7 +361,8 @@ qname_minimize_one_label = 4
 # Serve the root zone from a local copy: transferred over AXFR from the root
 # servers that publish it, verified against the zone's ZONEMD digest
 # (RFC 8976) chained to the root trust anchors, and refreshed on the zone's
-# own SOA schedule. Root referrals and junk-TLD NXDOMAINs then cost no
+# own SOA schedule. Root referrals, junk-TLD NXDOMAINs and questions asked
+# at the root itself then cost no
 # upstream query and leak nothing to the root servers. A copy that cannot be
 # refreshed is withdrawn at its SOA expire and resolution falls back to the
 # real root servers unchanged.

--- a/doc.go
+++ b/doc.go
@@ -17,6 +17,9 @@ metrics and operational endpoints (blocklist management, cache purge).
     denial-of-existence proofs, and RFC 5011 automatic root trust-anchor
     maintenance.
   - QNAME minimization (RFC 9156) for query privacy.
+  - Hyperlocal root (RFC 8806): a local copy of the root zone, verified
+    against its ZONEMD digest (RFC 8976) and the root trust anchors, so
+    referrals and denials at the root cost no upstream query.
   - High-performance caching: positive and negative caches, prefetch of
     popular entries, and EDNS Client Subnet (ECS, RFC 7871) aware keying.
   - Forwarding to upstream resolvers over UDP, TCP, DoT, and DoH.

--- a/internal/authority/cache.go
+++ b/internal/authority/cache.go
@@ -103,10 +103,18 @@ func (n *Cache) SetUntil(key uint64, dsSet []dns.RR, servers *Servers, expiresAt
 // exactly the expired value it examined (CompareAndSwap), so a real lease
 // published by a concurrent walk can never be displaced by the provisional
 // one racing it.
-func (n *Cache) SetUntilIfAbsent(key uint64, dsSet []dns.RR, servers *Servers, expiresAt time.Time) {
+//
+// It returns the delegation that is live under the key afterwards — the one
+// it stored, or the one that beat it. Callers that go on to use the
+// delegation must use the returned value and not their own inputs: servers,
+// DS set and expiry belong to one entry, and pairing a winner's servers
+// with a loser's DS chain would validate one delegation's answers against
+// another's keys. A nil return means nothing is live (a past deadline is
+// not stored).
+func (n *Cache) SetUntilIfAbsent(key uint64, dsSet []dns.RR, servers *Servers, expiresAt time.Time) *Delegation {
 	now := n.now()
 	if !expiresAt.After(now) {
-		return
+		return nil
 	}
 	if ceiling := now.Add(maximumTTL); expiresAt.After(ceiling) {
 		expiresAt = ceiling
@@ -121,16 +129,17 @@ func (n *Cache) SetUntilIfAbsent(key uint64, dsSet []dns.RR, servers *Servers, e
 		cur, ok := n.cache.Get(key)
 		if !ok {
 			if n.cache.AddIfAbsent(key, d) {
-				return
+				return d
 			}
 			// Lost the insert race; re-examine what landed.
 			continue
 		}
-		if n.now().Before(cur.(*Delegation).ExpiresAt) {
-			return
+		live := cur.(*Delegation)
+		if n.now().Before(live.ExpiresAt) {
+			return live
 		}
 		if n.cache.CompareAndSwap(key, cur, d) {
-			return
+			return d
 		}
 		// The expired value was replaced under us; re-examine the newer one.
 	}

--- a/middleware/forwarder/forwarder_test.go
+++ b/middleware/forwarder/forwarder_test.go
@@ -656,34 +656,36 @@ func startTruncatingForwarderServers(t *testing.T) (
 		resp.Truncated = true
 		_ = w.WriteMsg(resp)
 	})
-	// The forwarder retries TCP against the same server address, so the TCP
-	// listener must take exactly the port the UDP socket drew from :0. The
-	// kernel only promised that port for UDP — on Windows an ephemeral port
-	// can sit inside an excluded range for the other protocol and the TCP
-	// bind fails with a permission error — so a pair that does not bind is
-	// redrawn rather than fatal.
+	// The forwarder retries TCP against the same server address, so both
+	// listeners must hold the same port. Only one of the two draws it from
+	// :0, and it is the TCP one on purpose: a port the kernel hands out for
+	// TCP is one TCP can bind, whereas a port drawn for UDP carries no such
+	// promise for TCP — on Windows it can sit inside a range excluded for
+	// the other protocol, where the bind fails with a permission error.
+	// Drawing on the constrained side turns the likely failure into the
+	// unlikely one; the redraw covers what is left.
 	var (
 		packet   net.PacketConn
 		listener net.Listener
 	)
 	for attempt := 1; ; attempt++ {
 		var err error
-		packet, err = net.ListenPacket("udp", "127.0.0.1:0")
+		listener, err = net.Listen("tcp", "127.0.0.1:0")
 		if err != nil {
-			t.Fatalf("listen UDP: %v", err)
+			t.Fatalf("listen TCP: %v", err)
 		}
-		host, port, err := net.SplitHostPort(packet.LocalAddr().String())
+		host, port, err := net.SplitHostPort(listener.Addr().String())
 		if err != nil {
-			_ = packet.Close()
-			t.Fatalf("split UDP address: %v", err)
+			_ = listener.Close()
+			t.Fatalf("split TCP address: %v", err)
 		}
-		listener, err = net.Listen("tcp", net.JoinHostPort(host, port))
+		packet, err = net.ListenPacket("udp", net.JoinHostPort(host, port))
 		if err == nil {
 			break
 		}
-		_ = packet.Close()
+		_ = listener.Close()
 		if attempt == 10 {
-			t.Fatalf("listen TCP on UDP port after %d attempts: %v", attempt, err)
+			t.Fatalf("listen UDP on TCP port after %d attempts: %v", attempt, err)
 		}
 	}
 	udpServer := &dns.Server{Net: "udp", PacketConn: packet, Handler: udpMux}

--- a/middleware/resolver/dnssec/verify.go
+++ b/middleware/resolver/dnssec/verify.go
@@ -569,6 +569,17 @@ func rrsigID(sig *dns.RRSIG) rrsigIdentity {
 	}
 }
 
+// UniqueRRSIGs returns signatures with exact duplicates removed, in a
+// deterministic order. Identity spans every field a verification depends
+// on — owner, class, covered type, algorithm, labels, original TTL,
+// validity window, key tag, signer and the signature bytes — so two
+// records that differ anywhere that matters are kept apart. A caller
+// deduplicating on less can discard a sound signature as a copy of an
+// unsound one that merely resembles it.
+func UniqueRRSIGs(signatures []*dns.RRSIG) []*dns.RRSIG {
+	return uniqueSortedRRSIGs(signatures)
+}
+
 func uniqueSortedRRSIGs(signatures []*dns.RRSIG) []*dns.RRSIG {
 	if len(signatures) == 0 {
 		return signatures

--- a/middleware/resolver/dnssec/zonewire.go
+++ b/middleware/resolver/dnssec/zonewire.go
@@ -1,0 +1,32 @@
+package dnssec
+
+import (
+	"github.com/miekg/dns"
+)
+
+// CanonicalWireRR returns one record's canonical on-the-wire form as RFC
+// 4034 §6.2 defines it for zone-content digests (RFC 8976): the owner and
+// the RDATA names §6.2 lists are lowercased, the record packs without
+// compression, and the record's own TTL is retained — the original-TTL
+// substitution belongs to signature computation, not to a digest of the
+// zone as published. rdataOff is where the RDATA begins in wire, so a
+// caller ordering records per §6.3 can compare RDATA without re-walking
+// the owner labels.
+func CanonicalWireRR(r dns.RR) (wire []byte, rdataOff int, err error) {
+	r1 := dns.Copy(r)
+	r1.Header().Name = dns.CanonicalName(r1.Header().Name)
+	canonicalizeRdataNames(r1)
+
+	wire = make([]byte, dns.Len(r1)+1)
+	n, err := dns.PackRR(r1, wire, 0, nil, false)
+	if err != nil {
+		return nil, 0, err
+	}
+	wire = wire[:n]
+
+	off, ok := wireRdataOffset(wire)
+	if !ok {
+		return nil, 0, dns.ErrRdata
+	}
+	return wire, off, nil
+}

--- a/middleware/resolver/localroot/adversarial_test.go
+++ b/middleware/resolver/localroot/adversarial_test.go
@@ -6,6 +6,8 @@ import (
 	"crypto/sha512"
 	"encoding/hex"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -365,5 +367,86 @@ func TestVerifyZoneAcceptsUniqueTupleBesideDuplicates(t *testing.T) {
 
 	if err := verifyZone(mixed, z.Anchors); err != nil {
 		t.Fatalf("a sound unique tuple beside duplicated unsupported ones must verify: %v", err)
+	}
+}
+
+// TestLoadPublishIsExclusive pins the publish decision. The serial check and
+// the swap are one decision, not two: two loads that both observe the same
+// older copy can each pass the check and then store in the opposite order,
+// leaving the newer copy displaced by the older one. Every operation
+// involved is individually legal, so the race detector reports nothing, and
+// the window is a few instructions wide, so volume testing does not find it
+// either — the section has to be held open to prove it is exclusive.
+//
+// Held open: the first load pauses between its check and its swap while a
+// second load runs to completion with a newer serial. Under an exclusive
+// section the second load waits, sees the first one's copy, and its newer
+// serial wins. Without one, the paused load wakes and overwrites it.
+func TestLoadPublishIsExclusive(t *testing.T) {
+	base, err := roottest.Build(ComputeDigest)
+	if err != nil {
+		t.Fatalf("base zone: %v", err)
+	}
+	// One key throughout, so all three copies chain to the same anchor and
+	// the only thing separating them is the serial.
+	zoneAt := func(serial uint32) []dns.RR {
+		t.Helper()
+		z, err := roottest.BuildZoneWithKey(
+			ComputeDigest, roottest.DefaultLines(serial), serial, base.Key, base.Priv,
+		)
+		if err != nil {
+			t.Fatalf("zone %d: %v", serial, err)
+		}
+		return z.RRs
+	}
+	const (
+		oldest = roottest.Serial
+		middle = roottest.Serial + 1
+		newest = roottest.Serial + 2
+	)
+
+	m := New(nil, func() []dns.RR { return base.Anchors })
+	if err := m.Load(zoneAt(oldest)); err != nil {
+		t.Fatalf("seed load: %v", err)
+	}
+
+	paused := make(chan struct{})
+	release := make(chan struct{})
+	// Only the first load pauses, and later ones must pass straight
+	// through: sync.Once would block them inside the hook instead, which
+	// serializes the very overlap this test exists to create.
+	var first atomic.Bool
+	m.afterSerialCheck = func() {
+		if first.CompareAndSwap(false, true) {
+			close(paused)
+			<-release
+		}
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = m.Load(zoneAt(middle)) // pauses inside the section
+	}()
+
+	<-paused
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = m.Load(zoneAt(newest))
+	}()
+	// Give the newer load every chance to slip past an unguarded section.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	active := m.Active()
+	if active == nil {
+		t.Fatal("no copy active after the loads")
+	}
+	if active.Serial() != newest {
+		t.Fatalf("active serial = %d, want the newest %d — a paused load rolled the copy backwards",
+			active.Serial(), newest)
 	}
 }

--- a/middleware/resolver/localroot/adversarial_test.go
+++ b/middleware/resolver/localroot/adversarial_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"crypto/sha512"
+	"encoding/base64"
+	"encoding/binary"
 	"encoding/hex"
 	"strings"
 	"sync"
@@ -629,5 +631,143 @@ func TestHorizonFollowsTheVerifyingZONEMDSignature(t *testing.T) {
 	}
 	if !snap.Expired(now.Add(2 * time.Minute)) {
 		t.Fatal("the copy is still active past the ZONEMD signature's expiration")
+	}
+}
+
+// TestApexSignatureWorkIsBounded pins the cost of verifying an apex RRset.
+// Apex RRSIG(ZONEMD) records sit outside the digest, so a transfer can
+// carry any number of them, and verifying each in turn turns the generous
+// transfer limits into cryptographic work — the refresh worker stalls for
+// as long as an attacker cares to make it. Deduplication, descending
+// expiration order and a small attempt cap bound it, and a sound zone
+// still verifies on its first attempt.
+func TestApexSignatureWorkIsBounded(t *testing.T) {
+	z, err := roottest.Build(ComputeDigest)
+	if err != nil {
+		t.Fatalf("roottest.Build: %v", err)
+	}
+
+	var (
+		base  []dns.RR
+		sound *dns.RRSIG
+	)
+	for _, rr := range z.RRs {
+		if sig, ok := rr.(*dns.RRSIG); ok && sig.TypeCovered == dns.TypeZONEMD {
+			sound = sig
+			continue
+		}
+		base = append(base, rr)
+	}
+	if sound == nil {
+		t.Fatal("built zone has no RRSIG(ZONEMD)")
+	}
+
+	// Thousands of forgeries, each claiming to outlive the sound signature
+	// so ordering cannot skip them, each distinct so deduplication cannot
+	// collapse them, and each the exact width RFC 6605 §4 gives a P-256
+	// signature — a wrong length is refused before any public-key
+	// operation, which would make this measure nothing at all.
+	const forgeries = 4096
+	flooded := make([]dns.RR, 0, len(base)+forgeries+1)
+	flooded = append(flooded, base...)
+	for i := range forgeries {
+		raw := make([]byte, 64)
+		binary.BigEndian.PutUint32(raw, uint32(i)+1) //nolint:gosec // bounded test index
+		raw[40] = 0x7f                               // keep both halves non-trivial
+		fake := dns.Copy(sound).(*dns.RRSIG)
+		fake.Expiration = sound.Expiration + uint32(i) + 1 //nolint:gosec // bounded test index
+		fake.Signature = base64.StdEncoding.EncodeToString(raw)
+		flooded = append(flooded, fake)
+	}
+	flooded = append(flooded, sound)
+
+	// The cap is in force: the sound signature sits below thousands of
+	// higher-expiring forgeries, so it never gets an attempt and the zone
+	// is refused. Denial is not a capability this hands anyone — whoever
+	// can append these records can already break a digested one — but it
+	// is the observable proof that the attempt window is bounded.
+	start := time.Now()
+	if _, err := verifyZone(flooded, z.Anchors); err == nil {
+		t.Fatal("every attempt went to a forgery, yet the zone verified — the window is not bounded")
+	}
+	// And the refusal is cheap. Bounded, this is a handful of public-key
+	// operations; unbounded it is one per forgery, which on this input
+	// takes hundreds of milliseconds and scales with whatever a transfer
+	// carries. The threshold is loose on purpose — it is a guard against
+	// the work scaling, not a benchmark.
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("verification of %d appended signatures took %v — the work is not bounded",
+			forgeries, elapsed)
+	}
+}
+
+// TestApexSignatureOrderPicksTheLatestVerifying pins what the ordering buys
+// besides speed: stopping at the first signature that verifies is only
+// correct because everything longer-lived was tried before it, so the one
+// that stops the loop carries the latest expiration among those that would
+// have verified at all.
+func TestApexSignatureOrderPicksTheLatestVerifying(t *testing.T) {
+	z, err := roottest.Build(ComputeDigest)
+	if err != nil {
+		t.Fatalf("roottest.Build: %v", err)
+	}
+
+	var (
+		base   []dns.RR
+		zonemd *dns.ZONEMD
+		sound  *dns.RRSIG
+	)
+	for _, rr := range z.RRs {
+		if md, ok := rr.(*dns.ZONEMD); ok {
+			zonemd = md
+			continue
+		}
+		if sig, ok := rr.(*dns.RRSIG); ok && sig.TypeCovered == dns.TypeZONEMD {
+			sound = sig
+			continue
+		}
+		base = append(base, rr)
+	}
+	if zonemd == nil || sound == nil {
+		t.Fatal("built zone is missing its ZONEMD or its signature")
+	}
+
+	// A second sound signature over the same RRset, valid for a day rather
+	// than the hour the first one carries. The copy must live to the later
+	// of the two, since either one authenticates it.
+	now := time.Now()
+	longer := &dns.RRSIG{
+		Hdr: dns.RR_Header{
+			Name: ".", Rrtype: dns.TypeRRSIG,
+			Class: dns.ClassINET, Ttl: zonemd.Hdr.Ttl,
+		},
+		TypeCovered: dns.TypeZONEMD,
+		Algorithm:   dns.ECDSAP256SHA256,
+		OrigTtl:     zonemd.Hdr.Ttl,
+		Expiration:  uint32(now.Add(24 * time.Hour).Unix()), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+		Inception:   uint32(now.Add(-time.Hour).Unix()),     //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+		KeyTag:      z.Key.KeyTag(),
+		SignerName:  ".",
+	}
+	if err := longer.Sign(z.Priv.(*ecdsa.PrivateKey), []dns.RR{zonemd}); err != nil {
+		t.Fatalf("sign the longer-lived signature: %v", err)
+	}
+
+	// The shorter one first in the slice, so only the ordering can find the
+	// longer — and a forgery claiming to outlive both, which must not.
+	forged := dns.Copy(longer).(*dns.RRSIG)
+	forged.Expiration = uint32(now.Add(72 * time.Hour).Unix()) //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+	forged.Signature = "AAAAAAAA"
+
+	both := make([]dns.RR, 0, len(base)+4)
+	both = append(both, base...)
+	both = append(both, zonemd, sound, forged, longer)
+
+	authUntil, err := verifyZone(both, z.Anchors)
+	if err != nil {
+		t.Fatalf("verifyZone: %v", err)
+	}
+	if want := time.Unix(int64(longer.Expiration), 0); !authUntil.Equal(want) {
+		t.Fatalf("authenticated until %v, want the longer sound signature's %v", authUntil, want)
 	}
 }

--- a/middleware/resolver/localroot/adversarial_test.go
+++ b/middleware/resolver/localroot/adversarial_test.go
@@ -103,7 +103,7 @@ func TestVerifyZoneRefusesForeignSignerWithRealKSKPresent(t *testing.T) {
 	// The anchor is the victim's DS, and the forged zone carries the key
 	// that matches it — the zone must still be refused, because that key
 	// signed nothing here.
-	if err := verifyZone(forged, victim.anchors); err == nil {
+	if _, err := verifyZone(forged, victim.anchors); err == nil {
 		t.Fatal("a zone signed by a foreign key was accepted because the anchor-matching key rode along unsigned")
 	}
 }
@@ -137,7 +137,7 @@ func TestManagerRefusesSerialRollback(t *testing.T) {
 	}
 	// Sanity: the older zone is itself perfectly valid — it is refused for
 	// being older, not for being unverifiable.
-	if err := verifyZone(older.RRs, newer.Anchors); err != nil {
+	if _, err := verifyZone(older.RRs, newer.Anchors); err != nil {
 		t.Fatalf("the older zone must verify on its own merits: %v", err)
 	}
 	if err := m.Load(older.RRs); err == nil {
@@ -246,13 +246,13 @@ func TestVerifyZoneRefusesDuplicateZONEMDTuple(t *testing.T) {
 	dup := make([]dns.RR, 0, len(base)+3)
 	dup = append(dup, base...)
 	dup = append(dup, first, second, sig)
-	if err := verifyZone(dup, z.Anchors); err == nil {
+	if _, err := verifyZone(dup, z.Anchors); err == nil {
 		t.Fatal("a repeated ZONEMD scheme/hash tuple verified")
 	}
 
 	// Sanity: the same zone with the single original ZONEMD still verifies,
 	// so the refusal above is the duplicate rule and nothing else.
-	if err := verifyZone(z.RRs, z.Anchors); err != nil {
+	if _, err := verifyZone(z.RRs, z.Anchors); err != nil {
 		t.Fatalf("the unmodified zone must still verify: %v", err)
 	}
 }
@@ -276,7 +276,7 @@ func TestDSAnswerRequiresProvableNODATA(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build zone: %v", err)
 	}
-	if err := verifyZone(z.RRs, z.Anchors); err != nil {
+	if _, err := verifyZone(z.RRs, z.Anchors); err != nil {
 		t.Fatalf("the zone itself must verify — the defect is semantic: %v", err)
 	}
 	snap, err := buildSnapshot(z.RRs, time.Now())
@@ -365,7 +365,7 @@ func TestVerifyZoneAcceptsUniqueTupleBesideDuplicates(t *testing.T) {
 	mixed = append(mixed, base...)
 	mixed = append(mixed, simple, unsupportedA, unsupportedB, sig)
 
-	if err := verifyZone(mixed, z.Anchors); err != nil {
+	if _, err := verifyZone(mixed, z.Anchors); err != nil {
 		t.Fatalf("a sound unique tuple beside duplicated unsupported ones must verify: %v", err)
 	}
 }
@@ -477,7 +477,7 @@ func TestSnapshotHorizonIgnoresUnverifiedZONEMDSignature(t *testing.T) {
 	poisoned = append(poisoned, z.RRs...)
 	poisoned = append(poisoned, long)
 
-	if err := verifyZone(poisoned, z.Anchors); err != nil {
+	if _, err := verifyZone(poisoned, z.Anchors); err != nil {
 		t.Fatalf("the zone must still verify — the appended signature is not "+
 			"part of the digest and a sound one covers the RRset: %v", err)
 	}
@@ -556,5 +556,78 @@ func TestRefreshRejectsTransferBehindProbe(t *testing.T) {
 	}
 	if err := m2.refreshOnce(context.Background()); err == nil {
 		t.Fatal("a source that did not deliver what it announced reported success")
+	}
+}
+
+// TestHorizonFollowsTheVerifyingZONEMDSignature is the other half of the
+// poisoning fix. Skipping every apex RRSIG(ZONEMD) keeps an appended
+// expired signature from expiring a sound copy, but the signature that
+// actually carried the ZONEMD RRset through verification is what makes the
+// digest evidence at all: authenticated data may not outlive the signature
+// that authenticated it (RFC 4035 §5.3.3, RFC 8976 §6.4). So a zone whose
+// real ZONEMD signature lapses in a minute must not be served for an hour
+// on the strength of its longer-lived record signatures.
+func TestHorizonFollowsTheVerifyingZONEMDSignature(t *testing.T) {
+	z, err := roottest.Build(ComputeDigest)
+	if err != nil {
+		t.Fatalf("roottest.Build: %v", err)
+	}
+
+	// Re-sign the ZONEMD RRset with a one-minute validity, leaving every
+	// other signature in the zone at its original hour.
+	var (
+		base   []dns.RR
+		zonemd *dns.ZONEMD
+	)
+	for _, rr := range z.RRs {
+		if md, ok := rr.(*dns.ZONEMD); ok {
+			zonemd = md
+			continue
+		}
+		if sig, ok := rr.(*dns.RRSIG); ok && sig.TypeCovered == dns.TypeZONEMD {
+			continue
+		}
+		base = append(base, rr)
+	}
+	if zonemd == nil {
+		t.Fatal("built zone has no apex ZONEMD")
+	}
+
+	now := time.Now()
+	short := &dns.RRSIG{
+		Hdr: dns.RR_Header{
+			Name: ".", Rrtype: dns.TypeRRSIG,
+			Class: dns.ClassINET, Ttl: zonemd.Hdr.Ttl,
+		},
+		TypeCovered: dns.TypeZONEMD,
+		Algorithm:   dns.ECDSAP256SHA256,
+		OrigTtl:     zonemd.Hdr.Ttl,
+		Expiration:  uint32(now.Add(time.Minute).Unix()), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+		Inception:   uint32(now.Add(-time.Hour).Unix()),  //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+		KeyTag:      z.Key.KeyTag(),
+		SignerName:  ".",
+	}
+	if err := short.Sign(z.Priv.(*ecdsa.PrivateKey), []dns.RR{zonemd}); err != nil {
+		t.Fatalf("sign ZONEMD: %v", err)
+	}
+
+	shortLived := make([]dns.RR, 0, len(base)+2)
+	shortLived = append(shortLived, base...)
+	shortLived = append(shortLived, zonemd, short)
+
+	m := New(nil, func() []dns.RR { return z.Anchors })
+	if err := m.Load(shortLived); err != nil {
+		t.Fatalf("the zone must verify — only its authentication is short: %v", err)
+	}
+	snap := m.Active()
+	if snap == nil {
+		t.Fatal("no copy active")
+	}
+	if got := snap.ValidUntil(); got.After(now.Add(2 * time.Minute)) {
+		t.Fatalf("horizon %v outlives the signature that authenticated the digest (%v)",
+			got, time.Unix(int64(short.Expiration), 0))
+	}
+	if !snap.Expired(now.Add(2 * time.Minute)) {
+		t.Fatal("the copy is still active past the ZONEMD signature's expiration")
 	}
 }

--- a/middleware/resolver/localroot/adversarial_test.go
+++ b/middleware/resolver/localroot/adversarial_test.go
@@ -450,3 +450,111 @@ func TestLoadPublishIsExclusive(t *testing.T) {
 			active.Serial(), newest)
 	}
 }
+
+// TestSnapshotHorizonIgnoresUnverifiedZONEMDSignature pins which signatures
+// may shorten a copy's life. RFC 8976 excludes the apex RRSIG(ZONEMD) from
+// the digest — it is written after the digest is computed — and apex
+// verification accepts an RRset when one covering signature validates. So
+// an appended, already-expired RRSIG(ZONEMD) is the one record in a
+// transfer that is neither authenticated by the digest nor rejected by
+// verification, and trusting its expiration would let anyone who can add a
+// record to a transfer expire a sound copy the moment it arrives.
+func TestSnapshotHorizonIgnoresUnverifiedZONEMDSignature(t *testing.T) {
+	z, err := roottest.Build(ComputeDigest)
+	if err != nil {
+		t.Fatalf("roottest.Build: %v", err)
+	}
+
+	// An RRSIG(ZONEMD) that expired a year ago, signed by nobody in
+	// particular: the digest does not cover it and the sound sibling
+	// signature still carries the RRset through verification.
+	long, err := dns.NewRR(". 86400 IN RRSIG ZONEMD 13 0 86400 " +
+		"20250824000000 20250810000000 12345 . AAAA")
+	if err != nil {
+		t.Fatalf("NewRR: %v", err)
+	}
+	poisoned := make([]dns.RR, 0, len(z.RRs)+1)
+	poisoned = append(poisoned, z.RRs...)
+	poisoned = append(poisoned, long)
+
+	if err := verifyZone(poisoned, z.Anchors); err != nil {
+		t.Fatalf("the zone must still verify — the appended signature is not "+
+			"part of the digest and a sound one covers the RRset: %v", err)
+	}
+
+	now := time.Now()
+	snap, err := buildSnapshot(poisoned, now)
+	if err != nil {
+		t.Fatalf("buildSnapshot: %v", err)
+	}
+	if snap.Expired(now) {
+		t.Fatal("an appended expired RRSIG(ZONEMD) expired a sound copy on arrival")
+	}
+	// The horizon still follows the signatures that are authenticated: the
+	// test zone signs with a one-hour window.
+	if snap.ValidUntil().After(now.Add(2 * time.Hour)) {
+		t.Fatalf("horizon %v ignores the authenticated signatures", snap.ValidUntil())
+	}
+}
+
+// TestRefreshRejectsTransferBehindProbe pins the source's own claim as part
+// of acceptance. A source that advertises N+1 and then hands back the
+// current N has not delivered the update; taking it would mark the refresh
+// successful and sleep a full refresh interval on a zone the source itself
+// called stale. The transfer must carry at least what the probe announced,
+// and a source that fails that is failed over rather than believed.
+func TestRefreshRejectsTransferBehindProbe(t *testing.T) {
+	root := buildTestRoot(t)
+
+	m := New([]string{"stale.test:53", "honest.test:53"}, func() []dns.RR { return root.anchors })
+	if err := m.Load(root.rrs); err != nil {
+		t.Fatalf("seed load: %v", err)
+	}
+
+	bumped, err := roottest.BuildZoneWithKey(
+		ComputeDigest,
+		roottest.DefaultLines(roottest.Serial+1),
+		roottest.Serial+1,
+		root.key, root.priv,
+	)
+	if err != nil {
+		t.Fatalf("bumped zone: %v", err)
+	}
+
+	// Both sources announce the bump; the first serves the old zone anyway.
+	var served []string
+	m.probeFn = func(_ context.Context, addr string, _ time.Duration) (uint32, error) {
+		return roottest.Serial + 1, nil
+	}
+	m.transferFn = func(_ context.Context, addr string, _ time.Duration) ([]dns.RR, error) {
+		served = append(served, addr)
+		if addr == "stale.test:53" {
+			return root.rrs, nil // the zone it just said was superseded
+		}
+		return bumped.RRs, nil
+	}
+
+	if err := m.refreshOnce(context.Background()); err != nil {
+		t.Fatalf("refresh: %v", err)
+	}
+	if len(served) != 2 {
+		t.Fatalf("sources transferred from = %v, want the stale one to fail over", served)
+	}
+	if got := m.Active().Serial(); got != roottest.Serial+1 {
+		t.Fatalf("active serial = %d, want the announced %d", got, roottest.Serial+1)
+	}
+
+	// And with only the stale source, the refresh must fail rather than
+	// report success and sleep out the full interval.
+	m2 := New([]string{"stale.test:53"}, func() []dns.RR { return root.anchors })
+	if err := m2.Load(root.rrs); err != nil {
+		t.Fatalf("seed load: %v", err)
+	}
+	m2.probeFn = m.probeFn
+	m2.transferFn = func(context.Context, string, time.Duration) ([]dns.RR, error) {
+		return root.rrs, nil
+	}
+	if err := m2.refreshOnce(context.Background()); err == nil {
+		t.Fatal("a source that did not deliver what it announced reported success")
+	}
+}

--- a/middleware/resolver/localroot/adversarial_test.go
+++ b/middleware/resolver/localroot/adversarial_test.go
@@ -1,0 +1,185 @@
+package localroot
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"encoding/hex"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/middleware/resolver/localroot/roottest"
+)
+
+// TestVerifyZoneRefusesForeignSignerWithRealKSKPresent reproduces the
+// verification bypass a review caught. The real root KSK is public
+// knowledge, so an attacker builds a zone whose DNSKEY RRset CONTAINS the
+// anchor-matching key while every signature — DNSKEY, SOA, ZONEMD — is made
+// by a second key of their own, also in the set. Matching an anchor and
+// signing the zone are different claims: the first alone proved nothing,
+// and verifying signatures against the whole transferred set accepted the
+// attacker's. The DNSKEY RRset must verify under anchor-matched keys only;
+// nothing else promotes the rest of the set.
+func TestVerifyZoneRefusesForeignSignerWithRealKSKPresent(t *testing.T) {
+	victim := buildTestRoot(t) // its key plays the real KSK; its DS is the anchor
+
+	var victimKey *dns.DNSKEY
+	for _, rr := range victim.rrs {
+		if k, ok := rr.(*dns.DNSKEY); ok {
+			victimKey = k
+		}
+	}
+	if victimKey == nil {
+		t.Fatal("victim zone has no DNSKEY")
+	}
+
+	// The attacker's own zone, rebuilt with the victim's key spliced into
+	// the DNSKEY RRset. The set changed, so its RRSIG and the ZONEMD seal
+	// are remade — with the ATTACKER's key, exactly as the attack would.
+	az, err := roottest.Build(ComputeDigest)
+	if err != nil {
+		t.Fatalf("attacker zone: %v", err)
+	}
+	var forged []dns.RR
+	for _, rr := range az.RRs {
+		if rr.Header().Rrtype == dns.TypeZONEMD {
+			continue
+		}
+		if sig, ok := rr.(*dns.RRSIG); ok &&
+			(sig.TypeCovered == dns.TypeZONEMD || sig.TypeCovered == dns.TypeDNSKEY) {
+			continue
+		}
+		forged = append(forged, rr)
+	}
+	forged = append(forged, victimKey)
+
+	sign := func(rrset []dns.RR) dns.RR {
+		t.Helper()
+		now := time.Now()
+		sig := &dns.RRSIG{
+			Hdr: dns.RR_Header{
+				Name: ".", Rrtype: dns.TypeRRSIG,
+				Class: dns.ClassINET, Ttl: rrset[0].Header().Ttl,
+			},
+			TypeCovered: rrset[0].Header().Rrtype,
+			Algorithm:   dns.ECDSAP256SHA256,
+			OrigTtl:     rrset[0].Header().Ttl,
+			Expiration:  uint32(now.Add(time.Hour).Unix()),  //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+			Inception:   uint32(now.Add(-time.Hour).Unix()), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+			KeyTag:      az.Key.KeyTag(),
+			SignerName:  ".",
+		}
+		if err := sig.Sign(az.Priv.(*ecdsa.PrivateKey), rrset); err != nil {
+			t.Fatalf("attacker sign: %v", err)
+		}
+		return sig
+	}
+
+	var dnskeySet []dns.RR
+	for _, rr := range forged {
+		if rr.Header().Rrtype == dns.TypeDNSKEY {
+			dnskeySet = append(dnskeySet, rr)
+		}
+	}
+	forged = append(forged, sign(dnskeySet))
+
+	digest, err := ComputeDigest(forged, ".")
+	if err != nil {
+		t.Fatalf("forged digest: %v", err)
+	}
+	zonemd := &dns.ZONEMD{
+		Hdr:    dns.RR_Header{Name: ".", Rrtype: dns.TypeZONEMD, Class: dns.ClassINET, Ttl: 86400},
+		Serial: roottest.Serial,
+		Scheme: zonemdSchemeSimple,
+		Hash:   zonemdHashSHA384,
+		Digest: hex.EncodeToString(digest),
+	}
+	forged = append(forged, zonemd, sign([]dns.RR{zonemd}))
+
+	// The anchor is the victim's DS, and the forged zone carries the key
+	// that matches it — the zone must still be refused, because that key
+	// signed nothing here.
+	if err := verifyZone(forged, victim.anchors); err == nil {
+		t.Fatal("a zone signed by a foreign key was accepted because the anchor-matching key rode along unsigned")
+	}
+}
+
+// TestManagerRefusesSerialRollback pins RFC 1982 acceptance: an older,
+// validly signed zone replayed at the manager cannot displace a newer copy
+// — neither through Load nor by a probe steering a transfer. Without it a
+// captured older root, still correctly signed for its day, could be fed
+// back to reinstate withdrawn delegations and restart the expire horizon.
+func TestManagerRefusesSerialRollback(t *testing.T) {
+	newer, err := roottest.Build(ComputeDigest)
+	if err != nil {
+		t.Fatalf("newer zone: %v", err)
+	}
+	// The same key signs both, so the replay is a genuine rollback within
+	// one trust world rather than a chain failure.
+	older, err := roottest.BuildZoneWithKey(
+		ComputeDigest,
+		roottest.DefaultLines(roottest.Serial-10),
+		roottest.Serial-10,
+		newer.Key,
+		newer.Priv,
+	)
+	if err != nil {
+		t.Fatalf("older zone: %v", err)
+	}
+
+	m := New(nil, func() []dns.RR { return newer.Anchors })
+	if err := m.Load(newer.RRs); err != nil {
+		t.Fatalf("load newer: %v", err)
+	}
+	// Sanity: the older zone is itself perfectly valid — it is refused for
+	// being older, not for being unverifiable.
+	if err := verifyZone(older.RRs, newer.Anchors); err != nil {
+		t.Fatalf("the older zone must verify on its own merits: %v", err)
+	}
+	if err := m.Load(older.RRs); err == nil {
+		t.Fatal("an older serial displaced the live copy")
+	}
+	if got := m.Active().Serial(); got != roottest.Serial {
+		t.Fatalf("active serial = %d, want the newer %d", got, roottest.Serial)
+	}
+
+	// A source advertising the older serial must be skipped whole: nothing
+	// it could transfer is acceptable, so it is not transferred from.
+	transfers := 0
+	m.probeFn = func(context.Context, string, time.Duration) (uint32, error) {
+		return roottest.Serial - 10, nil
+	}
+	m.transferFn = func(context.Context, string, time.Duration) ([]dns.RR, error) {
+		transfers++
+		return older.RRs, nil
+	}
+	if err := m.refreshOnce(context.Background()); err == nil {
+		t.Fatal("a rollback-advertising source reported success")
+	}
+	if transfers != 0 {
+		t.Fatalf("a rollback-advertising source was transferred from (%d times)", transfers)
+	}
+	if got := m.Active().Serial(); got != roottest.Serial {
+		t.Fatalf("active serial = %d after the rollback attempt, want %d", got, roottest.Serial)
+	}
+}
+
+// TestSerialNewer pins the RFC 1982 comparison itself, wrap included.
+func TestSerialNewer(t *testing.T) {
+	cases := []struct {
+		a, b uint32
+		want bool
+	}{
+		{1, 2, true},
+		{2, 1, false},
+		{1, 1, false},
+		{0xFFFFFFFF, 0, true},           // wrap forward
+		{0, 0xFFFFFFFF, false},          // wrap backward
+		{2026082401, 2026082400, false}, // a real rollback by one
+	}
+	for _, c := range cases {
+		if got := serialNewer(c.a, c.b); got != c.want {
+			t.Fatalf("serialNewer(%d, %d) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}

--- a/middleware/resolver/localroot/adversarial_test.go
+++ b/middleware/resolver/localroot/adversarial_test.go
@@ -510,6 +510,10 @@ func TestRefreshRejectsTransferBehindProbe(t *testing.T) {
 	root := buildTestRoot(t)
 
 	m := New([]string{"stale.test:53", "honest.test:53"}, func() []dns.RR { return root.anchors })
+	// Start the walk at the stale source: the refresh rotates its starting
+	// point across the list, and this test is about what happens when the
+	// dishonest one is reached, not about which one that is.
+	m.sourceOffset.Store(0)
 	if err := m.Load(root.rrs); err != nil {
 		t.Fatalf("seed load: %v", err)
 	}

--- a/middleware/resolver/localroot/adversarial_test.go
+++ b/middleware/resolver/localroot/adversarial_test.go
@@ -299,3 +299,71 @@ func TestDSAnswerRequiresProvableNODATA(t *testing.T) {
 		t.Fatalf("the honest unsigned delegation must prove NODATA: ok=%v nsec=%d", ok, len(nsec))
 	}
 }
+
+// TestVerifyZoneAcceptsUniqueTupleBesideDuplicates pins the scope of the
+// duplicate rule. RFC 8976 §4 disqualifies "those ZONEMD RRs" that repeat a
+// tuple — not the zone — and §4 step 5 adds that "a match using any one of
+// the recipient's supported Schemes and Hash Algorithms is sufficient to
+// verify the zone". So a zone carrying a repeated *unsupported* tuple
+// alongside a sound unique SIMPLE/SHA-384 record still verifies through the
+// latter; rejecting it outright would let a malformed record nobody uses
+// deny an otherwise valid zone.
+func TestVerifyZoneAcceptsUniqueTupleBesideDuplicates(t *testing.T) {
+	z, err := roottest.Build(ComputeDigest)
+	if err != nil {
+		t.Fatalf("roottest.Build: %v", err)
+	}
+
+	var (
+		base   []dns.RR
+		simple *dns.ZONEMD
+	)
+	for _, rr := range z.RRs {
+		if md, ok := rr.(*dns.ZONEMD); ok {
+			simple = md
+			continue
+		}
+		if sig, ok := rr.(*dns.RRSIG); ok && sig.TypeCovered == dns.TypeZONEMD {
+			continue
+		}
+		base = append(base, rr)
+	}
+	if simple == nil {
+		t.Fatal("built zone has no apex ZONEMD")
+	}
+
+	// Two records sharing an unsupported tuple, beside the sound one.
+	unsupportedA := dns.Copy(simple).(*dns.ZONEMD)
+	unsupportedA.Scheme = 240 // private-use scheme this build does not implement
+	unsupportedA.Hash = 240
+	unsupportedA.Digest = strings.Repeat("11", sha512.Size384)
+	unsupportedB := dns.Copy(unsupportedA).(*dns.ZONEMD)
+	unsupportedB.Digest = strings.Repeat("22", sha512.Size384)
+
+	set := []dns.RR{simple, unsupportedA, unsupportedB}
+	now := time.Now()
+	sig := &dns.RRSIG{
+		Hdr: dns.RR_Header{
+			Name: ".", Rrtype: dns.TypeRRSIG,
+			Class: dns.ClassINET, Ttl: simple.Hdr.Ttl,
+		},
+		TypeCovered: dns.TypeZONEMD,
+		Algorithm:   dns.ECDSAP256SHA256,
+		OrigTtl:     simple.Hdr.Ttl,
+		Expiration:  uint32(now.Add(time.Hour).Unix()),  //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+		Inception:   uint32(now.Add(-time.Hour).Unix()), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+		KeyTag:      z.Key.KeyTag(),
+		SignerName:  ".",
+	}
+	if err := sig.Sign(z.Priv.(*ecdsa.PrivateKey), set); err != nil {
+		t.Fatalf("sign the ZONEMD RRset: %v", err)
+	}
+
+	mixed := make([]dns.RR, 0, len(base)+4)
+	mixed = append(mixed, base...)
+	mixed = append(mixed, simple, unsupportedA, unsupportedB, sig)
+
+	if err := verifyZone(mixed, z.Anchors); err != nil {
+		t.Fatalf("a sound unique tuple beside duplicated unsupported ones must verify: %v", err)
+	}
+}

--- a/middleware/resolver/localroot/adversarial_test.go
+++ b/middleware/resolver/localroot/adversarial_test.go
@@ -3,7 +3,9 @@ package localroot
 import (
 	"context"
 	"crypto/ecdsa"
+	"crypto/sha512"
 	"encoding/hex"
+	"strings"
 	"testing"
 	"time"
 
@@ -181,5 +183,119 @@ func TestSerialNewer(t *testing.T) {
 		if got := serialNewer(c.a, c.b); got != c.want {
 			t.Fatalf("serialNewer(%d, %d) = %v, want %v", c.a, c.b, got, c.want)
 		}
+	}
+}
+
+// TestVerifyZoneRefusesDuplicateZONEMDTuple pins RFC 8976 §4 step 4: "When
+// multiple ZONEMD RRs are present, each MUST specify a unique Scheme and
+// Hash Algorithm tuple." The duplicate here is validly signed as part of
+// the ZONEMD RRset and does not disturb the digest (apex ZONEMD records are
+// excluded from it), so nothing else in the chain can catch it — only the
+// uniqueness rule stands between a malformed RRset and a verifier that
+// takes whichever digest it happens to read first.
+func TestVerifyZoneRefusesDuplicateZONEMDTuple(t *testing.T) {
+	z, err := roottest.Build(ComputeDigest)
+	if err != nil {
+		t.Fatalf("roottest.Build: %v", err)
+	}
+
+	var (
+		base  []dns.RR
+		first *dns.ZONEMD
+	)
+	for _, rr := range z.RRs {
+		if md, ok := rr.(*dns.ZONEMD); ok {
+			first = md
+			continue
+		}
+		if sig, ok := rr.(*dns.RRSIG); ok && sig.TypeCovered == dns.TypeZONEMD {
+			continue
+		}
+		base = append(base, rr)
+	}
+	if first == nil {
+		t.Fatal("built zone has no apex ZONEMD")
+	}
+
+	// A second record with the same scheme/hash tuple, carrying a digest an
+	// attacker (or a broken signer) chose.
+	second := dns.Copy(first).(*dns.ZONEMD)
+	second.Digest = strings.Repeat("ab", sha512.Size384)
+
+	set := []dns.RR{first, second}
+	now := time.Now()
+	sig := &dns.RRSIG{
+		Hdr: dns.RR_Header{
+			Name: ".", Rrtype: dns.TypeRRSIG,
+			Class: dns.ClassINET, Ttl: first.Hdr.Ttl,
+		},
+		TypeCovered: dns.TypeZONEMD,
+		Algorithm:   dns.ECDSAP256SHA256,
+		OrigTtl:     first.Hdr.Ttl,
+		Expiration:  uint32(now.Add(time.Hour).Unix()),  //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+		Inception:   uint32(now.Add(-time.Hour).Unix()), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+		KeyTag:      z.Key.KeyTag(),
+		SignerName:  ".",
+	}
+	if err := sig.Sign(z.Priv.(*ecdsa.PrivateKey), set); err != nil {
+		t.Fatalf("sign the two-record ZONEMD RRset: %v", err)
+	}
+
+	dup := make([]dns.RR, 0, len(base)+3)
+	dup = append(dup, base...)
+	dup = append(dup, first, second, sig)
+	if err := verifyZone(dup, z.Anchors); err == nil {
+		t.Fatal("a repeated ZONEMD scheme/hash tuple verified")
+	}
+
+	// Sanity: the same zone with the single original ZONEMD still verifies,
+	// so the refusal above is the duplicate rule and nothing else.
+	if err := verifyZone(z.RRs, z.Anchors); err != nil {
+		t.Fatalf("the unmodified zone must still verify: %v", err)
+	}
+}
+
+// TestDSAnswerRequiresProvableNODATA pins the unsigned-delegation proof: an
+// exact-owner NSEC denies DS only when its type bitmap says so. A bitmap
+// asserting DS contradicts the missing record — a truncated index, or a
+// zone the copy did not fully hold — and must not be dressed as an
+// authenticated NODATA.
+func TestDSAnswerRequiresProvableNODATA(t *testing.T) {
+	// org. has no DS record, but its NSEC claims the type exists.
+	lines := []string{
+		". 86400 IN SOA a.root-servers.test. nstld.test. 2026082401 1800 900 604800 86400",
+		". 518400 IN NS a.root-servers.test.",
+		". 86400 IN NSEC org. NS SOA RRSIG NSEC DNSKEY ZONEMD",
+		"org. 172800 IN NS ns.org.",
+		"org. 86400 IN NSEC . NS DS RRSIG NSEC",
+		"ns.org. 172800 IN A 198.51.100.2",
+	}
+	z, err := roottest.BuildZone(ComputeDigest, lines, roottest.Serial)
+	if err != nil {
+		t.Fatalf("build zone: %v", err)
+	}
+	if err := verifyZone(z.RRs, z.Anchors); err != nil {
+		t.Fatalf("the zone itself must verify — the defect is semantic: %v", err)
+	}
+	snap, err := buildSnapshot(z.RRs, time.Now())
+	if err != nil {
+		t.Fatalf("buildSnapshot: %v", err)
+	}
+
+	if _, _, _, _, ok := snap.DSAnswer("org."); ok {
+		t.Fatal("an NSEC whose bitmap asserts DS was served as a DS NODATA proof")
+	}
+
+	// The honest shape still answers: bitmap without DS proves the absence.
+	honest, err := roottest.Build(ComputeDigest)
+	if err != nil {
+		t.Fatalf("roottest.Build: %v", err)
+	}
+	honestSnap, err := buildSnapshot(honest.RRs, time.Now())
+	if err != nil {
+		t.Fatalf("buildSnapshot: %v", err)
+	}
+	if _, _, nsec, _, ok := honestSnap.DSAnswer("org."); !ok || len(nsec) != 1 {
+		t.Fatalf("the honest unsigned delegation must prove NODATA: ok=%v nsec=%d", ok, len(nsec))
 	}
 }

--- a/middleware/resolver/localroot/adversarial_test.go
+++ b/middleware/resolver/localroot/adversarial_test.go
@@ -771,3 +771,69 @@ func TestApexSignatureOrderPicksTheLatestVerifying(t *testing.T) {
 		t.Fatalf("authenticated until %v, want the longer sound signature's %v", authUntil, want)
 	}
 }
+
+// TestApexSignatureDedupeKeepsDistinctSignatures pins what "the same
+// signature" means. Deduplication exists to keep a flood of identical
+// copies from spending the attempt budget, but every field an RRSIG signs
+// over is part of its identity: two records differing in one of them sign
+// different data, so one may verify where the other cannot. Dedupe on less
+// and a sound signature is discarded as a copy of the unsound sibling that
+// happened to arrive first — the flood then succeeds by resemblance where
+// it could not succeed by volume.
+func TestApexSignatureDedupeKeepsDistinctSignatures(t *testing.T) {
+	z, err := roottest.Build(ComputeDigest)
+	if err != nil {
+		t.Fatalf("roottest.Build: %v", err)
+	}
+
+	var (
+		base  []dns.RR
+		sound *dns.RRSIG
+	)
+	for _, rr := range z.RRs {
+		if sig, ok := rr.(*dns.RRSIG); ok && sig.TypeCovered == dns.TypeZONEMD {
+			sound = sig
+			continue
+		}
+		base = append(base, rr)
+	}
+	if sound == nil {
+		t.Fatal("built zone has no RRSIG(ZONEMD)")
+	}
+
+	// One decoy per field that the previous, narrower identity ignored and
+	// that a decoy can actually vary here. Each carries the sound
+	// signature's bytes and window, so a dedupe key missing that field
+	// sees a duplicate and drops the sound record.
+	//
+	// The owner name is deliberately absent. Moving it off the apex takes
+	// the record out of the set this function is handed, and — because
+	// only apex RRSIG(ZONEMD) records are excluded from the digest — puts
+	// it into the digest instead, where the mismatch refuses the zone
+	// outright. That field is guarded by a different mechanism, not this
+	// one, and asserting it here would be asserting the wrong defense.
+	for _, tc := range []struct {
+		field  string
+		mangle func(*dns.RRSIG)
+	}{
+		{"OrigTtl", func(s *dns.RRSIG) { s.OrigTtl++ }},
+		{"Labels", func(s *dns.RRSIG) { s.Labels++ }},
+		{"SignerName", func(s *dns.RRSIG) { s.SignerName = "example." }},
+		{"class", func(s *dns.RRSIG) { s.Hdr.Class = dns.ClassCHAOS }},
+	} {
+		t.Run(tc.field, func(t *testing.T) {
+			decoy := dns.Copy(sound).(*dns.RRSIG)
+			tc.mangle(decoy)
+
+			// The decoy first, so a collision would discard the sound one.
+			withDecoy := make([]dns.RR, 0, len(base)+2)
+			withDecoy = append(withDecoy, base...)
+			withDecoy = append(withDecoy, decoy, sound)
+
+			if _, err := verifyZone(withDecoy, z.Anchors); err != nil {
+				t.Fatalf("a sound zone was refused because a sibling differing only "+
+					"in %s was treated as the same signature: %v", tc.field, err)
+			}
+		})
+	}
+}

--- a/middleware/resolver/localroot/adversarial_test.go
+++ b/middleware/resolver/localroot/adversarial_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/base64"
 	"encoding/binary"
 	"encoding/hex"
+	"errors"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -835,5 +836,80 @@ func TestApexSignatureDedupeKeepsDistinctSignatures(t *testing.T) {
 					"in %s was treated as the same signature: %v", tc.field, err)
 			}
 		})
+	}
+}
+
+// TestApexCardinalityIsBounded pins the other half of the work bound.
+// Capping how many signatures are tried does not cap what each attempt
+// costs: a verification hashes the entire RRset it covers, and every key is
+// digested once per trust anchor. So an inflated apex DNSKEY or ZONEMD
+// RRset turns transfer bytes into cryptographic work no matter how few
+// signatures are examined, and the refusal has to come before any of it.
+func TestApexCardinalityIsBounded(t *testing.T) {
+	z, err := roottest.Build(ComputeDigest)
+	if err != nil {
+		t.Fatalf("roottest.Build: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name string
+		bulk func(base []dns.RR) []dns.RR
+	}{
+		{"DNSKEY", func(base []dns.RR) []dns.RR {
+			out := base
+			for i := range maxApexRecords + 1 {
+				k := &dns.DNSKEY{
+					Hdr: dns.RR_Header{
+						Name: ".", Rrtype: dns.TypeDNSKEY,
+						Class: dns.ClassINET, Ttl: 172800,
+					},
+					Flags:     256,
+					Protocol:  3,
+					Algorithm: dns.ECDSAP256SHA256,
+					PublicKey: base64.StdEncoding.EncodeToString(
+						append([]byte{byte(i)}, make([]byte, 63)...)),
+				}
+				out = append(out, k)
+			}
+			return out
+		}},
+		{"ZONEMD", func(base []dns.RR) []dns.RR {
+			out := base
+			for i := range maxApexRecords + 1 {
+				md := &dns.ZONEMD{
+					Hdr: dns.RR_Header{
+						Name: ".", Rrtype: dns.TypeZONEMD,
+						Class: dns.ClassINET, Ttl: 86400,
+					},
+					Serial: roottest.Serial,
+					Scheme: uint8(i%200) + 2, //nolint:gosec // bounded test index
+					Hash:   uint8(i%200) + 2, //nolint:gosec // bounded test index
+					Digest: strings.Repeat("ab", sha512.Size384),
+				}
+				out = append(out, md)
+			}
+			return out
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bloated := tc.bulk(append([]dns.RR(nil), z.RRs...))
+
+			// The assertion is *which* check refused it, not merely that
+			// something did. Such a zone fails several ways — a changed
+			// DNSKEY RRset breaks the digest, a changed ZONEMD RRset breaks
+			// its signature — and every one of those verdicts costs the
+			// cryptography this cap exists to avoid. Only errApexTooLarge
+			// says the refusal came from the size check, before any of it.
+			_, err := verifyZone(bloated, z.Anchors)
+			if !errors.Is(err, errApexTooLarge) {
+				t.Fatalf("oversized apex refused with %v, want the size check to "+
+					"refuse it before anything is hashed", err)
+			}
+		})
+	}
+
+	// And the sound zone is nowhere near the cap.
+	if _, err := verifyZone(z.RRs, z.Anchors); err != nil {
+		t.Fatalf("an ordinary zone must be well within the cap: %v", err)
 	}
 }

--- a/middleware/resolver/localroot/manager.go
+++ b/middleware/resolver/localroot/manager.go
@@ -232,7 +232,8 @@ func (m *Manager) Load(rrs []dns.RR) error {
 // update, and accepting it would mark the refresh successful and wait a
 // full refresh interval before asking anyone again.
 func (m *Manager) load(rrs []dns.RR, expect uint32, expected bool) error {
-	if err := verifyZone(rrs, m.anchors()); err != nil {
+	authUntil, err := verifyZone(rrs, m.anchors())
+	if err != nil {
 		metricTransfers.WithLabelValues("verify_error").Inc()
 		return err
 	}
@@ -241,6 +242,9 @@ func (m *Manager) load(rrs []dns.RR, expect uint32, expected bool) error {
 		metricTransfers.WithLabelValues("build_error").Inc()
 		return err
 	}
+	// The digest is evidence only while the signature over it holds, so the
+	// copy cannot outlive that signature however long its records run.
+	snap.BoundTo(authUntil)
 	if expected && snap.serial != expect && !serialNewer(expect, snap.serial) {
 		metricTransfers.WithLabelValues("serial_behind_probe").Inc()
 		return errSerialBehindProbe

--- a/middleware/resolver/localroot/manager.go
+++ b/middleware/resolver/localroot/manager.go
@@ -3,6 +3,7 @@ package localroot
 import (
 	"context"
 	"math/rand/v2"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -47,6 +48,13 @@ var (
 	}, []string{"kind"})
 )
 
+func init() {
+	// The gauge is registered whether or not the feature is enabled, and a
+	// Prometheus gauge starts at zero — which this one's own scale reads as
+	// "transferred this instant". Start it where it belongs: no copy.
+	metricAge.Set(-1)
+}
+
 // CountReferral, CountDenial, CountDS and CountFallback attribute walk
 // consultations on the resolver side without exporting the metric vec.
 func CountReferral() { metricAnswers.WithLabelValues("referral").Inc() }
@@ -60,8 +68,10 @@ func CountDS() { metricAnswers.WithLabelValues("ds").Inc() }
 // CountApex counts a question at the root's own name answered from the copy.
 func CountApex() { metricAnswers.WithLabelValues("apex").Inc() }
 
-// CountFallback counts a root consult that fell back to the real root
-// servers because no verified copy was active.
+// CountFallback counts a root consult the copy did not answer, so the walk
+// went to the real root servers: no verified copy was active, or the copy
+// held no proof of the answer being asked for. Every consult is either an
+// answer of one kind or a fallback, so the kinds sum to the consults.
 func CountFallback() { metricAnswers.WithLabelValues("fallback").Inc() }
 
 // Manager owns the verified snapshot and its refresh lifecycle. Refresh
@@ -99,6 +109,16 @@ type Manager struct {
 // New builds a Manager over the given transfer sources (DefaultSources when
 // empty) and a trust-anchor supplier.
 func New(sources []string, anchors func() []dns.RR) *Manager {
+	// Blank entries are dropped before the emptiness test, so a config that
+	// sets the list to [""] falls back to the built-in sources instead of
+	// leaving one unusable address and silently disabling the feature.
+	usable := make([]string, 0, len(sources))
+	for _, addr := range sources {
+		if addr = strings.TrimSpace(addr); addr != "" {
+			usable = append(usable, addr)
+		}
+	}
+	sources = usable
 	if len(sources) == 0 {
 		sources = DefaultSources
 	}
@@ -173,6 +193,17 @@ func (m *Manager) Run(ctx context.Context) {
 // when no copy exists yet). Sources rotate: the probe's source is the
 // transfer's source, so a host that cannot answer is skipped whole.
 func (m *Manager) refreshOnce(ctx context.Context) error {
+	// Without anchors nothing this cycle transfers can be verified, and the
+	// refusal would come only after the zone was on the wire. Checking first
+	// costs one comparison and saves pulling a few megabytes from every
+	// source, every retry interval, for as long as the anchors stay empty —
+	// which is a state the resolver can hold indefinitely if the trust
+	// anchors fail closed.
+	if len(m.anchors()) == 0 {
+		metricTransfers.WithLabelValues("no_anchors").Inc()
+		return errNoAnchors
+	}
+
 	cur := m.snap.Load()
 
 	var lastErr error

--- a/middleware/resolver/localroot/manager.go
+++ b/middleware/resolver/localroot/manager.go
@@ -152,13 +152,20 @@ func (m *Manager) refreshOnce(ctx context.Context) error {
 				lastErr = err
 				continue
 			}
+			if serial != cur.serial && !serialNewer(cur.serial, serial) {
+				// A source advertising an older zone is skipped whole:
+				// nothing it transfers can be accepted (RFC 1982).
+				lastErr = errSerialRollback
+				continue
+			}
 			if serial == cur.serial {
-				// Current: touch nothing. The copy's expire horizon is
-				// anchored at its transfer; a probe is not a transfer.
-				// Transfer again once the copy has spent half its
-				// expire interval, so the horizon keeps moving on a
-				// healthy source well before it threatens.
-				if m.now().Sub(cur.loaded) < time.Duration(cur.soa.Expire)*time.Second/2 {
+				// Current: touch nothing. The copy's horizon — SOA expire
+				// or earliest signature expiration, whichever is nearer —
+				// is anchored at its transfer; a probe is not a transfer.
+				// Transfer again once the copy has spent half that
+				// horizon, so it keeps moving on a healthy source well
+				// before it threatens.
+				if m.now().Before(cur.loaded.Add(cur.expireAt.Sub(cur.loaded) / 2)) {
 					return nil
 				}
 			}
@@ -184,8 +191,10 @@ func (m *Manager) refreshOnce(ctx context.Context) error {
 
 // Load installs a zone copy obtained by any means, subject to the same
 // gate as a live transfer: full ZONEMD verification against the trust
-// anchors, then an atomic swap. There is no unverified path into the
-// active snapshot.
+// anchors, RFC 1982 serial acceptance against the live copy, then an
+// atomic swap. There is no unverified path into the active snapshot, and
+// no path backwards — a replayed older zone, however validly signed for
+// its day, cannot displace a newer copy or restart its expire horizon.
 func (m *Manager) Load(rrs []dns.RR) error {
 	if err := verifyZone(rrs, m.anchors()); err != nil {
 		metricTransfers.WithLabelValues("verify_error").Inc()
@@ -196,10 +205,21 @@ func (m *Manager) Load(rrs []dns.RR) error {
 		metricTransfers.WithLabelValues("build_error").Inc()
 		return err
 	}
+	if cur := m.snap.Load(); cur != nil &&
+		snap.serial != cur.serial && !serialNewer(cur.serial, snap.serial) {
+		metricTransfers.WithLabelValues("serial_rollback").Inc()
+		return errSerialRollback
+	}
 	m.snap.Store(snap)
 	metricTransfers.WithLabelValues("success").Inc()
 	zlog.Info("Local root zone updated", "serial", snap.serial, "records", len(rrs))
 	return nil
+}
+
+// serialNewer reports whether b is newer than a in RFC 1982 serial
+// arithmetic (the SOA serial's number space).
+func serialNewer(a, b uint32) bool {
+	return (b > a && b-a < 1<<31) || (b < a && a-b > 1<<31)
 }
 
 // jitter spreads d by ±10% so a fleet restarted together does not probe the

--- a/middleware/resolver/localroot/manager.go
+++ b/middleware/resolver/localroot/manager.go
@@ -57,6 +57,9 @@ func CountDenial() { metricAnswers.WithLabelValues("denial").Inc() }
 // CountDS counts a DS answer served from the local copy.
 func CountDS() { metricAnswers.WithLabelValues("ds").Inc() }
 
+// CountApex counts a question at the root's own name answered from the copy.
+func CountApex() { metricAnswers.WithLabelValues("apex").Inc() }
+
 // CountFallback counts a root consult that fell back to the real root
 // servers because no verified copy was active.
 func CountFallback() { metricAnswers.WithLabelValues("fallback").Inc() }

--- a/middleware/resolver/localroot/manager.go
+++ b/middleware/resolver/localroot/manager.go
@@ -1,0 +1,213 @@
+package localroot
+
+import (
+	"context"
+	"math/rand/v2"
+	"sync/atomic"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/semihalev/zlog/v2"
+)
+
+// DefaultSources are the root servers and ICANN hosts that publish the root
+// zone over AXFR (RFC 8806 appendix A).
+var DefaultSources = []string{
+	"b.root-servers.net:53",
+	"c.root-servers.net:53",
+	"f.root-servers.net:53",
+	"g.root-servers.net:53",
+	"k.root-servers.net:53",
+	"xfr.cjr.dns.icann.org:53",
+	"xfr.lax.dns.icann.org:53",
+}
+
+var (
+	metricAge = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "dns_localroot_copy_age_seconds",
+		Help: "Age of the active local root zone copy; -1 when none is active",
+	})
+	metricTransfers = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "dns_localroot_transfers_total",
+		Help: "Root zone transfer attempts by outcome",
+	}, []string{"outcome"})
+	metricAnswers = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "dns_localroot_answers_total",
+		Help: "Walk consultations answered from the local root copy",
+	}, []string{"kind"})
+)
+
+// CountReferral, CountDenial, CountDS and CountFallback attribute walk
+// consultations on the resolver side without exporting the metric vec.
+func CountReferral() { metricAnswers.WithLabelValues("referral").Inc() }
+
+// CountDenial counts an NXDOMAIN synthesized from the local copy.
+func CountDenial() { metricAnswers.WithLabelValues("denial").Inc() }
+
+// CountDS counts a DS answer served from the local copy.
+func CountDS() { metricAnswers.WithLabelValues("ds").Inc() }
+
+// CountFallback counts a root consult that fell back to the real root
+// servers because no verified copy was active.
+func CountFallback() { metricAnswers.WithLabelValues("fallback").Inc() }
+
+// Manager owns the verified snapshot and its refresh lifecycle. Refresh
+// follows the zone's own SOA schedule (RFC 8806 defers to RFC 1035
+// secondary semantics): probe the serial every REFRESH seconds, fall to
+// RETRY on failure, and never serve a copy past EXPIRE — Active goes nil
+// and the resolver walks to the real roots.
+type Manager struct {
+	sources []string
+	anchors func() []dns.RR // trust anchors as a DS set; empty = cannot verify
+	timeout time.Duration
+
+	snap atomic.Pointer[Snapshot]
+
+	// now/transferFn/probeFn are the test seams; production uses the
+	// package functions and the wall clock.
+	now        func() time.Time
+	transferFn func(ctx context.Context, addr string, timeout time.Duration) ([]dns.RR, error)
+	probeFn    func(ctx context.Context, addr string, timeout time.Duration) (uint32, error)
+}
+
+// New builds a Manager over the given transfer sources (DefaultSources when
+// empty) and a trust-anchor supplier.
+func New(sources []string, anchors func() []dns.RR) *Manager {
+	if len(sources) == 0 {
+		sources = DefaultSources
+	}
+	return &Manager{
+		sources:    sources,
+		anchors:    anchors,
+		timeout:    30 * time.Second,
+		now:        time.Now,
+		transferFn: axfr,
+		probeFn:    probeSerial,
+	}
+}
+
+// Active returns the verified snapshot to serve from, or nil when there is
+// none — never transferred, or the copy has outlived its SOA expire.
+func (m *Manager) Active() *Snapshot {
+	s := m.snap.Load()
+	if s == nil || s.Expired(m.now()) {
+		return nil
+	}
+	return s
+}
+
+// Run drives the refresh loop until ctx is cancelled. The first transfer is
+// attempted immediately; afterwards the loop probes the serial on the SOA
+// refresh interval (jittered ±10%) and transfers only on change, retrying
+// on the SOA retry interval after any failure.
+func (m *Manager) Run(ctx context.Context) {
+	const (
+		fallbackRefresh = 30 * time.Minute
+		fallbackRetry   = 15 * time.Minute
+	)
+
+	next := time.Duration(0) // immediate first attempt
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(jitter(next)):
+		}
+
+		cur := m.snap.Load()
+		refresh, retry := fallbackRefresh, fallbackRetry
+		if cur != nil {
+			refresh = time.Duration(cur.soa.Refresh) * time.Second
+			retry = time.Duration(cur.soa.Retry) * time.Second
+		}
+
+		if err := m.refreshOnce(ctx); err != nil {
+			zlog.Warn("Local root refresh failed", "error", err.Error())
+			next = retry
+		} else {
+			next = refresh
+		}
+
+		if s := m.Active(); s != nil {
+			metricAge.Set(m.now().Sub(s.Loaded()).Seconds())
+		} else {
+			metricAge.Set(-1)
+		}
+	}
+}
+
+// refreshOnce probes for a serial change and transfers when one is seen (or
+// when no copy exists yet). Sources rotate: the probe's source is the
+// transfer's source, so a host that cannot answer is skipped whole.
+func (m *Manager) refreshOnce(ctx context.Context) error {
+	cur := m.snap.Load()
+
+	var lastErr error
+	for _, addr := range m.sources {
+		if cur != nil {
+			serial, err := m.probeFn(ctx, addr, m.timeout)
+			if err != nil {
+				lastErr = err
+				continue
+			}
+			if serial == cur.serial {
+				// Current: touch nothing. The copy's expire horizon is
+				// anchored at its transfer; a probe is not a transfer.
+				// Transfer again once the copy has spent half its
+				// expire interval, so the horizon keeps moving on a
+				// healthy source well before it threatens.
+				if m.now().Sub(cur.loaded) < time.Duration(cur.soa.Expire)*time.Second/2 {
+					return nil
+				}
+			}
+		}
+
+		rrs, err := m.transferFn(ctx, addr, m.timeout)
+		if err != nil {
+			lastErr = err
+			metricTransfers.WithLabelValues("transfer_error").Inc()
+			continue
+		}
+		if err := m.Load(rrs); err != nil {
+			lastErr = err
+			continue
+		}
+		return nil
+	}
+	if lastErr == nil {
+		lastErr = errTransferShape
+	}
+	return lastErr
+}
+
+// Load installs a zone copy obtained by any means, subject to the same
+// gate as a live transfer: full ZONEMD verification against the trust
+// anchors, then an atomic swap. There is no unverified path into the
+// active snapshot.
+func (m *Manager) Load(rrs []dns.RR) error {
+	if err := verifyZone(rrs, m.anchors()); err != nil {
+		metricTransfers.WithLabelValues("verify_error").Inc()
+		return err
+	}
+	snap, err := buildSnapshot(rrs, m.now())
+	if err != nil {
+		metricTransfers.WithLabelValues("build_error").Inc()
+		return err
+	}
+	m.snap.Store(snap)
+	metricTransfers.WithLabelValues("success").Inc()
+	zlog.Info("Local root zone updated", "serial", snap.serial, "records", len(rrs))
+	return nil
+}
+
+// jitter spreads d by ±10% so a fleet restarted together does not probe the
+// same source in the same second forever.
+func jitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 0
+	}
+	spread := int64(d / 10)
+	return d - time.Duration(spread) + time.Duration(rand.Int64N(2*spread+1)) //nolint:gosec // schedule jitter, not key material.
+}

--- a/middleware/resolver/localroot/manager.go
+++ b/middleware/resolver/localroot/manager.go
@@ -38,6 +38,10 @@ var (
 		Name: "dns_localroot_copy_age_seconds",
 		Help: "Age of the active local root zone copy; -1 when none is active",
 	})
+	metricSerial = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "dns_localroot_serial",
+		Help: "SOA serial of the active local root zone copy; -1 when none is active",
+	})
 	metricTransfers = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "dns_localroot_transfers_total",
 		Help: "Root zone transfer attempts by outcome",
@@ -49,10 +53,12 @@ var (
 )
 
 func init() {
-	// The gauge is registered whether or not the feature is enabled, and a
-	// Prometheus gauge starts at zero — which this one's own scale reads as
-	// "transferred this instant". Start it where it belongs: no copy.
+	// Both gauges are registered whether or not the feature is enabled, and a
+	// Prometheus gauge starts at zero — which on these scales reads as
+	// "transferred this instant" and "serial 0". Start them where they
+	// belong: no copy.
 	metricAge.Set(-1)
+	metricSerial.Set(-1)
 }
 
 // CountReferral, CountDenial, CountDS and CountFallback attribute walk
@@ -181,12 +187,23 @@ func (m *Manager) Run(ctx context.Context) {
 			next = refresh
 		}
 
-		if s := m.Active(); s != nil {
-			metricAge.Set(m.now().Sub(s.Loaded()).Seconds())
-		} else {
-			metricAge.Set(-1)
-		}
+		age, serial := m.observe()
+		metricAge.Set(age)
+		metricSerial.Set(serial)
 	}
+}
+
+// observe reports what the gauges should say about the copy right now: its
+// age in seconds and its SOA serial, or -1 for both when no copy is active.
+// The two travel together — an age without a serial cannot tell a fleet
+// whether its nodes converged on the same zone, and a serial without an age
+// cannot tell whether the copy behind it is still moving.
+func (m *Manager) observe() (age, serial float64) {
+	s := m.Active()
+	if s == nil {
+		return -1, -1
+	}
+	return m.now().Sub(s.Loaded()).Seconds(), float64(s.serial)
 }
 
 // refreshOnce probes for a serial change and transfers when one is seen (or

--- a/middleware/resolver/localroot/manager.go
+++ b/middleware/resolver/localroot/manager.go
@@ -18,6 +18,7 @@ import (
 var DefaultSources = []string{
 	"b.root-servers.net:53",
 	"c.root-servers.net:53",
+	"d.root-servers.net:53",
 	"f.root-servers.net:53",
 	"g.root-servers.net:53",
 	"k.root-servers.net:53",
@@ -160,12 +161,20 @@ func (m *Manager) refreshOnce(ctx context.Context) error {
 
 	var lastErr error
 	for _, addr := range m.sources {
+		// probed carries what this source announced into the acceptance
+		// check below, so the transfer is measured against the source's
+		// own claim and not only against what is already installed.
+		var (
+			probed     uint32
+			haveProbed bool
+		)
 		if cur != nil {
 			serial, err := m.probeFn(ctx, addr, m.timeout)
 			if err != nil {
 				lastErr = err
 				continue
 			}
+			probed, haveProbed = serial, true
 			if serial != cur.serial && !serialNewer(cur.serial, serial) {
 				// A source advertising an older zone is skipped whole:
 				// nothing it transfers can be accepted (RFC 1982).
@@ -191,7 +200,11 @@ func (m *Manager) refreshOnce(ctx context.Context) error {
 			metricTransfers.WithLabelValues("transfer_error").Inc()
 			continue
 		}
-		if err := m.Load(rrs); err != nil {
+		// A source that announced a serial must deliver it. Failing over
+		// to the next source is the point: the alternative is calling the
+		// refresh a success and sleeping through a full interval on a copy
+		// the source itself said was stale.
+		if err := m.load(rrs, probed, haveProbed); err != nil {
 			lastErr = err
 			continue
 		}
@@ -210,6 +223,15 @@ func (m *Manager) refreshOnce(ctx context.Context) error {
 // no path backwards — a replayed older zone, however validly signed for
 // its day, cannot displace a newer copy or restart its expire horizon.
 func (m *Manager) Load(rrs []dns.RR) error {
+	return m.load(rrs, 0, false)
+}
+
+// load is Load with the serial a probe advertised, when there was one.
+// The transfer must deliver at least the zone the source announced: a
+// source that advertises N+1 and then hands back N has not delivered the
+// update, and accepting it would mark the refresh successful and wait a
+// full refresh interval before asking anyone again.
+func (m *Manager) load(rrs []dns.RR, expect uint32, expected bool) error {
 	if err := verifyZone(rrs, m.anchors()); err != nil {
 		metricTransfers.WithLabelValues("verify_error").Inc()
 		return err
@@ -218,6 +240,10 @@ func (m *Manager) Load(rrs []dns.RR) error {
 	if err != nil {
 		metricTransfers.WithLabelValues("build_error").Inc()
 		return err
+	}
+	if expected && snap.serial != expect && !serialNewer(expect, snap.serial) {
+		metricTransfers.WithLabelValues("serial_behind_probe").Inc()
+		return errSerialBehindProbe
 	}
 
 	m.publish.Lock()

--- a/middleware/resolver/localroot/manager.go
+++ b/middleware/resolver/localroot/manager.go
@@ -13,6 +13,12 @@ import (
 	"github.com/semihalev/zlog/v2"
 )
 
+// initialTransferDelay is how long the first transfer holds off after
+// startup, before jitter widens it. Long enough for a cold resolver to
+// prime, refresh its anchors and answer its first queries without sharing
+// the link; short enough that the copy is serving within seconds.
+const initialTransferDelay = 10 * time.Second
+
 // DefaultSources are the root servers and ICANN hosts that publish the root
 // zone over AXFR (RFC 8806 appendix A).
 var DefaultSources = []string{
@@ -123,7 +129,14 @@ func (m *Manager) Run(ctx context.Context) {
 		fallbackRetry   = 15 * time.Minute
 	)
 
-	next := time.Duration(0) // immediate first attempt
+	// The first transfer waits out the resolver's own cold start rather
+	// than racing it. A couple of megabytes pulled over TCP while the
+	// priming query, the trust-anchor refresh and the first client queries
+	// are all in flight measurably slows them on a modest link — and the
+	// copy is an optimization, so it should yield to the path it exists to
+	// make faster. The jitter also keeps a fleet restarted together from
+	// asking one transfer source for the zone in the same second.
+	next := initialTransferDelay
 	for {
 		select {
 		case <-ctx.Done():

--- a/middleware/resolver/localroot/manager.go
+++ b/middleware/resolver/localroot/manager.go
@@ -3,6 +3,7 @@ package localroot
 import (
 	"context"
 	"math/rand/v2"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -64,12 +65,25 @@ type Manager struct {
 	timeout time.Duration
 
 	snap atomic.Pointer[Snapshot]
+	// publish serializes the serial check and the swap in Load. The atomic
+	// pointer keeps Active() lock-free on the read side, but the two steps
+	// together are one decision: without this, two loads that both observe
+	// an older serial can each pass the check and store in the opposite
+	// order, quietly rolling the copy backwards — a sequence no race
+	// detector reports, because every individual operation is legal.
+	publish sync.Mutex
 
 	// now/transferFn/probeFn are the test seams; production uses the
 	// package functions and the wall clock.
 	now        func() time.Time
 	transferFn func(ctx context.Context, addr string, timeout time.Duration) ([]dns.RR, error)
 	probeFn    func(ctx context.Context, addr string, timeout time.Duration) (uint32, error)
+	// afterSerialCheck runs between the rollback check and the swap, nil in
+	// production. The window it widens is a few instructions wide, which is
+	// exactly why the ordering bug it guards against is invisible to both
+	// the race detector and to volume testing: a test needs to hold the
+	// section open to prove the section is exclusive.
+	afterSerialCheck func()
 }
 
 // New builds a Manager over the given transfer sources (DefaultSources when
@@ -205,10 +219,16 @@ func (m *Manager) Load(rrs []dns.RR) error {
 		metricTransfers.WithLabelValues("build_error").Inc()
 		return err
 	}
+
+	m.publish.Lock()
+	defer m.publish.Unlock()
 	if cur := m.snap.Load(); cur != nil &&
 		snap.serial != cur.serial && !serialNewer(cur.serial, snap.serial) {
 		metricTransfers.WithLabelValues("serial_rollback").Inc()
 		return errSerialRollback
+	}
+	if m.afterSerialCheck != nil {
+		m.afterSerialCheck()
 	}
 	m.snap.Store(snap)
 	metricTransfers.WithLabelValues("success").Inc()

--- a/middleware/resolver/localroot/manager.go
+++ b/middleware/resolver/localroot/manager.go
@@ -2,7 +2,9 @@ package localroot
 
 import (
 	"context"
+	"crypto/sha256"
 	"math/rand/v2"
+	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -33,14 +35,36 @@ var DefaultSources = []string{
 	"xfr.lax.dns.icann.org:53",
 }
 
+// serving is the manager driving the refresh loop, which is the one the
+// gauges below describe. Set when Run starts; nil in a process where the
+// feature is off, and in tests, which drive a manager directly.
+var serving atomic.Pointer[Manager]
+
+// observed reports what the live copy looks like at scrape time, or -1 when
+// there is nothing to describe. Reading at scrape rather than writing on
+// refresh is what keeps the age honest: the refresh loop wakes on the zone's
+// SOA schedule, so a pushed value would sit frozen for up to a refresh
+// interval and read as though the copy had just arrived.
+func observed(pick func(age, serial float64) float64) float64 {
+	m := serving.Load()
+	if m == nil {
+		return -1
+	}
+	return pick(m.observe())
+}
+
 var (
-	metricAge = promauto.NewGauge(prometheus.GaugeOpts{
+	_ = promauto.NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "dns_localroot_copy_age_seconds",
 		Help: "Age of the active local root zone copy; -1 when none is active",
+	}, func() float64 {
+		return observed(func(age, _ float64) float64 { return age })
 	})
-	metricSerial = promauto.NewGauge(prometheus.GaugeOpts{
+	_ = promauto.NewGaugeFunc(prometheus.GaugeOpts{
 		Name: "dns_localroot_serial",
 		Help: "SOA serial of the active local root zone copy; -1 when none is active",
+	}, func() float64 {
+		return observed(func(_, serial float64) float64 { return serial })
 	})
 	metricTransfers = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "dns_localroot_transfers_total",
@@ -51,15 +75,6 @@ var (
 		Help: "Walk consultations answered from the local root copy",
 	}, []string{"kind"})
 )
-
-func init() {
-	// Both gauges are registered whether or not the feature is enabled, and a
-	// Prometheus gauge starts at zero — which on these scales reads as
-	// "transferred this instant" and "serial 0". Start them where they
-	// belong: no copy.
-	metricAge.Set(-1)
-	metricSerial.Set(-1)
-}
 
 // CountReferral, CountDenial, CountDS and CountFallback attribute walk
 // consultations on the resolver side without exporting the metric vec.
@@ -91,6 +106,16 @@ type Manager struct {
 	timeout time.Duration
 
 	snap atomic.Pointer[Snapshot]
+	// anchorNow caches the last observation of the live trust anchor set,
+	// so Active can compare against it without rebuilding the DS set on
+	// every root consult.
+	anchorNow atomic.Pointer[anchorState]
+
+	// sourceOffset is where the next refresh starts in the source list. It
+	// begins at a random point so a fleet does not converge on one host, and
+	// advances per cycle so a single resolver spreads its own transfers too.
+	// Tests set it to make the walk deterministic.
+	sourceOffset atomic.Uint64
 	// publish serializes the serial check and the swap in Load. The atomic
 	// pointer keeps Active() lock-free on the read side, but the two steps
 	// together are one decision: without this, two loads that both observe
@@ -128,7 +153,7 @@ func New(sources []string, anchors func() []dns.RR) *Manager {
 	if len(sources) == 0 {
 		sources = DefaultSources
 	}
-	return &Manager{
+	m := &Manager{
 		sources:    sources,
 		anchors:    anchors,
 		timeout:    30 * time.Second,
@@ -136,16 +161,86 @@ func New(sources []string, anchors func() []dns.RR) *Manager {
 		transferFn: axfr,
 		probeFn:    probeSerial,
 	}
+	m.sourceOffset.Store(rand.Uint64()) //nolint:gosec // load spreading, not key material.
+	return m
+}
+
+// anchorRecheckInterval bounds how stale Active's view of the trust anchors
+// may be. Rebuilding the anchor DS set costs a lock and a hash per key, and
+// Active runs on every root consult, so the answer is reused for this long —
+// a second of staleness against an anchor change measured in years.
+const anchorRecheckInterval = time.Second
+
+// anchorState is one observation of the live trust anchor set.
+type anchorState struct {
+	fp        [sha256.Size]byte
+	usable    bool
+	checkedAt time.Time
 }
 
 // Active returns the verified snapshot to serve from, or nil when there is
-// none — never transferred, or the copy has outlived its SOA expire.
+// none — never transferred, the copy has outlived its horizon, or the trust
+// anchors that verified it are no longer the resolver's.
 func (m *Manager) Active() *Snapshot {
 	s := m.snap.Load()
 	if s == nil || s.Expired(m.now()) {
 		return nil
 	}
+	if !m.anchorsStillHold(s) {
+		return nil
+	}
 	return s
+}
+
+// anchorsStillHold reports whether the trust anchors that verified this copy
+// are still the ones the resolver holds.
+//
+// Expiry alone is not enough to decide a copy may still be served. RFC 8806
+// §2 requires the copy to be validated with an up-to-date root KSK, and RFC
+// 8976 §6.4 notes that a ZONEMD digest is only as good as the DNSSEC chain
+// behind it — once the anchors are gone, nothing here can be re-derived. So
+// an anchor set that AutoTA has emptied fail-closed, or one whose keys have
+// been replaced or revoked, withdraws the copy immediately rather than
+// letting days of horizon run on evidence that no longer exists. The walk
+// falls back to the real roots and the next refresh re-verifies the zone
+// under whatever anchors are current by then.
+func (m *Manager) anchorsStillHold(s *Snapshot) bool {
+	now := m.now()
+	cur := m.anchorNow.Load()
+	if cur == nil || now.Sub(cur.checkedAt) >= anchorRecheckInterval {
+		fp, usable := anchorFingerprint(m.anchors())
+		cur = &anchorState{fp: fp, usable: usable, checkedAt: now}
+		m.anchorNow.Store(cur)
+	}
+	return cur.usable && cur.fp == s.anchorFP
+}
+
+// anchorFingerprint identifies a trust anchor set independently of the order
+// its records arrive in. An empty set is not usable: it cannot verify
+// anything, so it cannot keep a copy alive either.
+func anchorFingerprint(anchors []dns.RR) (fp [sha256.Size]byte, usable bool) {
+	if len(anchors) == 0 {
+		return fp, false
+	}
+	presentations := make([]string, 0, len(anchors))
+	for _, rr := range anchors {
+		if rr == nil {
+			continue
+		}
+		presentations = append(presentations, strings.ToLower(rr.String()))
+	}
+	if len(presentations) == 0 {
+		return fp, false
+	}
+	sort.Strings(presentations)
+
+	h := sha256.New()
+	for _, p := range presentations {
+		_, _ = h.Write([]byte(p))
+		_, _ = h.Write([]byte{0})
+	}
+	h.Sum(fp[:0])
+	return fp, true
 }
 
 // Run drives the refresh loop until ctx is cancelled. The first transfer is
@@ -157,6 +252,10 @@ func (m *Manager) Run(ctx context.Context) {
 		fallbackRefresh = 30 * time.Minute
 		fallbackRetry   = 15 * time.Minute
 	)
+
+	// The manager that owns the refresh lifecycle is the one the gauges
+	// describe; they read it at scrape time.
+	serving.Store(m)
 
 	// The first transfer waits out the resolver's own cold start rather
 	// than racing it. A couple of megabytes pulled over TCP while the
@@ -187,9 +286,6 @@ func (m *Manager) Run(ctx context.Context) {
 			next = refresh
 		}
 
-		age, serial := m.observe()
-		metricAge.Set(age)
-		metricSerial.Set(serial)
 	}
 }
 
@@ -207,8 +303,13 @@ func (m *Manager) observe() (age, serial float64) {
 }
 
 // refreshOnce probes for a serial change and transfers when one is seen (or
-// when no copy exists yet). Sources rotate: the probe's source is the
-// transfer's source, so a host that cannot answer is skipped whole.
+// when no copy exists yet). The probe's source is the transfer's source, so a
+// host that cannot answer is skipped whole.
+//
+// Each cycle starts at a different source. Walking the list from the top
+// every time would send every healthy resolver in a fleet to the same first
+// host for every transfer it ever makes, which is the opposite of what a
+// list of eight equivalent sources is for.
 func (m *Manager) refreshOnce(ctx context.Context) error {
 	// Without anchors nothing this cycle transfers can be verified, and the
 	// refusal would come only after the zone was on the wire. Checking first
@@ -224,7 +325,12 @@ func (m *Manager) refreshOnce(ctx context.Context) error {
 	cur := m.snap.Load()
 
 	var lastErr error
-	for _, addr := range m.sources {
+	// The modulo happens in uint64: converting the counter to int first
+	// turns any value past MaxInt64 negative, and a negative remainder
+	// indexes backwards out of the slice.
+	start := int((m.sourceOffset.Add(1) - 1) % uint64(len(m.sources))) //nolint:gosec // the modulo bounds this below len(m.sources), an int.
+	for i := range m.sources {
+		addr := m.sources[(start+i)%len(m.sources)]
 		// probed carries what this source announced into the acceptance
 		// check below, so the transfer is measured against the source's
 		// own claim and not only against what is already installed.
@@ -296,7 +402,14 @@ func (m *Manager) Load(rrs []dns.RR) error {
 // update, and accepting it would mark the refresh successful and wait a
 // full refresh interval before asking anyone again.
 func (m *Manager) load(rrs []dns.RR, expect uint32, expected bool) error {
-	authUntil, err := verifyZone(rrs, m.anchors())
+	// One normalization stage, ahead of every reader: see normalizeZone.
+	rrs = normalizeZone(rrs)
+
+	// One reading of the anchors for both the verification and the
+	// fingerprint stamped on the copy: taking them twice could verify
+	// against one set and record another.
+	anchors := m.anchors()
+	authUntil, err := verifyZone(rrs, anchors)
 	if err != nil {
 		metricTransfers.WithLabelValues("verify_error").Inc()
 		return err
@@ -309,6 +422,9 @@ func (m *Manager) load(rrs []dns.RR, expect uint32, expected bool) error {
 	// The digest is evidence only while the signature over it holds, so the
 	// copy cannot outlive that signature however long its records run.
 	snap.BoundTo(authUntil)
+	// verifyZone refuses an empty anchor set, so usable is true here; the
+	// fingerprint is what Active later compares the live anchors against.
+	snap.anchorFP, _ = anchorFingerprint(anchors)
 	if expected && snap.serial != expect && !serialNewer(expect, snap.serial) {
 		metricTransfers.WithLabelValues("serial_behind_probe").Inc()
 		return errSerialBehindProbe

--- a/middleware/resolver/localroot/manager.go
+++ b/middleware/resolver/localroot/manager.go
@@ -227,7 +227,14 @@ func anchorFingerprint(anchors []dns.RR) (fp [sha256.Size]byte, usable bool) {
 		if rr == nil {
 			continue
 		}
-		presentations = append(presentations, strings.ToLower(rr.String()))
+		// The TTL is not part of a trust anchor's identity — the same key
+		// material re-read with a different lifetime is the same anchor. It
+		// is zeroed rather than left in, because a fingerprint that moved
+		// with it would withdraw a sound copy and send the walk to the real
+		// roots over nothing.
+		identity := dns.Copy(rr)
+		identity.Header().Ttl = 0
+		presentations = append(presentations, strings.ToLower(identity.String()))
 	}
 	if len(presentations) == 0 {
 		return fp, false

--- a/middleware/resolver/localroot/manager_test.go
+++ b/middleware/resolver/localroot/manager_test.go
@@ -209,3 +209,52 @@ func TestRunDefersTheFirstTransfer(t *testing.T) {
 		t.Fatal("a copy became active before any transfer")
 	}
 }
+
+// TestRefreshWithoutAnchorsDoesNotTransfer pins the guard in front of the
+// wire. Trust anchors can fail closed and stay empty, and nothing transferred
+// in that state could ever verify — so pulling a few megabytes from every
+// source on every retry interval, indefinitely, is waste aimed at root
+// infrastructure.
+func TestRefreshWithoutAnchorsDoesNotTransfer(t *testing.T) {
+	var transfers, probes atomic.Int64
+
+	m := New(nil, func() []dns.RR { return nil })
+	m.transferFn = func(context.Context, string, time.Duration) ([]dns.RR, error) {
+		transfers.Add(1)
+		return nil, errors.New("transfer must not be reached")
+	}
+	m.probeFn = func(context.Context, string, time.Duration) (uint32, error) {
+		probes.Add(1)
+		return 0, errors.New("probe must not be reached")
+	}
+
+	if err := m.refreshOnce(context.Background()); !errors.Is(err, errNoAnchors) {
+		t.Fatalf("refreshOnce with no anchors = %v, want errNoAnchors", err)
+	}
+	if transfers.Load() != 0 || probes.Load() != 0 {
+		t.Fatalf("an anchorless refresh still reached the network: %d transfers, %d probes",
+			transfers.Load(), probes.Load())
+	}
+}
+
+// TestNewDropsBlankSources pins that a blank configured source cannot leave
+// the manager with one unusable address and the feature silently off.
+func TestNewDropsBlankSources(t *testing.T) {
+	anchors := func() []dns.RR { return nil }
+
+	for name, sources := range map[string][]string{
+		"a single empty entry": {""},
+		"only whitespace":      {"   ", "\t"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := New(sources, anchors).sources; len(got) != len(DefaultSources) {
+				t.Fatalf("sources = %v, want the built-in set", got)
+			}
+		})
+	}
+
+	got := New([]string{"", "example.test:53", "  "}, anchors).sources
+	if len(got) != 1 || got[0] != "example.test:53" {
+		t.Fatalf("sources = %v, want only the usable entry", got)
+	}
+}

--- a/middleware/resolver/localroot/manager_test.go
+++ b/middleware/resolver/localroot/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/middleware/resolver/localroot/roottest"
 )
 
 // TestManagerLifecycle drives refreshOnce through the states the RFC 8806
@@ -20,6 +21,23 @@ func TestManagerLifecycle(t *testing.T) {
 	transfers := 0
 	serial := root.serial
 	failing := false
+	// The source serves the zone it advertises: probe and transfer move
+	// together, as a healthy source's do.
+	served := map[uint32][]dns.RR{root.serial: root.rrs}
+	serve := func(s uint32) []dns.RR {
+		t.Helper()
+		if rrs, ok := served[s]; ok {
+			return rrs
+		}
+		z, err := roottest.BuildZoneWithKey(
+			ComputeDigest, roottest.DefaultLines(s), s, root.key, root.priv,
+		)
+		if err != nil {
+			t.Fatalf("zone %d: %v", s, err)
+		}
+		served[s] = z.RRs
+		return z.RRs
+	}
 
 	m := New(nil, func() []dns.RR { return root.anchors })
 	m.now = func() time.Time { return now }
@@ -34,7 +52,7 @@ func TestManagerLifecycle(t *testing.T) {
 			return nil, errors.New("transfer down")
 		}
 		transfers++
-		return root.rrs, nil
+		return serve(serial), nil
 	}
 
 	if m.Active() != nil {

--- a/middleware/resolver/localroot/manager_test.go
+++ b/middleware/resolver/localroot/manager_test.go
@@ -3,6 +3,7 @@ package localroot
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -172,5 +173,39 @@ func TestManagerRefusesUnverifiedSwap(t *testing.T) {
 	}
 	if m.Active() != good {
 		t.Fatal("a tampered transfer displaced the verified copy")
+	}
+}
+
+// TestRunDefersTheFirstTransfer pins that the copy yields to the resolver's
+// cold start. Pulling the zone the instant the process comes up shares the
+// link with the priming query, the trust-anchor refresh and the first
+// client queries — measurably slowing them on a modest connection, which is
+// the opposite of what the copy is for. The delay is generous compared to
+// the window this test watches, so a regression to an immediate transfer
+// shows up immediately rather than as a timing flake.
+func TestRunDefersTheFirstTransfer(t *testing.T) {
+	root := buildTestRoot(t)
+
+	var transfers atomic.Int32
+	m := New(nil, func() []dns.RR { return root.anchors })
+	m.probeFn = func(context.Context, string, time.Duration) (uint32, error) {
+		return root.serial, nil
+	}
+	m.transferFn = func(context.Context, string, time.Duration) ([]dns.RR, error) {
+		transfers.Add(1)
+		return root.rrs, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go m.Run(ctx)
+
+	time.Sleep(250 * time.Millisecond)
+	if got := transfers.Load(); got != 0 {
+		t.Fatalf("%d transfers within 250ms of start — the first one must wait out "+
+			"the resolver's cold start (%v)", got, initialTransferDelay)
+	}
+	if m.Active() != nil {
+		t.Fatal("a copy became active before any transfer")
 	}
 }

--- a/middleware/resolver/localroot/manager_test.go
+++ b/middleware/resolver/localroot/manager_test.go
@@ -364,3 +364,30 @@ func TestAnchorFingerprintIsOrderIndependent(t *testing.T) {
 		t.Fatal("an empty anchor set reported itself usable")
 	}
 }
+
+// TestAnchorFingerprintIgnoresTTL pins that a trust anchor's lifetime is not
+// part of its identity. The same key material re-read with a different TTL is
+// the same anchor, and a fingerprint that moved with it would withdraw a
+// sound copy and send the walk to the real roots over nothing.
+func TestAnchorFingerprintIgnoresTTL(t *testing.T) {
+	anchor := rrsFromText(t,
+		". 172800 IN DS 111 13 2 49FD46E6C4B45C55D4AC69CBD3CD34AC1AFE51DE58AB7A66C82AABE7A9E10F53",
+	)[0]
+	retimed := dns.Copy(anchor)
+	retimed.Header().Ttl = 60
+
+	original, ok := anchorFingerprint([]dns.RR{anchor})
+	if !ok {
+		t.Fatal("a single-record anchor set is not usable")
+	}
+	moved, ok := anchorFingerprint([]dns.RR{retimed})
+	if !ok {
+		t.Fatal("the retimed anchor set is not usable")
+	}
+	if original != moved {
+		t.Fatal("the fingerprint follows the anchor's TTL, so a re-read would withdraw the copy")
+	}
+	if anchor.Header().Ttl != 172800 {
+		t.Fatal("fingerprinting mutated the anchor it was given")
+	}
+}

--- a/middleware/resolver/localroot/manager_test.go
+++ b/middleware/resolver/localroot/manager_test.go
@@ -258,3 +258,37 @@ func TestNewDropsBlankSources(t *testing.T) {
 		t.Fatalf("sources = %v, want only the usable entry", got)
 	}
 }
+
+// TestObserveReportsSerialAndAge pins what the gauges say. A fleet watching
+// only the copy's age cannot tell whether its nodes settled on the same zone
+// version, which is the question a rollout actually asks.
+func TestObserveReportsSerialAndAge(t *testing.T) {
+	root := buildTestRoot(t)
+	now := time.Now()
+
+	m := New(nil, func() []dns.RR { return root.anchors })
+	m.now = func() time.Time { return now }
+
+	if age, serial := m.observe(); age != -1 || serial != -1 {
+		t.Fatalf("with no copy: age=%v serial=%v, want -1/-1", age, serial)
+	}
+
+	if err := m.Load(root.rrs); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	now = now.Add(90 * time.Second)
+	age, serial := m.observe()
+	if age != 90 {
+		t.Fatalf("age = %v, want 90 seconds since the transfer", age)
+	}
+	if serial != float64(root.serial) {
+		t.Fatalf("serial = %v, want the copy's %d", serial, root.serial)
+	}
+
+	// Past the horizon the copy is withdrawn, and the gauges must say so
+	// rather than freezing on the last serial they saw.
+	now = now.Add(24 * time.Hour)
+	if age, serial := m.observe(); age != -1 || serial != -1 {
+		t.Fatalf("past the horizon: age=%v serial=%v, want -1/-1", age, serial)
+	}
+}

--- a/middleware/resolver/localroot/manager_test.go
+++ b/middleware/resolver/localroot/manager_test.go
@@ -74,10 +74,11 @@ func TestManagerLifecycle(t *testing.T) {
 		t.Fatal("a failed refresh withdrew a live copy")
 	}
 
-	// Past the SOA expire horizon the copy is withdrawn, not served stale.
-	now = now.Add(time.Duration(root.rrs[0].(*dns.SOA).Expire)*time.Second + time.Second)
+	// Past the horizon (here the signature window, the nearer bound) the
+	// copy is withdrawn, not served stale.
+	now = now.Add(2 * time.Hour)
 	if m.Active() != nil {
-		t.Fatal("a copy served past its SOA expire")
+		t.Fatal("a copy served past its horizon")
 	}
 }
 
@@ -104,10 +105,11 @@ func TestManagerReanchorsExpireHorizon(t *testing.T) {
 		t.Fatalf("first load: %v", err)
 	}
 
-	expire := time.Duration(root.rrs[0].(*dns.SOA).Expire) * time.Second
-	now = now.Add(expire/2 + time.Second)
+	// The horizon here is the one-hour signature window; half of it spent
+	// must trigger a fresh transfer even with the serial unchanged.
+	now = now.Add(31 * time.Minute)
 	if err := m.refreshOnce(context.Background()); err != nil {
-		t.Fatalf("half-expire refresh: %v", err)
+		t.Fatalf("half-horizon refresh: %v", err)
 	}
 	if transfers != 2 {
 		t.Fatalf("the half-expire horizon did not re-anchor (transfers=%d)", transfers)

--- a/middleware/resolver/localroot/manager_test.go
+++ b/middleware/resolver/localroot/manager_test.go
@@ -1,0 +1,156 @@
+package localroot
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// TestManagerLifecycle drives refreshOnce through the states the RFC 8806
+// schedule produces: first load, an unchanged serial (no transfer), a serial
+// bump (transfer + swap), a failing source (previous copy stays), and the
+// SOA expire horizon (Active withdraws the copy).
+func TestManagerLifecycle(t *testing.T) {
+	root := buildTestRoot(t)
+	now := time.Now()
+
+	transfers := 0
+	serial := root.serial
+	failing := false
+
+	m := New(nil, func() []dns.RR { return root.anchors })
+	m.now = func() time.Time { return now }
+	m.probeFn = func(context.Context, string, time.Duration) (uint32, error) {
+		if failing {
+			return 0, errors.New("probe down")
+		}
+		return serial, nil
+	}
+	m.transferFn = func(context.Context, string, time.Duration) ([]dns.RR, error) {
+		if failing {
+			return nil, errors.New("transfer down")
+		}
+		transfers++
+		return root.rrs, nil
+	}
+
+	if m.Active() != nil {
+		t.Fatal("a copy active before any transfer")
+	}
+
+	if err := m.refreshOnce(context.Background()); err != nil {
+		t.Fatalf("first load: %v", err)
+	}
+	if m.Active() == nil || transfers != 1 {
+		t.Fatalf("first load did not install a copy (transfers=%d)", transfers)
+	}
+
+	// Unchanged serial inside the re-transfer horizon: probe only.
+	if err := m.refreshOnce(context.Background()); err != nil {
+		t.Fatalf("steady refresh: %v", err)
+	}
+	if transfers != 1 {
+		t.Fatalf("an unchanged serial transferred anyway (transfers=%d)", transfers)
+	}
+
+	// A serial bump transfers and swaps.
+	serial++
+	if err := m.refreshOnce(context.Background()); err != nil {
+		t.Fatalf("bumped refresh: %v", err)
+	}
+	if transfers != 2 {
+		t.Fatalf("a bumped serial did not transfer (transfers=%d)", transfers)
+	}
+
+	// Every source failing keeps the previous copy serving.
+	failing = true
+	if err := m.refreshOnce(context.Background()); err == nil {
+		t.Fatal("refresh reported success with every source down")
+	}
+	if m.Active() == nil {
+		t.Fatal("a failed refresh withdrew a live copy")
+	}
+
+	// Past the SOA expire horizon the copy is withdrawn, not served stale.
+	now = now.Add(time.Duration(root.rrs[0].(*dns.SOA).Expire)*time.Second + time.Second)
+	if m.Active() != nil {
+		t.Fatal("a copy served past its SOA expire")
+	}
+}
+
+// TestManagerReanchorsExpireHorizon pins the half-expire rule: a source
+// whose serial never changes must still hand over a fresh transfer before
+// the copy's expire horizon threatens, because the horizon anchors at the
+// transfer, not at the probe.
+func TestManagerReanchorsExpireHorizon(t *testing.T) {
+	root := buildTestRoot(t)
+	now := time.Now()
+
+	transfers := 0
+	m := New(nil, func() []dns.RR { return root.anchors })
+	m.now = func() time.Time { return now }
+	m.probeFn = func(context.Context, string, time.Duration) (uint32, error) {
+		return root.serial, nil
+	}
+	m.transferFn = func(context.Context, string, time.Duration) ([]dns.RR, error) {
+		transfers++
+		return root.rrs, nil
+	}
+
+	if err := m.refreshOnce(context.Background()); err != nil {
+		t.Fatalf("first load: %v", err)
+	}
+
+	expire := time.Duration(root.rrs[0].(*dns.SOA).Expire) * time.Second
+	now = now.Add(expire/2 + time.Second)
+	if err := m.refreshOnce(context.Background()); err != nil {
+		t.Fatalf("half-expire refresh: %v", err)
+	}
+	if transfers != 2 {
+		t.Fatalf("the half-expire horizon did not re-anchor (transfers=%d)", transfers)
+	}
+	if s := m.Active(); s == nil || m.now().Sub(s.Loaded()) > time.Second {
+		t.Fatal("the re-anchored copy does not carry the fresh horizon")
+	}
+}
+
+// TestManagerRefusesUnverifiedSwap pins the gate: a source serving a zone
+// that does not verify must not displace the live copy.
+func TestManagerRefusesUnverifiedSwap(t *testing.T) {
+	root := buildTestRoot(t)
+	tampered := append([]dns.RR(nil), root.rrs...)
+	for i, rr := range tampered {
+		if a, ok := rr.(*dns.A); ok {
+			evil := dns.Copy(a).(*dns.A)
+			evil.A[3]++
+			tampered[i] = evil
+			break
+		}
+	}
+
+	now := time.Now()
+	serve := root.rrs
+	serial := root.serial
+
+	m := New(nil, func() []dns.RR { return root.anchors })
+	m.now = func() time.Time { return now }
+	m.probeFn = func(context.Context, string, time.Duration) (uint32, error) { return serial, nil }
+	m.transferFn = func(context.Context, string, time.Duration) ([]dns.RR, error) { return serve, nil }
+
+	if err := m.refreshOnce(context.Background()); err != nil {
+		t.Fatalf("first load: %v", err)
+	}
+	good := m.Active()
+
+	serve = tampered
+	serial++
+	if err := m.refreshOnce(context.Background()); err == nil {
+		t.Fatal("a tampered transfer reported success")
+	}
+	if m.Active() != good {
+		t.Fatal("a tampered transfer displaced the verified copy")
+	}
+}

--- a/middleware/resolver/localroot/manager_test.go
+++ b/middleware/resolver/localroot/manager_test.go
@@ -292,3 +292,75 @@ func TestObserveReportsSerialAndAge(t *testing.T) {
 		t.Fatalf("past the horizon: age=%v serial=%v, want -1/-1", age, serial)
 	}
 }
+
+// TestActiveFollowsTheTrustAnchors pins that a copy stops being served the
+// moment the anchors that verified it stop being the resolver's. Expiry alone
+// is not enough: an anchor set emptied fail-closed, or one whose keys were
+// replaced, withdraws the basis on which every answer built from the copy
+// claims AD=1 — and days of horizon could otherwise run on evidence that no
+// longer exists.
+func TestActiveFollowsTheTrustAnchors(t *testing.T) {
+	root := buildTestRoot(t)
+	other, err := roottest.Build(ComputeDigest)
+	if err != nil {
+		t.Fatalf("second zone: %v", err)
+	}
+	now := time.Now()
+
+	anchors := root.anchors
+	m := New(nil, func() []dns.RR { return anchors })
+	m.now = func() time.Time { return now }
+	if err := m.Load(root.rrs); err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if m.Active() == nil {
+		t.Fatal("a freshly verified copy is not being served")
+	}
+
+	// The observation is cached for anchorRecheckInterval, so move past it
+	// before each change — the staleness is deliberate and bounded.
+	advance := func() { now = now.Add(2 * anchorRecheckInterval) }
+
+	anchors = nil
+	advance()
+	if m.Active() != nil {
+		t.Fatal("the copy is still served with no trust anchors at all")
+	}
+
+	// A different anchor set is not this copy's anchor set: the key that
+	// signed what we hold is no longer one the resolver trusts.
+	anchors = other.Anchors
+	advance()
+	if m.Active() != nil {
+		t.Fatal("the copy is still served under a foreign anchor set")
+	}
+
+	// Restored anchors restore the copy — the snapshot never changed, only
+	// the basis for trusting it did.
+	anchors = root.anchors
+	advance()
+	if m.Active() == nil {
+		t.Fatal("the copy was not restored when its own anchors came back")
+	}
+}
+
+func TestAnchorFingerprintIsOrderIndependent(t *testing.T) {
+	rrs := rrsFromText(t,
+		". 172800 IN DS 111 13 2 49FD46E6C4B45C55D4AC69CBD3CD34AC1AFE51DE58AB7A66C82AABE7A9E10F53",
+		". 172800 IN DS 222 8 2 0000000000000000000000000000000000000000000000000000000000000000",
+	)
+	forward, ok := anchorFingerprint(rrs)
+	if !ok {
+		t.Fatal("a two-record anchor set is not usable")
+	}
+	reversed, ok := anchorFingerprint([]dns.RR{rrs[1], rrs[0]})
+	if !ok {
+		t.Fatal("the reversed set is not usable")
+	}
+	if forward != reversed {
+		t.Fatal("the fingerprint depends on the order the anchors arrive in")
+	}
+	if _, ok := anchorFingerprint(nil); ok {
+		t.Fatal("an empty anchor set reported itself usable")
+	}
+}

--- a/middleware/resolver/localroot/roottest/roottest.go
+++ b/middleware/resolver/localroot/roottest/roottest.go
@@ -15,7 +15,7 @@ import (
 	"github.com/miekg/dns"
 )
 
-// Serial is the zone serial every built zone carries.
+// Serial is the zone serial every default-built zone carries.
 const Serial = 2026082401
 
 // Zone is one built test root.
@@ -26,24 +26,11 @@ type Zone struct {
 	Priv    crypto.PrivateKey
 }
 
-// Build generates a fresh key and assembles the sealed zone. digest is the
-// RFC 8976 computation to seal with — localroot.ComputeDigest in every real
-// caller; a parameter so this package does not import the one it exists to
-// test.
-func Build(digest func(rrs []dns.RR, apex string) ([]byte, error)) (*Zone, error) {
-	key := &dns.DNSKEY{
-		Hdr:       dns.RR_Header{Name: ".", Rrtype: dns.TypeDNSKEY, Class: dns.ClassINET, Ttl: 172800},
-		Flags:     257,
-		Protocol:  3,
-		Algorithm: dns.ECDSAP256SHA256,
-	}
-	priv, err := key.Generate(256)
-	if err != nil {
-		return nil, err
-	}
-
-	lines := []string{
-		". 86400 IN SOA a.root-servers.test. nstld.test. 2026082401 1800 900 604800 86400",
+// DefaultLines is the default zone body: a signed com. delegation, an
+// unsigned org. delegation, and in-zone glue. serial lands in the SOA.
+func DefaultLines(serial uint32) []string {
+	return []string{
+		fmt.Sprintf(". 86400 IN SOA a.root-servers.test. nstld.test. %d 1800 900 604800 86400", serial),
 		". 518400 IN NS a.root-servers.test.",
 		". 86400 IN NSEC com. NS SOA RRSIG NSEC DNSKEY ZONEMD",
 		"com. 172800 IN NS ns.com.",
@@ -55,6 +42,42 @@ func Build(digest func(rrs []dns.RR, apex string) ([]byte, error)) (*Zone, error
 		"ns.com. 172800 IN AAAA 2001:db8::1",
 		"ns.org. 172800 IN A 198.51.100.2",
 	}
+}
+
+// Build generates a fresh key and assembles the sealed default zone. digest
+// is the RFC 8976 computation to seal with — localroot.ComputeDigest in
+// every real caller; a parameter so this package does not import the one it
+// exists to test.
+func Build(digest func(rrs []dns.RR, apex string) ([]byte, error)) (*Zone, error) {
+	return BuildZone(digest, DefaultLines(Serial), Serial)
+}
+
+// BuildZone assembles and seals a zone from the given body lines, whose SOA
+// must carry serial, under a freshly generated key.
+func BuildZone(digest func(rrs []dns.RR, apex string) ([]byte, error), lines []string, serial uint32) (*Zone, error) {
+	key := &dns.DNSKEY{
+		Hdr:       dns.RR_Header{Name: ".", Rrtype: dns.TypeDNSKEY, Class: dns.ClassINET, Ttl: 172800},
+		Flags:     257,
+		Protocol:  3,
+		Algorithm: dns.ECDSAP256SHA256,
+	}
+	priv, err := key.Generate(256)
+	if err != nil {
+		return nil, err
+	}
+	return BuildZoneWithKey(digest, lines, serial, key, priv)
+}
+
+// BuildZoneWithKey is BuildZone under an existing key, so a test can produce
+// two zones — different serials, different contents — that chain to the same
+// trust anchor.
+func BuildZoneWithKey(
+	digest func(rrs []dns.RR, apex string) ([]byte, error),
+	lines []string,
+	serial uint32,
+	key *dns.DNSKEY,
+	priv crypto.PrivateKey,
+) (*Zone, error) {
 	zone := make([]dns.RR, 0, len(lines)+8)
 	for _, l := range lines {
 		rr, err := dns.NewRR(l)
@@ -117,7 +140,7 @@ func Build(digest func(rrs []dns.RR, apex string) ([]byte, error)) (*Zone, error
 	}
 	zonemd := &dns.ZONEMD{
 		Hdr:    dns.RR_Header{Name: ".", Rrtype: dns.TypeZONEMD, Class: dns.ClassINET, Ttl: 86400},
-		Serial: Serial,
+		Serial: serial,
 		Scheme: 1,
 		Hash:   1,
 		Digest: hex.EncodeToString(sum),

--- a/middleware/resolver/localroot/roottest/roottest.go
+++ b/middleware/resolver/localroot/roottest/roottest.go
@@ -38,6 +38,10 @@ func DefaultLines(serial uint32) []string {
 		"com. 86400 IN NSEC org. NS DS RRSIG NSEC",
 		"org. 172800 IN NS ns.org.",
 		"org. 86400 IN NSEC . NS RRSIG NSEC",
+		// Glue for the root's own NS target, as the real root zone carries
+		// it: unsigned, and the additional section of a priming answer.
+		"a.root-servers.test. 172800 IN A 198.51.100.53",
+		"a.root-servers.test. 172800 IN AAAA 2001:db8::53",
 		"ns.com. 172800 IN A 198.51.100.1",
 		"ns.com. 172800 IN AAAA 2001:db8::1",
 		"ns.org. 172800 IN A 198.51.100.2",

--- a/middleware/resolver/localroot/roottest/roottest.go
+++ b/middleware/resolver/localroot/roottest/roottest.go
@@ -1,0 +1,135 @@
+// Package roottest builds a miniature signed root zone for tests: an apex
+// with SOA/NS/DNSKEY/NSEC sealed by a ZONEMD, a signed delegation (com.,
+// with DS), an unsigned delegation (org., NSEC without the DS bit), and
+// in-zone glue. Everything chains from one generated CSK whose DS is the
+// returned trust anchor. Nothing here runs outside test binaries.
+package roottest
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// Serial is the zone serial every built zone carries.
+const Serial = 2026082401
+
+// Zone is one built test root.
+type Zone struct {
+	RRs     []dns.RR
+	Anchors []dns.RR // the CSK's DS — the trust anchor the zone chains to
+	Key     *dns.DNSKEY
+	Priv    crypto.PrivateKey
+}
+
+// Build generates a fresh key and assembles the sealed zone. digest is the
+// RFC 8976 computation to seal with — localroot.ComputeDigest in every real
+// caller; a parameter so this package does not import the one it exists to
+// test.
+func Build(digest func(rrs []dns.RR, apex string) ([]byte, error)) (*Zone, error) {
+	key := &dns.DNSKEY{
+		Hdr:       dns.RR_Header{Name: ".", Rrtype: dns.TypeDNSKEY, Class: dns.ClassINET, Ttl: 172800},
+		Flags:     257,
+		Protocol:  3,
+		Algorithm: dns.ECDSAP256SHA256,
+	}
+	priv, err := key.Generate(256)
+	if err != nil {
+		return nil, err
+	}
+
+	lines := []string{
+		". 86400 IN SOA a.root-servers.test. nstld.test. 2026082401 1800 900 604800 86400",
+		". 518400 IN NS a.root-servers.test.",
+		". 86400 IN NSEC com. NS SOA RRSIG NSEC DNSKEY ZONEMD",
+		"com. 172800 IN NS ns.com.",
+		"com. 86400 IN DS 12345 13 2 49FD46E6C4B45C55D4AC69CBD3CD34AC1AFE51DE58AB7A66C82AABE7A9E10F53",
+		"com. 86400 IN NSEC org. NS DS RRSIG NSEC",
+		"org. 172800 IN NS ns.org.",
+		"org. 86400 IN NSEC . NS RRSIG NSEC",
+		"ns.com. 172800 IN A 198.51.100.1",
+		"ns.com. 172800 IN AAAA 2001:db8::1",
+		"ns.org. 172800 IN A 198.51.100.2",
+	}
+	zone := make([]dns.RR, 0, len(lines)+8)
+	for _, l := range lines {
+		rr, err := dns.NewRR(l)
+		if err != nil {
+			return nil, fmt.Errorf("test zone RR %q: %w", l, err)
+		}
+		zone = append(zone, rr)
+	}
+	zone = append(zone, key)
+
+	sign := func(rrset []dns.RR) (dns.RR, error) {
+		now := time.Now()
+		sig := &dns.RRSIG{
+			Hdr: dns.RR_Header{
+				Name: rrset[0].Header().Name, Rrtype: dns.TypeRRSIG,
+				Class: dns.ClassINET, Ttl: rrset[0].Header().Ttl,
+			},
+			TypeCovered: rrset[0].Header().Rrtype,
+			Algorithm:   dns.ECDSAP256SHA256,
+			Labels:      uint8(dns.CountLabel(rrset[0].Header().Name)), //nolint:gosec // test names are tiny
+			OrigTtl:     rrset[0].Header().Ttl,
+			Expiration:  uint32(now.Add(time.Hour).Unix()),  //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+			Inception:   uint32(now.Add(-time.Hour).Unix()), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+			KeyTag:      key.KeyTag(),
+			SignerName:  ".",
+		}
+		if err := sig.Sign(priv.(*ecdsa.PrivateKey), rrset); err != nil {
+			return nil, err
+		}
+		return sig, nil
+	}
+
+	// Sign what the real root signs: every authoritative RRset. Delegation
+	// NS sets at the TLDs stay unsigned; glue stays unsigned.
+	group := make(map[string]map[uint16][]dns.RR)
+	for _, rr := range zone {
+		owner := dns.CanonicalName(rr.Header().Name)
+		if group[owner] == nil {
+			group[owner] = make(map[uint16][]dns.RR)
+		}
+		group[owner][rr.Header().Rrtype] = append(group[owner][rr.Header().Rrtype], rr)
+	}
+	for owner, sets := range group {
+		for rtype, set := range sets {
+			if owner == "." || rtype == dns.TypeDS || rtype == dns.TypeNSEC {
+				sig, err := sign(set)
+				if err != nil {
+					return nil, err
+				}
+				zone = append(zone, sig)
+			}
+		}
+	}
+
+	// Seal with ZONEMD last: the digest excludes the apex ZONEMD and its
+	// RRSIG by rule, so sealing after signing digests exactly the zone.
+	sum, err := digest(zone, ".")
+	if err != nil {
+		return nil, err
+	}
+	zonemd := &dns.ZONEMD{
+		Hdr:    dns.RR_Header{Name: ".", Rrtype: dns.TypeZONEMD, Class: dns.ClassINET, Ttl: 86400},
+		Serial: Serial,
+		Scheme: 1,
+		Hash:   1,
+		Digest: hex.EncodeToString(sum),
+	}
+	zonemdSig, err := sign([]dns.RR{zonemd})
+	if err != nil {
+		return nil, err
+	}
+	zone = append(zone, zonemd, zonemdSig)
+
+	ds := key.ToDS(dns.SHA256)
+	ds.Hdr.Ttl = 172800
+
+	return &Zone{RRs: zone, Anchors: []dns.RR{ds}, Key: key, Priv: priv}, nil
+}

--- a/middleware/resolver/localroot/snapshot.go
+++ b/middleware/resolver/localroot/snapshot.go
@@ -68,6 +68,14 @@ type Referral struct {
 	NS   []dns.RR
 	DS   []dns.RR
 	Glue map[string][]dns.RR // canonical NS host -> A/AAAA records
+
+	// SecurityTTL is how long the delegation's DNSSEC status may be relied
+	// on: the DS RRset's own smallest TTL when the delegation is signed, or
+	// the TTL of the NSEC that proves no DS exists when it is not. A
+	// delegation whose status the copy cannot evidence at all reports zero,
+	// which drives the caller's lease to zero and sends the walk to the
+	// real roots rather than asserting an unproven security status.
+	SecurityTTL uint32
 }
 
 // Referral returns the delegation for tld (a canonical, rooted, one-label
@@ -82,6 +90,13 @@ func (s *Snapshot) Referral(tld string) (Referral, bool) {
 		return Referral{}, false
 	}
 	ref := Referral{NS: ns, DS: sets[dns.TypeDS], Glue: make(map[string][]dns.RR)}
+	if len(ref.DS) > 0 {
+		ref.SecurityTTL = minRRSetTTL(ref.DS)
+	} else {
+		// Unsigned: the evidence is the NSEC denying DS at this owner, and
+		// its lifetime is what bounds the claim.
+		ref.SecurityTTL = minRRSetTTL(sets[dns.TypeNSEC])
+	}
 	for _, rr := range ns {
 		host := dns.CanonicalName(rr.(*dns.NS).Ns)
 		if hostSets, ok := s.owners[host]; ok {
@@ -184,6 +199,19 @@ func (s *Snapshot) coveringOwner(name string) (string, bool) {
 		return "", false
 	}
 	return owner, true
+}
+
+// minRRSetTTL returns the smallest TTL among rrs, or 0 when rrs is empty —
+// the same shape the resolver's delegation path uses, where "has records"
+// and "their TTL is positive" are deliberately separate questions.
+func minRRSetTTL(rrs []dns.RR) uint32 {
+	var minTTL uint32
+	for i, rr := range rrs {
+		if i == 0 || rr.Header().Ttl < minTTL {
+			minTTL = rr.Header().Ttl
+		}
+	}
+	return minTTL
 }
 
 // sigsCovering filters an owner's RRSIGs to those covering one type.

--- a/middleware/resolver/localroot/snapshot.go
+++ b/middleware/resolver/localroot/snapshot.go
@@ -58,6 +58,16 @@ func (s *Snapshot) Expired(now time.Time) bool { return now.After(s.expireAt) }
 // may claim a longer life.
 func (s *Snapshot) ValidUntil() time.Time { return s.expireAt }
 
+// BoundTo shortens the horizon to at most until. The caller uses it for a
+// bound the records themselves cannot express — the expiration of the
+// signature that authenticated the zone digest, which is what makes the
+// whole copy evidence in the first place.
+func (s *Snapshot) BoundTo(until time.Time) {
+	if until.Before(s.expireAt) {
+		s.expireAt = until
+	}
+}
+
 // SOA returns the apex SOA and its RRSIGs.
 func (s *Snapshot) SOA() (*dns.SOA, []dns.RR) { return s.soa, s.soaSig }
 
@@ -309,10 +319,10 @@ func buildSnapshot(rrs []dns.RR, now time.Time) (*Snapshot, error) {
 		// the RRset as long as one covering signature validates. So an
 		// appended, already-expired RRSIG(ZONEMD) rides in unauthenticated,
 		// and trusting its expiration here would let anyone who can add a
-		// record to a transfer expire a sound copy on arrival. Nothing is
-		// served from these signatures either; every proof the copy hands
-		// out carries signatures the digest does authenticate, and those
-		// still bound the horizon below.
+		// record to a transfer expire a sound copy on arrival. They are
+		// skipped as a group; the one that actually carried verification is
+		// folded in separately by BoundTo, so the copy still cannot outlive
+		// the signature that authenticated it.
 		if sig.TypeCovered == dns.TypeZONEMD &&
 			dns.CanonicalName(sig.Header().Name) == "." {
 			continue

--- a/middleware/resolver/localroot/snapshot.go
+++ b/middleware/resolver/localroot/snapshot.go
@@ -79,6 +79,12 @@ type Referral struct {
 	DS   []dns.RR
 	Glue map[string][]dns.RR // canonical NS host -> A/AAAA records
 
+	// NSTTL is the delegation's own lifetime: the smallest TTL among its NS
+	// records. Computed here, with the same helper as every other RRset
+	// lifetime, so callers do not each grow their own notion of what an
+	// empty or zero-TTL set means.
+	NSTTL uint32
+
 	// SecurityTTL is how long the delegation's DNSSEC status may be relied
 	// on: the DS RRset's own smallest TTL when the delegation is signed, or
 	// the TTL of the NSEC that proves no DS exists when it is not. A
@@ -99,7 +105,12 @@ func (s *Snapshot) Referral(tld string) (Referral, bool) {
 	if len(ns) == 0 {
 		return Referral{}, false
 	}
-	ref := Referral{NS: ns, DS: sets[dns.TypeDS], Glue: make(map[string][]dns.RR)}
+	ref := Referral{
+		NS:    ns,
+		DS:    sets[dns.TypeDS],
+		Glue:  make(map[string][]dns.RR),
+		NSTTL: minRRSetTTL(ns),
+	}
 	if len(ref.DS) > 0 {
 		ref.SecurityTTL = minRRSetTTL(ref.DS)
 	} else if nsec, _, ok := dsAbsenceProof(sets); ok {

--- a/middleware/resolver/localroot/snapshot.go
+++ b/middleware/resolver/localroot/snapshot.go
@@ -92,10 +92,13 @@ func (s *Snapshot) Referral(tld string) (Referral, bool) {
 	ref := Referral{NS: ns, DS: sets[dns.TypeDS], Glue: make(map[string][]dns.RR)}
 	if len(ref.DS) > 0 {
 		ref.SecurityTTL = minRRSetTTL(ref.DS)
-	} else {
-		// Unsigned: the evidence is the NSEC denying DS at this owner, and
-		// its lifetime is what bounds the claim.
-		ref.SecurityTTL = minRRSetTTL(sets[dns.TypeNSEC])
+	} else if nsec, _, ok := dsAbsenceProof(sets); ok {
+		// Unsigned: the evidence is the NSEC that actually denies DS at
+		// this owner, and its lifetime is what bounds the claim. An NSEC
+		// that does not deny it leaves SecurityTTL at zero — installing the
+		// delegation with an empty DS set would assert the child is
+		// insecure on a proof the copy does not hold.
+		ref.SecurityTTL = minRRSetTTL(nsec)
 	}
 	for _, rr := range ns {
 		host := dns.CanonicalName(rr.(*dns.NS).Ns)
@@ -125,33 +128,47 @@ func (s *Snapshot) DSAnswer(tld string) (ds, dsSig []dns.RR, nsec, nsecSig []dns
 	if len(sets[dns.TypeDS]) > 0 {
 		return sets[dns.TypeDS], sigsCovering(sets[dns.TypeRRSIG], dns.TypeDS), nil, nil, true
 	}
-	nsecSet := sets[dns.TypeNSEC]
-	if len(nsecSet) == 0 {
+	nsec, nsecSig, ok = dsAbsenceProof(sets)
+	if !ok {
 		return nil, nil, nil, nil, false
 	}
-	// RFC 4035 §5.4: an exact-owner NSEC denies a type only when its type
-	// bitmap says so. Three bits disqualify it here, and the resolver's own
-	// VerifyNODATANSEC refuses the same shapes:
-	//
-	//   - DS, because a bitmap asserting the type contradicts the missing
-	//     record — a truncated or tampered index, or a zone the copy did
-	//     not fully hold;
-	//   - SOA, because DS non-existence is only provable on the parent
-	//     side: an NSEC carrying SOA is the child apex's own, and the
-	//     child cannot testify about its delegation;
-	//   - CNAME, because then the NSEC proves something else entirely.
+	return nil, nil, nsec, nsecSig, true
+}
+
+// dsAbsenceProof returns the exact-owner NSEC RRset that proves no DS exists
+// at this owner, with its RRSIGs, or ok=false when the records at the owner
+// prove no such thing. It is the single place that answers the question, so
+// the referral's security lifetime and the DS answer cannot disagree about
+// what counts as a proof.
+//
+// RFC 4035 §5.4: an exact-owner NSEC denies a type only when its type bitmap
+// says so. Three bits disqualify it, and the resolver's own
+// VerifyNODATANSEC refuses the same shapes:
+//
+//   - DS, because a bitmap asserting the type contradicts the missing
+//     record — a truncated or tampered index, or a zone the copy did not
+//     fully hold;
+//   - SOA, because DS non-existence is only provable on the parent side: an
+//     NSEC carrying SOA is the child apex's own, and the child cannot
+//     testify about its own delegation;
+//   - CNAME, because then the NSEC proves something else entirely.
+func dsAbsenceProof(sets map[uint16][]dns.RR) (nsec, nsecSig []dns.RR, ok bool) {
+	nsecSet := sets[dns.TypeNSEC]
+	if len(nsecSet) == 0 {
+		return nil, nil, false
+	}
 	for _, rr := range nsecSet {
 		n, isNSEC := rr.(*dns.NSEC)
 		if !isNSEC {
-			return nil, nil, nil, nil, false
+			return nil, nil, false
 		}
 		for _, t := range n.TypeBitMap {
 			if t == dns.TypeDS || t == dns.TypeSOA || t == dns.TypeCNAME {
-				return nil, nil, nil, nil, false
+				return nil, nil, false
 			}
 		}
 	}
-	return nil, nil, nsecSet, sigsCovering(sets[dns.TypeRRSIG], dns.TypeNSEC), true
+	return nsecSet, sigsCovering(sets[dns.TypeRRSIG], dns.TypeNSEC), true
 }
 
 // Denial returns the NSEC records proving name does not exist under the

--- a/middleware/resolver/localroot/snapshot.go
+++ b/middleware/resolver/localroot/snapshot.go
@@ -10,6 +10,7 @@
 package localroot
 
 import (
+	"crypto/sha256"
 	"sort"
 	"time"
 
@@ -24,6 +25,12 @@ type Snapshot struct {
 	serial   uint32
 	loaded   time.Time
 	expireAt time.Time
+
+	// anchorFP identifies the trust anchor set this copy was verified
+	// against. The copy is evidence only for as long as those anchors are
+	// still the resolver's own: an anchor set that has been emptied or
+	// replaced withdraws the basis on which every answer here claims AD=1.
+	anchorFP [sha256.Size]byte
 
 	soa    *dns.SOA
 	soaSig []dns.RR // RRSIG(SOA) at the apex
@@ -125,7 +132,7 @@ func (s *Snapshot) ApexAnswer(qtype uint16) (rrs, sigs, nsec, nsecSig []dns.RR, 
 }
 
 // ApexGlue returns the address records the copy holds for the root's own NS
-// targets — the additional section of a priming response (RFC 8109). The
+// targets — the additional section of a priming response (RFC 9609). The
 // root zone carries these as glue below the delegation that owns them, so
 // they have no signatures of their own; the ZONEMD digest is what
 // authenticates them, and the additional section is outside what AD claims
@@ -420,15 +427,6 @@ func buildSnapshot(rrs []dns.RR, now time.Time) (*Snapshot, error) {
 			s.owners[owner] = sets
 		}
 		t := rr.Header().Rrtype
-		// RFC 5936 §2.2: "AXFR clients MUST ignore any duplicate RRs
-		// received." The digest already tolerates them — equal records hash
-		// once — but the index is what answers are built from, so a source
-		// that double-sends a record would otherwise put it in an answer
-		// twice. Identity is owner, class, type and RDATA, excluding the
-		// TTL (RFC 2181 §5.2), which is what dns.IsDuplicate compares.
-		if hasDuplicate(sets[t], rr) {
-			continue
-		}
 		sets[t] = append(sets[t], rr)
 	}
 

--- a/middleware/resolver/localroot/snapshot.go
+++ b/middleware/resolver/localroot/snapshot.go
@@ -48,9 +48,15 @@ func (s *Snapshot) Serial() uint32 { return s.serial }
 // Loaded returns when this copy was transferred.
 func (s *Snapshot) Loaded() time.Time { return s.loaded }
 
-// Expired reports whether the copy has outlived its SOA expire interval and
-// must no longer be served (RFC 1035 secondary semantics).
+// Expired reports whether the copy has outlived its horizon — the SOA
+// expire interval (RFC 1035 secondary semantics) or the earliest RRSIG
+// expiration in the zone, whichever comes first — and must no longer be
+// served.
 func (s *Snapshot) Expired(now time.Time) bool { return now.After(s.expireAt) }
+
+// ValidUntil is the copy's serving horizon; nothing derived from the copy
+// may claim a longer life.
+func (s *Snapshot) ValidUntil() time.Time { return s.expireAt }
 
 // SOA returns the apex SOA and its RRSIGs.
 func (s *Snapshot) SOA() (*dns.SOA, []dns.RR) { return s.soa, s.soaSig }
@@ -197,8 +203,23 @@ func buildSnapshot(rrs []dns.RR, now time.Time) (*Snapshot, error) {
 	}
 	s.soa = soaSet[0].(*dns.SOA)
 	s.serial = s.soa.Serial
-	s.expireAt = now.Add(time.Duration(s.soa.Expire) * time.Second)
 	s.soaSig = sigsCovering(apex[dns.TypeRRSIG], dns.TypeSOA)
+
+	// The copy's lifetime is the earlier of the SOA expire interval and the
+	// earliest RRSIG expiration anywhere in the zone: past that instant the
+	// copy would be handing clients proofs whose signatures no longer
+	// verify, and an AD=1 answer built on an expired signature is exactly
+	// the lie the verification gate exists to prevent. (RRSIG Expiration is
+	// a uint32 UNIX instant; the root re-signs on a ~2-week window, so the
+	// serial-arithmetic wrap is not reachable while the maths below holds.)
+	s.expireAt = now.Add(time.Duration(s.soa.Expire) * time.Second)
+	for _, rr := range rrs {
+		if sig, ok := rr.(*dns.RRSIG); ok {
+			if exp := time.Unix(int64(sig.Expiration), 0); exp.Before(s.expireAt) {
+				s.expireAt = exp
+			}
+		}
+	}
 
 	if nsecSet := apex[dns.TypeNSEC]; len(nsecSet) == 1 {
 		s.apexNSEC = nsecSet[0].(*dns.NSEC)

--- a/middleware/resolver/localroot/snapshot.go
+++ b/middleware/resolver/localroot/snapshot.go
@@ -386,16 +386,18 @@ func minRRSetTTL(rrs []dns.RR) uint32 {
 	return minTTL
 }
 
-// hasDuplicate reports whether rrs already holds rr. The sets it searches are
+// firstDuplicate returns the record in rrs that rr duplicates, or nil when it
+// is new. Identity is owner, class, type and RDATA — dns.IsDuplicate excludes
+// the TTL, which is what RFC 8976 §3.3.1.1 asks for. The sets it searches are
 // one owner's records of one type — a delegation's NS set, an apex RRSIG set —
 // so they are small enough that a linear scan is the whole of it.
-func hasDuplicate(rrs []dns.RR, rr dns.RR) bool {
+func firstDuplicate(rrs []dns.RR, rr dns.RR) dns.RR {
 	for _, have := range rrs {
 		if dns.IsDuplicate(have, rr) {
-			return true
+			return have
 		}
 	}
-	return false
+	return nil
 }
 
 // sigsCovering filters an owner's RRSIGs to those covering one type.

--- a/middleware/resolver/localroot/snapshot.go
+++ b/middleware/resolver/localroot/snapshot.go
@@ -84,8 +84,14 @@ func (s *Snapshot) SOA() (*dns.SOA, []dns.RR) { return s.soa, s.soaSig }
 func (s *Snapshot) ApexAnswer(qtype uint16) (rrs, sigs, nsec, nsecSig []dns.RR, ok bool) {
 	// RRSIG and ANY are asked about the zone rather than answered from it:
 	// a bare RRSIG query has no RRset to cover, and ANY needs a composition
-	// this does not attempt. Both go to the real roots.
-	if qtype == dns.TypeRRSIG || qtype == dns.TypeANY {
+	// this does not attempt. ZONEMD joins them for a different reason: RFC
+	// 8976 excludes the apex ZONEMD RRset's own signatures from the digest,
+	// so an appended RRSIG(ZONEMD) rides into the transfer unauthenticated —
+	// harmless where it already is (verification accepts the RRset on one
+	// good signature, and the expiry fold skips the group), but serving the
+	// set to a client would put unauthenticated records behind AD=1. The
+	// real roots answer this one.
+	if qtype == dns.TypeRRSIG || qtype == dns.TypeANY || qtype == dns.TypeZONEMD {
 		return nil, nil, nil, nil, false
 	}
 	apex, exists := s.owners["."]
@@ -193,8 +199,15 @@ func (s *Snapshot) DSAnswer(tld string) (ds, dsSig []dns.RR, nsec, nsecSig []dns
 	if !exists || len(sets[dns.TypeNS]) == 0 {
 		return nil, nil, nil, nil, false
 	}
-	if len(sets[dns.TypeDS]) > 0 {
-		return sets[dns.TypeDS], sigsCovering(sets[dns.TypeRRSIG], dns.TypeDS), nil, nil, true
+	if ds := sets[dns.TypeDS]; len(ds) > 0 {
+		// An unsigned DS set is not something the root publishes, and
+		// serving one would mean asserting a secure delegation the copy
+		// cannot evidence — the same refusal ApexAnswer makes.
+		dsSig = sigsCovering(sets[dns.TypeRRSIG], dns.TypeDS)
+		if len(dsSig) == 0 {
+			return nil, nil, nil, nil, false
+		}
+		return ds, dsSig, nil, nil, true
 	}
 	nsec, nsecSig, ok = dsAbsenceProof(sets)
 	if !ok {
@@ -314,6 +327,18 @@ func minRRSetTTL(rrs []dns.RR) uint32 {
 	return minTTL
 }
 
+// hasDuplicate reports whether rrs already holds rr. The sets it searches are
+// one owner's records of one type — a delegation's NS set, an apex RRSIG set —
+// so they are small enough that a linear scan is the whole of it.
+func hasDuplicate(rrs []dns.RR, rr dns.RR) bool {
+	for _, have := range rrs {
+		if dns.IsDuplicate(have, rr) {
+			return true
+		}
+	}
+	return false
+}
+
 // sigsCovering filters an owner's RRSIGs to those covering one type.
 func sigsCovering(sigs []dns.RR, covered uint16) []dns.RR {
 	var out []dns.RR
@@ -343,6 +368,15 @@ func buildSnapshot(rrs []dns.RR, now time.Time) (*Snapshot, error) {
 			s.owners[owner] = sets
 		}
 		t := rr.Header().Rrtype
+		// RFC 5936 §2.2: "AXFR clients MUST ignore any duplicate RRs
+		// received." The digest already tolerates them — equal records hash
+		// once — but the index is what answers are built from, so a source
+		// that double-sends a record would otherwise put it in an answer
+		// twice. Identity is owner, class, type and RDATA, excluding the
+		// TTL (RFC 2181 §5.2), which is what dns.IsDuplicate compares.
+		if hasDuplicate(sets[t], rr) {
+			continue
+		}
 		sets[t] = append(sets[t], rr)
 	}
 

--- a/middleware/resolver/localroot/snapshot.go
+++ b/middleware/resolver/localroot/snapshot.go
@@ -124,6 +124,37 @@ func (s *Snapshot) ApexAnswer(qtype uint16) (rrs, sigs, nsec, nsecSig []dns.RR, 
 	return nil, nil, []dns.RR{s.apexNSEC}, s.apexNSECSig, true
 }
 
+// ApexGlue returns the address records the copy holds for the root's own NS
+// targets — the additional section of a priming response (RFC 8109). The
+// root zone carries these as glue below the delegation that owns them, so
+// they have no signatures of their own; the ZONEMD digest is what
+// authenticates them, and the additional section is outside what AD claims
+// (RFC 4035 §3.2.3) exactly as it is in a real root server's answer.
+//
+// Without them the copy's answer to a root priming query names the servers
+// but gives no way to reach them, and the resolver's own 12-hourly priming
+// cannot refresh its root server list from it.
+func (s *Snapshot) ApexGlue() []dns.RR {
+	apex, ok := s.owners["."]
+	if !ok {
+		return nil
+	}
+	var glue []dns.RR
+	for _, rr := range apex[dns.TypeNS] {
+		ns, isNS := rr.(*dns.NS)
+		if !isNS {
+			continue
+		}
+		sets, held := s.owners[dns.CanonicalName(ns.Ns)]
+		if !held {
+			continue
+		}
+		glue = append(glue, sets[dns.TypeA]...)
+		glue = append(glue, sets[dns.TypeAAAA]...)
+	}
+	return glue
+}
+
 // Referral is the delegation material for one TLD: the NS set, the DS set
 // (empty for an unsigned delegation), and the glue addresses for each NS
 // target present in the zone.
@@ -264,7 +295,15 @@ func dsAbsenceProof(sets map[uint16][]dns.RR) (nsec, nsecSig []dns.RR, ok bool) 
 			return nil, nil, false
 		}
 	}
-	return nsecSet, sigsCovering(sets[dns.TypeRRSIG], dns.TypeNSEC), true
+	// A proof needs the signature that makes it one. The records themselves
+	// are authentic — the digest covered them — but an answer built from an
+	// unsigned NSEC would carry AD=1 with nothing a client could check, and
+	// the same refusal already guards the apex NODATA branch and the DS set.
+	nsecSig = sigsCovering(sets[dns.TypeRRSIG], dns.TypeNSEC)
+	if len(nsecSig) == 0 {
+		return nil, nil, false
+	}
+	return nsecSet, nsecSig, true
 }
 
 // Denial returns the NSEC records proving name does not exist under the
@@ -282,9 +321,22 @@ func (s *Snapshot) Denial(name string) (proof []dns.RR, ok bool) {
 	if len(covering) == 0 {
 		return nil, false
 	}
+	// As in dsAbsenceProof: an NSEC with no covering signature proves
+	// nothing a client can verify, so the denial goes to the real roots
+	// rather than being asserted here under AD=1.
+	coveringSig := sigsCovering(sets[dns.TypeRRSIG], dns.TypeNSEC)
+	if len(coveringSig) == 0 {
+		return nil, false
+	}
 	proof = append(proof, covering...)
-	proof = append(proof, sigsCovering(sets[dns.TypeRRSIG], dns.TypeNSEC)...)
-	if owner != "." && s.apexNSEC != nil {
+	proof = append(proof, coveringSig...)
+	if owner != "." {
+		// The wildcard denial is not optional for an NXDOMAIN, and it needs
+		// its signature for the same reason the covering NSEC does. Missing
+		// either one, the copy cannot prove the name absent and says so.
+		if s.apexNSEC == nil || len(s.apexNSECSig) == 0 {
+			return nil, false
+		}
 		proof = append(proof, s.apexNSEC)
 		proof = append(proof, s.apexNSECSig...)
 	}

--- a/middleware/resolver/localroot/snapshot.go
+++ b/middleware/resolver/localroot/snapshot.go
@@ -299,10 +299,26 @@ func buildSnapshot(rrs []dns.RR, now time.Time) (*Snapshot, error) {
 	// serial-arithmetic wrap is not reachable while the maths below holds.)
 	s.expireAt = now.Add(time.Duration(s.soa.Expire) * time.Second)
 	for _, rr := range rrs {
-		if sig, ok := rr.(*dns.RRSIG); ok {
-			if exp := time.Unix(int64(sig.Expiration), 0); exp.Before(s.expireAt) {
-				s.expireAt = exp
-			}
+		sig, ok := rr.(*dns.RRSIG)
+		if !ok {
+			continue
+		}
+		// The apex RRSIG(ZONEMD) records are the one part of the zone the
+		// digest does not cover — RFC 8976 excludes them, because they are
+		// written after the digest is computed — and verification accepts
+		// the RRset as long as one covering signature validates. So an
+		// appended, already-expired RRSIG(ZONEMD) rides in unauthenticated,
+		// and trusting its expiration here would let anyone who can add a
+		// record to a transfer expire a sound copy on arrival. Nothing is
+		// served from these signatures either; every proof the copy hands
+		// out carries signatures the digest does authenticate, and those
+		// still bound the horizon below.
+		if sig.TypeCovered == dns.TypeZONEMD &&
+			dns.CanonicalName(sig.Header().Name) == "." {
+			continue
+		}
+		if exp := time.Unix(int64(sig.Expiration), 0); exp.Before(s.expireAt) {
+			s.expireAt = exp
 		}
 	}
 

--- a/middleware/resolver/localroot/snapshot.go
+++ b/middleware/resolver/localroot/snapshot.go
@@ -141,17 +141,25 @@ func (s *Snapshot) DSAnswer(tld string) (ds, dsSig []dns.RR, nsec, nsecSig []dns
 // the referral's security lifetime and the DS answer cannot disagree about
 // what counts as a proof.
 //
-// RFC 4035 §5.4: an exact-owner NSEC denies a type only when its type bitmap
-// says so. Three bits disqualify it, and the resolver's own
-// VerifyNODATANSEC refuses the same shapes:
+// RFC 4035 §5.2: the proof of an insecure delegation is an NSEC at the
+// delegation name whose bitmap carries NS but neither DS nor SOA. Both
+// halves matter, and the resolver's own VerifyDelegationNSEC requires
+// exactly the same:
 //
-//   - DS, because a bitmap asserting the type contradicts the missing
-//     record — a truncated or tampered index, or a zone the copy did not
-//     fully hold;
-//   - SOA, because DS non-existence is only provable on the parent side: an
-//     NSEC carrying SOA is the child apex's own, and the child cannot
-//     testify about its own delegation;
-//   - CNAME, because then the NSEC proves something else entirely.
+//   - NS must be present, because that is what makes the record the
+//     parent's word about a delegation. Without it, a stripped-DS bitmap
+//     would be taken as evidence that a signed child is insecure — the
+//     downgrade the requirement exists to prevent. Here it is also an
+//     internal contradiction: the copy holds the owner's real NS RRset, so
+//     a bitmap that omits NS disagrees with the zone it came from.
+//   - DS must be absent, because a bitmap asserting the type contradicts
+//     the missing record — a truncated or tampered index, or a zone the
+//     copy did not fully hold.
+//   - SOA must be absent, because DS non-existence is only provable on the
+//     parent side: an NSEC carrying SOA is the child apex's own, and the
+//     child cannot testify about its own delegation.
+//   - CNAME disqualifies too, because then the NSEC proves something else
+//     entirely.
 func dsAbsenceProof(sets map[uint16][]dns.RR) (nsec, nsecSig []dns.RR, ok bool) {
 	nsecSet := sets[dns.TypeNSEC]
 	if len(nsecSet) == 0 {
@@ -162,10 +170,17 @@ func dsAbsenceProof(sets map[uint16][]dns.RR) (nsec, nsecSig []dns.RR, ok bool) 
 		if !isNSEC {
 			return nil, nil, false
 		}
+		hasNS := false
 		for _, t := range n.TypeBitMap {
-			if t == dns.TypeDS || t == dns.TypeSOA || t == dns.TypeCNAME {
+			switch t {
+			case dns.TypeNS:
+				hasNS = true
+			case dns.TypeDS, dns.TypeSOA, dns.TypeCNAME:
 				return nil, nil, false
 			}
+		}
+		if !hasNS {
+			return nil, nil, false
 		}
 	}
 	return nsecSet, sigsCovering(sets[dns.TypeRRSIG], dns.TypeNSEC), true

--- a/middleware/resolver/localroot/snapshot.go
+++ b/middleware/resolver/localroot/snapshot.go
@@ -1,0 +1,235 @@
+// Package localroot maintains a local, verified copy of the root zone (RFC
+// 8806) and answers the three questions the resolver's walk would otherwise
+// ask a root server: where a TLD's delegation lives, whether a TLD's DS
+// exists, and the signed proof that a TLD does not exist.
+//
+// A copy is only ever served after ZONEMD verification (RFC 8976) chained to
+// the resolver's root trust anchors; refresh follows the zone's own SOA
+// schedule; and a copy past its SOA expire is withdrawn, returning the walk
+// to the real root servers.
+package localroot
+
+import (
+	"sort"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/dnsname"
+)
+
+// Snapshot is one immutable, verified copy of the root zone, indexed for the
+// three lookups the resolver makes. It is built once and never mutated; the
+// manager publishes it with an atomic pointer swap.
+type Snapshot struct {
+	serial   uint32
+	loaded   time.Time
+	expireAt time.Time
+
+	soa    *dns.SOA
+	soaSig []dns.RR // RRSIG(SOA) at the apex
+
+	// apexNSEC proves the root's own types and, because "*" sorts before
+	// every TLD, doubles as the wildcard-denial proof for any NXDOMAIN.
+	apexNSEC    *dns.NSEC
+	apexNSECSig []dns.RR
+
+	// owners groups every record in the zone by canonical owner and type.
+	// TLD lookups, DS answers and glue collection all read from it.
+	owners map[string]map[uint16][]dns.RR
+
+	// nsecOwners is every NSEC owner in canonical order, for the covering
+	// search behind NXDOMAIN synthesis.
+	nsecOwners []string
+}
+
+// Serial returns the copy's SOA serial.
+func (s *Snapshot) Serial() uint32 { return s.serial }
+
+// Loaded returns when this copy was transferred.
+func (s *Snapshot) Loaded() time.Time { return s.loaded }
+
+// Expired reports whether the copy has outlived its SOA expire interval and
+// must no longer be served (RFC 1035 secondary semantics).
+func (s *Snapshot) Expired(now time.Time) bool { return now.After(s.expireAt) }
+
+// SOA returns the apex SOA and its RRSIGs.
+func (s *Snapshot) SOA() (*dns.SOA, []dns.RR) { return s.soa, s.soaSig }
+
+// Referral is the delegation material for one TLD: the NS set, the DS set
+// (empty for an unsigned delegation), and the glue addresses for each NS
+// target present in the zone.
+type Referral struct {
+	NS   []dns.RR
+	DS   []dns.RR
+	Glue map[string][]dns.RR // canonical NS host -> A/AAAA records
+}
+
+// Referral returns the delegation for tld (a canonical, rooted, one-label
+// name) or ok=false when the zone holds no such delegation.
+func (s *Snapshot) Referral(tld string) (Referral, bool) {
+	sets, ok := s.owners[tld]
+	if !ok {
+		return Referral{}, false
+	}
+	ns := sets[dns.TypeNS]
+	if len(ns) == 0 {
+		return Referral{}, false
+	}
+	ref := Referral{NS: ns, DS: sets[dns.TypeDS], Glue: make(map[string][]dns.RR)}
+	for _, rr := range ns {
+		host := dns.CanonicalName(rr.(*dns.NS).Ns)
+		if hostSets, ok := s.owners[host]; ok {
+			glue := append([]dns.RR(nil), hostSets[dns.TypeA]...)
+			glue = append(glue, hostSets[dns.TypeAAAA]...)
+			if len(glue) > 0 {
+				ref.Glue[host] = glue
+			}
+		}
+	}
+	return ref, true
+}
+
+// DSAnswer returns the material for an authoritative DS response at tld:
+// the DS set with its RRSIGs when the delegation is signed, or the TLD's
+// own NSEC with its RRSIGs as the exact-owner NODATA proof when it is not.
+// ok=false when the TLD does not exist.
+func (s *Snapshot) DSAnswer(tld string) (ds, dsSig []dns.RR, nsec, nsecSig []dns.RR, ok bool) {
+	sets, exists := s.owners[tld]
+	if !exists || len(sets[dns.TypeNS]) == 0 {
+		return nil, nil, nil, nil, false
+	}
+	if len(sets[dns.TypeDS]) > 0 {
+		return sets[dns.TypeDS], sigsCovering(sets[dns.TypeRRSIG], dns.TypeDS), nil, nil, true
+	}
+	nsecSet := sets[dns.TypeNSEC]
+	if len(nsecSet) == 0 {
+		return nil, nil, nil, nil, false
+	}
+	return nil, nil, nsecSet, sigsCovering(sets[dns.TypeRRSIG], dns.TypeNSEC), true
+}
+
+// Denial returns the NSEC records proving name does not exist under the
+// root: the covering NSEC for the name and the apex NSEC as the wildcard
+// proof (deduplicated when they are the same record), each with RRSIGs.
+// ok=false when the chain cannot cover the name — a snapshot in that state
+// is not usable for denial and the caller falls back.
+func (s *Snapshot) Denial(name string) (proof []dns.RR, ok bool) {
+	owner, found := s.coveringOwner(name)
+	if !found {
+		return nil, false
+	}
+	sets := s.owners[owner]
+	covering := sets[dns.TypeNSEC]
+	if len(covering) == 0 {
+		return nil, false
+	}
+	proof = append(proof, covering...)
+	proof = append(proof, sigsCovering(sets[dns.TypeRRSIG], dns.TypeNSEC)...)
+	if owner != "." && s.apexNSEC != nil {
+		proof = append(proof, s.apexNSEC)
+		proof = append(proof, s.apexNSECSig...)
+	}
+	return proof, true
+}
+
+// coveringOwner finds the NSEC owner whose span covers name: the greatest
+// owner canonically below it. The chain is circular, so a name below the
+// first owner or past the last is covered by the last NSEC.
+func (s *Snapshot) coveringOwner(name string) (string, bool) {
+	if len(s.nsecOwners) == 0 {
+		return "", false
+	}
+	// First owner canonically greater than name; the one before it covers.
+	i := sort.Search(len(s.nsecOwners), func(i int) bool {
+		return dnsname.CanonicalCompare(s.nsecOwners[i], name) > 0
+	})
+	if i == 0 {
+		// Below the apex: nothing sorts before "."; not coverable.
+		return "", false
+	}
+	owner := s.nsecOwners[i-1]
+	if dnsname.CanonicalCompare(owner, name) == 0 {
+		// The name exists; this is not a denial.
+		return "", false
+	}
+	return owner, true
+}
+
+// sigsCovering filters an owner's RRSIGs to those covering one type.
+func sigsCovering(sigs []dns.RR, covered uint16) []dns.RR {
+	var out []dns.RR
+	for _, rr := range sigs {
+		if sig, ok := rr.(*dns.RRSIG); ok && sig.TypeCovered == covered {
+			out = append(out, sig)
+		}
+	}
+	return out
+}
+
+// buildSnapshot indexes a verified record set into a Snapshot. It assumes
+// verify has already established the zone's integrity; structural gaps here
+// (no SOA, no apex NSEC) still refuse, because a snapshot that cannot answer
+// is worse than no snapshot.
+func buildSnapshot(rrs []dns.RR, now time.Time) (*Snapshot, error) {
+	s := &Snapshot{
+		loaded: now,
+		owners: make(map[string]map[uint16][]dns.RR),
+	}
+
+	for _, rr := range rrs {
+		owner := dns.CanonicalName(rr.Header().Name)
+		sets, ok := s.owners[owner]
+		if !ok {
+			sets = make(map[uint16][]dns.RR)
+			s.owners[owner] = sets
+		}
+		t := rr.Header().Rrtype
+		sets[t] = append(sets[t], rr)
+	}
+
+	apex, ok := s.owners["."]
+	if !ok {
+		return nil, errNoApex
+	}
+	soaSet := apex[dns.TypeSOA]
+	if len(soaSet) != 1 {
+		return nil, errNoApex
+	}
+	s.soa = soaSet[0].(*dns.SOA)
+	s.serial = s.soa.Serial
+	s.expireAt = now.Add(time.Duration(s.soa.Expire) * time.Second)
+	s.soaSig = sigsCovering(apex[dns.TypeRRSIG], dns.TypeSOA)
+
+	if nsecSet := apex[dns.TypeNSEC]; len(nsecSet) == 1 {
+		s.apexNSEC = nsecSet[0].(*dns.NSEC)
+		s.apexNSECSig = sigsCovering(apex[dns.TypeRRSIG], dns.TypeNSEC)
+	}
+
+	for owner, sets := range s.owners {
+		if len(sets[dns.TypeNSEC]) > 0 {
+			s.nsecOwners = append(s.nsecOwners, owner)
+		}
+	}
+	sort.Slice(s.nsecOwners, func(i, j int) bool {
+		return dnsname.CanonicalCompare(s.nsecOwners[i], s.nsecOwners[j]) < 0
+	})
+
+	return s, nil
+}
+
+// TLDOf returns the canonical last label of a rooted name, or "" for the
+// root itself. The split is label-aware: an escaped dot inside a label
+// ("a\.com.") must not masquerade as a boundary, or a hostile single-label
+// name would borrow a real TLD's delegation path.
+func TLDOf(name string) string {
+	name = dns.CanonicalName(name)
+	if name == "." {
+		return ""
+	}
+	labels := dns.CountLabel(name)
+	off, _ := dns.PrevLabel(name, 1)
+	if labels < 1 || off >= len(name) {
+		return ""
+	}
+	return name[off:]
+}

--- a/middleware/resolver/localroot/snapshot.go
+++ b/middleware/resolver/localroot/snapshot.go
@@ -98,7 +98,10 @@ func (s *Snapshot) Referral(tld string) (Referral, bool) {
 // DSAnswer returns the material for an authoritative DS response at tld:
 // the DS set with its RRSIGs when the delegation is signed, or the TLD's
 // own NSEC with its RRSIGs as the exact-owner NODATA proof when it is not.
-// ok=false when the TLD does not exist.
+// ok=false when the TLD does not exist, or when the copy holds no NSEC
+// that actually proves the DS absent — the absence of a DS record in the
+// index is not itself a proof, and an answer that cannot be proven is left
+// to the real roots.
 func (s *Snapshot) DSAnswer(tld string) (ds, dsSig []dns.RR, nsec, nsecSig []dns.RR, ok bool) {
 	sets, exists := s.owners[tld]
 	if !exists || len(sets[dns.TypeNS]) == 0 {
@@ -110,6 +113,22 @@ func (s *Snapshot) DSAnswer(tld string) (ds, dsSig []dns.RR, nsec, nsecSig []dns
 	nsecSet := sets[dns.TypeNSEC]
 	if len(nsecSet) == 0 {
 		return nil, nil, nil, nil, false
+	}
+	// RFC 4035 §5.4: an exact-owner NSEC denies a type only when its type
+	// bitmap says so. A bitmap asserting DS contradicts the missing record
+	// — a truncated or tampered index, or a zone the copy did not fully
+	// hold — and a CNAME at the owner means the NSEC proves something else
+	// entirely. Neither may be dressed as an authenticated NODATA.
+	for _, rr := range nsecSet {
+		n, isNSEC := rr.(*dns.NSEC)
+		if !isNSEC {
+			return nil, nil, nil, nil, false
+		}
+		for _, t := range n.TypeBitMap {
+			if t == dns.TypeDS || t == dns.TypeCNAME {
+				return nil, nil, nil, nil, false
+			}
+		}
 	}
 	return nil, nil, nsecSet, sigsCovering(sets[dns.TypeRRSIG], dns.TypeNSEC), true
 }

--- a/middleware/resolver/localroot/snapshot.go
+++ b/middleware/resolver/localroot/snapshot.go
@@ -71,6 +71,53 @@ func (s *Snapshot) BoundTo(until time.Time) {
 // SOA returns the apex SOA and its RRSIGs.
 func (s *Snapshot) SOA() (*dns.SOA, []dns.RR) { return s.soa, s.soaSig }
 
+// ApexAnswer returns what the copy holds at the root's own name for qtype:
+// the RRset with its signatures when the type exists there, or the apex
+// NSEC with its signatures as the NODATA proof when it does not. ok=false
+// when the copy can say neither — the caller then asks the real roots.
+//
+// The apex is the one part of the zone the copy is authoritative-shaped
+// about in the ordinary sense: NS, SOA, DNSKEY and the rest are the root's
+// own records, signed, and the copy carries them. Sending those questions
+// to a root server while holding a verified copy of the answer is the one
+// thing this whole package exists to stop doing.
+func (s *Snapshot) ApexAnswer(qtype uint16) (rrs, sigs, nsec, nsecSig []dns.RR, ok bool) {
+	// RRSIG and ANY are asked about the zone rather than answered from it:
+	// a bare RRSIG query has no RRset to cover, and ANY needs a composition
+	// this does not attempt. Both go to the real roots.
+	if qtype == dns.TypeRRSIG || qtype == dns.TypeANY {
+		return nil, nil, nil, nil, false
+	}
+	apex, exists := s.owners["."]
+	if !exists {
+		return nil, nil, nil, nil, false
+	}
+
+	if set := apex[qtype]; len(set) > 0 {
+		covering := sigsCovering(apex[dns.TypeRRSIG], qtype)
+		if len(covering) == 0 {
+			// Unsigned at the apex is not something the root publishes;
+			// serving it would mean asserting an answer the copy cannot
+			// evidence.
+			return nil, nil, nil, nil, false
+		}
+		return set, covering, nil, nil, true
+	}
+
+	// Absent: the apex NSEC denies it, provided its bitmap agrees. RFC 4035
+	// §5.4 — an NSEC listing the type proves the opposite of what is being
+	// claimed, and a copy that disagrees with itself answers nothing.
+	if s.apexNSEC == nil || len(s.apexNSECSig) == 0 {
+		return nil, nil, nil, nil, false
+	}
+	for _, t := range s.apexNSEC.TypeBitMap {
+		if t == qtype {
+			return nil, nil, nil, nil, false
+		}
+	}
+	return nil, nil, []dns.RR{s.apexNSEC}, s.apexNSECSig, true
+}
+
 // Referral is the delegation material for one TLD: the NS set, the DS set
 // (empty for an unsigned delegation), and the glue addresses for each NS
 // target present in the zone.

--- a/middleware/resolver/localroot/snapshot.go
+++ b/middleware/resolver/localroot/snapshot.go
@@ -115,17 +115,23 @@ func (s *Snapshot) DSAnswer(tld string) (ds, dsSig []dns.RR, nsec, nsecSig []dns
 		return nil, nil, nil, nil, false
 	}
 	// RFC 4035 §5.4: an exact-owner NSEC denies a type only when its type
-	// bitmap says so. A bitmap asserting DS contradicts the missing record
-	// — a truncated or tampered index, or a zone the copy did not fully
-	// hold — and a CNAME at the owner means the NSEC proves something else
-	// entirely. Neither may be dressed as an authenticated NODATA.
+	// bitmap says so. Three bits disqualify it here, and the resolver's own
+	// VerifyNODATANSEC refuses the same shapes:
+	//
+	//   - DS, because a bitmap asserting the type contradicts the missing
+	//     record — a truncated or tampered index, or a zone the copy did
+	//     not fully hold;
+	//   - SOA, because DS non-existence is only provable on the parent
+	//     side: an NSEC carrying SOA is the child apex's own, and the
+	//     child cannot testify about its delegation;
+	//   - CNAME, because then the NSEC proves something else entirely.
 	for _, rr := range nsecSet {
 		n, isNSEC := rr.(*dns.NSEC)
 		if !isNSEC {
 			return nil, nil, nil, nil, false
 		}
 		for _, t := range n.TypeBitMap {
-			if t == dns.TypeDS || t == dns.TypeCNAME {
+			if t == dns.TypeDS || t == dns.TypeSOA || t == dns.TypeCNAME {
 				return nil, nil, nil, nil, false
 			}
 		}

--- a/middleware/resolver/localroot/snapshot_test.go
+++ b/middleware/resolver/localroot/snapshot_test.go
@@ -132,30 +132,45 @@ func TestSnapshotApexAnswerRefusesZONEMD(t *testing.T) {
 	}
 }
 
-func TestBuildSnapshotIgnoresDuplicateRRs(t *testing.T) {
+// TestLoadIgnoresDuplicateRRs drives the whole load path, because that is
+// where normalization sits: a doubled record must not survive into the index,
+// must not be digested twice, and must not read as a second ZONEMD tuple.
+func TestLoadIgnoresDuplicateRRs(t *testing.T) {
 	root := buildTestRoot(t)
 
 	// RFC 5936 §2.2: a source that double-sends a record must not put it in
-	// an answer twice. The twin differs only in TTL, which is outside the
-	// RFC 2181 §5.2 identity the rule is written against.
-	doubled := make([]dns.RR, 0, len(root.rrs)+1)
-	twinned := false
+	// an answer twice. The NS twin differs only in TTL, which is outside the
+	// RFC 8976 §3.3.1.1 identity the rule is written against; the ZONEMD
+	// twin is exact, the case that used to read as a repeated tuple and
+	// refuse the whole zone.
+	doubled := make([]dns.RR, 0, len(root.rrs)+2)
+	var twinnedNS, twinnedZONEMD bool
 	for _, rr := range root.rrs {
 		doubled = append(doubled, rr)
-		if ns, ok := rr.(*dns.NS); ok && dns.CanonicalName(ns.Hdr.Name) == "com." {
-			twin := dns.Copy(ns)
-			twin.Header().Ttl += 60
-			doubled = append(doubled, twin)
-			twinned = true
+		switch record := rr.(type) {
+		case *dns.NS:
+			if dns.CanonicalName(record.Hdr.Name) == "com." {
+				twin := dns.Copy(record)
+				twin.Header().Ttl += 60
+				doubled = append(doubled, twin)
+				twinnedNS = true
+			}
+		case *dns.ZONEMD:
+			doubled = append(doubled, dns.Copy(record))
+			twinnedZONEMD = true
 		}
 	}
-	if !twinned {
-		t.Fatal("test zone has no com. NS record to duplicate")
+	if !twinnedNS || !twinnedZONEMD {
+		t.Fatalf("test zone lacks records to duplicate: ns=%v zonemd=%v", twinnedNS, twinnedZONEMD)
 	}
 
-	snap, err := buildSnapshot(doubled, time.Now())
-	if err != nil {
-		t.Fatalf("buildSnapshot: %v", err)
+	m := New(nil, func() []dns.RR { return root.anchors })
+	if err := m.Load(doubled); err != nil {
+		t.Fatalf("a zone with duplicate records was refused: %v", err)
+	}
+	snap := m.Active()
+	if snap == nil {
+		t.Fatal("no active copy after load")
 	}
 	ref, ok := snap.Referral("com.")
 	if !ok {

--- a/middleware/resolver/localroot/snapshot_test.go
+++ b/middleware/resolver/localroot/snapshot_test.go
@@ -1,0 +1,125 @@
+package localroot
+
+import (
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+func testSnapshot(t *testing.T) *Snapshot {
+	t.Helper()
+	root := buildTestRoot(t)
+	snap, err := buildSnapshot(root.rrs, time.Now())
+	if err != nil {
+		t.Fatalf("buildSnapshot: %v", err)
+	}
+	return snap
+}
+
+func TestSnapshotReferral(t *testing.T) {
+	snap := testSnapshot(t)
+
+	ref, ok := snap.Referral("com.")
+	if !ok {
+		t.Fatal("com. delegation missing")
+	}
+	if len(ref.NS) != 1 || len(ref.DS) != 1 {
+		t.Fatalf("com. referral NS=%d DS=%d, want 1/1", len(ref.NS), len(ref.DS))
+	}
+	glue := ref.Glue["ns.com."]
+	if len(glue) != 2 {
+		t.Fatalf("ns.com. glue = %d records, want A+AAAA", len(glue))
+	}
+
+	if ref, ok := snap.Referral("org."); !ok || len(ref.DS) != 0 {
+		t.Fatalf("org. must be an unsigned delegation; ok=%v DS=%d", ok, len(ref.DS))
+	}
+	if _, ok := snap.Referral("nope."); ok {
+		t.Fatal("a delegation the zone does not hold was returned")
+	}
+	// Glue owners are not delegations: a hostile query for a glue name's
+	// "TLD" must not fabricate a referral.
+	if _, ok := snap.Referral("ns.com."); ok {
+		t.Fatal("a glue owner masqueraded as a delegation")
+	}
+}
+
+func TestSnapshotDSAnswer(t *testing.T) {
+	snap := testSnapshot(t)
+
+	ds, dsSig, _, _, ok := snap.DSAnswer("com.")
+	if !ok || len(ds) != 1 || len(dsSig) != 1 {
+		t.Fatalf("com. DS answer = ds:%d sig:%d ok:%v, want signed DS", len(ds), len(dsSig), ok)
+	}
+
+	ds, _, nsec, nsecSig, ok := snap.DSAnswer("org.")
+	if !ok || len(ds) != 0 || len(nsec) != 1 || len(nsecSig) != 1 {
+		t.Fatalf("org. DS answer must be the NSEC NODATA proof; ds:%d nsec:%d sig:%d ok:%v",
+			len(ds), len(nsec), len(nsecSig), ok)
+	}
+
+	if _, _, _, _, ok := snap.DSAnswer("nope."); ok {
+		t.Fatal("a DS answer for an absent TLD")
+	}
+}
+
+func TestSnapshotDenial(t *testing.T) {
+	snap := testSnapshot(t)
+
+	// dev. sorts between com. and org.: covered by com.'s NSEC, with the
+	// apex NSEC riding along as the wildcard proof.
+	proof, ok := snap.Denial("dev.")
+	if !ok {
+		t.Fatal("dev. denial not covered")
+	}
+	var owners []string
+	nsecs := 0
+	for _, rr := range proof {
+		if rr.Header().Rrtype == dns.TypeNSEC {
+			nsecs++
+			owners = append(owners, rr.Header().Name)
+		}
+	}
+	if nsecs != 2 {
+		t.Fatalf("dev. denial carries %d NSECs (%v), want covering + apex", nsecs, owners)
+	}
+
+	// zzz. sorts past org., whose NSEC wraps to the apex: covered.
+	if _, ok := snap.Denial("zzz."); !ok {
+		t.Fatal("zzz. denial not covered by the wrapping NSEC")
+	}
+
+	// A name that exists is not deniable.
+	if _, ok := snap.Denial("com."); ok {
+		t.Fatal("an existing TLD was denied")
+	}
+}
+
+func TestSnapshotExpiry(t *testing.T) {
+	root := buildTestRoot(t)
+	now := time.Now()
+	snap, err := buildSnapshot(root.rrs, now)
+	if err != nil {
+		t.Fatalf("buildSnapshot: %v", err)
+	}
+	if snap.Expired(now.Add(604799 * time.Second)) {
+		t.Fatal("expired inside the SOA expire interval")
+	}
+	if !snap.Expired(now.Add(604801 * time.Second)) {
+		t.Fatal("not expired past the SOA expire interval")
+	}
+}
+
+func TestTLDOf(t *testing.T) {
+	for name, want := range map[string]string{
+		".":                "",
+		"com.":             "com.",
+		"www.example.com.": "com.",
+		`a\.com.`:          `a\.com.`,
+	} {
+		if got := TLDOf(name); got != want {
+			t.Fatalf("TLDOf(%q) = %q, want %q", name, got, want)
+		}
+	}
+}

--- a/middleware/resolver/localroot/snapshot_test.go
+++ b/middleware/resolver/localroot/snapshot_test.go
@@ -118,6 +118,82 @@ func TestSnapshotExpiry(t *testing.T) {
 	}
 }
 
+func TestSnapshotApexAnswerRefusesZONEMD(t *testing.T) {
+	snap := testSnapshot(t)
+
+	// Assert the zone actually holds the type: without this the refusal
+	// below would come from the NODATA branch and prove nothing.
+	if len(snap.owners["."][dns.TypeZONEMD]) == 0 {
+		t.Fatal("test zone has no apex ZONEMD, so its refusal cannot be tested here")
+	}
+	if _, _, _, _, ok := snap.ApexAnswer(dns.TypeZONEMD); ok {
+		t.Fatal("ZONEMD served from the copy: RFC 8976 leaves its signatures outside the digest, " +
+			"so serving the set would put unauthenticated records behind AD=1")
+	}
+}
+
+func TestBuildSnapshotIgnoresDuplicateRRs(t *testing.T) {
+	root := buildTestRoot(t)
+
+	// RFC 5936 §2.2: a source that double-sends a record must not put it in
+	// an answer twice. The twin differs only in TTL, which is outside the
+	// RFC 2181 §5.2 identity the rule is written against.
+	doubled := make([]dns.RR, 0, len(root.rrs)+1)
+	twinned := false
+	for _, rr := range root.rrs {
+		doubled = append(doubled, rr)
+		if ns, ok := rr.(*dns.NS); ok && dns.CanonicalName(ns.Hdr.Name) == "com." {
+			twin := dns.Copy(ns)
+			twin.Header().Ttl += 60
+			doubled = append(doubled, twin)
+			twinned = true
+		}
+	}
+	if !twinned {
+		t.Fatal("test zone has no com. NS record to duplicate")
+	}
+
+	snap, err := buildSnapshot(doubled, time.Now())
+	if err != nil {
+		t.Fatalf("buildSnapshot: %v", err)
+	}
+	ref, ok := snap.Referral("com.")
+	if !ok {
+		t.Fatal("com. delegation missing")
+	}
+	if len(ref.NS) != 1 {
+		t.Fatalf("com. NS set = %d records, want the duplicate ignored", len(ref.NS))
+	}
+}
+
+func TestSnapshotDSAnswerRefusesUnsignedDS(t *testing.T) {
+	root := buildTestRoot(t)
+
+	// A DS set the copy cannot evidence must not be served: stripping its
+	// signatures leaves a delegation whose secure status is unproven, and
+	// asserting it under AD=1 is the downgrade the proof requirement exists
+	// to prevent.
+	stripped := make([]dns.RR, 0, len(root.rrs))
+	for _, rr := range root.rrs {
+		if sig, ok := rr.(*dns.RRSIG); ok &&
+			sig.TypeCovered == dns.TypeDS && dns.CanonicalName(sig.Hdr.Name) == "com." {
+			continue
+		}
+		stripped = append(stripped, rr)
+	}
+	if len(stripped) == len(root.rrs) {
+		t.Fatal("test zone has no RRSIG(DS) at com. to strip")
+	}
+
+	snap, err := buildSnapshot(stripped, time.Now())
+	if err != nil {
+		t.Fatalf("buildSnapshot: %v", err)
+	}
+	if _, _, _, _, ok := snap.DSAnswer("com."); ok {
+		t.Fatal("an unsigned DS set was served from the copy")
+	}
+}
+
 func TestTLDOf(t *testing.T) {
 	for name, want := range map[string]string{
 		".":                "",

--- a/middleware/resolver/localroot/snapshot_test.go
+++ b/middleware/resolver/localroot/snapshot_test.go
@@ -103,11 +103,18 @@ func TestSnapshotExpiry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("buildSnapshot: %v", err)
 	}
-	if snap.Expired(now.Add(604799 * time.Second)) {
-		t.Fatal("expired inside the SOA expire interval")
+	// The test zone signs with a one-hour window against a seven-day SOA
+	// expire; the horizon must follow the signatures, the nearer bound.
+	// Past that instant every proof the copy could serve carries a dead
+	// signature.
+	if snap.Expired(now.Add(50 * time.Minute)) {
+		t.Fatal("expired inside the signature validity window")
 	}
-	if !snap.Expired(now.Add(604801 * time.Second)) {
-		t.Fatal("not expired past the SOA expire interval")
+	if !snap.Expired(now.Add(61 * time.Minute)) {
+		t.Fatal("not expired past the signature window — the SOA expire must not extend dead signatures")
+	}
+	if !snap.ValidUntil().Before(now.Add(2 * time.Hour)) {
+		t.Fatalf("ValidUntil = %v, not bounded by the signature window", snap.ValidUntil())
 	}
 }
 

--- a/middleware/resolver/localroot/snapshot_test.go
+++ b/middleware/resolver/localroot/snapshot_test.go
@@ -206,3 +206,70 @@ func TestTLDOf(t *testing.T) {
 		}
 	}
 }
+
+func TestSnapshotApexGlue(t *testing.T) {
+	snap := testSnapshot(t)
+
+	glue := snap.ApexGlue()
+	if len(glue) == 0 {
+		t.Fatal("the root's own NS targets have no glue in the copy")
+	}
+	named := make(map[string]bool)
+	for _, rr := range snap.owners["."][dns.TypeNS] {
+		named[dns.CanonicalName(rr.(*dns.NS).Ns)] = true
+	}
+	for _, rr := range glue {
+		switch rr.(type) {
+		case *dns.A, *dns.AAAA:
+		default:
+			t.Fatalf("apex glue carries a %s record", dns.TypeToString[rr.Header().Rrtype])
+		}
+		if owner := dns.CanonicalName(rr.Header().Name); !named[owner] {
+			t.Fatalf("apex glue carries an address for %s, which the root's NS set does not name", owner)
+		}
+	}
+}
+
+// TestSnapshotProofsRequireTheirSignatures pins the rule the DS set and the
+// apex NODATA branch already follow: the copy may hold a record the digest
+// authenticated, but a denial served to a client under AD=1 needs the
+// signature that lets the client check it too.
+func TestSnapshotProofsRequireTheirSignatures(t *testing.T) {
+	root := buildTestRoot(t)
+
+	withoutNSECSig := func(owner string) *Snapshot {
+		t.Helper()
+		kept := make([]dns.RR, 0, len(root.rrs))
+		stripped := false
+		for _, rr := range root.rrs {
+			if sig, ok := rr.(*dns.RRSIG); ok &&
+				sig.TypeCovered == dns.TypeNSEC && dns.CanonicalName(sig.Hdr.Name) == owner {
+				stripped = true
+				continue
+			}
+			kept = append(kept, rr)
+		}
+		if !stripped {
+			t.Fatalf("test zone has no RRSIG(NSEC) at %s to strip", owner)
+		}
+		snap, err := buildSnapshot(kept, time.Now())
+		if err != nil {
+			t.Fatalf("buildSnapshot: %v", err)
+		}
+		return snap
+	}
+
+	// org. is the unsigned delegation, so its DS answer is the NSEC NODATA
+	// proof — which is a proof only while it is signed.
+	if _, _, _, _, ok := withoutNSECSig("org.").DSAnswer("org."); ok {
+		t.Fatal("a DS NODATA proof with no signature was served")
+	}
+	// dev. sorts inside com.'s NSEC span, so com.'s NSEC is what denies it.
+	if _, ok := withoutNSECSig("com.").Denial("dev."); ok {
+		t.Fatal("an NXDOMAIN was synthesized from an unsigned covering NSEC")
+	}
+	// The apex NSEC is the wildcard half of every NXDOMAIN.
+	if _, ok := withoutNSECSig(".").Denial("dev."); ok {
+		t.Fatal("an NXDOMAIN was synthesized without a signed wildcard proof")
+	}
+}

--- a/middleware/resolver/localroot/testzone_test.go
+++ b/middleware/resolver/localroot/testzone_test.go
@@ -1,0 +1,112 @@
+package localroot
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/middleware/resolver/localroot/roottest"
+)
+
+// testRoot adapts roottest.Build for this package's tests: a miniature
+// signed root — apex SOA/NS/DNSKEY/NSEC sealed by ZONEMD, a signed com.
+// delegation, an unsigned org. delegation, in-zone glue — chained to one
+// CSK whose DS is the trust anchor.
+type testRoot struct {
+	rrs     []dns.RR
+	anchors []dns.RR
+	serial  uint32
+}
+
+func buildTestRoot(t *testing.T) *testRoot {
+	t.Helper()
+	z, err := roottest.Build(ComputeDigest)
+	if err != nil {
+		t.Fatalf("roottest.Build: %v", err)
+	}
+	return &testRoot{rrs: z.RRs, anchors: z.Anchors, serial: roottest.Serial}
+}
+
+func rrsFromText(t *testing.T, lines ...string) []dns.RR {
+	t.Helper()
+	out := make([]dns.RR, 0, len(lines))
+	for _, l := range lines {
+		rr, err := dns.NewRR(l)
+		if err != nil {
+			t.Fatalf("test zone RR %q: %v", l, err)
+		}
+		out = append(out, rr)
+	}
+	return out
+}
+
+func TestVerifyZoneChain(t *testing.T) {
+	root := buildTestRoot(t)
+
+	t.Run("a sealed zone verifies against its anchor", func(t *testing.T) {
+		if err := verifyZone(root.rrs, root.anchors); err != nil {
+			t.Fatalf("verifyZone: %v", err)
+		}
+	})
+
+	t.Run("a tampered record fails the digest", func(t *testing.T) {
+		tampered := append([]dns.RR(nil), root.rrs...)
+		for i, rr := range tampered {
+			if a, ok := rr.(*dns.A); ok {
+				evil := dns.Copy(a).(*dns.A)
+				evil.A[3]++
+				tampered[i] = evil
+				break
+			}
+		}
+		if err := verifyZone(tampered, root.anchors); err == nil {
+			t.Fatal("a tampered glue record verified")
+		}
+	})
+
+	t.Run("a foreign anchor refuses the chain", func(t *testing.T) {
+		foreign := rrsFromText(t,
+			". 172800 IN DS 999 13 2 0000000000000000000000000000000000000000000000000000000000000000",
+		)
+		if err := verifyZone(root.rrs, foreign); err == nil {
+			t.Fatal("zone verified against an anchor it does not chain to")
+		}
+	})
+
+	t.Run("no anchors means no verification", func(t *testing.T) {
+		if err := verifyZone(root.rrs, nil); err == nil {
+			t.Fatal("zone verified with no trust anchors at all")
+		}
+	})
+
+	t.Run("a serial mismatch refuses", func(t *testing.T) {
+		mangled := append([]dns.RR(nil), root.rrs...)
+		for i, rr := range mangled {
+			if z, ok := rr.(*dns.ZONEMD); ok {
+				evil := dns.Copy(z).(*dns.ZONEMD)
+				evil.Serial++
+				mangled[i] = evil
+			}
+		}
+		// The ZONEMD content changed, so its signature fails first — either
+		// refusal is correct; what must not happen is acceptance.
+		if err := verifyZone(mangled, root.anchors); err == nil {
+			t.Fatal("a ZONEMD serial mismatch verified")
+		}
+	})
+
+	t.Run("a stripped ZONEMD refuses", func(t *testing.T) {
+		var stripped []dns.RR
+		for _, rr := range root.rrs {
+			if rr.Header().Rrtype == dns.TypeZONEMD {
+				continue
+			}
+			if sig, ok := rr.(*dns.RRSIG); ok && sig.TypeCovered == dns.TypeZONEMD {
+				continue
+			}
+			stripped = append(stripped, rr)
+		}
+		if err := verifyZone(stripped, root.anchors); err == nil {
+			t.Fatal("a zone with no ZONEMD verified")
+		}
+	})
+}

--- a/middleware/resolver/localroot/testzone_test.go
+++ b/middleware/resolver/localroot/testzone_test.go
@@ -52,7 +52,7 @@ func TestVerifyZoneChain(t *testing.T) {
 	root := buildTestRoot(t)
 
 	t.Run("a sealed zone verifies against its anchor", func(t *testing.T) {
-		if err := verifyZone(root.rrs, root.anchors); err != nil {
+		if _, err := verifyZone(root.rrs, root.anchors); err != nil {
 			t.Fatalf("verifyZone: %v", err)
 		}
 	})
@@ -67,7 +67,7 @@ func TestVerifyZoneChain(t *testing.T) {
 				break
 			}
 		}
-		if err := verifyZone(tampered, root.anchors); err == nil {
+		if _, err := verifyZone(tampered, root.anchors); err == nil {
 			t.Fatal("a tampered glue record verified")
 		}
 	})
@@ -76,13 +76,13 @@ func TestVerifyZoneChain(t *testing.T) {
 		foreign := rrsFromText(t,
 			". 172800 IN DS 999 13 2 0000000000000000000000000000000000000000000000000000000000000000",
 		)
-		if err := verifyZone(root.rrs, foreign); err == nil {
+		if _, err := verifyZone(root.rrs, foreign); err == nil {
 			t.Fatal("zone verified against an anchor it does not chain to")
 		}
 	})
 
 	t.Run("no anchors means no verification", func(t *testing.T) {
-		if err := verifyZone(root.rrs, nil); err == nil {
+		if _, err := verifyZone(root.rrs, nil); err == nil {
 			t.Fatal("zone verified with no trust anchors at all")
 		}
 	})
@@ -98,7 +98,7 @@ func TestVerifyZoneChain(t *testing.T) {
 		}
 		// The ZONEMD content changed, so its signature fails first — either
 		// refusal is correct; what must not happen is acceptance.
-		if err := verifyZone(mangled, root.anchors); err == nil {
+		if _, err := verifyZone(mangled, root.anchors); err == nil {
 			t.Fatal("a ZONEMD serial mismatch verified")
 		}
 	})
@@ -114,7 +114,7 @@ func TestVerifyZoneChain(t *testing.T) {
 			}
 			stripped = append(stripped, rr)
 		}
-		if err := verifyZone(stripped, root.anchors); err == nil {
+		if _, err := verifyZone(stripped, root.anchors); err == nil {
 			t.Fatal("a zone with no ZONEMD verified")
 		}
 	})

--- a/middleware/resolver/localroot/testzone_test.go
+++ b/middleware/resolver/localroot/testzone_test.go
@@ -1,6 +1,7 @@
 package localroot
 
 import (
+	"crypto"
 	"testing"
 
 	"github.com/miekg/dns"
@@ -15,6 +16,8 @@ type testRoot struct {
 	rrs     []dns.RR
 	anchors []dns.RR
 	serial  uint32
+	key     *dns.DNSKEY
+	priv    crypto.PrivateKey
 }
 
 func buildTestRoot(t *testing.T) *testRoot {
@@ -23,7 +26,13 @@ func buildTestRoot(t *testing.T) *testRoot {
 	if err != nil {
 		t.Fatalf("roottest.Build: %v", err)
 	}
-	return &testRoot{rrs: z.RRs, anchors: z.Anchors, serial: roottest.Serial}
+	return &testRoot{
+		rrs:     z.RRs,
+		anchors: z.Anchors,
+		serial:  roottest.Serial,
+		key:     z.Key,
+		priv:    z.Priv,
+	}
 }
 
 func rrsFromText(t *testing.T, lines ...string) []dns.RR {

--- a/middleware/resolver/localroot/transfer.go
+++ b/middleware/resolver/localroot/transfer.go
@@ -99,6 +99,45 @@ func axfr(ctx context.Context, addr string, timeout time.Duration) ([]dns.RR, er
 	}
 }
 
+// rrKey identifies an RRset member for duplicate detection: everything RFC
+// 8976 §3.3.1.1 counts as identity except the RDATA, which dns.IsDuplicate
+// compares directly.
+type rrKey struct {
+	owner  string
+	rtype  uint16
+	rclass uint16
+}
+
+// normalizeZone drops duplicate RRs from a received zone, keeping the first
+// of each. RFC 5936 §2.2 requires an AXFR client to ignore duplicates, and
+// RFC 8976 §3.3.1.1 fixes the identity as owner, class, type and RDATA — the
+// TTL is not part of it.
+//
+// This runs once, before anything else reads the records, because every stage
+// downstream counts them: the apex cardinality bound, the ZONEMD scheme/hash
+// tuple check, the digest, and the index. A source that sends one record
+// twice must not look to any of them like a zone with two. Left to the tuple
+// check in particular, a doubled ZONEMD RR reads as a repeated tuple and
+// refuses a zone RFC 5936 says should simply have been deduplicated.
+func normalizeZone(rrs []dns.RR) []dns.RR {
+	seen := make(map[rrKey][]dns.RR, len(rrs))
+	out := make([]dns.RR, 0, len(rrs))
+	for _, rr := range rrs {
+		hdr := rr.Header()
+		key := rrKey{
+			owner:  dns.CanonicalName(hdr.Name),
+			rtype:  hdr.Rrtype,
+			rclass: hdr.Class,
+		}
+		if hasDuplicate(seen[key], rr) {
+			continue
+		}
+		seen[key] = append(seen[key], rr)
+		out = append(out, rr)
+	}
+	return out
+}
+
 // probeSerial asks addr for the root SOA over TCP and returns its serial.
 // TCP deliberately: the probe talks to the same transfer hosts the AXFR
 // will, so a host that cannot serve TCP is discovered at the probe.

--- a/middleware/resolver/localroot/transfer.go
+++ b/middleware/resolver/localroot/transfer.go
@@ -1,0 +1,128 @@
+package localroot
+
+import (
+	"context"
+	"errors"
+	"net"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/dnsclient"
+)
+
+var (
+	errTransferShape = errors.New("localroot: transfer did not carry a zone")
+	errTransferLimit = errors.New("localroot: transfer exceeded sanity bounds")
+)
+
+// Transfer sanity bounds: the root zone is a couple of megabytes and a few
+// tens of thousands of records. These caps exist so a hostile or broken
+// source cannot feed an unbounded stream; they are far above any real root.
+const (
+	maxTransferRecords = 1 << 20
+	maxTransferBytes   = 64 << 20
+)
+
+// axfr transfers the root zone from addr over TCP and returns its records,
+// the closing duplicate apex SOA dropped. The transfer is bounded by ctx and
+// the sanity caps; any structural surprise refuses the whole transfer —
+// there is no partial acceptance of a zone copy.
+func axfr(ctx context.Context, addr string, timeout time.Duration) ([]dns.RR, error) {
+	d := net.Dialer{Timeout: timeout}
+	raw, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	co := &dnsclient.Conn{Conn: raw}
+	defer func() { _ = co.Close() }()
+
+	deadline := time.Now().Add(timeout)
+	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
+		deadline = d
+	}
+	_ = raw.SetDeadline(deadline)
+
+	req := new(dns.Msg)
+	req.SetAxfr(".")
+
+	if err := co.WriteMsg(req); err != nil {
+		return nil, err
+	}
+
+	var (
+		rrs      []dns.RR
+		sawFirst bool
+		total    int
+	)
+	for {
+		resp, err := co.ReadMsg()
+		if err != nil {
+			return nil, err
+		}
+		if resp.Id != req.Id || resp.Rcode != dns.RcodeSuccess {
+			return nil, errTransferShape
+		}
+		for _, rr := range resp.Answer {
+			isApexSOA := rr.Header().Rrtype == dns.TypeSOA &&
+				dns.CanonicalName(rr.Header().Name) == "."
+			if !sawFirst {
+				if !isApexSOA {
+					return nil, errTransferShape
+				}
+				sawFirst = true
+				rrs = append(rrs, rr)
+				continue
+			}
+			if isApexSOA {
+				// The closing duplicate: the zone is complete.
+				return rrs, nil
+			}
+			total += dns.Len(rr)
+			if len(rrs) >= maxTransferRecords || total > maxTransferBytes {
+				return nil, errTransferLimit
+			}
+			rrs = append(rrs, rr)
+		}
+	}
+}
+
+// probeSerial asks addr for the root SOA over TCP and returns its serial.
+// TCP deliberately: the probe talks to the same transfer hosts the AXFR
+// will, so a host that cannot serve TCP is discovered at the probe.
+func probeSerial(ctx context.Context, addr string, timeout time.Duration) (uint32, error) {
+	d := net.Dialer{Timeout: timeout}
+	raw, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return 0, err
+	}
+	co := &dnsclient.Conn{Conn: raw}
+	defer func() { _ = co.Close() }()
+
+	deadline := time.Now().Add(timeout)
+	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
+		deadline = d
+	}
+	_ = raw.SetDeadline(deadline)
+
+	req := new(dns.Msg)
+	req.SetQuestion(".", dns.TypeSOA)
+	req.RecursionDesired = false
+
+	if err := co.WriteMsg(req); err != nil {
+		return 0, err
+	}
+	resp, err := co.ReadMsg()
+	if err != nil {
+		return 0, err
+	}
+	if resp.Id != req.Id || resp.Rcode != dns.RcodeSuccess {
+		return 0, errTransferShape
+	}
+	for _, rr := range resp.Answer {
+		if soa, ok := rr.(*dns.SOA); ok &&
+			dns.CanonicalName(soa.Header().Name) == "." {
+			return soa.Serial, nil
+		}
+	}
+	return 0, errTransferShape
+}

--- a/middleware/resolver/localroot/transfer.go
+++ b/middleware/resolver/localroot/transfer.go
@@ -129,9 +129,20 @@ func normalizeZone(rrs []dns.RR) []dns.RR {
 			rtype:  hdr.Rrtype,
 			rclass: hdr.Class,
 		}
-		if hasDuplicate(seen[key], rr) {
+		if kept := firstDuplicate(seen[key], rr); kept != nil {
+			// RFC 2181 §5.2: a receiver holding records of one RRset with
+			// differing TTLs treats them as if all carried the lowest. The
+			// duplicate is dropped, but its TTL still has a say — otherwise
+			// the surviving record's lifetime depends on which copy the
+			// source happened to send first.
+			if rr.Header().Ttl < kept.Header().Ttl {
+				kept.Header().Ttl = rr.Header().Ttl
+			}
 			continue
 		}
+		// Copied, because the TTL above is rewritten in place and the caller
+		// still owns the records it handed us.
+		rr = dns.Copy(rr)
 		seen[key] = append(seen[key], rr)
 		out = append(out, rr)
 	}

--- a/middleware/resolver/localroot/transfer.go
+++ b/middleware/resolver/localroot/transfer.go
@@ -74,7 +74,20 @@ func axfr(ctx context.Context, addr string, timeout time.Duration) ([]dns.RR, er
 				continue
 			}
 			if isApexSOA {
-				// The closing duplicate: the zone is complete.
+				// RFC 5936 §2.2: the stream begins and ends with the same
+				// SOA record. A terminator that differs from the opener is a
+				// source whose zone moved under the transfer, so the records
+				// in between belong to no single version of it. Refusing
+				// here fails over to the next source and names the fault at
+				// the transfer; without the check the stream is accepted and
+				// the inconsistency surfaces later as a digest mismatch,
+				// blamed on verification.
+				if !dns.IsDuplicate(rrs[0], rr) {
+					return nil, errTransferShape
+				}
+				// The closing duplicate: the zone is complete. Anything the
+				// source appends after it is not part of the zone and is
+				// left unread.
 				return rrs, nil
 			}
 			total += dns.Len(rr)

--- a/middleware/resolver/localroot/transfer_test.go
+++ b/middleware/resolver/localroot/transfer_test.go
@@ -2,6 +2,7 @@ package localroot
 
 import (
 	"context"
+	"errors"
 	"net"
 	"testing"
 	"time"
@@ -89,6 +90,59 @@ func TestAXFRRoundTrip(t *testing.T) {
 	}
 	if serial != root.serial {
 		t.Fatalf("probe serial = %d, want %d", serial, root.serial)
+	}
+}
+
+func TestAXFRRefusesMismatchedClosingSOA(t *testing.T) {
+	root := buildTestRoot(t)
+
+	var opening dns.RR
+	body := make([]dns.RR, 0, len(root.rrs))
+	for _, rr := range root.rrs {
+		if rr.Header().Rrtype == dns.TypeSOA && dns.CanonicalName(rr.Header().Name) == "." {
+			opening = rr
+			continue
+		}
+		body = append(body, rr)
+	}
+	if opening == nil {
+		t.Fatal("test zone has no apex SOA")
+	}
+	// RFC 5936 §2.2: the stream must end with the SOA it began with. This
+	// one announces a different zone version at the close, so the records in
+	// between belong to no single version of it.
+	closing := dns.Copy(opening).(*dns.SOA)
+	closing.Serial++
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+	go func() {
+		c, err := l.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = c.Close() }()
+		co := &dnsclient.Conn{Conn: c}
+		req, err := co.ReadMsg()
+		if err != nil {
+			return
+		}
+		reply := func(rrs []dns.RR) {
+			m := new(dns.Msg)
+			m.SetReply(req)
+			m.Answer = rrs
+			_ = co.WriteMsg(m)
+		}
+		reply(append([]dns.RR{opening}, body...))
+		reply([]dns.RR{closing})
+	}()
+
+	_, err = axfr(context.Background(), l.Addr().String(), 2*time.Second)
+	if !errors.Is(err, errTransferShape) {
+		t.Fatalf("mismatched closing SOA: err = %v, want errTransferShape", err)
 	}
 }
 

--- a/middleware/resolver/localroot/transfer_test.go
+++ b/middleware/resolver/localroot/transfer_test.go
@@ -79,7 +79,7 @@ func TestAXFRRoundTrip(t *testing.T) {
 	if len(got) != len(root.rrs) {
 		t.Fatalf("transfer carried %d records, want %d", len(got), len(root.rrs))
 	}
-	if err := verifyZone(got, root.anchors); err != nil {
+	if _, err := verifyZone(got, root.anchors); err != nil {
 		t.Fatalf("transferred zone does not verify: %v", err)
 	}
 

--- a/middleware/resolver/localroot/transfer_test.go
+++ b/middleware/resolver/localroot/transfer_test.go
@@ -1,0 +1,128 @@
+package localroot
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/dnsclient"
+)
+
+// axfrServer serves one AXFR of rrs on a loopback TCP listener: the apex SOA
+// first, the body split across two envelopes, the closing SOA last — the
+// shape a real transfer host produces.
+func axfrServer(t *testing.T, rrs []dns.RR) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	var soa dns.RR
+	body := make([]dns.RR, 0, len(rrs))
+	for _, rr := range rrs {
+		if rr.Header().Rrtype == dns.TypeSOA && dns.CanonicalName(rr.Header().Name) == "." {
+			soa = rr
+			continue
+		}
+		body = append(body, rr)
+	}
+	if soa == nil {
+		t.Fatal("test zone has no apex SOA")
+	}
+
+	go func() {
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer func() { _ = c.Close() }()
+				co := &dnsclient.Conn{Conn: c}
+				req, err := co.ReadMsg()
+				if err != nil || len(req.Question) != 1 {
+					return
+				}
+				reply := func(rrs []dns.RR) {
+					m := new(dns.Msg)
+					m.SetReply(req)
+					m.Answer = rrs
+					_ = co.WriteMsg(m)
+				}
+				switch req.Question[0].Qtype {
+				case dns.TypeSOA:
+					reply([]dns.RR{soa})
+				case dns.TypeAXFR:
+					half := len(body) / 2
+					reply(append([]dns.RR{soa}, body[:half]...))
+					reply(body[half:])
+					reply([]dns.RR{soa})
+				}
+			}(c)
+		}
+	}()
+	return l.Addr().String()
+}
+
+func TestAXFRRoundTrip(t *testing.T) {
+	root := buildTestRoot(t)
+	addr := axfrServer(t, root.rrs)
+
+	got, err := axfr(context.Background(), addr, 5*time.Second)
+	if err != nil {
+		t.Fatalf("axfr: %v", err)
+	}
+	if len(got) != len(root.rrs) {
+		t.Fatalf("transfer carried %d records, want %d", len(got), len(root.rrs))
+	}
+	if err := verifyZone(got, root.anchors); err != nil {
+		t.Fatalf("transferred zone does not verify: %v", err)
+	}
+
+	serial, err := probeSerial(context.Background(), addr, 5*time.Second)
+	if err != nil {
+		t.Fatalf("probeSerial: %v", err)
+	}
+	if serial != root.serial {
+		t.Fatalf("probe serial = %d, want %d", serial, root.serial)
+	}
+}
+
+func TestAXFRRefusesNonZoneStream(t *testing.T) {
+	// A stream that does not open with the apex SOA is not a zone.
+	notSOA := rrsFromText(t, "com. 172800 IN NS ns.com.")
+	addr := axfrServer(t, append(notSOA, rrsFromText(t,
+		". 86400 IN SOA a. b. 1 1800 900 604800 86400")...))
+	// axfrServer always puts the SOA first, so build the refusal case
+	// directly: a server that answers AXFR with a bare NS.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+	go func() {
+		c, err := l.Accept()
+		if err != nil {
+			return
+		}
+		defer func() { _ = c.Close() }()
+		co := &dnsclient.Conn{Conn: c}
+		req, err := co.ReadMsg()
+		if err != nil {
+			return
+		}
+		m := new(dns.Msg)
+		m.SetReply(req)
+		m.Answer = notSOA
+		_ = co.WriteMsg(m)
+	}()
+
+	if _, err := axfr(context.Background(), l.Addr().String(), 2*time.Second); err == nil {
+		t.Fatal("a stream that opened without the apex SOA was accepted")
+	}
+	_ = addr // the well-formed server above stays for symmetry
+}

--- a/middleware/resolver/localroot/transfer_test.go
+++ b/middleware/resolver/localroot/transfer_test.go
@@ -180,3 +180,35 @@ func TestAXFRRefusesNonZoneStream(t *testing.T) {
 	}
 	_ = addr // the well-formed server above stays for symmetry
 }
+
+// TestNormalizeZoneKeepsTheLowestTTL pins RFC 2181 §5.2 for the duplicates
+// normalization collapses: a receiver holding one RRset's records with
+// differing TTLs treats them as if all carried the lowest. Without it the
+// surviving record's lifetime would depend on which copy the source happened
+// to send first.
+func TestNormalizeZoneKeepsTheLowestTTL(t *testing.T) {
+	long := rrsFromText(t, "com. 86400 IN NS ns.com.")[0]
+	short := dns.Copy(long)
+	short.Header().Ttl = 300
+
+	for name, sent := range map[string][]dns.RR{
+		"longest first":  {long, short},
+		"shortest first": {short, long},
+	} {
+		t.Run(name, func(t *testing.T) {
+			out := normalizeZone(sent)
+			if len(out) != 1 {
+				t.Fatalf("normalized to %d records, want the duplicate collapsed", len(out))
+			}
+			if got := out[0].Header().Ttl; got != 300 {
+				t.Fatalf("surviving TTL = %d, want the lowest of the two (300)", got)
+			}
+		})
+	}
+
+	// Normalization rewrites TTLs, so it must not do so on the records the
+	// caller still holds.
+	if long.Header().Ttl != 86400 || short.Header().Ttl != 300 {
+		t.Fatalf("normalization mutated its input: %d / %d", long.Header().Ttl, short.Header().Ttl)
+	}
+}

--- a/middleware/resolver/localroot/zonemd.go
+++ b/middleware/resolver/localroot/zonemd.go
@@ -116,28 +116,38 @@ func verifyZone(rrs []dns.RR, anchors []dns.RR) error {
 		}
 	}
 
-	// RFC 8976 §4 step 4: "When multiple ZONEMD RRs are present, each MUST
-	// specify a unique Scheme and Hash Algorithm tuple." A repeated tuple
-	// is a malformed RRset, and picking the first match would let an
-	// attacker append a second digest of their own next to the real one.
-	// The check covers every tuple, not only the one this build uses.
-	seen := make(map[uint16]struct{}, len(zonemds))
+	// RFC 8976 §4 step 4: "If the ZONEMD RRset contains more than one RR
+	// with the same Scheme and Hash Algorithm, digest verification for
+	// those ZONEMD RRs MUST NOT be considered successful." The
+	// disqualification is scoped to the repeated tuple — step 5 adds that
+	// "a match using any one of the recipient's supported Schemes and Hash
+	// Algorithms is sufficient to verify the zone" — so a zone carrying a
+	// duplicated tuple alongside a sound unique one still verifies through
+	// the latter. Counting first, then skipping only the duplicates, is
+	// what keeps an appended digest from being usable without letting it
+	// deny an otherwise valid zone.
+	tupleCount := make(map[uint16]int, len(zonemds))
 	for _, z := range zonemds {
-		tuple := uint16(z.Scheme)<<8 | uint16(z.Hash)
-		if _, dup := seen[tuple]; dup {
-			return errDuplicateZONEMD
-		}
-		seen[tuple] = struct{}{}
+		tupleCount[uint16(z.Scheme)<<8|uint16(z.Hash)]++
 	}
 
 	var chosen *dns.ZONEMD
+	duplicated := false
 	for _, z := range zonemds {
-		if z.Scheme == zonemdSchemeSimple && z.Hash == zonemdHashSHA384 {
-			chosen = z
-			break
+		if z.Scheme != zonemdSchemeSimple || z.Hash != zonemdHashSHA384 {
+			continue
 		}
+		if tupleCount[uint16(z.Scheme)<<8|uint16(z.Hash)] > 1 {
+			duplicated = true
+			continue
+		}
+		chosen = z
+		break
 	}
 	if chosen == nil {
+		if duplicated {
+			return errDuplicateZONEMD
+		}
 		return errNoZONEMD
 	}
 	if chosen.Serial != soa.Serial {

--- a/middleware/resolver/localroot/zonemd.go
+++ b/middleware/resolver/localroot/zonemd.go
@@ -225,33 +225,17 @@ const maxApexSignatureAttempts = 16
 func verifyApexRRset(keys map[uint16][]*dns.DNSKEY, set []dns.RR, sigs []dns.RR) (time.Time, error) {
 	covered := set[0].Header().Rrtype
 
-	type sigID struct {
-		keyTag     uint16
-		algorithm  uint8
-		expiration uint32
-		inception  uint32
-		signature  string
-	}
-	seen := make(map[sigID]struct{})
-	candidates := make([]*dns.RRSIG, 0, 4)
+	covering := make([]*dns.RRSIG, 0, 4)
 	for _, rr := range sigs {
-		sig, ok := rr.(*dns.RRSIG)
-		if !ok || sig.TypeCovered != covered {
-			continue
+		if sig, ok := rr.(*dns.RRSIG); ok && sig.TypeCovered == covered {
+			covering = append(covering, sig)
 		}
-		id := sigID{
-			keyTag:     sig.KeyTag,
-			algorithm:  sig.Algorithm,
-			expiration: sig.Expiration,
-			inception:  sig.Inception,
-			signature:  sig.Signature,
-		}
-		if _, dup := seen[id]; dup {
-			continue
-		}
-		seen[id] = struct{}{}
-		candidates = append(candidates, sig)
 	}
+	// Deduplicate on the identity the verifier itself uses. Anything less
+	// can collapse a sound signature into an unsound one that merely
+	// resembles it — two records differing only in, say, original TTL sign
+	// different data, so one may verify where the other cannot.
+	candidates := dnssec.UniqueRRSIGs(covering)
 
 	sort.SliceStable(candidates, func(i, j int) bool {
 		return candidates[i].Expiration > candidates[j].Expiration

--- a/middleware/resolver/localroot/zonemd.go
+++ b/middleware/resolver/localroot/zonemd.go
@@ -6,6 +6,7 @@ import (
 	"crypto/subtle"
 	"errors"
 	"sort"
+	"strings"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/internal/dnsname"
@@ -19,6 +20,7 @@ var (
 	errDigestMismatch = errors.New("localroot: zone digest does not match ZONEMD")
 	errAnchorChain    = errors.New("localroot: DNSKEY set does not chain to a trust anchor")
 	errBadSignature   = errors.New("localroot: apex RRset signature did not verify")
+	errSerialRollback = errors.New("localroot: zone serial is older than the live copy")
 )
 
 const (
@@ -70,25 +72,38 @@ func verifyZone(rrs []dns.RR, anchors []dns.RR) error {
 		return errAnchorChain
 	}
 
+	if len(anchors) == 0 {
+		return errAnchorChain
+	}
+
+	// The chain order is the whole defense. First, only the keys that
+	// actually match a trust anchor DS may authenticate the DNSKEY RRset —
+	// handing that verification the full transferred set would let an
+	// attacker include the well-known real KSK for the anchor match while
+	// signing everything with a key of their own, also in the set. Only a
+	// DNSKEY RRset signed by an anchor-matched key promotes the rest of
+	// the set into keyMap for the SOA and ZONEMD checks.
+	anchorKeys := make(map[uint16][]*dns.DNSKEY)
+	for _, k := range dnskeys {
+		if dnskeyMatchesAnchor(k, anchors) {
+			tag := dnssec.KeyTag(k)
+			anchorKeys[tag] = append(anchorKeys[tag], k)
+		}
+	}
+	if len(anchorKeys) == 0 {
+		return errAnchorChain
+	}
+	if err := verifyApexRRset(anchorKeys, typedApexSet(dnskeys), apexSig); err != nil {
+		return errAnchorChain
+	}
+
 	keyMap := make(map[uint16][]*dns.DNSKEY, len(dnskeys))
 	for _, k := range dnskeys {
 		tag := dnssec.KeyTag(k)
 		keyMap[tag] = append(keyMap[tag], k)
 	}
 
-	if len(anchors) == 0 {
-		return errAnchorChain
-	}
-	// VerifyDS reports success as (false, nil): the bool is the resolver's
-	// "no supported digest, treat insecure" signal, and insecure is exactly
-	// what a local root copy must never be.
-	if insecure, err := dnssec.VerifyDS(keyMap, anchors); err != nil || insecure {
-		return errAnchorChain
-	}
-
-	// Each apex RRset the chain depends on must verify against the keys.
 	for _, set := range [][]dns.RR{
-		typedApexSet(dnskeys),
 		{soa},
 		typedApexSet(zonemds),
 	} {
@@ -126,6 +141,27 @@ func verifyZone(rrs []dns.RR, anchors []dns.RR) error {
 		return errDigestMismatch
 	}
 	return nil
+}
+
+// dnskeyMatchesAnchor reports whether key's DS, computed at each anchor's
+// own digest type, reproduces that anchor exactly — tag, algorithm and
+// digest alike.
+func dnskeyMatchesAnchor(key *dns.DNSKEY, anchors []dns.RR) bool {
+	for _, rr := range anchors {
+		ds, ok := rr.(*dns.DS)
+		if !ok || ds.Algorithm != key.Algorithm {
+			continue
+		}
+		computed, err := dnssec.DNSKEYToDSWithWork(key, ds.DigestType, nil)
+		if err != nil {
+			continue
+		}
+		if computed.KeyTag == ds.KeyTag &&
+			strings.EqualFold(computed.Digest, ds.Digest) {
+			return true
+		}
+	}
+	return false
 }
 
 // verifyApexRRset verifies one apex RRset against the zone keys using the

--- a/middleware/resolver/localroot/zonemd.go
+++ b/middleware/resolver/localroot/zonemd.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/internal/dnsname"
@@ -45,7 +46,12 @@ const (
 // The ZONEMD match authenticates the entire zone contents in one stroke;
 // individual RRSIGs elsewhere in the zone are carried for clients, not
 // re-verified here.
-func verifyZone(rrs []dns.RR, anchors []dns.RR) error {
+//
+// authUntil is when that authentication lapses — the expiration of the
+// signature that carried the ZONEMD RRset through verification. The copy
+// may not be served past it: the digest is only evidence for as long as
+// the signature over it holds.
+func verifyZone(rrs []dns.RR, anchors []dns.RR) (authUntil time.Time, err error) {
 	var (
 		dnskeys []*dns.DNSKEY
 		zonemds []*dns.ZONEMD
@@ -68,14 +74,14 @@ func verifyZone(rrs []dns.RR, anchors []dns.RR) error {
 		}
 	}
 	if soa == nil {
-		return errNoApex
+		return time.Time{}, errNoApex
 	}
 	if len(dnskeys) == 0 {
-		return errAnchorChain
+		return time.Time{}, errAnchorChain
 	}
 
 	if len(anchors) == 0 {
-		return errAnchorChain
+		return time.Time{}, errAnchorChain
 	}
 
 	// The chain order is the whole defense. First, only the keys that
@@ -93,10 +99,10 @@ func verifyZone(rrs []dns.RR, anchors []dns.RR) error {
 		}
 	}
 	if len(anchorKeys) == 0 {
-		return errAnchorChain
+		return time.Time{}, errAnchorChain
 	}
-	if err := verifyApexRRset(anchorKeys, typedApexSet(dnskeys), apexSig); err != nil {
-		return errAnchorChain
+	if _, err := verifyApexRRset(anchorKeys, typedApexSet(dnskeys), apexSig); err != nil {
+		return time.Time{}, errAnchorChain
 	}
 
 	keyMap := make(map[uint16][]*dns.DNSKEY, len(dnskeys))
@@ -105,16 +111,18 @@ func verifyZone(rrs []dns.RR, anchors []dns.RR) error {
 		keyMap[tag] = append(keyMap[tag], k)
 	}
 
-	for _, set := range [][]dns.RR{
-		{soa},
-		typedApexSet(zonemds),
-	} {
-		if len(set) == 0 {
-			continue
-		}
-		if err := verifyApexRRset(keyMap, set, apexSig); err != nil {
-			return err
-		}
+	if _, err := verifyApexRRset(keyMap, []dns.RR{soa}, apexSig); err != nil {
+		return time.Time{}, err
+	}
+	if len(zonemds) == 0 {
+		return time.Time{}, errNoZONEMD
+	}
+	// The ZONEMD RRset's own signature is what makes the digest evidence,
+	// so its expiration is the authentication's, and the caller carries it
+	// into the copy's horizon.
+	authUntil, err = verifyApexRRset(keyMap, typedApexSet(zonemds), apexSig)
+	if err != nil {
+		return time.Time{}, err
 	}
 
 	// RFC 8976 §4 step 4: "If the ZONEMD RRset contains more than one RR
@@ -147,26 +155,26 @@ func verifyZone(rrs []dns.RR, anchors []dns.RR) error {
 	}
 	if chosen == nil {
 		if duplicated {
-			return errDuplicateZONEMD
+			return time.Time{}, errDuplicateZONEMD
 		}
-		return errNoZONEMD
+		return time.Time{}, errNoZONEMD
 	}
 	if chosen.Serial != soa.Serial {
-		return errSerialMismatch
+		return time.Time{}, errSerialMismatch
 	}
 
 	digest, err := ComputeDigest(rrs, ".")
 	if err != nil {
-		return err
+		return time.Time{}, err
 	}
 	want, err := hexDecode(chosen.Digest)
 	if err != nil || len(want) != sha512.Size384 {
-		return errDigestMismatch
+		return time.Time{}, errDigestMismatch
 	}
 	if subtle.ConstantTimeCompare(digest, want) != 1 {
-		return errDigestMismatch
+		return time.Time{}, errDigestMismatch
 	}
-	return nil
+	return authUntil, nil
 }
 
 // dnskeyMatchesAnchor reports whether key's DS, computed at each anchor's
@@ -190,24 +198,39 @@ func dnskeyMatchesAnchor(key *dns.DNSKEY, anchors []dns.RR) bool {
 	return false
 }
 
-// verifyApexRRset verifies one apex RRset against the zone keys using the
-// covering RRSIG from the apex signature pool.
-func verifyApexRRset(keys map[uint16][]*dns.DNSKEY, set []dns.RR, sigs []dns.RR) error {
+// verifyApexRRset verifies one apex RRset against the zone keys and returns
+// how long the result holds: the latest expiration among the signatures
+// that actually verified. Authentication is only as good as the signature
+// that carried it (RFC 4035 §5.3.3), and where several signatures verify,
+// the RRset stays authenticated until the last of them lapses.
+//
+// Candidates are tried one at a time rather than as a set, because the
+// caller needs to know which signature carried the verification and not
+// merely that one did — a sibling that fails to verify must not lend its
+// timestamps to the result.
+func verifyApexRRset(keys map[uint16][]*dns.DNSKEY, set []dns.RR, sigs []dns.RR) (time.Time, error) {
 	covered := set[0].Header().Rrtype
-	msg := new(dns.Msg)
-	msg.Answer = append(msg.Answer, set...)
+
+	var until time.Time
 	for _, rr := range sigs {
-		if sig, ok := rr.(*dns.RRSIG); ok && sig.TypeCovered == covered {
-			msg.Answer = append(msg.Answer, sig)
+		sig, ok := rr.(*dns.RRSIG)
+		if !ok || sig.TypeCovered != covered {
+			continue
+		}
+		msg := new(dns.Msg)
+		msg.Answer = append(msg.Answer, set...)
+		msg.Answer = append(msg.Answer, sig)
+		if verified, err := dnssec.VerifyRRSIG(".", keys, msg); err != nil || !verified {
+			continue
+		}
+		if exp := time.Unix(int64(sig.Expiration), 0); exp.After(until) {
+			until = exp
 		}
 	}
-	if len(msg.Answer) == len(set) {
-		return errBadSignature // no covering signature at all
+	if until.IsZero() {
+		return time.Time{}, errBadSignature
 	}
-	if ok, err := dnssec.VerifyRRSIG(".", keys, msg); err != nil || !ok {
-		return errBadSignature
-	}
-	return nil
+	return until, nil
 }
 
 func typedApexSet[T dns.RR](set []T) []dns.RR {

--- a/middleware/resolver/localroot/zonemd.go
+++ b/middleware/resolver/localroot/zonemd.go
@@ -334,9 +334,18 @@ func ComputeDigest(rrs []dns.RR, apex string) ([]byte, error) {
 	h := sha512.New384()
 	var prev []byte
 	for i := range entries {
-		// Duplicate RRs (equal owner, class, type, RDATA) digest once.
-		// After sorting, duplicates are adjacent and their canonical
-		// wire forms are byte-identical.
+		// Duplicate RRs digest once (RFC 8976 §3.3.1.1). Sorting makes them
+		// adjacent, so byte-equal canonical forms collapse here.
+		//
+		// The RFC's identity is owner, class, type and RDATA — it excludes
+		// the TTL, which the canonical form carries. Twins differing only in
+		// TTL are therefore digested twice here and the zone fails to
+		// verify, where the RFC would have collapsed them. That is the
+		// deliberate direction to err: such a zone is already a protocol
+		// error (RFC 2181 §5.2), the outcome is a refused copy and a walk to
+		// the real roots, and the alternative — collapsing on an identity
+		// looser than the bytes being hashed — would let an injected
+		// TTL-variant twin pass the digest and reach served data.
 		if prev != nil && bytes.Equal(prev, entries[i].wire) {
 			continue
 		}

--- a/middleware/resolver/localroot/zonemd.go
+++ b/middleware/resolver/localroot/zonemd.go
@@ -20,6 +20,7 @@ var (
 	errSerialMismatch    = errors.New("localroot: ZONEMD serial does not match the SOA")
 	errDigestMismatch    = errors.New("localroot: zone digest does not match ZONEMD")
 	errAnchorChain       = errors.New("localroot: DNSKEY set does not chain to a trust anchor")
+	errNoAnchors         = errors.New("localroot: no trust anchors to verify a transfer against")
 	errBadSignature      = errors.New("localroot: apex RRset signature did not verify")
 	errSerialRollback    = errors.New("localroot: zone serial is older than the live copy")
 	errSerialBehindProbe = errors.New("localroot: transferred zone is older than the serial the source announced")

--- a/middleware/resolver/localroot/zonemd.go
+++ b/middleware/resolver/localroot/zonemd.go
@@ -24,6 +24,7 @@ var (
 	errSerialRollback    = errors.New("localroot: zone serial is older than the live copy")
 	errSerialBehindProbe = errors.New("localroot: transferred zone is older than the serial the source announced")
 	errDuplicateZONEMD   = errors.New("localroot: apex carries a repeated ZONEMD scheme/hash tuple")
+	errApexTooLarge      = errors.New("localroot: apex carries an implausible number of keys or digests")
 )
 
 const (
@@ -78,6 +79,17 @@ func verifyZone(rrs []dns.RR, anchors []dns.RR) (authUntil time.Time, err error)
 	}
 	if len(dnskeys) == 0 {
 		return time.Time{}, errAnchorChain
+	}
+	// Refuse an implausible apex before any of it is hashed. Capping the
+	// number of candidate signatures is not enough on its own: each
+	// verification hashes the whole RRset it covers, and each key is
+	// digested once per anchor, so an inflated DNSKEY or ZONEMD RRset
+	// turns transfer bytes into cryptographic work regardless of how few
+	// signatures are tried. The root publishes a handful of keys and one
+	// or two digests; a zone claiming dozens is not one this should be
+	// spending anything on.
+	if len(dnskeys) > maxApexRecords || len(zonemds) > maxApexRecords {
+		return time.Time{}, errApexTooLarge
 	}
 
 	if len(anchors) == 0 {
@@ -198,15 +210,24 @@ func dnskeyMatchesAnchor(key *dns.DNSKEY, anchors []dns.RR) bool {
 	return false
 }
 
-// maxApexSignatureAttempts bounds the public-key operations one apex RRset
-// may cost. A zone carrying more than a handful of signatures over one
-// RRset is already pathological — the root publishes one, a rollover a few
-// — and the cap cannot be used to hide a sound signature behind
+// maxApexSignatureAttempts bounds how many public-key operations one apex
+// RRset may cost. A zone carrying more than a handful of signatures over
+// one RRset is already pathological — the root publishes one, a rollover a
+// few — and the cap cannot be used to hide a sound signature behind
 // higher-expiring forgeries in any meaningful sense: anyone able to add
 // records to a transfer can already deny the copy outright by disturbing a
 // digested record. What the cap removes is the amplification, which is a
 // capability they did not otherwise have.
+//
+// It bounds the count of operations only. What each one costs is bounded
+// separately by maxApexRecords, since a verification hashes the whole
+// RRset it covers.
 const maxApexSignatureAttempts = 16
+
+// maxApexRecords bounds how many records of one apex type verification will
+// look at. The real root publishes about four DNSKEYs and one ZONEMD; the
+// margin here is for a rollover, not for a zone that wants to be expensive.
+const maxApexRecords = 32
 
 // verifyApexRRset verifies one apex RRset against the zone keys and returns
 // how long the result holds: the expiration of the signature that carried

--- a/middleware/resolver/localroot/zonemd.go
+++ b/middleware/resolver/localroot/zonemd.go
@@ -14,14 +14,15 @@ import (
 )
 
 var (
-	errNoApex          = errors.New("localroot: zone has no usable apex")
-	errNoZONEMD        = errors.New("localroot: no supported ZONEMD at the apex")
-	errSerialMismatch  = errors.New("localroot: ZONEMD serial does not match the SOA")
-	errDigestMismatch  = errors.New("localroot: zone digest does not match ZONEMD")
-	errAnchorChain     = errors.New("localroot: DNSKEY set does not chain to a trust anchor")
-	errBadSignature    = errors.New("localroot: apex RRset signature did not verify")
-	errSerialRollback  = errors.New("localroot: zone serial is older than the live copy")
-	errDuplicateZONEMD = errors.New("localroot: apex carries a repeated ZONEMD scheme/hash tuple")
+	errNoApex            = errors.New("localroot: zone has no usable apex")
+	errNoZONEMD          = errors.New("localroot: no supported ZONEMD at the apex")
+	errSerialMismatch    = errors.New("localroot: ZONEMD serial does not match the SOA")
+	errDigestMismatch    = errors.New("localroot: zone digest does not match ZONEMD")
+	errAnchorChain       = errors.New("localroot: DNSKEY set does not chain to a trust anchor")
+	errBadSignature      = errors.New("localroot: apex RRset signature did not verify")
+	errSerialRollback    = errors.New("localroot: zone serial is older than the live copy")
+	errSerialBehindProbe = errors.New("localroot: transferred zone is older than the serial the source announced")
+	errDuplicateZONEMD   = errors.New("localroot: apex carries a repeated ZONEMD scheme/hash tuple")
 )
 
 const (

--- a/middleware/resolver/localroot/zonemd.go
+++ b/middleware/resolver/localroot/zonemd.go
@@ -338,15 +338,13 @@ func ComputeDigest(rrs []dns.RR, apex string) ([]byte, error) {
 		// Duplicate RRs digest once (RFC 8976 §3.3.1.1). Sorting makes them
 		// adjacent, so byte-equal canonical forms collapse here.
 		//
-		// The RFC's identity is owner, class, type and RDATA — it excludes
-		// the TTL, which the canonical form carries. Twins differing only in
-		// TTL are therefore digested twice here and the zone fails to
-		// verify, where the RFC would have collapsed them. That is the
-		// deliberate direction to err: such a zone is already a protocol
-		// error (RFC 2181 §5.2), the outcome is a refused copy and a walk to
-		// the real roots, and the alternative — collapsing on an identity
-		// looser than the bytes being hashed — would let an injected
-		// TTL-variant twin pass the digest and reach served data.
+		// The RFC's identity excludes the TTL, which the canonical form
+		// carries, so this pass alone would digest a TTL-variant twin twice.
+		// It does not have to catch that: normalizeZone has already reduced
+		// a transferred zone to one record per identity before verification
+		// begins. This stays as the backstop for callers that hash records
+		// directly — ComputeDigest is exported, and sealing a zone is not a
+		// transfer.
 		if prev != nil && bytes.Equal(prev, entries[i].wire) {
 			continue
 		}

--- a/middleware/resolver/localroot/zonemd.go
+++ b/middleware/resolver/localroot/zonemd.go
@@ -198,39 +198,78 @@ func dnskeyMatchesAnchor(key *dns.DNSKEY, anchors []dns.RR) bool {
 	return false
 }
 
+// maxApexSignatureAttempts bounds the public-key operations one apex RRset
+// may cost. A zone carrying more than a handful of signatures over one
+// RRset is already pathological — the root publishes one, a rollover a few
+// — and the cap cannot be used to hide a sound signature behind
+// higher-expiring forgeries in any meaningful sense: anyone able to add
+// records to a transfer can already deny the copy outright by disturbing a
+// digested record. What the cap removes is the amplification, which is a
+// capability they did not otherwise have.
+const maxApexSignatureAttempts = 16
+
 // verifyApexRRset verifies one apex RRset against the zone keys and returns
-// how long the result holds: the latest expiration among the signatures
-// that actually verified. Authentication is only as good as the signature
-// that carried it (RFC 4035 §5.3.3), and where several signatures verify,
-// the RRset stays authenticated until the last of them lapses.
-//
-// Candidates are tried one at a time rather than as a set, because the
-// caller needs to know which signature carried the verification and not
-// merely that one did — a sibling that fails to verify must not lend its
+// how long the result holds: the expiration of the signature that carried
+// it. Authentication is only as good as the signature behind it (RFC 4035
+// §5.3.3), so the answer must name a specific signature rather than the
+// RRset as a whole — a sibling that fails to verify cannot lend its
 // timestamps to the result.
+//
+// Candidates are deduplicated, ordered by descending expiration and tried
+// until one verifies. Order is what makes stopping correct: the first
+// signature to verify necessarily carries the latest expiration among those
+// that would, because everything longer-lived was tried before it. It is
+// also what keeps the work down — a sound zone verifies on the first
+// attempt — and the cap bounds the rest, since apex RRSIG(ZONEMD) records
+// sit outside the digest and can be appended freely.
 func verifyApexRRset(keys map[uint16][]*dns.DNSKEY, set []dns.RR, sigs []dns.RR) (time.Time, error) {
 	covered := set[0].Header().Rrtype
 
-	var until time.Time
+	type sigID struct {
+		keyTag     uint16
+		algorithm  uint8
+		expiration uint32
+		inception  uint32
+		signature  string
+	}
+	seen := make(map[sigID]struct{})
+	candidates := make([]*dns.RRSIG, 0, 4)
 	for _, rr := range sigs {
 		sig, ok := rr.(*dns.RRSIG)
 		if !ok || sig.TypeCovered != covered {
 			continue
 		}
+		id := sigID{
+			keyTag:     sig.KeyTag,
+			algorithm:  sig.Algorithm,
+			expiration: sig.Expiration,
+			inception:  sig.Inception,
+			signature:  sig.Signature,
+		}
+		if _, dup := seen[id]; dup {
+			continue
+		}
+		seen[id] = struct{}{}
+		candidates = append(candidates, sig)
+	}
+
+	sort.SliceStable(candidates, func(i, j int) bool {
+		return candidates[i].Expiration > candidates[j].Expiration
+	})
+	if len(candidates) > maxApexSignatureAttempts {
+		candidates = candidates[:maxApexSignatureAttempts]
+	}
+
+	for _, sig := range candidates {
 		msg := new(dns.Msg)
 		msg.Answer = append(msg.Answer, set...)
 		msg.Answer = append(msg.Answer, sig)
 		if verified, err := dnssec.VerifyRRSIG(".", keys, msg); err != nil || !verified {
 			continue
 		}
-		if exp := time.Unix(int64(sig.Expiration), 0); exp.After(until) {
-			until = exp
-		}
+		return time.Unix(int64(sig.Expiration), 0), nil
 	}
-	if until.IsZero() {
-		return time.Time{}, errBadSignature
-	}
-	return until, nil
+	return time.Time{}, errBadSignature
 }
 
 func typedApexSet[T dns.RR](set []T) []dns.RR {

--- a/middleware/resolver/localroot/zonemd.go
+++ b/middleware/resolver/localroot/zonemd.go
@@ -14,13 +14,14 @@ import (
 )
 
 var (
-	errNoApex         = errors.New("localroot: zone has no usable apex")
-	errNoZONEMD       = errors.New("localroot: no supported ZONEMD at the apex")
-	errSerialMismatch = errors.New("localroot: ZONEMD serial does not match the SOA")
-	errDigestMismatch = errors.New("localroot: zone digest does not match ZONEMD")
-	errAnchorChain    = errors.New("localroot: DNSKEY set does not chain to a trust anchor")
-	errBadSignature   = errors.New("localroot: apex RRset signature did not verify")
-	errSerialRollback = errors.New("localroot: zone serial is older than the live copy")
+	errNoApex          = errors.New("localroot: zone has no usable apex")
+	errNoZONEMD        = errors.New("localroot: no supported ZONEMD at the apex")
+	errSerialMismatch  = errors.New("localroot: ZONEMD serial does not match the SOA")
+	errDigestMismatch  = errors.New("localroot: zone digest does not match ZONEMD")
+	errAnchorChain     = errors.New("localroot: DNSKEY set does not chain to a trust anchor")
+	errBadSignature    = errors.New("localroot: apex RRset signature did not verify")
+	errSerialRollback  = errors.New("localroot: zone serial is older than the live copy")
+	errDuplicateZONEMD = errors.New("localroot: apex carries a repeated ZONEMD scheme/hash tuple")
 )
 
 const (
@@ -113,6 +114,20 @@ func verifyZone(rrs []dns.RR, anchors []dns.RR) error {
 		if err := verifyApexRRset(keyMap, set, apexSig); err != nil {
 			return err
 		}
+	}
+
+	// RFC 8976 §4 step 4: "When multiple ZONEMD RRs are present, each MUST
+	// specify a unique Scheme and Hash Algorithm tuple." A repeated tuple
+	// is a malformed RRset, and picking the first match would let an
+	// attacker append a second digest of their own next to the real one.
+	// The check covers every tuple, not only the one this build uses.
+	seen := make(map[uint16]struct{}, len(zonemds))
+	for _, z := range zonemds {
+		tuple := uint16(z.Scheme)<<8 | uint16(z.Hash)
+		if _, dup := seen[tuple]; dup {
+			return errDuplicateZONEMD
+		}
+		seen[tuple] = struct{}{}
 	}
 
 	var chosen *dns.ZONEMD

--- a/middleware/resolver/localroot/zonemd.go
+++ b/middleware/resolver/localroot/zonemd.go
@@ -1,0 +1,247 @@
+package localroot
+
+import (
+	"bytes"
+	"crypto/sha512"
+	"crypto/subtle"
+	"errors"
+	"sort"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/dnsname"
+	"github.com/semihalev/sdns/middleware/resolver/dnssec"
+)
+
+var (
+	errNoApex         = errors.New("localroot: zone has no usable apex")
+	errNoZONEMD       = errors.New("localroot: no supported ZONEMD at the apex")
+	errSerialMismatch = errors.New("localroot: ZONEMD serial does not match the SOA")
+	errDigestMismatch = errors.New("localroot: zone digest does not match ZONEMD")
+	errAnchorChain    = errors.New("localroot: DNSKEY set does not chain to a trust anchor")
+	errBadSignature   = errors.New("localroot: apex RRset signature did not verify")
+)
+
+const (
+	zonemdSchemeSimple = 1 // RFC 8976 §2.2.4
+	zonemdHashSHA384   = 1 // RFC 8976 §2.2.5
+)
+
+// verifyZone establishes a transferred record set as an authentic copy of
+// the root zone, chained to the resolver's trust anchors, before anything
+// is built from it. The chain (RFC 8976 §4, RFC 8806 §3):
+//
+//  1. The apex DNSKEY RRset must match a configured trust anchor DS and
+//     carry a valid self-signature.
+//  2. The apex SOA and ZONEMD RRsets must verify against those keys.
+//  3. A supported ZONEMD (SIMPLE/SHA-384) must carry the SOA's serial, and
+//     the digest of the whole zone in canonical form — every record, glue
+//     included, deduplicated, excluding the apex ZONEMD RRset and the
+//     RRSIGs covering it — must match it exactly.
+//
+// The ZONEMD match authenticates the entire zone contents in one stroke;
+// individual RRSIGs elsewhere in the zone are carried for clients, not
+// re-verified here.
+func verifyZone(rrs []dns.RR, anchors []dns.RR) error {
+	var (
+		dnskeys []*dns.DNSKEY
+		zonemds []*dns.ZONEMD
+		soa     *dns.SOA
+		apexSig []dns.RR
+	)
+	for _, rr := range rrs {
+		if dns.CanonicalName(rr.Header().Name) != "." {
+			continue
+		}
+		switch t := rr.(type) {
+		case *dns.DNSKEY:
+			dnskeys = append(dnskeys, t)
+		case *dns.ZONEMD:
+			zonemds = append(zonemds, t)
+		case *dns.SOA:
+			soa = t
+		case *dns.RRSIG:
+			apexSig = append(apexSig, t)
+		}
+	}
+	if soa == nil {
+		return errNoApex
+	}
+	if len(dnskeys) == 0 {
+		return errAnchorChain
+	}
+
+	keyMap := make(map[uint16][]*dns.DNSKEY, len(dnskeys))
+	for _, k := range dnskeys {
+		tag := dnssec.KeyTag(k)
+		keyMap[tag] = append(keyMap[tag], k)
+	}
+
+	if len(anchors) == 0 {
+		return errAnchorChain
+	}
+	// VerifyDS reports success as (false, nil): the bool is the resolver's
+	// "no supported digest, treat insecure" signal, and insecure is exactly
+	// what a local root copy must never be.
+	if insecure, err := dnssec.VerifyDS(keyMap, anchors); err != nil || insecure {
+		return errAnchorChain
+	}
+
+	// Each apex RRset the chain depends on must verify against the keys.
+	for _, set := range [][]dns.RR{
+		typedApexSet(dnskeys),
+		{soa},
+		typedApexSet(zonemds),
+	} {
+		if len(set) == 0 {
+			continue
+		}
+		if err := verifyApexRRset(keyMap, set, apexSig); err != nil {
+			return err
+		}
+	}
+
+	var chosen *dns.ZONEMD
+	for _, z := range zonemds {
+		if z.Scheme == zonemdSchemeSimple && z.Hash == zonemdHashSHA384 {
+			chosen = z
+			break
+		}
+	}
+	if chosen == nil {
+		return errNoZONEMD
+	}
+	if chosen.Serial != soa.Serial {
+		return errSerialMismatch
+	}
+
+	digest, err := ComputeDigest(rrs, ".")
+	if err != nil {
+		return err
+	}
+	want, err := hexDecode(chosen.Digest)
+	if err != nil || len(want) != sha512.Size384 {
+		return errDigestMismatch
+	}
+	if subtle.ConstantTimeCompare(digest, want) != 1 {
+		return errDigestMismatch
+	}
+	return nil
+}
+
+// verifyApexRRset verifies one apex RRset against the zone keys using the
+// covering RRSIG from the apex signature pool.
+func verifyApexRRset(keys map[uint16][]*dns.DNSKEY, set []dns.RR, sigs []dns.RR) error {
+	covered := set[0].Header().Rrtype
+	msg := new(dns.Msg)
+	msg.Answer = append(msg.Answer, set...)
+	for _, rr := range sigs {
+		if sig, ok := rr.(*dns.RRSIG); ok && sig.TypeCovered == covered {
+			msg.Answer = append(msg.Answer, sig)
+		}
+	}
+	if len(msg.Answer) == len(set) {
+		return errBadSignature // no covering signature at all
+	}
+	if ok, err := dnssec.VerifyRRSIG(".", keys, msg); err != nil || !ok {
+		return errBadSignature
+	}
+	return nil
+}
+
+func typedApexSet[T dns.RR](set []T) []dns.RR {
+	out := make([]dns.RR, 0, len(set))
+	for _, rr := range set {
+		out = append(out, rr)
+	}
+	return out
+}
+
+// ComputeDigest is RFC 8976 §3.3.1's SIMPLE scheme over SHA-384: every
+// record in canonical wire form and canonical order — owner order (§6.1 of
+// RFC 4034), then ascending TYPE for RRsets sharing an owner, then RDATA
+// (§6.3) — with duplicates collapsed and two exclusions at the apex: the
+// ZONEMD RRset itself, and the RRSIGs covering it.
+func ComputeDigest(rrs []dns.RR, apex string) ([]byte, error) {
+	type entry struct {
+		owner    string
+		rtype    uint16
+		wire     []byte
+		rdataOff int
+	}
+	entries := make([]entry, 0, len(rrs))
+	for _, rr := range rrs {
+		owner := dns.CanonicalName(rr.Header().Name)
+		rtype := rr.Header().Rrtype
+		if !dns.IsSubDomain(apex, owner) {
+			// Out-of-zone data is not part of the zone and not digested.
+			continue
+		}
+		if owner == apex {
+			if rtype == dns.TypeZONEMD {
+				continue
+			}
+			if sig, ok := rr.(*dns.RRSIG); ok && sig.TypeCovered == dns.TypeZONEMD {
+				continue
+			}
+		}
+		wire, off, err := dnssec.CanonicalWireRR(rr)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, entry{owner: owner, rtype: rtype, wire: wire, rdataOff: off})
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		a, b := entries[i], entries[j]
+		if c := dnsname.CanonicalCompare(a.owner, b.owner); c != 0 {
+			return c < 0
+		}
+		if a.rtype != b.rtype {
+			return a.rtype < b.rtype
+		}
+		return bytes.Compare(a.wire[a.rdataOff:], b.wire[b.rdataOff:]) < 0
+	})
+
+	h := sha512.New384()
+	var prev []byte
+	for i := range entries {
+		// Duplicate RRs (equal owner, class, type, RDATA) digest once.
+		// After sorting, duplicates are adjacent and their canonical
+		// wire forms are byte-identical.
+		if prev != nil && bytes.Equal(prev, entries[i].wire) {
+			continue
+		}
+		h.Write(entries[i].wire)
+		prev = entries[i].wire
+	}
+	return h.Sum(nil), nil
+}
+
+// hexDecode decodes the ZONEMD digest presentation (hex, upper or lower).
+func hexDecode(s string) ([]byte, error) {
+	if len(s)%2 != 0 {
+		return nil, errDigestMismatch
+	}
+	out := make([]byte, len(s)/2)
+	for i := range out {
+		hi, ok1 := hexVal(s[2*i])
+		lo, ok2 := hexVal(s[2*i+1])
+		if !ok1 || !ok2 {
+			return nil, errDigestMismatch
+		}
+		out[i] = hi<<4 | lo
+	}
+	return out, nil
+}
+
+func hexVal(c byte) (byte, bool) {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0', true
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10, true
+	case c >= 'A' && c <= 'F':
+		return c - 'A' + 10, true
+	}
+	return 0, false
+}

--- a/middleware/resolver/localroot/zonemd_test.go
+++ b/middleware/resolver/localroot/zonemd_test.go
@@ -1,0 +1,95 @@
+package localroot
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// The two example zones and their digests are RFC 8976 Appendix A verbatim.
+// They pin the digest rules an implementation gets wrong first: apex ZONEMD
+// excluded but a non-apex ZONEMD included, duplicates digested once,
+// occluded data included, out-of-zone data excluded, owner and RDATA names
+// canonicalized, and RRsets ordered by owner, type, then RDATA.
+
+const rfc8976SimpleZone = `
+$ORIGIN example.
+example.      86400  IN  SOA     ns1 admin 2018031900 1800 900 604800 86400
+example.      86400  IN  NS      ns1
+example.      86400  IN  NS      ns2
+example.      86400  IN  ZONEMD  2018031900 1 1 c68090d90a7aed716bc459f9340e3d7c1370d4d24b7e2fc3a1ddc0b9a87153b9a9713b3c9ae5cc27777f98b8e730044c
+ns1           3600   IN  A       203.0.113.63
+ns2           3600   IN  AAAA    2001:db8::63
+`
+
+const rfc8976ComplexZone = `
+$ORIGIN example.
+example.      86400  IN  SOA     ns1 admin 2018031900 1800 900 604800 86400
+example.      86400  IN  NS      ns1
+example.      86400  IN  NS      ns2
+example.      86400  IN  ZONEMD  2018031900 1 1 a3b69bad980a3504e1cffcb0fd6397f93848071c93151f552ae2f6b1711d4bd2d8b39808226d7b9db71e34b72077f8fe
+ns1           3600   IN  A       203.0.113.63
+NS2           3600   IN  AAAA    2001:db8::63
+occluded.sub  7200   IN  TXT     "I'm occluded but must be digested"
+sub           7200   IN  NS      ns1
+duplicate     300    IN  TXT     "I must be digested just once"
+duplicate     300    IN  TXT     "I must be digested just once"
+foo.test.     555    IN  TXT     "out-of-zone data must be excluded"
+UPPERCASE     3600   IN  TXT     "canonicalize uppercase owner names"
+*             777    IN  PTR     dont-forget-about-wildcards
+mail          3600   IN  MX      20 MAIL1
+mail          3600   IN  MX      10 Mail2.Example.
+sortme        3600   IN  AAAA    2001:db8::5:61
+sortme        3600   IN  AAAA    2001:db8::3:62
+sortme        3600   IN  AAAA    2001:db8::4:63
+sortme        3600   IN  AAAA    2001:db8::1:65
+sortme        3600   IN  AAAA    2001:db8::2:64
+non-apex      900    IN  ZONEMD  2018031900 1 1 616c6c6f776564206275742069676e6f7265642e20616c6c6f776564206275742069676e6f7265642e20616c6c6f7765
+`
+
+func parseZoneText(t *testing.T, text string) []dns.RR {
+	t.Helper()
+	var rrs []dns.RR
+	zp := dns.NewZoneParser(strings.NewReader(text), "example.", "rfc8976-appendix-a")
+	for rr, ok := zp.Next(); ok; rr, ok = zp.Next() {
+		rrs = append(rrs, rr)
+	}
+	if err := zp.Err(); err != nil {
+		t.Fatalf("zone parse: %v", err)
+	}
+	if len(rrs) == 0 {
+		t.Fatal("zone parse yielded nothing")
+	}
+	return rrs
+}
+
+func zonemdDigest(t *testing.T, rrs []dns.RR) string {
+	t.Helper()
+	for _, rr := range rrs {
+		if z, ok := rr.(*dns.ZONEMD); ok && dns.CanonicalName(z.Header().Name) == "example." {
+			return strings.ToLower(z.Digest)
+		}
+	}
+	t.Fatal("no apex ZONEMD in the vector")
+	return ""
+}
+
+func TestComputeDigestRFC8976Vectors(t *testing.T) {
+	for name, text := range map[string]string{
+		"simple":  rfc8976SimpleZone,
+		"complex": rfc8976ComplexZone,
+	} {
+		t.Run(name, func(t *testing.T) {
+			rrs := parseZoneText(t, text)
+			got, err := ComputeDigest(rrs, "example.")
+			if err != nil {
+				t.Fatalf("computeDigest: %v", err)
+			}
+			if want := zonemdDigest(t, rrs); hex.EncodeToString(got) != want {
+				t.Fatalf("digest = %s, want RFC 8976's %s", hex.EncodeToString(got), want)
+			}
+		})
+	}
+}

--- a/middleware/resolver/localroot_seam.go
+++ b/middleware/resolver/localroot_seam.go
@@ -48,13 +48,14 @@ func (r *Resolver) consultLocalRoot(ctx context.Context, rs *resolveState) (answ
 		return nil, false
 	}
 	qname := dns.CanonicalName(q.Name)
+	cd := rs.req.CheckingDisabled
 	tld := localroot.TLDOf(qname)
 	if tld == "" {
-		// The apex itself (. SOA/NS/DNSKEY): rare, and the real roots
-		// answer it authoritatively; the copy stays out of it.
-		return nil, false
+		// The root's own records — NS, SOA, DNSKEY — are in the copy, and
+		// asking a root server for an answer already held here is the one
+		// thing this package exists to stop doing.
+		return r.localRootApexAnswer(rs, snap, q.Qtype, cd)
 	}
-	cd := rs.req.CheckingDisabled
 
 	if ref, ok := snap.Referral(tld); ok {
 		if qname == tld && q.Qtype == dns.TypeDS {
@@ -103,6 +104,57 @@ func (r *Resolver) consultLocalRoot(ctx context.Context, rs *resolveState) (answ
 
 	localroot.CountDenial()
 	return r.localRootDenial(ctx, rs, snap, qname, proof, cd), true
+}
+
+// localRootApexAnswer serves a question asked at the root's own name from
+// the copy: the signed RRset when the apex holds the type, the apex NSEC as
+// the NODATA proof when it does not. A copy that can evidence neither
+// answers nothing and the walk goes to the real roots.
+//
+// This includes DNSKEY, which the RFC 5011 anchor refresh also asks for, so
+// that query is answered from the copy too. That is sound and deliberate:
+// the copy's DNSKEY RRset is the published one, transferred within the
+// refresh interval and verified under an anchor-matched key before
+// anything was built from it — a faithful observation of the zone, against
+// a hold-down measured in weeks. It is also fail-safe in the direction that
+// matters: a rollover the current anchors can no longer verify leaves no
+// copy at all, so the refresh falls back to querying the roots live, which
+// is exactly when it needs to.
+func (r *Resolver) localRootApexAnswer(
+	rs *resolveState,
+	snap *localroot.Snapshot,
+	qtype uint16,
+	cd bool,
+) (*dns.Msg, bool) {
+	rrs, sigs, nsec, nsecSig, ok := snap.ApexAnswer(qtype)
+	if !ok {
+		localroot.CountFallback()
+		return nil, false
+	}
+
+	resp := new(dns.Msg)
+	resp.SetRcode(rs.req, dns.RcodeSuccess)
+	resp.Authoritative = false
+	resp.RecursionAvailable = true
+	// The handler clears RD before resolution and setTags restores it on
+	// the way out; this answer returns early, so it restores its own.
+	resp.RecursionDesired = true
+
+	if len(rrs) > 0 {
+		resp.Answer = append(resp.Answer, rrs...)
+		resp.Answer = append(resp.Answer, sigs...)
+	} else {
+		soa, soaSig := snap.SOA()
+		resp.Ns = append(resp.Ns, soa)
+		resp.Ns = append(resp.Ns, soaSig...)
+		resp.Ns = append(resp.Ns, nsec...)
+		resp.Ns = append(resp.Ns, nsecSig...)
+	}
+	if !cd {
+		resp.AuthenticatedData = true
+	}
+	localroot.CountApex()
+	return resp, true
 }
 
 // installLocalRootReferral stores the TLD's delegation as a root referral

--- a/middleware/resolver/localroot_seam.go
+++ b/middleware/resolver/localroot_seam.go
@@ -40,6 +40,13 @@ func (r *Resolver) consultLocalRoot(ctx context.Context, rs *resolveState) (answ
 	}
 
 	q := rs.req.Question[0]
+	if q.Qclass != dns.ClassINET {
+		// The copy is an IN zone and every answer built from it — the
+		// delegation key, the NSEC question, the SOA — is IN. Answering a
+		// CHAOS or HESIOD question from it would pair the client's class
+		// with another class's records, so those go to the real roots.
+		return nil, false
+	}
 	qname := dns.CanonicalName(q.Name)
 	tld := localroot.TLDOf(qname)
 	if tld == "" {
@@ -103,16 +110,6 @@ func (r *Resolver) installLocalRootReferral(
 ) bool {
 	key := cache.Key(dns.Question{Name: tld, Qtype: dns.TypeNS, Qclass: dns.ClassINET}, cd)
 
-	if d, err := r.delegations.Get(key); err == nil {
-		rs.servers = d.Servers
-		rs.parentDS = d.DSSet
-		rs.level = 1
-		rs.isRoot = false
-		rs.cutDeadline, rs.cutKey = minCut(rs.cutDeadline, rs.cutKey, d.ExpiresAt, key)
-		noteCut(ctx, rs.cutDeadline, rs.cutKey)
-		return true
-	}
-
 	servers := &authority.Servers{Zone: tld}
 	var minTTL uint32
 	for _, nsRR := range ref.NS {
@@ -142,17 +139,22 @@ func (r *Resolver) installLocalRootReferral(
 	if until := snap.ValidUntil(); until.Before(deadline) {
 		deadline = until
 	}
-	r.delegations.SetUntilIfAbsent(key, ref.DS, servers, deadline)
-	// Read back what won the store so racing walks share one identity.
-	if d, err := r.delegations.Get(key); err == nil {
-		servers = d.Servers
+	// The store returns whatever is live under the key — this call's entry,
+	// or the one a racing walk published first — and the walk takes that
+	// delegation whole. Servers, DS set and lease belong to one entry:
+	// pairing a winner's servers with this call's DS chain would validate
+	// one delegation's answers against another's keys, so there is no
+	// separate readback to get wrong.
+	live := r.delegations.SetUntilIfAbsent(key, ref.DS, servers, deadline)
+	if live == nil {
+		return false
 	}
 
-	rs.servers = servers
-	rs.parentDS = ref.DS
+	rs.servers = live.Servers
+	rs.parentDS = live.DSSet
 	rs.level = 1
 	rs.isRoot = false
-	rs.cutDeadline, rs.cutKey = minCut(rs.cutDeadline, rs.cutKey, deadline, key)
+	rs.cutDeadline, rs.cutKey = minCut(rs.cutDeadline, rs.cutKey, live.ExpiresAt, key)
 	noteCut(ctx, rs.cutDeadline, rs.cutKey)
 	return true
 }
@@ -169,6 +171,9 @@ func (r *Resolver) localRootDSAnswer(rs *resolveState, snap *localroot.Snapshot,
 	resp.SetRcode(rs.req, dns.RcodeSuccess)
 	resp.Authoritative = false
 	resp.RecursionAvailable = true
+	// The handler clears RD before resolution and setTags restores it on
+	// the way out; this answer returns early, so it restores its own.
+	resp.RecursionDesired = true
 	if !ok {
 		// Unreachable behind a Referral hit, but never answer garbage.
 		resp.Rcode = dns.RcodeServerFailure
@@ -206,6 +211,8 @@ func (r *Resolver) localRootDenial(
 	resp := new(dns.Msg)
 	resp.SetRcode(rs.req, dns.RcodeNameError)
 	resp.RecursionAvailable = true
+	// As above: the early return misses setTags, so RD is restored here.
+	resp.RecursionDesired = true
 
 	soa, soaSig := snap.SOA()
 	resp.Ns = append(resp.Ns, soa)

--- a/middleware/resolver/localroot_seam.go
+++ b/middleware/resolver/localroot_seam.go
@@ -55,7 +55,11 @@ func (r *Resolver) consultLocalRoot(ctx context.Context, rs *resolveState) (answ
 		// The root's own records — NS, SOA, DNSKEY — are in the copy, and
 		// asking a root server for an answer already held here is the one
 		// thing this package exists to stop doing.
-		return r.localRootApexAnswer(rs, snap, q.Qtype, cd)
+		answer, handled := r.localRootApexAnswer(rs, snap, q.Qtype, cd)
+		if handled {
+			noteCopyHorizon(ctx, snap)
+		}
+		return answer, handled
 	}
 
 	if ref, ok := snap.Referral(tld); ok {
@@ -69,6 +73,7 @@ func (r *Resolver) consultLocalRoot(ctx context.Context, rs *resolveState) (answ
 				localroot.CountFallback()
 				return nil, false
 			}
+			noteCopyHorizon(ctx, snap)
 			return answer, true
 		}
 		if r.installLocalRootReferral(ctx, rs, snap, tld, ref, cd) {
@@ -109,7 +114,26 @@ func (r *Resolver) consultLocalRoot(ctx context.Context, rs *resolveState) (answ
 	}
 
 	localroot.CountDenial()
+	noteCopyHorizon(ctx, snap)
 	return r.localRootDenial(ctx, rs, snap, qname, proof, cd), true
+}
+
+// noteCopyHorizon binds the request tree to the copy's serving horizon, so
+// the answer cache cannot outlive the copy it was built from.
+//
+// Bounding the wire TTLs is not enough on its own. The cache applies a
+// five-second floor to any TTL below it (dnsutil.MinCacheTTL), so an answer
+// taken in the last seconds of the horizon — TTL bounded to zero or one —
+// would still be admitted for five, and served from cache after Active() had
+// already withdrawn the copy. RFC 8806 asks for an immediate return to the
+// real root servers at that instant, not a few seconds later.
+//
+// The referral path bounds the tree the same way, through the delegation
+// lease. The key is zero because this deadline is an exact instant rather
+// than one a delegation entry supplied — the same shape the cache's own
+// boundRequestTo uses.
+func noteCopyHorizon(ctx context.Context, snap *localroot.Snapshot) {
+	noteCut(ctx, snap.ValidUntil(), 0)
 }
 
 // boundToCopy finishes a response built from the local copy: every record is
@@ -194,7 +218,7 @@ func (r *Resolver) localRootApexAnswer(
 		resp.Answer = append(resp.Answer, sigs...)
 		if qtype == dns.TypeNS {
 			// A root server answers ". NS" with the addresses of the servers
-			// it names (RFC 8109), and the copy holds them as glue. Without
+			// it names (RFC 9609), and the copy holds them as glue. Without
 			// them this answer names thirteen servers and gives no way to
 			// reach any of them — which is also what the resolver's own
 			// 12-hourly priming reads, so it would find no addresses and

--- a/middleware/resolver/localroot_seam.go
+++ b/middleware/resolver/localroot_seam.go
@@ -106,6 +106,46 @@ func (r *Resolver) consultLocalRoot(ctx context.Context, rs *resolveState) (answ
 	return r.localRootDenial(ctx, rs, snap, qname, proof, cd), true
 }
 
+// boundToCopy finishes a response built from the local copy: every record is
+// replaced by a copy of itself whose TTL is bounded by the copy's serving
+// horizon. Both halves are requirements, not tidiness:
+//
+//   - RFC 4035 §5.3.3 caps an authenticated RRset's TTL at the remaining life
+//     of the signature that authenticates it. The horizon is the earliest
+//     RRSIG expiration anywhere in the zone, so bounding by it is at least as
+//     strict as the rule demands for every RRset served here. It is the same
+//     third bound installLocalRootReferral already applies to a delegation
+//     lease, applied now to the answers the copy serves directly — without
+//     it, an answer taken shortly before the horizon can advertise days of
+//     TTL for records whose signatures lapse within the hour.
+//   - The Snapshot is immutable and read by every goroutine serving from the
+//     copy. Handing out its records would let any downstream TTL rewrite —
+//     clampTTLsToCut is one, and it writes in place — reach into the live
+//     copy and silently change what every later answer says, from an
+//     arbitrary request goroutine.
+//
+// A horizon less than a second away yields TTL 0, which is the honest answer:
+// serve it, and tell the client not to hold it.
+func boundToCopy(resp *dns.Msg, snap *localroot.Snapshot) {
+	ttl := uint32(max(time.Until(snap.ValidUntil()), 0) / time.Second) //nolint:gosec // bounded above by the SOA expire interval.
+	resp.Answer = copyBoundedTTL(resp.Answer, ttl)
+	resp.Ns = copyBoundedTTL(resp.Ns, ttl)
+}
+
+// copyBoundedTTL replaces each record in rrs with a copy capped at ttl. The
+// slice itself belongs to the caller's freshly built response, so it is
+// rewritten in place; the records do not.
+func copyBoundedTTL(rrs []dns.RR, ttl uint32) []dns.RR {
+	for i, rr := range rrs {
+		c := dns.Copy(rr)
+		if c.Header().Ttl > ttl {
+			c.Header().Ttl = ttl
+		}
+		rrs[i] = c
+	}
+	return rrs
+}
+
 // localRootApexAnswer serves a question asked at the root's own name from
 // the copy: the signed RRset when the apex holds the type, the apex NSEC as
 // the NODATA proof when it does not. A copy that can evidence neither
@@ -153,6 +193,7 @@ func (r *Resolver) localRootApexAnswer(
 	if !cd {
 		resp.AuthenticatedData = true
 	}
+	boundToCopy(resp, snap)
 	localroot.CountApex()
 	return resp, true
 }
@@ -267,6 +308,7 @@ func (r *Resolver) localRootDSAnswer(rs *resolveState, snap *localroot.Snapshot,
 	if !cd {
 		resp.AuthenticatedData = true
 	}
+	boundToCopy(resp, snap)
 	return resp
 }
 
@@ -292,6 +334,10 @@ func (r *Resolver) localRootDenial(
 	resp.Ns = append(resp.Ns, soa)
 	resp.Ns = append(resp.Ns, soaSig...)
 	resp.Ns = append(resp.Ns, proof...)
+	// Before the provenance mark, never after: the fingerprint seals the
+	// authority section's TTLs, so a rewrite afterwards would disqualify the
+	// proof at the admission gate it exists to pass.
+	boundToCopy(resp, snap)
 
 	if cd {
 		return resp

--- a/middleware/resolver/localroot_seam.go
+++ b/middleware/resolver/localroot_seam.go
@@ -58,7 +58,16 @@ func (r *Resolver) consultLocalRoot(ctx context.Context, rs *resolveState) (answ
 
 	if ref, ok := snap.Referral(tld); ok {
 		if qname == tld && q.Qtype == dns.TypeDS {
-			return r.localRootDSAnswer(rs, snap, tld, cd), true
+			// A copy that cannot prove the answer does not answer: the
+			// real roots do. Handing back a SERVFAIL here would turn a
+			// gap in the copy into a client-visible failure, which is
+			// the opposite of what the fallback exists for.
+			answer := r.localRootDSAnswer(rs, snap, tld, cd)
+			if answer == nil {
+				localroot.CountFallback()
+				return nil, false
+			}
+			return answer, true
 		}
 		if r.installLocalRootReferral(ctx, rs, snap, tld, ref, cd) {
 			localroot.CountReferral()
@@ -161,11 +170,16 @@ func (r *Resolver) installLocalRootReferral(
 
 // localRootDSAnswer serves the parent-side DS question for a TLD from the
 // verified copy: the signed DS set, or the exact-owner NSEC NODATA proof
-// for an unsigned delegation. The reply is built on the live request so
-// the transaction ID and flags survive — this answer returns directly,
-// without the normalization the exchange path would apply.
+// for an unsigned delegation. It returns nil when the copy holds no proof
+// of either — the caller falls back to the real roots rather than inventing
+// a failure. The reply is built on the live request so the transaction ID
+// and flags survive, since this answer returns directly, without the
+// normalization the exchange path would apply.
 func (r *Resolver) localRootDSAnswer(rs *resolveState, snap *localroot.Snapshot, tld string, cd bool) *dns.Msg {
 	ds, dsSig, nsec, nsecSig, ok := snap.DSAnswer(tld)
+	if !ok {
+		return nil
+	}
 
 	resp := new(dns.Msg)
 	resp.SetRcode(rs.req, dns.RcodeSuccess)
@@ -174,11 +188,6 @@ func (r *Resolver) localRootDSAnswer(rs *resolveState, snap *localroot.Snapshot,
 	// The handler clears RD before resolution and setTags restores it on
 	// the way out; this answer returns early, so it restores its own.
 	resp.RecursionDesired = true
-	if !ok {
-		// Unreachable behind a Referral hit, but never answer garbage.
-		resp.Rcode = dns.RcodeServerFailure
-		return resp
-	}
 	localroot.CountDS()
 	if len(ds) > 0 {
 		resp.Answer = append(resp.Answer, ds...)

--- a/middleware/resolver/localroot_seam.go
+++ b/middleware/resolver/localroot_seam.go
@@ -120,12 +120,8 @@ func (r *Resolver) installLocalRootReferral(
 	key := cache.Key(dns.Question{Name: tld, Qtype: dns.TypeNS, Qclass: dns.ClassINET}, cd)
 
 	servers := &authority.Servers{Zone: tld}
-	var minTTL uint32
 	for _, nsRR := range ref.NS {
 		host := dns.CanonicalName(nsRR.(*dns.NS).Ns)
-		if minTTL == 0 || nsRR.Header().Ttl < minTTL {
-			minTTL = nsRR.Header().Ttl
-		}
 		for _, glue := range ref.Glue[host] {
 			switch g := glue.(type) {
 			case *dns.A:
@@ -158,7 +154,7 @@ func (r *Resolver) installLocalRootReferral(
 	// refuses it and the walk falls back rather than asserting an unproven
 	// status.
 	observedAt := time.Now()
-	deadline := observedAt.Add(time.Duration(minTTL) * time.Second)
+	deadline := observedAt.Add(time.Duration(ref.NSTTL) * time.Second)
 	if security := observedAt.Add(time.Duration(ref.SecurityTTL) * time.Second); security.Before(deadline) {
 		deadline = security
 	}

--- a/middleware/resolver/localroot_seam.go
+++ b/middleware/resolver/localroot_seam.go
@@ -51,9 +51,9 @@ func (r *Resolver) consultLocalRoot(ctx context.Context, rs *resolveState) (answ
 
 	if ref, ok := snap.Referral(tld); ok {
 		if qname == tld && q.Qtype == dns.TypeDS {
-			return r.localRootDSAnswer(snap, tld, cd), true
+			return r.localRootDSAnswer(rs, snap, tld, cd), true
 		}
-		if r.installLocalRootReferral(ctx, rs, tld, ref, cd) {
+		if r.installLocalRootReferral(ctx, rs, snap, tld, ref, cd) {
 			localroot.CountReferral()
 			return nil, false
 		}
@@ -66,6 +66,25 @@ func (r *Resolver) consultLocalRoot(ctx context.Context, rs *resolveState) (answ
 	if !ok {
 		return nil, false
 	}
+
+	// The proof must independently classify as this exact NXDOMAIN under
+	// the strict RFC 8198 evaluator before anything is served from it: a
+	// chain gap the covering search cannot see — an NSEC whose span does
+	// not actually reach the name — must fall back to the real roots, not
+	// become an authenticated denial.
+	var nsecSet []dns.RR
+	for _, rr := range proof {
+		if rr.Header().Rrtype == dns.TypeNSEC {
+			nsecSet = append(nsecSet, rr)
+		}
+	}
+	evalQ := dns.Question{Name: qname, Qtype: q.Qtype, Qclass: dns.ClassINET}
+	result, err := dnssec.EvaluateAggressiveNSEC(evalQ, rootzone, nsecSet)
+	if err != nil || result.Rcode != dns.RcodeNameError {
+		localroot.CountFallback()
+		return nil, false
+	}
+
 	localroot.CountDenial()
 	return r.localRootDenial(ctx, rs, snap, qname, proof, cd), true
 }
@@ -77,6 +96,7 @@ func (r *Resolver) consultLocalRoot(ctx context.Context, rs *resolveState) (answ
 func (r *Resolver) installLocalRootReferral(
 	ctx context.Context,
 	rs *resolveState,
+	snap *localroot.Snapshot,
 	tld string,
 	ref localroot.Referral,
 	cd bool,
@@ -115,7 +135,13 @@ func (r *Resolver) installLocalRootReferral(
 		return false
 	}
 
+	// The lease is the earlier of the NS TTL and the copy's own serving
+	// horizon: nothing derived from the copy outlives the signatures and
+	// SOA expire that made it trustworthy.
 	deadline := time.Now().Add(time.Duration(minTTL) * time.Second)
+	if until := snap.ValidUntil(); until.Before(deadline) {
+		deadline = until
+	}
 	r.delegations.SetUntilIfAbsent(key, ref.DS, servers, deadline)
 	// Read back what won the store so racing walks share one identity.
 	if d, err := r.delegations.Get(key); err == nil {
@@ -133,12 +159,14 @@ func (r *Resolver) installLocalRootReferral(
 
 // localRootDSAnswer serves the parent-side DS question for a TLD from the
 // verified copy: the signed DS set, or the exact-owner NSEC NODATA proof
-// for an unsigned delegation.
-func (r *Resolver) localRootDSAnswer(snap *localroot.Snapshot, tld string, cd bool) *dns.Msg {
+// for an unsigned delegation. The reply is built on the live request so
+// the transaction ID and flags survive — this answer returns directly,
+// without the normalization the exchange path would apply.
+func (r *Resolver) localRootDSAnswer(rs *resolveState, snap *localroot.Snapshot, tld string, cd bool) *dns.Msg {
 	ds, dsSig, nsec, nsecSig, ok := snap.DSAnswer(tld)
 
 	resp := new(dns.Msg)
-	resp.SetRcode(reqForLocalRoot(tld, dns.TypeDS, cd), dns.RcodeSuccess)
+	resp.SetRcode(rs.req, dns.RcodeSuccess)
 	resp.Authoritative = false
 	resp.RecursionAvailable = true
 	if !ok {
@@ -187,35 +215,15 @@ func (r *Resolver) localRootDenial(
 	if cd {
 		return resp
 	}
+	// The caller's evaluator gate already classified this exact proof as
+	// the NXDOMAIN being served, so the provenance carries the aggressive
+	// bit outright — an unclassifiable proof never reaches this builder.
 	resp.AuthenticatedData = true
-
-	q := dns.Question{Name: qname, Qtype: rs.req.Question[0].Qtype, Qclass: dns.ClassINET}
-	var nsecSet []dns.RR
-	for _, rr := range resp.Ns {
-		if rr.Header().Rrtype == dns.TypeNSEC {
-			nsecSet = append(nsecSet, rr)
-		}
-	}
-	aggressive := false
-	if result, err := dnssec.EvaluateAggressiveNSEC(q, rootzone, nsecSet); err == nil &&
-		result.Rcode == dns.RcodeNameError {
-		aggressive = true
-	}
 	middleware.MarkValidatedNegativeProofResponse(ctx, resp, middleware.ValidatedNegativeProof{
 		Subject:    qname,
 		Zone:       rootzone,
 		Kind:       middleware.ValidatedNegativeProofNSEC,
-		Aggressive: aggressive,
+		Aggressive: true,
 	})
 	return resp
-}
-
-// reqForLocalRoot builds the request shape SetRcode needs for a
-// resolver-synthesized parent-side answer.
-func reqForLocalRoot(name string, qtype uint16, cd bool) *dns.Msg {
-	m := new(dns.Msg)
-	m.SetQuestion(name, qtype)
-	m.CheckingDisabled = cd
-	m.RecursionDesired = false
-	return m
 }

--- a/middleware/resolver/localroot_seam.go
+++ b/middleware/resolver/localroot_seam.go
@@ -1,0 +1,221 @@
+package resolver
+
+import (
+	"context"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/authority"
+	"github.com/semihalev/sdns/internal/cache"
+	"github.com/semihalev/sdns/middleware"
+	"github.com/semihalev/sdns/middleware/resolver/dnssec"
+	"github.com/semihalev/sdns/middleware/resolver/localroot"
+)
+
+// consultLocalRoot is the one seam the local root copy (RFC 8806) has into
+// the walk: the root step, where nothing deeper is cached and the next
+// query would otherwise go to a real root server. Three shapes come back
+// from the verified copy:
+//
+//   - the TLD exists: its delegation is installed exactly as a root
+//     referral would have installed it, and the walk continues without a
+//     root query (answer=nil, handled=false, servers updated);
+//   - the query is the TLD's DS: the parent-side answer is served straight
+//     from the copy (handled=true);
+//   - the TLD does not exist: the zone's own signed NSEC proof synthesizes
+//     the NXDOMAIN (handled=true).
+//
+// No active verified copy — disabled, never transferred, or past its SOA
+// expire — reports consulted=false and the walk proceeds to the real roots
+// unchanged.
+func (r *Resolver) consultLocalRoot(ctx context.Context, rs *resolveState) (answer *dns.Msg, handled bool) {
+	mgr := r.localRoot.Load()
+	if mgr == nil {
+		return nil, false
+	}
+	snap := mgr.Active()
+	if snap == nil {
+		localroot.CountFallback()
+		return nil, false
+	}
+
+	q := rs.req.Question[0]
+	qname := dns.CanonicalName(q.Name)
+	tld := localroot.TLDOf(qname)
+	if tld == "" {
+		// The apex itself (. SOA/NS/DNSKEY): rare, and the real roots
+		// answer it authoritatively; the copy stays out of it.
+		return nil, false
+	}
+	cd := rs.req.CheckingDisabled
+
+	if ref, ok := snap.Referral(tld); ok {
+		if qname == tld && q.Qtype == dns.TypeDS {
+			return r.localRootDSAnswer(snap, tld, cd), true
+		}
+		if r.installLocalRootReferral(ctx, rs, tld, ref, cd) {
+			localroot.CountReferral()
+			return nil, false
+		}
+		// A referral the walk cannot use (no glue at all): the real
+		// roots resolve it the ordinary way.
+		return nil, false
+	}
+
+	proof, ok := snap.Denial(qname)
+	if !ok {
+		return nil, false
+	}
+	localroot.CountDenial()
+	return r.localRootDenial(ctx, rs, snap, qname, proof, cd), true
+}
+
+// installLocalRootReferral stores the TLD's delegation as a root referral
+// would have and points the walk at it. The delegation entry persists in
+// the delegations cache so upstream RTT evidence accumulates on a stable
+// Servers identity across queries.
+func (r *Resolver) installLocalRootReferral(
+	ctx context.Context,
+	rs *resolveState,
+	tld string,
+	ref localroot.Referral,
+	cd bool,
+) bool {
+	key := cache.Key(dns.Question{Name: tld, Qtype: dns.TypeNS, Qclass: dns.ClassINET}, cd)
+
+	if d, err := r.delegations.Get(key); err == nil {
+		rs.servers = d.Servers
+		rs.parentDS = d.DSSet
+		rs.level = 1
+		rs.isRoot = false
+		rs.cutDeadline, rs.cutKey = minCut(rs.cutDeadline, rs.cutKey, d.ExpiresAt, key)
+		noteCut(ctx, rs.cutDeadline, rs.cutKey)
+		return true
+	}
+
+	servers := &authority.Servers{Zone: tld}
+	var minTTL uint32
+	for _, nsRR := range ref.NS {
+		host := dns.CanonicalName(nsRR.(*dns.NS).Ns)
+		if minTTL == 0 || nsRR.Header().Ttl < minTTL {
+			minTTL = nsRR.Header().Ttl
+		}
+		for _, glue := range ref.Glue[host] {
+			switch g := glue.(type) {
+			case *dns.A:
+				servers.List = append(servers.List, authority.NewServer(g.A.String()+":53", authority.IPv4))
+			case *dns.AAAA:
+				if r.cfg.IPv6Access {
+					servers.List = append(servers.List, authority.NewServer("["+g.AAAA.String()+"]:53", authority.IPv6))
+				}
+			}
+		}
+	}
+	if len(servers.List) == 0 {
+		return false
+	}
+
+	deadline := time.Now().Add(time.Duration(minTTL) * time.Second)
+	r.delegations.SetUntilIfAbsent(key, ref.DS, servers, deadline)
+	// Read back what won the store so racing walks share one identity.
+	if d, err := r.delegations.Get(key); err == nil {
+		servers = d.Servers
+	}
+
+	rs.servers = servers
+	rs.parentDS = ref.DS
+	rs.level = 1
+	rs.isRoot = false
+	rs.cutDeadline, rs.cutKey = minCut(rs.cutDeadline, rs.cutKey, deadline, key)
+	noteCut(ctx, rs.cutDeadline, rs.cutKey)
+	return true
+}
+
+// localRootDSAnswer serves the parent-side DS question for a TLD from the
+// verified copy: the signed DS set, or the exact-owner NSEC NODATA proof
+// for an unsigned delegation.
+func (r *Resolver) localRootDSAnswer(snap *localroot.Snapshot, tld string, cd bool) *dns.Msg {
+	ds, dsSig, nsec, nsecSig, ok := snap.DSAnswer(tld)
+
+	resp := new(dns.Msg)
+	resp.SetRcode(reqForLocalRoot(tld, dns.TypeDS, cd), dns.RcodeSuccess)
+	resp.Authoritative = false
+	resp.RecursionAvailable = true
+	if !ok {
+		// Unreachable behind a Referral hit, but never answer garbage.
+		resp.Rcode = dns.RcodeServerFailure
+		return resp
+	}
+	localroot.CountDS()
+	if len(ds) > 0 {
+		resp.Answer = append(resp.Answer, ds...)
+		resp.Answer = append(resp.Answer, dsSig...)
+	} else {
+		soa, soaSig := snap.SOA()
+		resp.Ns = append(resp.Ns, soa)
+		resp.Ns = append(resp.Ns, soaSig...)
+		resp.Ns = append(resp.Ns, nsec...)
+		resp.Ns = append(resp.Ns, nsecSig...)
+	}
+	if !cd {
+		resp.AuthenticatedData = true
+	}
+	return resp
+}
+
+// localRootDenial synthesizes the NXDOMAIN a root server would return for a
+// name under an absent TLD, from the copy's own signed proof, and marks the
+// validated-denial provenance exactly as the live validation path does — the
+// RFC 8020 cut and RFC 8198 stores fill from it through their normal seams.
+func (r *Resolver) localRootDenial(
+	ctx context.Context,
+	rs *resolveState,
+	snap *localroot.Snapshot,
+	qname string,
+	proof []dns.RR,
+	cd bool,
+) *dns.Msg {
+	resp := new(dns.Msg)
+	resp.SetRcode(rs.req, dns.RcodeNameError)
+	resp.RecursionAvailable = true
+
+	soa, soaSig := snap.SOA()
+	resp.Ns = append(resp.Ns, soa)
+	resp.Ns = append(resp.Ns, soaSig...)
+	resp.Ns = append(resp.Ns, proof...)
+
+	if cd {
+		return resp
+	}
+	resp.AuthenticatedData = true
+
+	q := dns.Question{Name: qname, Qtype: rs.req.Question[0].Qtype, Qclass: dns.ClassINET}
+	var nsecSet []dns.RR
+	for _, rr := range resp.Ns {
+		if rr.Header().Rrtype == dns.TypeNSEC {
+			nsecSet = append(nsecSet, rr)
+		}
+	}
+	aggressive := false
+	if result, err := dnssec.EvaluateAggressiveNSEC(q, rootzone, nsecSet); err == nil &&
+		result.Rcode == dns.RcodeNameError {
+		aggressive = true
+	}
+	middleware.MarkValidatedNegativeProofResponse(ctx, resp, middleware.ValidatedNegativeProof{
+		Subject:    qname,
+		Zone:       rootzone,
+		Kind:       middleware.ValidatedNegativeProofNSEC,
+		Aggressive: aggressive,
+	})
+	return resp
+}
+
+// reqForLocalRoot builds the request shape SetRcode needs for a
+// resolver-synthesized parent-side answer.
+func reqForLocalRoot(name string, qtype uint16, cd bool) *dns.Msg {
+	m := new(dns.Msg)
+	m.SetQuestion(name, qtype)
+	m.CheckingDisabled = cd
+	m.RecursionDesired = false
+	return m
+}

--- a/middleware/resolver/localroot_seam.go
+++ b/middleware/resolver/localroot_seam.go
@@ -45,6 +45,7 @@ func (r *Resolver) consultLocalRoot(ctx context.Context, rs *resolveState) (answ
 		// delegation key, the NSEC question, the SOA — is IN. Answering a
 		// CHAOS or HESIOD question from it would pair the client's class
 		// with another class's records, so those go to the real roots.
+		localroot.CountFallback()
 		return nil, false
 	}
 	qname := dns.CanonicalName(q.Name)
@@ -76,11 +77,16 @@ func (r *Resolver) consultLocalRoot(ctx context.Context, rs *resolveState) (answ
 		}
 		// A referral the walk cannot use (no glue at all): the real
 		// roots resolve it the ordinary way.
+		localroot.CountFallback()
 		return nil, false
 	}
 
 	proof, ok := snap.Denial(qname)
 	if !ok {
+		// The TLD is absent from the copy and the copy cannot prove it
+		// absent either. That is a gap in the chain worth seeing, not a
+		// silent walk to the roots.
+		localroot.CountFallback()
 		return nil, false
 	}
 
@@ -130,6 +136,9 @@ func boundToCopy(resp *dns.Msg, snap *localroot.Snapshot) {
 	ttl := uint32(max(time.Until(snap.ValidUntil()), 0) / time.Second) //nolint:gosec // bounded above by the SOA expire interval.
 	resp.Answer = copyBoundedTTL(resp.Answer, ttl)
 	resp.Ns = copyBoundedTTL(resp.Ns, ttl)
+	// Extra carries the priming glue; the OPT record is attached further
+	// down the writer stack, well after this.
+	resp.Extra = copyBoundedTTL(resp.Extra, ttl)
 }
 
 // copyBoundedTTL replaces each record in rrs with a copy capped at ttl. The
@@ -183,6 +192,15 @@ func (r *Resolver) localRootApexAnswer(
 	if len(rrs) > 0 {
 		resp.Answer = append(resp.Answer, rrs...)
 		resp.Answer = append(resp.Answer, sigs...)
+		if qtype == dns.TypeNS {
+			// A root server answers ". NS" with the addresses of the servers
+			// it names (RFC 8109), and the copy holds them as glue. Without
+			// them this answer names thirteen servers and gives no way to
+			// reach any of them — which is also what the resolver's own
+			// 12-hourly priming reads, so it would find no addresses and
+			// leave its root server list unrefreshed.
+			resp.Extra = append(resp.Extra, snap.ApexGlue()...)
+		}
 	} else {
 		soa, soaSig := snap.SOA()
 		resp.Ns = append(resp.Ns, soa)

--- a/middleware/resolver/localroot_seam.go
+++ b/middleware/resolver/localroot_seam.go
@@ -141,10 +141,27 @@ func (r *Resolver) installLocalRootReferral(
 		return false
 	}
 
-	// The lease is the earlier of the NS TTL and the copy's own serving
-	// horizon: nothing derived from the copy outlives the signatures and
-	// SOA expire that made it trustworthy.
-	deadline := time.Now().Add(time.Duration(minTTL) * time.Second)
+	// The lease is the earliest of three bounds, all measured from one
+	// observation instant so scheduling delay cannot re-inflate any of
+	// them (GHSA-mqfw-f48p-2vc8):
+	//
+	//   - the NS TTL, which is how long the delegation itself may be held;
+	//   - the delegation's security evidence — the DS RRset's TTL when
+	//     signed, the denying NSEC's when not — exactly as
+	//     processDelegation bounds a referral learned off the wire, so a
+	//     withdrawn DS cannot be trusted for the NS set's longer life;
+	//   - the copy's own serving horizon, since nothing derived from it may
+	//     outlive the signatures and SOA expire that made it trustworthy.
+	//
+	// A delegation whose security status the copy cannot evidence reports a
+	// zero SecurityTTL, which drives the lease into the past: the store
+	// refuses it and the walk falls back rather than asserting an unproven
+	// status.
+	observedAt := time.Now()
+	deadline := observedAt.Add(time.Duration(minTTL) * time.Second)
+	if security := observedAt.Add(time.Duration(ref.SecurityTTL) * time.Second); security.Before(deadline) {
+		deadline = security
+	}
 	if until := snap.ValidUntil(); until.Before(deadline) {
 		deadline = until
 	}

--- a/middleware/resolver/localroot_seam_test.go
+++ b/middleware/resolver/localroot_seam_test.go
@@ -870,7 +870,7 @@ func TestLocalRootAnswersDoNotAliasTheCopy(t *testing.T) {
 
 // TestLocalRootApexNSCarriesPrimingGlue pins the additional section of the
 // copy's answer to ". NS". A root server answers a priming query with the
-// addresses of the servers it names (RFC 8109), and the resolver's own
+// addresses of the servers it names (RFC 9609), and the resolver's own
 // 12-hourly checkPriming reads addresses from Extra and nowhere else — so an
 // answer without them leaves the root server list unrefreshed for the life of
 // the process, and a client asking ". NS" gets names it cannot reach.
@@ -908,4 +908,56 @@ func TestLocalRootApexNSCarriesPrimingGlue(t *testing.T) {
 	if len(reachable) == 0 {
 		t.Fatal(". NS carried no glue — root priming would find no addresses and abort")
 	}
+}
+
+// TestLocalRootAnswersBindTheRequestToTheCopy pins that every answer served
+// from the copy bounds the request tree at the copy's horizon. Bounding the
+// wire TTLs is not enough on its own: the answer cache applies a five-second
+// floor to any shorter TTL, so an answer taken at the edge of the horizon
+// would otherwise be served from cache after the copy had been withdrawn.
+func TestLocalRootAnswersBindTheRequestToTheCopy(t *testing.T) {
+	r, _ := localRootTestResolver(t)
+	horizon := r.localRoot.Load().Active().ValidUntil()
+
+	for _, tc := range []struct {
+		name  string
+		qname string
+		qtype uint16
+	}{
+		{"apex", ".", dns.TypeNS},
+		{"ds", "com.", dns.TypeDS},
+		{"denial", "dev.", dns.TypeA},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var meta middleware.ResponseMeta
+			ctx := middleware.WithResponseMeta(context.Background(), &meta)
+
+			answer, handled := r.consultLocalRoot(ctx, localRootState(tc.qname, tc.qtype, false))
+			if !handled || answer == nil {
+				t.Fatalf("%s %s was not answered from the copy", tc.qname, dns.TypeToString[tc.qtype])
+			}
+			cut, _ := meta.Cut()
+			if cut.IsZero() {
+				t.Fatalf("%s %s left the request tree unbounded", tc.qname, dns.TypeToString[tc.qtype])
+			}
+			if cut.After(horizon) {
+				t.Fatalf("%s %s bound the tree to %v, past the copy horizon %v",
+					tc.qname, dns.TypeToString[tc.qtype], cut, horizon)
+			}
+		})
+	}
+
+	// A consult the copy does not answer must leave the tree alone: the real
+	// roots' answer has its own lifetime and the copy has no claim on it.
+	t.Run("fallback binds nothing", func(t *testing.T) {
+		var meta middleware.ResponseMeta
+		ctx := middleware.WithResponseMeta(context.Background(), &meta)
+
+		if _, handled := r.consultLocalRoot(ctx, localRootState(".", dns.TypeZONEMD, false)); handled {
+			t.Fatal(". ZONEMD was answered from the copy")
+		}
+		if cut, _ := meta.Cut(); !cut.IsZero() {
+			t.Fatalf("a fallback bound the request tree to %v", cut)
+		}
+	})
 }

--- a/middleware/resolver/localroot_seam_test.go
+++ b/middleware/resolver/localroot_seam_test.go
@@ -448,26 +448,51 @@ func TestLocalRootUnprovableDSFallsBackOnTheWire(t *testing.T) {
 // resolver's own VerifyNODATANSEC enforces: DS non-existence is provable
 // only on the parent side, so an NSEC carrying SOA — the child apex's own —
 // cannot serve as the NODATA proof however well the zone verifies.
+//
+// Both entries into the copy are covered, because they reach the same
+// unproven claim by different doors: the DS question asks for the proof
+// outright, while an ordinary name under the delegation gets there quietly,
+// installing an empty DS set that declares the child insecure.
 func TestLocalRootDSNODATARequiresParentSideProof(t *testing.T) {
 	z, err := roottest.BuildZone(localroot.ComputeDigest, unprovableDSZoneLines(), roottest.Serial)
 	if err != nil {
 		t.Fatalf("build zone: %v", err)
 	}
-	r := newWiredTestResolver(makeTestConfig())
-	mgr := localroot.New(nil, func() []dns.RR { return z.Anchors })
-	if err := mgr.Load(z.RRs); err != nil {
-		t.Fatalf("manager load: %v", err)
+	newResolver := func(t *testing.T) *Resolver {
+		t.Helper()
+		r := newWiredTestResolver(makeTestConfig())
+		mgr := localroot.New(nil, func() []dns.RR { return z.Anchors })
+		if err := mgr.Load(z.RRs); err != nil {
+			t.Fatalf("manager load: %v", err)
+		}
+		r.localRoot.Store(mgr)
+		return r
 	}
-	r.localRoot.Store(mgr)
 
-	rs := localRootState("org.", dns.TypeDS, false)
-	answer, handled := r.consultLocalRoot(context.Background(), rs)
-	if handled || answer != nil {
-		t.Fatalf("a child-apex NSEC was served as a DS NODATA proof (handled=%v)", handled)
-	}
-	if rs.level != 0 || !rs.isRoot {
-		t.Fatal("the refused DS answer disturbed the walk")
-	}
+	t.Run("the DS question", func(t *testing.T) {
+		r := newResolver(t)
+		rs := localRootState("org.", dns.TypeDS, false)
+		answer, handled := r.consultLocalRoot(context.Background(), rs)
+		if handled || answer != nil {
+			t.Fatalf("a child-apex NSEC was served as a DS NODATA proof (handled=%v)", handled)
+		}
+		if rs.level != 0 || !rs.isRoot {
+			t.Fatal("the refused DS answer disturbed the walk")
+		}
+	})
+
+	t.Run("an ordinary name under the delegation", func(t *testing.T) {
+		r := newResolver(t)
+		rs := localRootState("www.example.org.", dns.TypeA, false)
+		answer, handled := r.consultLocalRoot(context.Background(), rs)
+		if handled || answer != nil {
+			t.Fatalf("consult answered (handled=%v)", handled)
+		}
+		if rs.level != 0 || !rs.isRoot {
+			t.Fatal("a delegation was installed with an empty DS set on a proof " +
+				"the copy does not hold — the child would be treated as insecure")
+		}
+	})
 }
 
 // TestLocalRootLeaseBoundedBySecurityEvidence pins the bound the ordinary

--- a/middleware/resolver/localroot_seam_test.go
+++ b/middleware/resolver/localroot_seam_test.go
@@ -470,6 +470,91 @@ func TestLocalRootDSNODATARequiresParentSideProof(t *testing.T) {
 	}
 }
 
+// TestLocalRootLeaseBoundedBySecurityEvidence pins the bound the ordinary
+// delegation path applies and this one was missing: a delegation may be
+// held only as long as the evidence for its DNSSEC status lives. A DS with
+// a short TTL beside a long NS TTL must not let a withdrawn key be trusted
+// for the NS set's life; the same holds for the NSEC that evidences an
+// unsigned delegation, and a delegation with no evidence at all is not
+// installed from the copy at all.
+func TestLocalRootLeaseBoundedBySecurityEvidence(t *testing.T) {
+	load := func(t *testing.T, lines []string) *Resolver {
+		t.Helper()
+		z, err := roottest.BuildZone(localroot.ComputeDigest, lines, roottest.Serial)
+		if err != nil {
+			t.Fatalf("build zone: %v", err)
+		}
+		r := newWiredTestResolver(makeTestConfig())
+		mgr := localroot.New(nil, func() []dns.RR { return z.Anchors })
+		if err := mgr.Load(z.RRs); err != nil {
+			t.Fatalf("manager load: %v", err)
+		}
+		r.localRoot.Store(mgr)
+		return r
+	}
+
+	t.Run("a short DS TTL bounds a long NS TTL", func(t *testing.T) {
+		r := load(t, []string{
+			". 86400 IN SOA a.root-servers.test. nstld.test. 2026082401 1800 900 604800 86400",
+			". 518400 IN NS a.root-servers.test.",
+			". 86400 IN NSEC com. NS SOA RRSIG NSEC DNSKEY ZONEMD",
+			"com. 172800 IN NS ns.com.",
+			"com. 60 IN DS 12345 13 2 49FD46E6C4B45C55D4AC69CBD3CD34AC1AFE51DE58AB7A66C82AABE7A9E10F53",
+			"com. 86400 IN NSEC . NS DS RRSIG NSEC",
+			"ns.com. 172800 IN A 198.51.100.1",
+		})
+
+		rs := localRootState("www.example.com.", dns.TypeA, false)
+		if _, handled := r.consultLocalRoot(context.Background(), rs); handled {
+			t.Fatal("referral consult synthesized an answer")
+		}
+		if got := time.Until(rs.cutDeadline); got > 61*time.Second {
+			t.Fatalf("lease runs %v, want the DS RRset's 60s — a withdrawn key "+
+				"must not be trusted for the NS set's longer life", got.Round(time.Second))
+		}
+	})
+
+	t.Run("an unsigned delegation is bounded by its denying NSEC", func(t *testing.T) {
+		r := load(t, []string{
+			". 86400 IN SOA a.root-servers.test. nstld.test. 2026082401 1800 900 604800 86400",
+			". 518400 IN NS a.root-servers.test.",
+			". 86400 IN NSEC org. NS SOA RRSIG NSEC DNSKEY ZONEMD",
+			"org. 172800 IN NS ns.org.",
+			"org. 90 IN NSEC . NS RRSIG NSEC",
+			"ns.org. 172800 IN A 198.51.100.2",
+		})
+
+		rs := localRootState("www.example.org.", dns.TypeA, false)
+		if _, handled := r.consultLocalRoot(context.Background(), rs); handled {
+			t.Fatal("referral consult synthesized an answer")
+		}
+		if got := time.Until(rs.cutDeadline); got > 91*time.Second {
+			t.Fatalf("lease runs %v, want the denying NSEC's 90s", got.Round(time.Second))
+		}
+	})
+
+	t.Run("no evidence means no local delegation", func(t *testing.T) {
+		// A delegation with neither a DS nor an NSEC: the copy cannot say
+		// whether it is signed, so it must not assert either.
+		r := load(t, []string{
+			". 86400 IN SOA a.root-servers.test. nstld.test. 2026082401 1800 900 604800 86400",
+			". 518400 IN NS a.root-servers.test.",
+			". 86400 IN NSEC net. NS SOA RRSIG NSEC DNSKEY ZONEMD",
+			"net. 172800 IN NS ns.net.",
+			"ns.net. 172800 IN A 198.51.100.3",
+		})
+
+		rs := localRootState("www.example.net.", dns.TypeA, false)
+		answer, handled := r.consultLocalRoot(context.Background(), rs)
+		if handled || answer != nil {
+			t.Fatal("a delegation with no security evidence was answered from the copy")
+		}
+		if rs.level != 0 || !rs.isRoot {
+			t.Fatal("the refused referral disturbed the walk")
+		}
+	})
+}
+
 // TestLocalRootFallbacks pins every path that must leave the walk exactly
 // as it was: no manager, no active copy, the apex itself.
 func TestLocalRootFallbacks(t *testing.T) {

--- a/middleware/resolver/localroot_seam_test.go
+++ b/middleware/resolver/localroot_seam_test.go
@@ -379,6 +379,97 @@ func TestLocalRootReferralTakesTheWinningDelegationWhole(t *testing.T) {
 	}
 }
 
+// unprovableDSZoneLines is a sealed zone whose org. delegation carries an
+// NSEC with the SOA bit — the child apex's own NSEC, which cannot testify
+// about its delegation's DS. The zone verifies; only the DS proof is
+// unusable, which is the shape both new tests below need.
+func unprovableDSZoneLines() []string {
+	return []string{
+		". 86400 IN SOA a.root-servers.test. nstld.test. 2026082401 1800 900 604800 86400",
+		". 518400 IN NS a.root-servers.test.",
+		". 86400 IN NSEC org. NS SOA RRSIG NSEC DNSKEY ZONEMD",
+		"org. 172800 IN NS ns.org.",
+		"org. 86400 IN NSEC . NS SOA RRSIG NSEC",
+		"ns.org. 172800 IN A 198.51.100.2",
+	}
+}
+
+// TestLocalRootUnprovableDSFallsBackOnTheWire pins the fallback contract at
+// the handler, where it matters: a copy that cannot prove the DS answer
+// must send the query to the real roots, not turn its own gap into a
+// client-visible SERVFAIL. The root here is a loopback authority that
+// counts what reaches the wire, so "fell back" is observable rather than
+// inferred.
+func TestLocalRootUnprovableDSFallsBackOnTheWire(t *testing.T) {
+	orgDS, err := dns.NewRR("org. 86400 IN DS 4321 13 2 " +
+		"1111111111111111111111111111111111111111111111111111111111111111")
+	if err != nil {
+		t.Fatalf("NewRR: %v", err)
+	}
+	addr, queries, stop := startTestAuthority(t, map[string][]dns.RR{
+		"org.": {orgDS},
+	})
+	defer stop()
+
+	z, err := roottest.BuildZone(localroot.ComputeDigest, unprovableDSZoneLines(), roottest.Serial)
+	if err != nil {
+		t.Fatalf("build zone: %v", err)
+	}
+
+	cfg := makeTestConfig()
+	cfg.RootServers = []string{addr}
+	cfg.Root6Servers = nil
+	cfg.IPv6Access = false
+	cfg.DNSSEC = "off"
+	handler := New(cfg)
+	mgr := localroot.New(nil, func() []dns.RR { return z.Anchors })
+	if err := mgr.Load(z.RRs); err != nil {
+		t.Fatalf("manager load: %v", err)
+	}
+	handler.resolver.localRoot.Store(mgr)
+
+	m := new(dns.Msg)
+	m.SetQuestion("org.", dns.TypeDS)
+	m.RecursionDesired = true
+	resp := handler.handle(context.Background(), m)
+
+	if resp == nil {
+		t.Fatal("handler returned no response")
+	}
+	if resp.Rcode == dns.RcodeServerFailure {
+		t.Fatal("an unprovable DS became a SERVFAIL instead of falling back to the roots")
+	}
+	if queries("org.") == 0 {
+		t.Fatal("the query never reached the wire — the copy answered from a proof it does not have")
+	}
+}
+
+// TestLocalRootDSNODATARequiresParentSideProof pins the bitmap rule the
+// resolver's own VerifyNODATANSEC enforces: DS non-existence is provable
+// only on the parent side, so an NSEC carrying SOA — the child apex's own —
+// cannot serve as the NODATA proof however well the zone verifies.
+func TestLocalRootDSNODATARequiresParentSideProof(t *testing.T) {
+	z, err := roottest.BuildZone(localroot.ComputeDigest, unprovableDSZoneLines(), roottest.Serial)
+	if err != nil {
+		t.Fatalf("build zone: %v", err)
+	}
+	r := newWiredTestResolver(makeTestConfig())
+	mgr := localroot.New(nil, func() []dns.RR { return z.Anchors })
+	if err := mgr.Load(z.RRs); err != nil {
+		t.Fatalf("manager load: %v", err)
+	}
+	r.localRoot.Store(mgr)
+
+	rs := localRootState("org.", dns.TypeDS, false)
+	answer, handled := r.consultLocalRoot(context.Background(), rs)
+	if handled || answer != nil {
+		t.Fatalf("a child-apex NSEC was served as a DS NODATA proof (handled=%v)", handled)
+	}
+	if rs.level != 0 || !rs.isRoot {
+		t.Fatal("the refused DS answer disturbed the walk")
+	}
+}
+
 // TestLocalRootFallbacks pins every path that must leave the walk exactly
 // as it was: no manager, no active copy, the apex itself.
 func TestLocalRootFallbacks(t *testing.T) {

--- a/middleware/resolver/localroot_seam_test.go
+++ b/middleware/resolver/localroot_seam_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/authority"
 	"github.com/semihalev/sdns/internal/cache"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/sdns/middleware/resolver/localroot"
@@ -261,6 +262,120 @@ func TestLocalRootReferralLeaseBoundedByCopy(t *testing.T) {
 	// window, so the horizon must be what bounded it.
 	if rs.cutDeadline.After(time.Now().Add(2 * time.Hour)) {
 		t.Fatalf("lease %v ignores the signature window", rs.cutDeadline)
+	}
+}
+
+// TestLocalRootHandlerRestoresRD drives the production path. The handler
+// clears RD before resolution and setTags restores it on the way out, but a
+// local-root answer returns early and misses that restoration — a client
+// receiving RD=0 on its own recursive query may discard it. Calling
+// consultLocalRoot directly cannot see this; the handler must.
+func TestLocalRootHandlerRestoresRD(t *testing.T) {
+	z, err := roottest.Build(localroot.ComputeDigest)
+	if err != nil {
+		t.Fatalf("roottest.Build: %v", err)
+	}
+
+	cfg := makeTestConfig()
+	cfg.IPv6Access = false
+	handler := New(cfg)
+	mgr := localroot.New(nil, func() []dns.RR { return z.Anchors })
+	if err := mgr.Load(z.RRs); err != nil {
+		t.Fatalf("manager load: %v", err)
+	}
+	handler.resolver.localRoot.Store(mgr)
+
+	for _, tc := range []struct {
+		name  string
+		qname string
+		qtype uint16
+		rcode int
+	}{
+		{"signed DS", "com.", dns.TypeDS, dns.RcodeSuccess},
+		{"unsigned DS", "org.", dns.TypeDS, dns.RcodeSuccess},
+		{"denial", "foo.nonexistent.", dns.TypeA, dns.RcodeNameError},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := new(dns.Msg)
+			m.SetQuestion(tc.qname, tc.qtype)
+			m.RecursionDesired = true
+			m.Id = 0x1234
+
+			resp := handler.handle(context.Background(), m)
+			if resp == nil {
+				t.Fatal("handler returned no response")
+			}
+			if resp.Rcode != tc.rcode {
+				t.Fatalf("rcode = %s, want %s",
+					dns.RcodeToString[resp.Rcode], dns.RcodeToString[tc.rcode])
+			}
+			if !resp.RecursionDesired {
+				t.Fatal("the client's RD bit did not survive the handler path")
+			}
+			if !resp.RecursionAvailable {
+				t.Fatal("RA missing on a recursive answer")
+			}
+			if resp.Id != m.Id {
+				t.Fatalf("answer ID = %#x, want the client's %#x", resp.Id, m.Id)
+			}
+		})
+	}
+}
+
+// TestLocalRootNonINQueryFallsBack pins the class gate. The copy is an IN
+// zone and every record built from it is IN; answering a CHAOS question
+// from it would pair the client's class with another class's records.
+func TestLocalRootNonINQueryFallsBack(t *testing.T) {
+	r, _ := localRootTestResolver(t)
+
+	for _, qclass := range []uint16{dns.ClassCHAOS, dns.ClassHESIOD, dns.ClassANY} {
+		rs := localRootState("foo.nonexistent.", dns.TypeA, false)
+		rs.req.Question[0].Qclass = qclass
+		answer, handled := r.consultLocalRoot(context.Background(), rs)
+		if handled || answer != nil {
+			t.Fatalf("class %d answered from the IN copy", qclass)
+		}
+		if rs.level != 0 || !rs.isRoot {
+			t.Fatalf("class %d disturbed the walk", qclass)
+		}
+	}
+}
+
+// TestLocalRootReferralTakesTheWinningDelegationWhole pins the race
+// readback. When another walk wins the delegation store, this call must
+// adopt that entry's servers, DS set and lease together: taking the
+// winner's servers while keeping this copy's DS chain would validate
+// answers from one delegation against another's keys.
+func TestLocalRootReferralTakesTheWinningDelegationWhole(t *testing.T) {
+	r, _ := localRootTestResolver(t)
+
+	// A delegation for com. published by "another walk", with servers and
+	// a DS set that differ from the copy's.
+	key := cache.Key(dns.Question{Name: "com.", Qtype: dns.TypeNS, Qclass: dns.ClassINET}, false)
+	rival := &authority.Servers{Zone: "com."}
+	rival.List = append(rival.List, authority.NewServer("203.0.113.9:53", authority.IPv4))
+	rivalDS, err := dns.NewRR("com. 86400 IN DS 999 13 2 " +
+		"0000000000000000000000000000000000000000000000000000000000000000")
+	if err != nil {
+		t.Fatalf("rival DS: %v", err)
+	}
+	rivalDeadline := time.Now().Add(3 * time.Minute)
+	r.delegations.SetUntilIfAbsent(key, []dns.RR{rivalDS}, rival, rivalDeadline)
+
+	rs := localRootState("www.example.com.", dns.TypeA, false)
+	if _, handled := r.consultLocalRoot(context.Background(), rs); handled {
+		t.Fatal("referral consult synthesized an answer")
+	}
+
+	if rs.servers != rival {
+		t.Fatal("the walk did not adopt the winning servers")
+	}
+	if len(rs.parentDS) != 1 || rs.parentDS[0].(*dns.DS).KeyTag != 999 {
+		t.Fatalf("parentDS = %v, want the winning delegation's DS — a mixed "+
+			"delegation validates one zone's answers against another's keys", rs.parentDS)
+	}
+	if !rs.cutDeadline.Equal(rivalDeadline) {
+		t.Fatalf("lease = %v, want the winning entry's %v", rs.cutDeadline, rivalDeadline)
 	}
 }
 

--- a/middleware/resolver/localroot_seam_test.go
+++ b/middleware/resolver/localroot_seam_test.go
@@ -756,3 +756,112 @@ func TestLocalRootApexAnswers(t *testing.T) {
 		}
 	})
 }
+
+// TestLocalRootAnswersBoundedByCopyHorizon pins RFC 4035 §5.3.3 at the copy's
+// seam: an authenticated record must not be served with more TTL than the
+// signature over it has life left. The copy's horizon is the earliest RRSIG
+// expiration anywhere in the zone, so bounding by it satisfies the rule for
+// every RRset the copy serves.
+func TestLocalRootAnswersBoundedByCopyHorizon(t *testing.T) {
+	r, _ := localRootTestResolver(t)
+	mgr := r.localRoot.Load()
+	snap := mgr.Active()
+	if snap == nil {
+		t.Fatal("no active copy to serve from")
+	}
+	horizon := uint32(time.Until(snap.ValidUntil())/time.Second) + 1 //nolint:gosec // test window is an hour.
+
+	// The test zone signs with a one-hour window while its shortest published
+	// TTL is a day, so every record served here has to be clamped for the
+	// assertions below to hold — without this the test could pass on a zone
+	// whose TTLs were already short enough.
+	if horizon >= 86400 {
+		t.Fatalf("copy horizon %ds does not bite against the zone's TTLs; the test proves nothing", horizon)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		qname   string
+		qtype   uint16
+		section func(*dns.Msg) []dns.RR
+	}{
+		{"apex", ".", dns.TypeNS, func(m *dns.Msg) []dns.RR { return m.Answer }},
+		{"ds", "com.", dns.TypeDS, func(m *dns.Msg) []dns.RR { return m.Answer }},
+		{"denial", "dev.", dns.TypeA, func(m *dns.Msg) []dns.RR { return m.Ns }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			answer, handled := r.consultLocalRoot(context.Background(), localRootState(tc.qname, tc.qtype, false))
+			if !handled || answer == nil {
+				t.Fatalf("%s %s was not answered from the copy", tc.qname, dns.TypeToString[tc.qtype])
+			}
+			records := tc.section(answer)
+			if len(records) == 0 {
+				t.Fatalf("%s %s answered with no records to bound", tc.qname, dns.TypeToString[tc.qtype])
+			}
+			for _, rr := range records {
+				if rr.Header().Ttl > horizon {
+					t.Fatalf("%s %s: %s TTL %d outlives the copy horizon %d",
+						tc.qname, dns.TypeToString[tc.qtype],
+						dns.TypeToString[rr.Header().Rrtype], rr.Header().Ttl, horizon)
+				}
+			}
+		})
+	}
+}
+
+// TestLocalRootAnswersDoNotAliasTheCopy pins that an answer carries copies of
+// the zone's records rather than the records themselves. The Snapshot is
+// immutable and read by every goroutine serving from the copy, while
+// downstream TTL rewrites — clampTTLsToCut is one, and it writes in place —
+// would otherwise reach through an answer into the live copy and change what
+// every later answer says, from an arbitrary request goroutine.
+func TestLocalRootAnswersDoNotAliasTheCopy(t *testing.T) {
+	r, _ := localRootTestResolver(t)
+
+	for _, tc := range []struct {
+		name    string
+		qname   string
+		qtype   uint16
+		section func(*dns.Msg) []dns.RR
+	}{
+		{"apex", ".", dns.TypeNS, func(m *dns.Msg) []dns.RR { return m.Answer }},
+		{"ds", "com.", dns.TypeDS, func(m *dns.Msg) []dns.RR { return m.Answer }},
+		{"denial", "dev.", dns.TypeA, func(m *dns.Msg) []dns.RR { return m.Ns }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			first, handled := r.consultLocalRoot(context.Background(), localRootState(tc.qname, tc.qtype, false))
+			if !handled || first == nil {
+				t.Fatalf("%s %s was not answered from the copy", tc.qname, dns.TypeToString[tc.qtype])
+			}
+			records := tc.section(first)
+			if len(records) == 0 {
+				t.Fatalf("%s %s answered with no records", tc.qname, dns.TypeToString[tc.qtype])
+			}
+			before := records[0].Header().Ttl
+			if before <= 1 {
+				t.Fatalf("%s %s served TTL %d, too short to detect an overwrite",
+					tc.qname, dns.TypeToString[tc.qtype], before)
+			}
+			// Stand in for any downstream rewrite of the served message.
+			for _, rr := range records {
+				rr.Header().Ttl = 1
+			}
+
+			second, handled := r.consultLocalRoot(context.Background(), localRootState(tc.qname, tc.qtype, false))
+			if !handled || second == nil {
+				t.Fatalf("%s %s was not answered a second time", tc.qname, dns.TypeToString[tc.qtype])
+			}
+			for _, rr := range tc.section(second) {
+				// The horizon shrinks by the time between the two calls, so
+				// the second answer may be a little shorter — but not by the
+				// overwrite above.
+				if rr.Header().Ttl+5 < before {
+					t.Fatalf("%s %s: a rewrite of the served answer reached the shared copy — "+
+						"%s came back with TTL %d, was %d",
+						tc.qname, dns.TypeToString[tc.qtype],
+						dns.TypeToString[rr.Header().Rrtype], rr.Header().Ttl, before)
+				}
+			}
+		})
+	}
+}

--- a/middleware/resolver/localroot_seam_test.go
+++ b/middleware/resolver/localroot_seam_test.go
@@ -3,6 +3,7 @@ package resolver
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/internal/cache"
@@ -157,6 +158,109 @@ func TestLocalRootDSBranch(t *testing.T) {
 	}
 	if len(answer.Answer) != 0 || len(answer.Ns) == 0 {
 		t.Fatalf("org. DS answer = %d answers %d authority, want a NODATA proof", len(answer.Answer), len(answer.Ns))
+	}
+}
+
+// TestLocalRootAnswersCarryTheClientRequest pins what a directly returned
+// answer must keep: this reply skips the exchange path's normalization, so
+// the transaction ID, the question and RD have to come from the live
+// request or a client discards the answer as unsolicited.
+func TestLocalRootAnswersCarryTheClientRequest(t *testing.T) {
+	r, _ := localRootTestResolver(t)
+
+	for _, tc := range []struct {
+		name  string
+		qname string
+		qtype uint16
+	}{
+		{"signed DS", "com.", dns.TypeDS},
+		{"unsigned DS", "org.", dns.TypeDS},
+		{"denial", "foo.nonexistent.", dns.TypeA},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := middleware.WithResponseMeta(context.Background(), &middleware.ResponseMeta{})
+			rs := localRootState(tc.qname, tc.qtype, false)
+			rs.req.Id = 0x4242
+			rs.req.RecursionDesired = true
+
+			answer, handled := r.consultLocalRoot(ctx, rs)
+			if !handled || answer == nil {
+				t.Fatal("consult not handled")
+			}
+			if answer.Id != rs.req.Id {
+				t.Fatalf("answer ID = %#x, want the client's %#x", answer.Id, rs.req.Id)
+			}
+			if !answer.Response {
+				t.Fatal("answer is not marked as a response")
+			}
+			if !answer.RecursionDesired {
+				t.Fatal("answer dropped the client's RD bit")
+			}
+			if len(answer.Question) != 1 || answer.Question[0] != rs.req.Question[0] {
+				t.Fatalf("answer question = %v, want the client's %v", answer.Question, rs.req.Question)
+			}
+		})
+	}
+}
+
+// TestLocalRootDenialRequiresCoverage pins the evaluator gate: a copy whose
+// NSEC chain does not actually prove the name absent must fall back to the
+// real roots rather than synthesize an authenticated denial. The zone here
+// is sealed and verified — its chain is simply too short to cover, which is
+// exactly the case a structural covering search can miss.
+func TestLocalRootDenialRequiresCoverage(t *testing.T) {
+	// The chain stops at com.: the apex NSEC spans (., com.) and com. has
+	// no NSEC of its own, so nothing proves anything about names sorting
+	// after com. A structural "greatest owner below the name" search still
+	// hands back the apex NSEC — whose span does not reach — which is
+	// precisely the shape the evaluator has to catch.
+	lines := []string{
+		". 86400 IN SOA a.root-servers.test. nstld.test. 2026082401 1800 900 604800 86400",
+		". 518400 IN NS a.root-servers.test.",
+		". 86400 IN NSEC com. NS SOA RRSIG NSEC DNSKEY ZONEMD",
+		"com. 172800 IN NS ns.com.",
+		"ns.com. 172800 IN A 198.51.100.1",
+	}
+	z, err := roottest.BuildZone(localroot.ComputeDigest, lines, roottest.Serial)
+	if err != nil {
+		t.Fatalf("build gapped zone: %v", err)
+	}
+	r := newWiredTestResolver(makeTestConfig())
+	mgr := localroot.New(nil, func() []dns.RR { return z.Anchors })
+	if err := mgr.Load(z.RRs); err != nil {
+		t.Fatalf("load gapped zone: %v", err)
+	}
+	r.localRoot.Store(mgr)
+
+	ctx := middleware.WithResponseMeta(context.Background(), &middleware.ResponseMeta{})
+	rs := localRootState("foo.nonexistent.", dns.TypeA, false)
+	answer, handled := r.consultLocalRoot(ctx, rs)
+	if handled || answer != nil {
+		t.Fatal("a denial was synthesized from a chain that does not cover the name")
+	}
+	if rs.level != 0 || !rs.isRoot {
+		t.Fatal("the failed denial disturbed the walk")
+	}
+}
+
+// TestLocalRootReferralLeaseBoundedByCopy pins that nothing derived from the
+// copy outlives it: the delegation lease cannot exceed the snapshot's own
+// horizon, however long the zone's NS TTL is.
+func TestLocalRootReferralLeaseBoundedByCopy(t *testing.T) {
+	r, _ := localRootTestResolver(t)
+	rs := localRootState("www.example.com.", dns.TypeA, false)
+
+	if _, handled := r.consultLocalRoot(context.Background(), rs); handled {
+		t.Fatal("referral consult synthesized an answer")
+	}
+	snap := r.localRoot.Load().Active()
+	if rs.cutDeadline.After(snap.ValidUntil()) {
+		t.Fatalf("lease %v outlives the copy's horizon %v", rs.cutDeadline, snap.ValidUntil())
+	}
+	// The test zone's NS TTL is 172800s against a one-hour signature
+	// window, so the horizon must be what bounded it.
+	if rs.cutDeadline.After(time.Now().Add(2 * time.Hour)) {
+		t.Fatalf("lease %v ignores the signature window", rs.cutDeadline)
 	}
 }
 

--- a/middleware/resolver/localroot_seam_test.go
+++ b/middleware/resolver/localroot_seam_test.go
@@ -495,6 +495,61 @@ func TestLocalRootDSNODATARequiresParentSideProof(t *testing.T) {
 	})
 }
 
+// TestLocalRootInsecureDelegationNeedsTheNSBit pins the other half of the
+// RFC 4035 §5.2 proof. An NSEC without the NS bit is not the parent's word
+// about a delegation, so treating it as one is the downgrade
+// VerifyDelegationNSEC exists to refuse: a stripped-DS bitmap would become
+// evidence that a signed child is insecure. In a local copy it is also an
+// internal contradiction — the owner's real NS RRset is right there, which
+// is how the referral was found in the first place.
+func TestLocalRootInsecureDelegationNeedsTheNSBit(t *testing.T) {
+	z, err := roottest.BuildZone(localroot.ComputeDigest, []string{
+		". 86400 IN SOA a.root-servers.test. nstld.test. 2026082401 1800 900 604800 86400",
+		". 518400 IN NS a.root-servers.test.",
+		". 86400 IN NSEC org. NS SOA RRSIG NSEC DNSKEY ZONEMD",
+		"org. 172800 IN NS ns.org.",
+		// The delegation's own NSEC omits NS: no DS is asserted, but
+		// neither is the delegation.
+		"org. 86400 IN NSEC . RRSIG NSEC",
+		"ns.org. 172800 IN A 198.51.100.2",
+	}, roottest.Serial)
+	if err != nil {
+		t.Fatalf("build zone: %v", err)
+	}
+	newResolver := func(t *testing.T) *Resolver {
+		t.Helper()
+		r := newWiredTestResolver(makeTestConfig())
+		mgr := localroot.New(nil, func() []dns.RR { return z.Anchors })
+		if err := mgr.Load(z.RRs); err != nil {
+			t.Fatalf("manager load: %v", err)
+		}
+		r.localRoot.Store(mgr)
+		return r
+	}
+
+	t.Run("an ordinary name under the delegation", func(t *testing.T) {
+		r := newResolver(t)
+		rs := localRootState("www.example.org.", dns.TypeA, false)
+		answer, handled := r.consultLocalRoot(context.Background(), rs)
+		if handled || answer != nil {
+			t.Fatalf("consult answered (handled=%v)", handled)
+		}
+		if rs.level != 0 || !rs.isRoot {
+			t.Fatal("a delegation was installed as insecure on an NSEC that does " +
+				"not claim the delegation — a stripped DS would read as unsigned")
+		}
+	})
+
+	t.Run("the DS question", func(t *testing.T) {
+		r := newResolver(t)
+		rs := localRootState("org.", dns.TypeDS, false)
+		answer, handled := r.consultLocalRoot(context.Background(), rs)
+		if handled || answer != nil {
+			t.Fatalf("an NSEC without the NS bit was served as a DS NODATA proof (handled=%v)", handled)
+		}
+	})
+}
+
 // TestLocalRootLeaseBoundedBySecurityEvidence pins the bound the ordinary
 // delegation path applies and this one was missing: a delegation may be
 // held only as long as the evidence for its DNSSEC status lives. A DS with

--- a/middleware/resolver/localroot_seam_test.go
+++ b/middleware/resolver/localroot_seam_test.go
@@ -786,6 +786,7 @@ func TestLocalRootAnswersBoundedByCopyHorizon(t *testing.T) {
 		section func(*dns.Msg) []dns.RR
 	}{
 		{"apex", ".", dns.TypeNS, func(m *dns.Msg) []dns.RR { return m.Answer }},
+		{"apex glue", ".", dns.TypeNS, func(m *dns.Msg) []dns.RR { return m.Extra }},
 		{"ds", "com.", dns.TypeDS, func(m *dns.Msg) []dns.RR { return m.Answer }},
 		{"denial", "dev.", dns.TypeA, func(m *dns.Msg) []dns.RR { return m.Ns }},
 	} {
@@ -825,6 +826,7 @@ func TestLocalRootAnswersDoNotAliasTheCopy(t *testing.T) {
 		section func(*dns.Msg) []dns.RR
 	}{
 		{"apex", ".", dns.TypeNS, func(m *dns.Msg) []dns.RR { return m.Answer }},
+		{"apex glue", ".", dns.TypeNS, func(m *dns.Msg) []dns.RR { return m.Extra }},
 		{"ds", "com.", dns.TypeDS, func(m *dns.Msg) []dns.RR { return m.Answer }},
 		{"denial", "dev.", dns.TypeA, func(m *dns.Msg) []dns.RR { return m.Ns }},
 	} {
@@ -863,5 +865,47 @@ func TestLocalRootAnswersDoNotAliasTheCopy(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestLocalRootApexNSCarriesPrimingGlue pins the additional section of the
+// copy's answer to ". NS". A root server answers a priming query with the
+// addresses of the servers it names (RFC 8109), and the resolver's own
+// 12-hourly checkPriming reads addresses from Extra and nowhere else — so an
+// answer without them leaves the root server list unrefreshed for the life of
+// the process, and a client asking ". NS" gets names it cannot reach.
+func TestLocalRootApexNSCarriesPrimingGlue(t *testing.T) {
+	r, _ := localRootTestResolver(t)
+
+	answer, handled := r.consultLocalRoot(context.Background(), localRootState(".", dns.TypeNS, false))
+	if !handled || answer == nil {
+		t.Fatal(". NS was not answered from the copy")
+	}
+
+	named := make(map[string]bool)
+	for _, rr := range answer.Answer {
+		if ns, ok := rr.(*dns.NS); ok {
+			named[dns.CanonicalName(ns.Ns)] = true
+		}
+	}
+	if len(named) == 0 {
+		t.Fatal(". NS answered without naming any server")
+	}
+
+	reachable := make(map[string]bool)
+	for _, rr := range answer.Extra {
+		switch rr.(type) {
+		case *dns.A, *dns.AAAA:
+		default:
+			t.Fatalf("additional section carries a %s record", dns.TypeToString[rr.Header().Rrtype])
+		}
+		owner := dns.CanonicalName(rr.Header().Name)
+		if !named[owner] {
+			t.Fatalf("additional section carries an address for %s, which . NS does not name", owner)
+		}
+		reachable[owner] = true
+	}
+	if len(reachable) == 0 {
+		t.Fatal(". NS carried no glue — root priming would find no addresses and abort")
 	}
 }

--- a/middleware/resolver/localroot_seam_test.go
+++ b/middleware/resolver/localroot_seam_test.go
@@ -1,0 +1,188 @@
+package resolver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/cache"
+	"github.com/semihalev/sdns/middleware"
+	"github.com/semihalev/sdns/middleware/resolver/localroot"
+	"github.com/semihalev/sdns/middleware/resolver/localroot/roottest"
+)
+
+// localRootTestResolver wires a resolver to a verified test root copy: the
+// zone chains to its own CSK, whose DS the manager treats as the anchor set.
+func localRootTestResolver(t *testing.T) (*Resolver, *roottest.Zone) {
+	t.Helper()
+	z, err := roottest.Build(localroot.ComputeDigest)
+	if err != nil {
+		t.Fatalf("roottest.Build: %v", err)
+	}
+	r := newWiredTestResolver(makeTestConfig())
+	mgr := localroot.New(nil, func() []dns.RR { return z.Anchors })
+	if err := mgr.Load(z.RRs); err != nil {
+		t.Fatalf("manager load: %v", err)
+	}
+	r.localRoot.Store(mgr)
+	return r, z
+}
+
+func localRootState(name string, qtype uint16, cd bool) *resolveState {
+	req := new(dns.Msg)
+	req.SetQuestion(name, qtype)
+	req.CheckingDisabled = cd
+	return &resolveState{req: req, isRoot: true, depth: 10}
+}
+
+// TestLocalRootReferralBranch pins the referral shape: the walk is pointed
+// at the TLD's glue with the DS set as parentDS, the delegation lands in
+// the delegations cache, and no answer is synthesized.
+func TestLocalRootReferralBranch(t *testing.T) {
+	r, _ := localRootTestResolver(t)
+	rs := localRootState("www.example.com.", dns.TypeA, false)
+
+	answer, handled := r.consultLocalRoot(context.Background(), rs)
+	if handled || answer != nil {
+		t.Fatalf("referral consult returned an answer (handled=%v)", handled)
+	}
+	if rs.level != 1 || rs.isRoot {
+		t.Fatalf("walk not advanced to the TLD: level=%d isRoot=%v", rs.level, rs.isRoot)
+	}
+	if rs.servers == nil || rs.servers.Zone != "com." {
+		t.Fatalf("servers zone = %v, want com.", rs.servers)
+	}
+	rs.servers.RLock()
+	endpoints := len(rs.servers.List)
+	rs.servers.RUnlock()
+	if endpoints == 0 {
+		t.Fatal("referral installed no glue endpoints")
+	}
+	if len(rs.parentDS) != 1 {
+		t.Fatalf("parentDS carries %d records, want com.'s DS", len(rs.parentDS))
+	}
+	if rs.cutDeadline.IsZero() {
+		t.Fatal("referral did not bound the walk with a lease")
+	}
+
+	key := cache.Key(dns.Question{Name: "com.", Qtype: dns.TypeNS, Qclass: dns.ClassINET}, false)
+	if _, err := r.delegations.Get(key); err != nil {
+		t.Fatalf("delegation not stored: %v", err)
+	}
+
+	// A second consult must reuse the stored Servers identity, so RTT
+	// evidence accumulates instead of resetting per query.
+	first := rs.servers
+	rs2 := localRootState("mail.example.com.", dns.TypeMX, false)
+	if _, handled := r.consultLocalRoot(context.Background(), rs2); handled {
+		t.Fatal("second referral consult synthesized an answer")
+	}
+	if rs2.servers != first {
+		t.Fatal("second consult built a new Servers identity")
+	}
+}
+
+// TestLocalRootDenialBranch pins the NXDOMAIN synthesis: signed proof from
+// the copy, AD for a validating client, and validated-denial provenance
+// marked so the RFC 8020/8198 stores can fill from it.
+func TestLocalRootDenialBranch(t *testing.T) {
+	r, _ := localRootTestResolver(t)
+
+	var meta middleware.ResponseMeta
+	ctx := middleware.WithResponseMeta(context.Background(), &meta)
+	rs := localRootState("foo.nonexistent.", dns.TypeA, false)
+
+	answer, handled := r.consultLocalRoot(ctx, rs)
+	if !handled || answer == nil {
+		t.Fatal("an absent TLD did not synthesize a denial")
+	}
+	if answer.Rcode != dns.RcodeNameError {
+		t.Fatalf("rcode = %s, want NXDOMAIN", dns.RcodeToString[answer.Rcode])
+	}
+	if !answer.AuthenticatedData {
+		t.Fatal("a verified denial served without AD")
+	}
+	var soa, nsec, sigs int
+	for _, rr := range answer.Ns {
+		switch rr.(type) {
+		case *dns.SOA:
+			soa++
+		case *dns.NSEC:
+			nsec++
+		case *dns.RRSIG:
+			sigs++
+		}
+	}
+	if soa != 1 || nsec == 0 || sigs == 0 {
+		t.Fatalf("denial authority carries soa=%d nsec=%d rrsig=%d", soa, nsec, sigs)
+	}
+	negative, ok := middleware.ValidatedNegativeProofForResponse(ctx, answer)
+	if !ok {
+		t.Fatal("denial carries no validated provenance")
+	}
+	if negative.Zone != "." || negative.Kind != middleware.ValidatedNegativeProofNSEC {
+		t.Fatalf("provenance = zone %q kind %d, want the root NSEC proof", negative.Zone, negative.Kind)
+	}
+
+	// CD leaves validation to the client: same proof, no AD, no provenance.
+	cdCtx := middleware.WithResponseMeta(context.Background(), &middleware.ResponseMeta{})
+	cdRS := localRootState("foo.nonexistent.", dns.TypeA, true)
+	cdAnswer, handled := r.consultLocalRoot(cdCtx, cdRS)
+	if !handled || cdAnswer.AuthenticatedData {
+		t.Fatalf("CD denial: handled=%v ad=%v, want handled without AD", handled, cdAnswer.AuthenticatedData)
+	}
+}
+
+// TestLocalRootDSBranch pins the parent-side DS answers: the signed DS set
+// for a signed delegation, the NSEC NODATA proof for an unsigned one.
+func TestLocalRootDSBranch(t *testing.T) {
+	r, _ := localRootTestResolver(t)
+
+	rs := localRootState("com.", dns.TypeDS, false)
+	answer, handled := r.consultLocalRoot(context.Background(), rs)
+	if !handled || answer == nil || answer.Rcode != dns.RcodeSuccess {
+		t.Fatalf("com. DS consult: handled=%v answer=%v", handled, answer)
+	}
+	if len(answer.Answer) != 2 { // DS + RRSIG
+		t.Fatalf("com. DS answer carries %d records, want DS+RRSIG", len(answer.Answer))
+	}
+	if !answer.AuthenticatedData {
+		t.Fatal("a verified DS answer served without AD")
+	}
+
+	rs = localRootState("org.", dns.TypeDS, false)
+	answer, handled = r.consultLocalRoot(context.Background(), rs)
+	if !handled || answer == nil {
+		t.Fatal("org. DS consult not handled")
+	}
+	if len(answer.Answer) != 0 || len(answer.Ns) == 0 {
+		t.Fatalf("org. DS answer = %d answers %d authority, want a NODATA proof", len(answer.Answer), len(answer.Ns))
+	}
+}
+
+// TestLocalRootFallbacks pins every path that must leave the walk exactly
+// as it was: no manager, no active copy, the apex itself.
+func TestLocalRootFallbacks(t *testing.T) {
+	t.Run("no manager", func(t *testing.T) {
+		r := newWiredTestResolver(makeTestConfig())
+		rs := localRootState("www.example.com.", dns.TypeA, false)
+		if _, handled := r.consultLocalRoot(context.Background(), rs); handled || rs.level != 0 {
+			t.Fatal("a nil manager touched the walk")
+		}
+	})
+	t.Run("no active copy", func(t *testing.T) {
+		r := newWiredTestResolver(makeTestConfig())
+		r.localRoot.Store(localroot.New(nil, func() []dns.RR { return nil }))
+		rs := localRootState("www.example.com.", dns.TypeA, false)
+		if _, handled := r.consultLocalRoot(context.Background(), rs); handled || rs.level != 0 {
+			t.Fatal("an empty manager touched the walk")
+		}
+	})
+	t.Run("the apex stays with the real roots", func(t *testing.T) {
+		r, _ := localRootTestResolver(t)
+		rs := localRootState(".", dns.TypeNS, false)
+		if _, handled := r.consultLocalRoot(context.Background(), rs); handled || rs.level != 0 {
+			t.Fatal("an apex query was taken from the real roots")
+		}
+	})
+}

--- a/middleware/resolver/localroot_seam_test.go
+++ b/middleware/resolver/localroot_seam_test.go
@@ -653,11 +653,106 @@ func TestLocalRootFallbacks(t *testing.T) {
 			t.Fatal("an empty manager touched the walk")
 		}
 	})
-	t.Run("the apex stays with the real roots", func(t *testing.T) {
+	t.Run("an apex type the copy cannot evidence", func(t *testing.T) {
+		// The copy answers the apex from what it holds; a type it can
+		// neither produce nor deny goes to the real roots. ANY is that
+		// case by construction — it needs a composition this does not
+		// attempt — so it stands in for the general shape here.
 		r, _ := localRootTestResolver(t)
-		rs := localRootState(".", dns.TypeNS, false)
+		rs := localRootState(".", dns.TypeANY, false)
 		if _, handled := r.consultLocalRoot(context.Background(), rs); handled || rs.level != 0 {
-			t.Fatal("an apex query was taken from the real roots")
+			t.Fatal("a question the copy cannot answer was taken from it anyway")
+		}
+	})
+}
+
+// TestLocalRootApexAnswers pins what the copy does with questions asked at
+// the root's own name. Holding a verified copy of the root zone and then
+// asking a root server for the root's own NS set is the contradiction this
+// closes: the records are right here, signed, and were verified before
+// anything was built from them.
+func TestLocalRootApexAnswers(t *testing.T) {
+	r, _ := localRootTestResolver(t)
+
+	t.Run("types the apex holds are answered from it", func(t *testing.T) {
+		for _, qtype := range []uint16{dns.TypeNS, dns.TypeSOA, dns.TypeDNSKEY} {
+			name := dns.TypeToString[qtype]
+			rs := localRootState(".", qtype, false)
+			rs.req.Id = 0x5151
+			rs.req.RecursionDesired = true
+
+			answer, handled := r.consultLocalRoot(context.Background(), rs)
+			if !handled || answer == nil {
+				t.Fatalf(". %s was not answered from the copy", name)
+			}
+			if answer.Rcode != dns.RcodeSuccess {
+				t.Fatalf(". %s rcode = %s, want NOERROR", name, dns.RcodeToString[answer.Rcode])
+			}
+			var records, sigs int
+			for _, rr := range answer.Answer {
+				if rr.Header().Rrtype == dns.TypeRRSIG {
+					sigs++
+					continue
+				}
+				if rr.Header().Rrtype != qtype {
+					t.Fatalf(". %s answer carries a %s record", name, dns.TypeToString[rr.Header().Rrtype])
+				}
+				records++
+			}
+			if records == 0 || sigs == 0 {
+				t.Fatalf(". %s answer = %d records %d signatures, want both", name, records, sigs)
+			}
+			if !answer.AuthenticatedData {
+				t.Fatalf(". %s served without AD", name)
+			}
+			if answer.Id != rs.req.Id || !answer.RecursionDesired {
+				t.Fatalf(". %s lost the client's request identity", name)
+			}
+			if rs.level != 0 || !rs.isRoot {
+				t.Fatalf(". %s disturbed the walk", name)
+			}
+		}
+	})
+
+	t.Run("a type the apex lacks is denied from its own NSEC", func(t *testing.T) {
+		// The test root's apex NSEC lists NS, SOA, RRSIG, NSEC, DNSKEY and
+		// ZONEMD — so MX is absent and provably so.
+		rs := localRootState(".", dns.TypeMX, false)
+		answer, handled := r.consultLocalRoot(context.Background(), rs)
+		if !handled || answer == nil {
+			t.Fatal(". MX was not answered from the copy")
+		}
+		if answer.Rcode != dns.RcodeSuccess || len(answer.Answer) != 0 {
+			t.Fatalf(". MX = %s with %d answers, want NODATA",
+				dns.RcodeToString[answer.Rcode], len(answer.Answer))
+		}
+		var soa, nsec, sigs int
+		for _, rr := range answer.Ns {
+			switch rr.Header().Rrtype {
+			case dns.TypeSOA:
+				soa++
+			case dns.TypeNSEC:
+				nsec++
+			case dns.TypeRRSIG:
+				sigs++
+			}
+		}
+		if soa != 1 || nsec != 1 || sigs == 0 {
+			t.Fatalf(". MX authority = soa:%d nsec:%d rrsig:%d, want a signed NODATA proof", soa, nsec, sigs)
+		}
+		if !answer.AuthenticatedData {
+			t.Fatal(". MX NODATA served without AD")
+		}
+	})
+
+	t.Run("CD leaves validation to the client", func(t *testing.T) {
+		rs := localRootState(".", dns.TypeNS, true)
+		answer, handled := r.consultLocalRoot(context.Background(), rs)
+		if !handled || answer == nil {
+			t.Fatal(". NS with CD was not answered from the copy")
+		}
+		if answer.AuthenticatedData {
+			t.Fatal("a CD query was answered with AD set")
 		}
 	})
 }

--- a/middleware/resolver/resolver.go
+++ b/middleware/resolver/resolver.go
@@ -23,6 +23,7 @@ import (
 	"github.com/semihalev/sdns/internal/dnsutil"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/sdns/middleware/resolver/dnssec"
+	"github.com/semihalev/sdns/middleware/resolver/localroot"
 	"github.com/semihalev/zlog/v2"
 	"golang.org/x/sync/errgroup"
 )
@@ -58,6 +59,13 @@ type Resolver struct {
 	// glue addrs cache
 	glueV4 *cache.Cache
 	glueV6 *cache.Cache
+
+	// localRoot serves TLD referrals, DS answers and NXDOMAIN proofs from
+	// a verified local root zone copy (RFC 8806); nil when disabled. Its
+	// consult sits at the walk's root step only. Atomic because tests (and
+	// any future reconfiguration) install a manager after the background
+	// run loop has started reading.
+	localRoot atomic.Pointer[localroot.Manager]
 
 	dnssec   bool
 	rootKeys []dns.RR
@@ -340,6 +348,16 @@ func NewResolver(cfg *config.Config) *Resolver {
 		)
 	}
 
+	if cfg.HyperlocalRoot {
+		r.localRoot.Store(localroot.New(cfg.HyperlocalRootSources, func() []dns.RR {
+			anchors, err := r.dsRRFromRootKeys(context.Background())
+			if err != nil {
+				return nil
+			}
+			return anchors
+		}))
+	}
+
 	go r.run()
 
 	return r
@@ -473,6 +491,17 @@ func (r *Resolver) resolve(ctx context.Context, rs *resolveState) (*dns.Msg, err
 		// delegation established below it inherits this bound.
 		rs.cutDeadline, rs.cutKey = minCut(rs.cutDeadline, rs.cutKey, m.deadline, m.key)
 		noteCut(ctx, rs.cutDeadline, rs.cutKey)
+
+		// Nothing deeper is cached and the next query would go to a real
+		// root server: the verified local root copy (RFC 8806), when one
+		// is active, answers instead — a referral installed into rs, a
+		// parent-side DS answer, or a signed NXDOMAIN. No active copy
+		// changes nothing.
+		if rs.level == 0 {
+			if answer, handled := r.consultLocalRoot(ctx, rs); handled {
+				return answer, nil
+			}
+		}
 	}
 
 	// RFC 9156 query minimization, bounded by qnameMinCount probes per
@@ -3703,6 +3732,11 @@ func (r *Resolver) run() {
 	r.checkPriming() // update root server list from priming query
 	if r.dnssec {
 		r.AutoTA() // RFC 5011 automated trust anchor updates
+	}
+	if mgr := r.localRoot.Load(); mgr != nil {
+		// After AutoTA: the first transfer verifies against the loaded
+		// anchors. The manager owns its schedule from here.
+		go mgr.Run(context.Background())
 	}
 
 	ticker := time.NewTicker(12 * time.Hour)

--- a/sdns.go
+++ b/sdns.go
@@ -21,7 +21,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const version = "1.8.1"
+const version = "1.8.2"
 
 var (
 	cfgPath    string


### PR DESCRIPTION
Task #34 of the feature arc. The busiest zone in every walk becomes local.

## What it does

A verified copy of the root zone answers the three questions the walk would otherwise ask a root server:

- **Referrals**: a TLD's delegation (NS + glue + DS) is installed exactly as a root referral would have installed it — same delegations-cache path, same lease bounds, stable `Servers` identity so upstream RTT evidence accumulates across queries.
- **Parent-side DS**: the signed DS set, or the exact-owner NSEC NODATA proof for an unsigned delegation.
- **NXDOMAIN**: synthesized from the zone's own signed NSEC chain, marked with validated-denial provenance so the RFC 8020 cut and RFC 8198 aggressive caches fill through their normal seams — the junk-TLD flood costs nothing and leaks nothing.

## The gate

Nothing is served unverified. A transfer is accepted only when the apex DNSKEY set matches a root trust anchor, the SOA and ZONEMD RRsets verify against those keys, and the **RFC 8976** SIMPLE/SHA-384 digest of the entire zone matches exactly (canonical form and order, duplicates once, out-of-zone excluded, apex ZONEMD + covering RRSIGs excluded). The digest computation is pinned to **RFC 8976's own Appendix A vectors** as known-answer tests, so it is anchored to the RFC rather than to itself.

## The schedule (RFC compliance, periodic update, fallback)

AXFR over TCP from the RFC 8806 appendix hosts, rotating. Refresh follows the zone's own SOA: jittered serial probe every REFRESH (1800 s), retry at RETRY (900 s), a fresh transfer once the copy has spent half its EXPIRE so the horizon keeps moving on a healthy source — and a copy past EXPIRE (7 d) is **withdrawn, never served stale**: `Active()` goes nil and the walk falls back to the real root servers unchanged.

## Shape

- New package `middleware/resolver/rootzone`-style sibling: `localroot` (transfer, ZONEMD verify, immutable snapshot with atomic swap, manager loop). `roottest` builds a sealed miniature root for tests.
- Exactly one seam into the resolver: the root step of `resolve()`, where nothing deeper was cached. No chain middleware, no exchange interception.
- `dnssec.CanonicalWireRR` exported for the digest's canonical wire form.
- Off by default: `hyperlocal_root = true` + optional `hyperlocal_root_sources`. Metrics: copy age, transfer outcomes, referral/denial/DS/fallback counters.

## Tests

RFC 8976 Appendix A digest vectors; the full verify chain with tamper/foreign-anchor/no-anchor/serial/stripped-ZONEMD refusals; snapshot lookups incl. the glue-owner-is-not-a-delegation and escaped-label guards; loopback AXFR round-trip + malformed-stream refusal; manager lifecycle (swap on serial change, failure keeps the live copy, expire withdraws it, tampered transfer cannot displace a verified copy — all under -race); and the resolver seam's four branches (referral, denial with provenance, DS, fallbacks).

Phase 2 left open: an end-to-end resolve() walk through a local-root referral needs hermetic authorities on port 53 semantics; the seam is unit-pinned instead.