### PR TITLE
cache: answer from an expired entry when resolution fails (RFC 8767)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ example.com.		0	CH	HINFO	"Host" "IPv6:[2001:500:8d::53]:53 rtt:148ms health:[GOO
 | **dnssec**           | Enable DNSSEC validation for secure DNS responses. Options: "on" or "off". Default: "on"                            |
 | **rfc8198**          | Aggressively reuse validated NSEC/NSEC3 proofs. Set false to stop RFC 8198 admission and synthesis without disabling DNSSEC, exact negative caching, or RFC 8020 cuts. Default: true |
 | **rfc9520**          | Cache shared recursive-resolution and failed-authority state. Emergency rollback switch; setting false means SERVFAIL responses and failed-authority state are not cached, which can increase upstream retry load. Per-server retry ceilings, request work limits, and ordinary DNS caching remain active. Default: true |
+| **serve_stale**      | Serve expired positive answers as a last resort after resolution ends in SERVFAIL (RFC 8767). A learned delegation lease remains a hard ceiling. Default: false |
+| **serve_stale_max_ttl** | Maximum time an answer may be served after its TTL expires (duration string). An explicit `0s` leaves the delegation lease as the only upper bound; because forwarder mode learns no delegation cut, `0s` there permits retention until cache eviction. Default: `24h` |
 | **[recursion_firewall]** | Request-tree work budgets (outbound/internal queries, DNSSEC operations) with off/shadow/enforce modes, plus RFC 9520 failure-cache tuning. See the Recursion Firewall section below |
 | **rootkeys**         | DNSSEC root zone trust anchors in DNSKEY format                                                                     |
 | **fallbackservers**  | Upstream DNS servers used when all others fail. Format: "IP:port" (e.g., "8.8.8.8:53")                             |
@@ -423,7 +425,8 @@ SDNS exports comprehensive cache metrics via the Prometheus `/metrics` endpoint 
 - `dns_cache_misses_total` - Total number of cache misses
 - `dns_cache_evictions_total` - Total number of cache evictions
 - `dns_cache_prefetches_total` - Total number of prefetch operations
-- `dns_cache_size{type="positive|negative"}` - Current number of entries in the cache
+- `dns_cache_stale_answers_total` - Expired positive answers served after a resolution failure
+- `dns_cache_size{type="positive|negative"}` - Current number of entries in the cache. With serve-stale enabled, the positive count includes expired entries retained as stale candidates until eviction
 - `dns_cache_hit_rate` - Cache hit rate percentage
 
 **Example Prometheus Queries:**

--- a/config/config.go
+++ b/config/config.go
@@ -18,19 +18,29 @@ import (
 	"github.com/semihalev/zlog/v2"
 )
 
-const configver = "1.8.2"
+const (
+	configver               = "1.8.2"
+	defaultServeStaleMaxTTL = 24 * time.Hour
+)
 
 // Config type.
 type Config struct {
-	Version          string
-	Directory        string
-	BlockLists       []string
-	BlockListDir     string
-	RootServers      []string
-	Root6Servers     []string
-	DNSSEC           string
-	RFC8198          *bool `toml:"rfc8198"` // nil is default-on for backward compatibility
-	RFC9520          *bool `toml:"rfc9520"` // nil is default-on; false is an emergency kill switch
+	Version      string
+	Directory    string
+	BlockLists   []string
+	BlockListDir string
+	RootServers  []string
+	Root6Servers []string
+	DNSSEC       string
+	RFC8198      *bool `toml:"rfc8198"` // nil is default-on for backward compatibility
+	RFC9520      *bool `toml:"rfc9520"` // nil is default-on; false is an emergency kill switch
+	ServeStale   bool  `toml:"serve_stale"`
+	// ServeStaleMaxTTL caps how long a positive answer may be reused after
+	// its admitted TTL expires. Omission defaults to 24 hours. An explicit
+	// zero leaves the delegation lease as the only bound; in forwarder mode,
+	// where no delegation cut is learned, that means retention until eviction.
+	// Serve-stale itself remains opt-in through ServeStale.
+	ServeStaleMaxTTL Duration `toml:"serve_stale_max_ttl"`
 	RootKeys         []string
 	FallbackServers  []string
 	ForwarderServers []string
@@ -578,6 +588,16 @@ rfc8198 = true
 # work limits, DNSSEC validation, and ordinary positive/NXDOMAIN caching remain
 # active.
 rfc9520 = true
+
+# Serve an expired positive answer as a last resort when resolution ends in
+# SERVFAIL (RFC 8767). A learned delegation lease remains a hard ceiling, so
+# this cannot revive data after a known parent-granted cut expires. The
+# optional duration is measured from the answer TTL's expiry. It defaults to
+# 24 hours. An explicit zero leaves the delegation lease as the only upper
+# bound; in forwarder mode, which has no learned delegation cut, zero permits
+# retention until cache eviction.
+serve_stale = false
+serve_stale_max_ttl = "24h"
 
 # DNSSEC root trust anchors
 # These are the public keys used to verify the DNS root zone
@@ -1240,8 +1260,12 @@ func Load(cfgfile, version string) (*Config, error) {
 
 	zlog.Info("Loading config file...", zlog.String("path", cfgfile))
 
-	if _, err := toml.DecodeFile(cfgfile, config); err != nil {
+	metadata, err := toml.DecodeFile(cfgfile, config)
+	if err != nil {
 		return nil, fmt.Errorf("could not load config: %s", err)
+	}
+	if !metadata.IsDefined("serve_stale_max_ttl") {
+		config.ServeStaleMaxTTL.Duration = defaultServeStaleMaxTTL
 	}
 
 	if config.Version != configver {
@@ -1253,6 +1277,9 @@ func Load(cfgfile, version string) (*Config, error) {
 	config.RecursionFirewall.Normalize()
 	if err := config.RecursionFirewall.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid recursion firewall config: %w", err)
+	}
+	if config.ServeStaleMaxTTL.Duration < 0 {
+		return nil, fmt.Errorf("serve_stale_max_ttl must not be negative")
 	}
 
 	if _, err := os.Stat(config.Directory); os.IsNotExist(err) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -808,6 +808,76 @@ ipv6access = true
 	}
 }
 
+func TestLoadServeStalePolicy(t *testing.T) {
+	tests := []struct {
+		name       string
+		settings   string
+		wantEnable bool
+		wantMax    time.Duration
+	}{
+		{name: "omitted defaults off", wantMax: defaultServeStaleMaxTTL},
+		{
+			name:       "explicit zero keeps lease-only policy",
+			settings:   "serve_stale = true\nserve_stale_max_ttl = \"0s\"",
+			wantEnable: true,
+		},
+		{
+			name:       "explicitly enabled with ceiling",
+			settings:   "serve_stale = true\nserve_stale_max_ttl = \"36h\"",
+			wantEnable: true,
+			wantMax:    36 * time.Hour,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			cfgFile := filepath.Join(tmpDir, "sdns.conf")
+			workDir := filepath.Join(tmpDir, "db")
+			content := fmt.Sprintf(`version = %q
+directory = %q
+ipv6access = true
+%s
+`, configver, workDir, tt.settings)
+			if err := os.WriteFile(cfgFile, []byte(content), 0644); err != nil { //nolint:gosec // G306 - test file
+				t.Fatal(err)
+			}
+
+			cfg, err := Load(cfgFile, "test")
+			if err != nil {
+				t.Fatalf("Load() error = %v", err)
+			}
+			if cfg.ServeStale != tt.wantEnable || cfg.ServeStaleMaxTTL.Duration != tt.wantMax {
+				t.Fatalf("serve-stale config = (%v, %v), want (%v, %v)",
+					cfg.ServeStale, cfg.ServeStaleMaxTTL.Duration, tt.wantEnable, tt.wantMax)
+			}
+		})
+	}
+}
+
+func TestLoadRejectsNegativeServeStaleTTL(t *testing.T) {
+	tmpDir := t.TempDir()
+	cfgFile := filepath.Join(tmpDir, "sdns.conf")
+	workDir := filepath.Join(tmpDir, "db")
+	content := fmt.Sprintf(`version = %q
+directory = %q
+ipv6access = true
+serve_stale = true
+serve_stale_max_ttl = "-1s"
+`, configver, workDir)
+	if err := os.WriteFile(cfgFile, []byte(content), 0644); err != nil { //nolint:gosec // G306 - test file
+		t.Fatal(err)
+	}
+
+	_, err := Load(cfgFile, "test")
+	if err == nil || !strings.Contains(err.Error(), "serve_stale_max_ttl must not be negative") {
+		t.Fatalf("Load() error = %v, want negative serve-stale TTL rejection", err)
+	}
+	if _, statErr := os.Stat(workDir); !os.IsNotExist(statErr) {
+		t.Fatalf("invalid config created working directory: stat error = %v", statErr)
+	}
+}
+
 func TestLoadRecursionFirewallPolicy(t *testing.T) {
 	t.Run("explicit enforce values", func(t *testing.T) {
 		tmpDir := t.TempDir()
@@ -903,6 +973,8 @@ func TestConfigDefaults(t *testing.T) {
 		"# DNSSEC Configuration",
 		"rfc8198 = true",
 		"rfc9520 = true",
+		"serve_stale = false",
+		"serve_stale_max_ttl = \"24h\"",
 		"# Upstream Servers",
 		"# API and Logging",
 		"# Filtering and Blocking",

--- a/contrib/linux/sdns.conf
+++ b/contrib/linux/sdns.conf
@@ -110,6 +110,16 @@ rfc8198 = true
 # active.
 rfc9520 = true
 
+# Serve an expired positive answer as a last resort when resolution ends in
+# SERVFAIL (RFC 8767). A learned delegation lease remains a hard ceiling, so
+# this cannot revive data after a known parent-granted cut expires. The
+# optional duration is measured from the answer TTL's expiry. It defaults to
+# 24 hours. An explicit zero leaves the delegation lease as the only upper
+# bound; in forwarder mode, which has no learned delegation cut, zero permits
+# retention until cache eviction.
+serve_stale = false
+serve_stale_max_ttl = "24h"
+
 # DNSSEC root trust anchors
 # These are the public keys used to verify the DNS root zone
 rootkeys = [

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -147,14 +147,16 @@ func New(cfg *config.Config) *Cache {
 
 	// Build cache configuration
 	cacheConfig := CacheConfig{
-		Size:        cfg.CacheSize,
-		Prefetch:    int(cfg.Prefetch),
-		PositiveTTL: maxTTL,
-		NegativeTTL: time.Duration(cfg.Expire) * time.Second,
-		MinTTL:      minTTL,
-		MaxTTL:      maxTTL,
-		RateLimit:   cfg.RateLimit,
-		ECSMaxTTL:   cfg.ECS.CacheLimitTTL.Duration,
+		Size:             cfg.CacheSize,
+		Prefetch:         int(cfg.Prefetch),
+		PositiveTTL:      maxTTL,
+		NegativeTTL:      time.Duration(cfg.Expire) * time.Second,
+		MinTTL:           minTTL,
+		MaxTTL:           maxTTL,
+		RateLimit:        cfg.RateLimit,
+		ECSMaxTTL:        cfg.ECS.CacheLimitTTL.Duration,
+		ServeStale:       cfg.ServeStale,
+		ServeStaleMaxTTL: cfg.ServeStaleMaxTTL.Duration,
 	}
 
 	// Validate configuration and actually apply defaults when
@@ -176,6 +178,9 @@ func New(cfg *config.Config) *Cache {
 		}
 		if cacheConfig.MaxTTL < cacheConfig.MinTTL {
 			cacheConfig.MaxTTL = maxTTL
+		}
+		if cacheConfig.ServeStaleMaxTTL < 0 {
+			cacheConfig.ServeStaleMaxTTL = 0
 		}
 	}
 
@@ -498,28 +503,28 @@ func (c *Cache) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	//
 	// When the request carries ECS, probe scoped keys first
 	// (longest-prefix-match), then fall through to the shared key
-	// so SCOPE=0 / pre-Stage-2 entries still hit. checkCache
-	// records the generic Hit/Miss metric on the shared-key path;
-	// scopedLookup records its own Hit on the scoped path so we
-	// don't double-count or under-count. ecsLookups breaks ECS
+	// so SCOPE=0 / pre-Stage-2 entries still hit. Generic and ECS
+	// hit metrics are recorded only after handleCacheHit accepts and
+	// serves the entry, so retained expired candidates remain misses.
+	// ecsLookups breaks ECS
 	// requests down by which path served them — operators read it
 	// to see how much of the ECS-aware code path is actually
 	// carrying traffic (non-ECS lookups are already counted by
 	// dns_cache_hits_total / dns_cache_misses_total).
 	if clientScope.IsValid() {
 		if entry, scopedKey, scope := c.scopedLookup(q, req.CheckingDisabled, clientScope); entry != nil {
-			ecsLookupHitScoped.Inc()
 			if c.handleCacheHit(ctx, ch, entry, scopedKey, scope, spent) {
+				ecsLookupHitScoped.Inc()
 				c.metrics.Hit()
 				return
 			}
 		}
 	}
 	if entry := c.checkCache(cacheKey); entry != nil {
-		if clientScope.IsValid() {
-			ecsLookupHitShared.Inc()
-		}
 		if c.handleCacheHit(ctx, ch, entry, cacheKey, netip.Prefix{}, spent) {
+			if clientScope.IsValid() {
+				ecsLookupHitShared.Inc()
+			}
 			c.metrics.Hit()
 			return
 		}
@@ -547,8 +552,7 @@ func (c *Cache) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	}
 	if hit, ok := c.store.LookupFailure(req, clientScope); ok {
 		c.metrics.Hit()
-		failureCacheHits.Inc()
-		c.handleFailureHit(ctx, ch, hit)
+		c.handleFailureHit(ctx, ch, clientScope, hit)
 		return
 	}
 	failureProbe := false
@@ -637,14 +641,14 @@ func (c *Cache) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 				// Re-election can span several short-lived request-local
 				// probe generations. Do not retain a canceled client tree
 				// indefinitely while fresh followers keep winning leadership.
-				c.stopCanceledRequest(ctx, ch)
+				c.stopCanceledRequest(ctx, ch, clientScope)
 				return
 			}
 			// The leader completion and request deadline can become ready in
 			// the same scheduler turn. Prefer cancellation deterministically
 			// instead of letting select choose the wait branch and regroup.
 			if contextutil.EffectiveError(ctx) != nil {
-				c.stopCanceledRequest(ctx, ch)
+				c.stopCanceledRequest(ctx, ch, clientScope)
 				return
 			}
 
@@ -681,8 +685,7 @@ func (c *Cache) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 			}
 			if hit, ok := c.store.LookupFailure(req, clientScope); ok {
 				c.metrics.Hit()
-				failureCacheHits.Inc()
-				c.handleFailureHit(ctx, ch, hit)
+				c.handleFailureHit(ctx, ch, clientScope, hit)
 				return
 			}
 
@@ -717,7 +720,7 @@ func (c *Cache) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	// query budget expires. Never start downstream resolution for a request
 	// whose client tree is already canceled.
 	if contextutil.EffectiveError(ctx) != nil {
-		c.stopCanceledRequest(ctx, ch)
+		c.stopCanceledRequest(ctx, ch, clientScope)
 		return
 	}
 
@@ -791,9 +794,21 @@ func (c *Cache) writeFailureProbeLimit(ctx context.Context, ch *middleware.Chain
 	)
 }
 
-func (c *Cache) stopCanceledRequest(ctx context.Context, ch *middleware.Chain) {
+func (c *Cache) stopCanceledRequest(
+	ctx context.Context,
+	ch *middleware.Chain,
+	clientScope netip.Prefix,
+) {
 	err := contextutil.EffectiveError(ctx)
 	if errors.Is(err, context.DeadlineExceeded) {
+		req := ch.Request.Msg()
+		if stale, entry := c.staleResponse(req, req.CheckingDisabled, clientScope); stale != nil {
+			boundRequestToStaleLifetime(ctx, entry, time.Now())
+			staleAnswers.Inc()
+			_ = ch.Writer.WriteMsg(stale)
+			ch.Cancel()
+			return
+		}
 		c.writeRequestLocalFailure(
 			ctx,
 			ch,
@@ -921,14 +936,13 @@ func hasEDNSClientSubnet(req *dns.Msg) bool {
 	return false
 }
 
-// scopedLookup probes the cache for the longest scope match that
-// covers `clientPrefix`. Returns the entry, the key it was found
-// under, and the scope that key was built from — the hit chokepoint
-// needs the scope to verify the entry against the full preimage.
-// Returns (nil, 0, zero) on miss. The shared-key fallback is the
-// caller's responsibility — a scoped probe that misses should still
-// try the unscoped key in case the authority returned SCOPE=0
-// (cached shared) or the entry predates Stage 2.
+// scopedLookup probes the cache for the most-specific fresh scope that covers
+// clientPrefix. When serve-stale retention exposes expired positive entries,
+// the first such entry is remembered but does not stop the walk: a wider fresh
+// scope must win. If no fresh scoped entry exists, the most-specific expired
+// entry is returned so the ordinary hit path can treat it as a miss without
+// losing the retained stale candidate. The shared-key fallback remains the
+// caller's responsibility.
 //
 // Iteration runs from the client's source bits down to /1. The
 // upper bound is the client's own prefix because a stored prefix
@@ -949,17 +963,30 @@ func (c *Cache) scopedLookup(q dns.Question, cd bool, clientPrefix netip.Prefix)
 	if !clientPrefix.IsValid() {
 		return nil, 0, netip.Prefix{}
 	}
+	var (
+		expiredEntry *CacheEntry
+		expiredKey   uint64
+		expiredScope netip.Prefix
+	)
+	now := time.Now()
 	for bits := clientPrefix.Bits(); bits >= 1; bits-- {
 		scope, err := clientPrefix.Addr().Prefix(bits)
 		if err != nil {
 			continue
 		}
 		key := CacheKey{Question: q, CD: cd, Scope: scope}.Hash()
-		if entry, ok := c.store.LookupByKey(key); ok {
+		entry, ok := c.store.LookupByKey(key)
+		if !ok || !entryMatchesKey(entry, CacheKey{Question: q, CD: cd, Scope: scope}) {
+			continue
+		}
+		if entry.remaining(now) > 0 {
 			return entry, key, scope
 		}
+		if expiredEntry == nil {
+			expiredEntry, expiredKey, expiredScope = entry, key, scope
+		}
 	}
-	return nil, 0, netip.Prefix{}
+	return expiredEntry, expiredKey, expiredScope
 }
 
 // lookupNXDomainCut checks the RFC 8020 subtree index after an exact answer
@@ -1067,7 +1094,21 @@ func (c *Cache) handleDenialProofHit(
 	return true
 }
 
-func (c *Cache) handleFailureHit(ctx context.Context, ch *middleware.Chain, hit FailureHit) {
+func (c *Cache) handleFailureHit(
+	ctx context.Context,
+	ch *middleware.Chain,
+	clientScope netip.Prefix,
+	hit FailureHit,
+) {
+	if resp, entry := c.staleResponse(ch.Request.Msg(), ch.Request.CD(), clientScope); resp != nil {
+		boundRequestToStaleLifetime(ctx, entry, time.Now())
+		staleAnswers.Inc()
+		_ = ch.Writer.WriteMsg(resp)
+		ch.Cancel()
+		return
+	}
+
+	failureCacheHits.Inc()
 	resp := hit.Response(ch.Request.Msg())
 	if meta := middleware.ResponseMetaFrom(ctx); meta != nil {
 		release := meta.MarkCachedFailureResponse(resp)
@@ -1192,6 +1233,9 @@ func (c *Cache) serveHitFromWire(
 	if w.Internal() {
 		return false
 	}
+	if entry == nil || entry.remaining(time.Now()) <= 0 {
+		return false
+	}
 	// The deterministic declines run before the limiter spends anything:
 	// a prefetch-due entry, an ineligible body, a writer without the
 	// lease all fall to the Msg path (or, inline, to the replay), and a
@@ -1302,6 +1346,13 @@ func (c *Cache) handleCacheHit(
 		CD:       req.CheckingDisabled,
 		Scope:    scope,
 	}) {
+		return false
+	}
+	// Expired entries are misses until a downstream resolution failure makes
+	// them eligible for the serve-stale policy. Do this before spending an
+	// entry rate-limit token so the later fallback is not charged twice (and
+	// cannot be suppressed by a token spent on a response we did not serve).
+	if entry.remaining(time.Now()) <= 0 {
 		return false
 	}
 
@@ -1643,14 +1694,7 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 	// hit is synthesized as EDE 13.
 	mt, _ := dnsutil.ClassifyResponse(res, time.Now().UTC())
 	if mt == dnsutil.TypeServerFailure {
-		out := res
-		if res.Rcode == dns.RcodeServerFailure && middleware.RecursionWorkEnforcementError(ctx) != nil {
-			out = w.recursionWorkFailure(res)
-		}
-		if cacheableResolutionFailure(ctx, out) {
-			w.cache.store.RecordFailure(out, w.clientScope, FailureProvenance("response"), w.denialMissWitness)
-		}
-		return w.ResponseWriter.WriteMsg(out)
+		return w.writeResolutionFailure(ctx, res)
 	}
 
 	// Complete any synchronous CNAME chase before reading ResponseMeta and
@@ -1664,14 +1708,7 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 		res = w.cache.additionalAnswer(withCnameChaseDepth(ctx, depth+1), res)
 	}
 	if chasedType, _ := dnsutil.ClassifyResponse(res, time.Now().UTC()); chasedType == dnsutil.TypeServerFailure {
-		out := res
-		if res.Rcode == dns.RcodeServerFailure && middleware.RecursionWorkEnforcementError(ctx) != nil {
-			out = w.recursionWorkFailure(res)
-		}
-		if cacheableResolutionFailure(ctx, out) {
-			w.cache.store.RecordFailure(out, w.clientScope, FailureProvenance("response"), w.denialMissWitness)
-		}
-		return w.ResponseWriter.WriteMsg(out)
+		return w.writeResolutionFailure(ctx, res)
 	}
 
 	// Classify, filter, and store via Store. Key is derived from
@@ -1777,12 +1814,49 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 	return w.ResponseWriter.WriteMsg(res)
 }
 
+func (w *ResponseWriter) writeResolutionFailure(ctx context.Context, res *dns.Msg) error {
+	out := res
+	if res.Rcode == dns.RcodeServerFailure && middleware.RecursionWorkEnforcementError(ctx) != nil {
+		out = w.recursionWorkFailure(res)
+	}
+
+	if cacheableResolutionFailure(ctx, out) {
+		w.cache.store.RecordFailure(out, w.clientScope, FailureProvenance("response"), w.denialMissWitness)
+	}
+	if out.Rcode == dns.RcodeServerFailure && staleEligibleResolutionFailure(ctx, out) {
+		req := w.req
+		if req == nil {
+			req = res
+		}
+		if stale, entry := w.cache.staleResponse(req, w.requestCD, w.clientScope); stale != nil {
+			boundRequestToStaleLifetime(ctx, entry, time.Now())
+			staleAnswers.Inc()
+			return w.ResponseWriter.WriteMsg(stale)
+		}
+	}
+	return w.ResponseWriter.WriteMsg(out)
+}
+
 // cacheableResolutionFailure admits only failures that describe shared
 // resolution state. Work-budget and attempt-limit rejections belong to one
 // request tree; optional enrichment, cancellation, and deadline paths likewise
 // cannot poison independent clients through the RFC 9520 cache.
 func cacheableResolutionFailure(ctx context.Context, res *dns.Msg) bool {
 	return contextutil.EffectiveError(ctx) == nil &&
+		!middleware.IsBestEffortRecursionWork(ctx) &&
+		middleware.RecursionWorkEnforcementError(ctx) == nil &&
+		middleware.RequestLocalFailureForResponse(ctx, res) == nil
+}
+
+// staleEligibleResolutionFailure is deliberately broader than shared failure
+// admission: a request deadline may use an already-retained answer, but it is
+// still request-local evidence and must never be published into RFC 9520 state.
+// Transport cancellation, optional recursion work, enforcement failures, and
+// explicitly marked request-local responses remain ineligible.
+func staleEligibleResolutionFailure(ctx context.Context, res *dns.Msg) bool {
+	err := contextutil.EffectiveError(ctx)
+	return (err == nil || errors.Is(err, context.DeadlineExceeded)) &&
+		!errors.Is(err, context.Canceled) &&
 		!middleware.IsBestEffortRecursionWork(ctx) &&
 		middleware.RecursionWorkEnforcementError(ctx) == nil &&
 		middleware.RequestLocalFailureForResponse(ctx, res) == nil

--- a/middleware/cache/cutuntil_test.go
+++ b/middleware/cache/cutuntil_test.go
@@ -111,6 +111,30 @@ func TestCacheEntry_CutUntil(t *testing.T) {
 	}
 }
 
+func TestCacheEntryRemainingBoundsStayIndependent(t *testing.T) {
+	now := time.Now()
+	entry := NewCacheEntry(cutTestMsg("bounds.example.", dns.RcodeSuccess, 60), time.Minute, 0)
+	entry.stored = now.Add(-20 * time.Second)
+	entry.cutUntil = now.Add(10 * time.Second)
+
+	ttlRemaining, leaseRemaining := entry.remainingBounds(now)
+	if ttlRemaining != 40*time.Second {
+		t.Fatalf("TTL remaining = %v, want 40s", ttlRemaining)
+	}
+	if leaseRemaining != 10*time.Second {
+		t.Fatalf("lease remaining = %v, want 10s", leaseRemaining)
+	}
+	if remaining := entry.remaining(now); remaining != 10*time.Second {
+		t.Fatalf("effective remaining = %v, want lease-bounded 10s", remaining)
+	}
+
+	entry.cutUntil = time.Time{}
+	_, leaseRemaining = entry.remainingBounds(now)
+	if leaseRemaining != 0 {
+		t.Fatalf("unbounded lease remaining = %v, want zero sentinel", leaseRemaining)
+	}
+}
+
 // TestStore_CutUntil_OverridesMinTTLFloor: the configured MinTTL floor
 // (5s) inflates stored TTLs, which is exactly how a ghost answer under
 // a short cut would outlive its delegation. The cut bound is enforced

--- a/middleware/cache/inline_charge_test.go
+++ b/middleware/cache/inline_charge_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"context"
+	"net/netip"
 	"testing"
 	"time"
 
@@ -108,5 +109,77 @@ func TestChaseDeclineDoesNotChargeEntryLimiter(t *testing.T) {
 	}
 	if !entry.GetRateLimiter().Allow() {
 		t.Fatal("declined chase consumed the entry's only token")
+	}
+}
+
+func TestExpiredWireHitDoesNotChargeEntryLimiter(t *testing.T) {
+	c := New(&config.Config{Expire: 600, CacheSize: 1024, RateLimit: 1, ServeStale: true})
+	defer c.Stop()
+
+	resp := new(dns.Msg)
+	resp.SetQuestion("expired-wire.zone.test.", dns.TypeA)
+	resp.Response = true
+	resp.Answer = []dns.RR{&dns.A{
+		Hdr: dns.RR_Header{Name: "expired-wire.zone.test.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+		A:   []byte{192, 0, 2, 63},
+	}}
+	entry := NewCacheEntryWithKey(resp, time.Minute, 1, 0x87670001)
+	entry.stored = time.Now().Add(-2 * time.Minute)
+	limiter := entry.GetRateLimiter()
+	if limiter == nil {
+		t.Fatal("test needs a rate-limited entry")
+	}
+	awaitToken(t, limiter)
+
+	req, _ := wireTestRequest(t, "expired-wire.zone.test.", dns.TypeA, false)
+	tr := &leaseTransport{Writer: mock.NewWriter("udp", "203.0.113.63:4242")}
+	ch := middleware.NewChain(nil)
+	ch.ResetWire(tr, req)
+	ch.AllowDirectPack()
+
+	var spent *rate.Limiter
+	if c.serveHitFromWire(context.Background(), ch, entry, &spent) {
+		t.Fatal("expired wire entry was served as a normal cache hit")
+	}
+	if spent != nil {
+		t.Fatal("expired wire hit recorded a spent limiter")
+	}
+	if !limiter.Allow() {
+		t.Fatal("expired wire hit consumed the entry's only token")
+	}
+}
+
+func TestExpiredMsgHitDoesNotChargeEntryLimiter(t *testing.T) {
+	c := New(&config.Config{Expire: 600, CacheSize: 1024, RateLimit: 1, ServeStale: true})
+	defer c.Stop()
+
+	req := new(dns.Msg)
+	req.SetQuestion("expired-msg.zone.test.", dns.TypeA)
+	resp := new(dns.Msg)
+	resp.SetReply(req)
+	resp.Answer = []dns.RR{&dns.A{
+		Hdr: dns.RR_Header{Name: "expired-msg.zone.test.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+		A:   []byte{192, 0, 2, 64},
+	}}
+	key := CacheKey{Question: req.Question[0]}.Hash()
+	entry := NewCacheEntryWithKey(resp, time.Minute, 1, key)
+	entry.stored = time.Now().Add(-2 * time.Minute)
+	limiter := entry.GetRateLimiter()
+	if limiter == nil {
+		t.Fatal("test needs a rate-limited entry")
+	}
+	awaitToken(t, limiter)
+
+	writer := mock.NewWriter("udp", "203.0.113.64:4242")
+	ch := middleware.NewChain(nil)
+	ch.Reset(writer, req)
+	if c.handleCacheHit(context.Background(), ch, entry, key, netip.Prefix{}, nil) {
+		t.Fatal("expired Msg entry was served as a normal cache hit")
+	}
+	if writer.Written() {
+		t.Fatal("expired Msg entry wrote a normal cache response")
+	}
+	if !limiter.Allow() {
+		t.Fatal("expired Msg hit consumed the entry's only token")
 	}
 }

--- a/middleware/cache/positive_cache.go
+++ b/middleware/cache/positive_cache.go
@@ -42,6 +42,18 @@ func (pc *PositiveCache) Get(key uint64) (*CacheEntry, bool) {
 	return entry, true
 }
 
+// retained returns an entry without applying expiry cleanup. Serve-stale is
+// the only production caller: it needs the immutable wire image after the
+// ordinary TTL has elapsed, while every public/fresh lookup keeps Get's
+// historical miss-and-delete behavior when the feature is disabled.
+func (pc *PositiveCache) retained(key uint64) (*CacheEntry, bool) {
+	v, ok := pc.cache.Get(key)
+	if !ok {
+		return nil, false
+	}
+	return v.(*CacheEntry), true
+}
+
 // (*PositiveCache).Set set stores an entry in the positive cache.
 func (pc *PositiveCache) Set(key uint64, entry *CacheEntry) {
 	pc.cache.Add(key, entry)

--- a/middleware/cache/prometheus.go
+++ b/middleware/cache/prometheus.go
@@ -40,6 +40,11 @@ var (
 		Help: "Total number of RFC 9520 cached resolution failures served",
 	})
 
+	staleAnswers = metric.NewCounter(nil, prometheus.CounterOpts{
+		Name: "dns_cache_stale_answers_total",
+		Help: "Total number of expired positive answers served after a resolution failure",
+	})
+
 	wireFastPath = metric.NewCounterVec(nil, prometheus.CounterOpts{
 		Name: "dns_cache_wire_fastpath_total",
 		Help: "Cache hits attempted on the byte serving path, by outcome",

--- a/middleware/cache/serve_stale.go
+++ b/middleware/cache/serve_stale.go
@@ -1,0 +1,180 @@
+package cache
+
+import (
+	"context"
+	"net/netip"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/dnsutil"
+	"github.com/semihalev/sdns/middleware"
+)
+
+const staleAnswerTTL = 30 * time.Second
+
+// staleResponse applies the single RFC 8767 policy used by both failure
+// seams. Every applicable scoped key and then the shared key is checked for a
+// fresh entry before any stale answer is returned. Among stale candidates the
+// most-specific eligible scope wins, so stale retention cannot let an expired
+// narrow scope shadow a fresh wider answer or cross ECS audiences.
+func (c *Cache) staleResponse(
+	req *dns.Msg,
+	requestCD bool,
+	clientScope netip.Prefix,
+) (*dns.Msg, *CacheEntry) {
+	if c == nil || !c.config.ServeStale || req == nil || len(req.Question) != 1 {
+		return nil, nil
+	}
+
+	now := time.Now()
+	q := req.Question[0]
+	var (
+		stale      *dns.Msg
+		staleEntry *CacheEntry
+	)
+	if clientScope.IsValid() {
+		for bits := clientScope.Bits(); bits >= 1; bits-- {
+			scope, err := clientScope.Addr().Prefix(bits)
+			if err != nil {
+				continue
+			}
+			want := CacheKey{Question: q, CD: requestCD, Scope: scope}
+			entry, ok := c.store.LookupByKeyVerified(want.Hash(), want)
+			if !ok {
+				continue
+			}
+			if entry.remaining(now) > 0 {
+				return nil, nil
+			}
+			if stale == nil {
+				if resp := c.staleResponseFromEntry(entry, req, requestCD, now); resp != nil {
+					stale, staleEntry = resp, entry
+				}
+			}
+		}
+	}
+
+	want := CacheKey{Question: q, CD: requestCD}
+	entry, ok := c.store.lookupRetainedPositiveVerified(want.Hash(), want)
+	if ok {
+		if entry.remaining(now) > 0 {
+			return nil, nil
+		}
+		if stale == nil {
+			if resp := c.staleResponseFromEntry(entry, req, requestCD, now); resp != nil {
+				stale, staleEntry = resp, entry
+			}
+		}
+	}
+	return stale, staleEntry
+}
+
+func (c *Cache) staleResponseFromEntry(
+	entry *CacheEntry,
+	req *dns.Msg,
+	requestCD bool,
+	now time.Time,
+) *dns.Msg {
+	if entry == nil {
+		return nil
+	}
+
+	ttlRemaining, leaseRemaining := entry.remainingBounds(now)
+	if ttlRemaining > 0 {
+		return nil
+	}
+	// A zero cut is explicitly unbounded. A real delegation lease is a
+	// non-negotiable security ceiling: never revive an answer after it.
+	if !entry.cutUntil.IsZero() && leaseRemaining <= 0 {
+		return nil
+	}
+	if maxStale := c.config.ServeStaleMaxTTL; maxStale > 0 && -ttlRemaining > maxStale {
+		return nil
+	}
+
+	resp := entry.storedMsg()
+	if resp == nil || resp.Rcode != dns.RcodeSuccess || len(resp.Answer) == 0 {
+		return nil
+	}
+
+	originalRcode := resp.Rcode
+	originalExtra := resp.Extra
+	resp.SetReply(req)
+	resp.Rcode = originalRcode
+	resp.Extra = originalExtra
+	resp.Id = req.Id
+	resp.Authoritative = false
+	resp.CheckingDisabled = requestCD
+
+	responseTTL := staleAnswerTTL
+	if !entry.cutUntil.IsZero() && leaseRemaining < responseTTL {
+		// The ordinary response path never advertises a TTL beyond the
+		// delegation lease. Preserve that ghost-domain guarantee in the
+		// narrow final window where less than RFC 8767's 30 seconds remain.
+		responseTTL = leaseRemaining
+	}
+	setStaleTTLs(resp.Answer, responseTTL)
+	setStaleTTLs(resp.Ns, responseTTL)
+	setStaleTTLs(resp.Extra, responseTTL)
+
+	// AD is meaningful only while every retained signature is still inside
+	// its validity period. CD=1 always clears it, as on an ordinary hit.
+	if requestCD || (resp.AuthenticatedData && !allSignaturesCurrent(resp, now)) {
+		resp.AuthenticatedData = false
+	}
+
+	// OPT is hop-by-hop and was stripped at admission. Rebuild only the
+	// capabilities needed for this response, then identify it with EDE 3.
+	if reqOPT := req.IsEdns0(); reqOPT != nil {
+		resp.SetEdns0(reqOPT.UDPSize(), reqOPT.Do())
+		dnsutil.SetEDE(resp, dns.ExtendedErrorCodeStaleAnswer, "Stale Answer")
+	}
+
+	return resp
+}
+
+func setStaleTTLs(records []dns.RR, ttl time.Duration) {
+	seconds := uint32(max(ttl/time.Second, 0)) //nolint:gosec // capped at 30 seconds
+	for _, rr := range records {
+		if rr.Header().Rrtype != dns.TypeOPT {
+			rr.Header().Ttl = seconds
+		}
+	}
+}
+
+func allSignaturesCurrent(msg *dns.Msg, now time.Time) bool {
+	found := false
+	check := func(records []dns.RR) bool {
+		for _, rr := range records {
+			sig, ok := rr.(*dns.RRSIG)
+			if !ok {
+				continue
+			}
+			found = true
+			if !sig.ValidityPeriod(now) {
+				return false
+			}
+		}
+		return true
+	}
+	return check(msg.Answer) && check(msg.Ns) && check(msg.Extra) && found
+}
+
+// boundRequestToStaleLifetime lets an internal CNAME/DNAME consumer derive
+// from a stale answer for at most the advertised 30 seconds, and never beyond
+// the original delegation lease. It deliberately does not reuse the expired
+// answer TTL as a bound: that would make the just-served response instantly
+// unusable by the enclosing cache layer.
+func boundRequestToStaleLifetime(ctx context.Context, entry *CacheEntry, now time.Time) {
+	if entry == nil {
+		return
+	}
+	hardUntil := now.Add(staleAnswerTTL)
+	hardKey := uint64(0)
+	if !entry.cutUntil.IsZero() && entry.cutUntil.Before(hardUntil) {
+		hardUntil, hardKey = entry.cutUntil, entry.cutKey
+	}
+	if meta := middleware.ResponseMetaFrom(ctx); meta != nil {
+		meta.BoundCutFor(hardUntil, hardKey)
+	}
+}

--- a/middleware/cache/serve_stale_test.go
+++ b/middleware/cache/serve_stale_test.go
@@ -1,0 +1,624 @@
+package cache
+
+import (
+	"context"
+	"net/netip"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/dnsutil"
+	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/middleware"
+	"github.com/semihalev/sdns/middleware/edns"
+)
+
+type controllableDeadlineContext struct {
+	context.Context
+	expired bool
+}
+
+func (c *controllableDeadlineContext) Deadline() (time.Time, bool) {
+	if c.expired {
+		return time.Unix(1, 0), true
+	}
+	return time.Now().Add(time.Hour), true
+}
+
+func staleTestAnswer(req *dns.Msg, address string) *dns.Msg {
+	resp := new(dns.Msg)
+	resp.SetReply(req)
+	resp.RecursionAvailable = true
+	resp.Answer = []dns.RR{&dns.A{
+		Hdr: dns.RR_Header{
+			Name:   req.Question[0].Name,
+			Rrtype: dns.TypeA,
+			Class:  dns.ClassINET,
+			Ttl:    300,
+		},
+		A: netip.MustParseAddr(address).AsSlice(),
+	}}
+	return resp
+}
+
+func seedStaleEntry(
+	t *testing.T,
+	c *Cache,
+	resp *dns.Msg,
+	scope netip.Prefix,
+	staleFor time.Duration,
+	leaseRemaining time.Duration,
+) *CacheEntry {
+	t.Helper()
+	q := resp.Question[0]
+	want := CacheKey{Question: q, CD: resp.CheckingDisabled, Scope: scope}
+	entry := NewCacheEntryWithKey(resp, time.Minute, 0, want.Hash())
+	if entry == nil {
+		t.Fatal("failed to construct stale cache entry")
+	}
+	entry.scope = normalizeKeyScope(scope)
+	entry.stored = time.Now().Add(-time.Minute - staleFor)
+	if leaseRemaining != 0 {
+		entry.cutUntil = time.Now().Add(leaseRemaining)
+	}
+	c.store.SetEntryWithKey(want.Hash(), entry, dnsutil.TypeSuccess)
+	return entry
+}
+
+func runStaleQuery(
+	t *testing.T,
+	c *Cache,
+	req *dns.Msg,
+	downstream middleware.Handler,
+	ctx context.Context,
+) *dns.Msg {
+	t.Helper()
+	writer := mock.NewWriter("udp", "192.0.2.1:53000")
+	ch := middleware.NewChain([]middleware.Handler{c, downstream})
+	ch.Reset(writer, req)
+	ch.Next(ctx)
+	if !writer.Written() {
+		t.Fatal("query wrote no response")
+	}
+	return writer.Msg()
+}
+
+func servfailHandler(calls *int) middleware.Handler {
+	return middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		(*calls)++
+		resp := new(dns.Msg)
+		resp.SetRcode(ch.Request.Msg(), dns.RcodeServerFailure)
+		_ = ch.Writer.WriteMsg(resp)
+		ch.Cancel()
+	})
+}
+
+func TestServeStaleOnFreshSERVFAIL(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, ServeStale: true})
+	defer c.Stop()
+
+	req := new(dns.Msg)
+	req.SetQuestion("stale.example.", dns.TypeA)
+	req.SetEdns0(1232, true)
+	answer := staleTestAnswer(req, "192.0.2.44")
+	answer.Ns = []dns.RR{&dns.NS{
+		Hdr: dns.RR_Header{Name: "example.", Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: 600},
+		Ns:  "ns.example.",
+	}}
+	answer.Extra = []dns.RR{&dns.A{
+		Hdr: dns.RR_Header{Name: "ns.example.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 900},
+		A:   netip.MustParseAddr("192.0.2.99").AsSlice(),
+	}}
+	seedStaleEntry(t, c, answer, netip.Prefix{}, time.Second, time.Hour)
+
+	calls := 0
+	resp := runStaleQuery(t, c, req, servfailHandler(&calls), context.Background())
+	if calls != 1 {
+		t.Fatalf("downstream calls = %d, want 1", calls)
+	}
+	if resp.Rcode != dns.RcodeSuccess || len(resp.Answer) != 1 {
+		t.Fatalf("response = rcode %s, answers %d; want stale positive answer", dns.RcodeToString[resp.Rcode], len(resp.Answer))
+	}
+	for _, section := range [][]dns.RR{resp.Answer, resp.Ns, resp.Extra} {
+		for _, rr := range section {
+			if rr.Header().Rrtype != dns.TypeOPT && rr.Header().Ttl != 30 {
+				t.Fatalf("%s TTL = %d, want 30", rr.Header().Name, rr.Header().Ttl)
+			}
+		}
+	}
+	if ede := dnsutil.GetEDE(resp); ede == nil || ede.InfoCode != dns.ExtendedErrorCodeStaleAnswer || ede.ExtraText != "Stale Answer" {
+		t.Fatalf("EDE = %+v, want code 3 Stale Answer", ede)
+	}
+}
+
+func TestServeStaleRespectsLeaseAndOperatorCeiling(t *testing.T) {
+	tests := []struct {
+		name           string
+		maxStale       time.Duration
+		staleFor       time.Duration
+		leaseRemaining time.Duration
+	}{
+		{name: "expired delegation lease", staleFor: time.Second, leaseRemaining: -time.Second},
+		{name: "operator ceiling", maxStale: time.Minute, staleFor: 2 * time.Minute, leaseRemaining: time.Hour},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{CacheSize: 1024, ServeStale: true}
+			cfg.ServeStaleMaxTTL.Duration = tt.maxStale
+			c := New(cfg)
+			defer c.Stop()
+
+			req := new(dns.Msg)
+			req.SetQuestion("bounded.example.", dns.TypeA)
+			req.SetEdns0(1232, false)
+			seedStaleEntry(t, c, staleTestAnswer(req, "192.0.2.45"), netip.Prefix{}, tt.staleFor, tt.leaseRemaining)
+
+			calls := 0
+			resp := runStaleQuery(t, c, req, servfailHandler(&calls), context.Background())
+			if resp.Rcode != dns.RcodeServerFailure {
+				t.Fatalf("rcode = %s, want SERVFAIL", dns.RcodeToString[resp.Rcode])
+			}
+		})
+	}
+}
+
+func TestServeStaleAdvertisedTTLDoesNotOutliveLease(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, ServeStale: true})
+	defer c.Stop()
+	req := new(dns.Msg)
+	req.SetQuestion("short-lease.example.", dns.TypeA)
+	req.SetEdns0(1232, false)
+	seedStaleEntry(t, c, staleTestAnswer(req, "192.0.2.55"), netip.Prefix{}, time.Second, 2*time.Second)
+
+	calls := 0
+	resp := runStaleQuery(t, c, req, servfailHandler(&calls), context.Background())
+	if resp.Rcode != dns.RcodeSuccess || len(resp.Answer) == 0 {
+		t.Fatalf("response = rcode %s, answers %d; want stale positive answer", dns.RcodeToString[resp.Rcode], len(resp.Answer))
+	}
+	if ttl := resp.Answer[0].Header().Ttl; ttl > 2 {
+		t.Fatalf("stale TTL = %d, must not outlive the 2s delegation lease", ttl)
+	}
+}
+
+func TestServeStaleRequiresActualSERVFAIL(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, ServeStale: true})
+	defer c.Stop()
+	req := new(dns.Msg)
+	req.SetQuestion("refused.example.", dns.TypeA)
+	req.SetEdns0(1232, false)
+	seedStaleEntry(t, c, staleTestAnswer(req, "192.0.2.56"), netip.Prefix{}, time.Second, time.Hour)
+
+	downstream := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		resp := new(dns.Msg)
+		resp.SetRcode(ch.Request.Msg(), dns.RcodeRefused)
+		_ = ch.Writer.WriteMsg(resp)
+		ch.Cancel()
+	})
+	resp := runStaleQuery(t, c, req, downstream, context.Background())
+	if resp.Rcode != dns.RcodeRefused {
+		t.Fatalf("rcode = %s, want unchanged REFUSED", dns.RcodeToString[resp.Rcode])
+	}
+}
+
+func TestServeStaleRejectsNegativeAnswers(t *testing.T) {
+	tests := []struct {
+		name  string
+		rcode int
+	}{
+		{name: "NXDOMAIN", rcode: dns.RcodeNameError},
+		{name: "NODATA", rcode: dns.RcodeSuccess},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := New(&config.Config{CacheSize: 1024, ServeStale: true})
+			defer c.Stop()
+			req := new(dns.Msg)
+			req.SetQuestion("negative.example.", dns.TypeA)
+			req.SetEdns0(1232, false)
+			negative := new(dns.Msg)
+			negative.SetRcode(req, tt.rcode)
+			negative.Ns = []dns.RR{&dns.SOA{
+				Hdr:     dns.RR_Header{Name: "example.", Rrtype: dns.TypeSOA, Class: dns.ClassINET, Ttl: 300},
+				Ns:      "ns.example.",
+				Mbox:    "hostmaster.example.",
+				Serial:  1,
+				Refresh: 3600,
+				Retry:   600,
+				Expire:  86400,
+				Minttl:  300,
+			}}
+			seedStaleEntry(t, c, negative, netip.Prefix{}, time.Second, time.Hour)
+
+			calls := 0
+			resp := runStaleQuery(t, c, req, servfailHandler(&calls), context.Background())
+			if resp.Rcode != dns.RcodeServerFailure {
+				t.Fatalf("rcode = %s, want SERVFAIL", dns.RcodeToString[resp.Rcode])
+			}
+		})
+	}
+}
+
+func TestServeStaleDisabledAndFreshEntryUnchanged(t *testing.T) {
+	t.Run("disabled", func(t *testing.T) {
+		c := New(&config.Config{CacheSize: 1024})
+		defer c.Stop()
+		req := new(dns.Msg)
+		req.SetQuestion("disabled.example.", dns.TypeA)
+		req.SetEdns0(1232, false)
+		seedStaleEntry(t, c, staleTestAnswer(req, "192.0.2.46"), netip.Prefix{}, time.Second, time.Hour)
+
+		calls := 0
+		resp := runStaleQuery(t, c, req, servfailHandler(&calls), context.Background())
+		if resp.Rcode != dns.RcodeServerFailure || dnsutil.GetEDE(resp) != nil {
+			t.Fatalf("disabled response = rcode %s, EDE %+v; want unchanged SERVFAIL", dns.RcodeToString[resp.Rcode], dnsutil.GetEDE(resp))
+		}
+	})
+
+	t.Run("fresh entry", func(t *testing.T) {
+		c := New(&config.Config{CacheSize: 1024, ServeStale: true})
+		defer c.Stop()
+		req := new(dns.Msg)
+		req.SetQuestion("fresh.example.", dns.TypeA)
+		req.SetEdns0(1232, false)
+		answer := staleTestAnswer(req, "192.0.2.47")
+		c.store.SetFromResponse(answer, false, time.Now().Add(time.Hour))
+
+		calls := 0
+		resp := runStaleQuery(t, c, req, servfailHandler(&calls), context.Background())
+		if calls != 0 {
+			t.Fatalf("fresh cache hit reached downstream %d times", calls)
+		}
+		if ede := dnsutil.GetEDE(resp); ede != nil {
+			t.Fatalf("fresh response carried stale EDE: %+v", ede)
+		}
+		if resp.Answer[0].Header().Ttl == 30 {
+			t.Fatal("fresh response was reshaped with the stale TTL")
+		}
+	})
+}
+
+func TestServeStaleADTracksSignatureValidity(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name       string
+		expiration time.Time
+		wantAD     bool
+	}{
+		{name: "current signature", expiration: now.Add(time.Hour), wantAD: true},
+		{name: "expired signature", expiration: now.Add(-time.Second), wantAD: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := New(&config.Config{CacheSize: 1024, ServeStale: true})
+			defer c.Stop()
+			req := new(dns.Msg)
+			req.SetQuestion("signed.example.", dns.TypeA)
+			req.SetEdns0(1232, true)
+			answer := staleTestAnswer(req, "192.0.2.48")
+			answer.AuthenticatedData = true
+			answer.Answer = append(answer.Answer, &dns.RRSIG{
+				Hdr: dns.RR_Header{
+					Name:   req.Question[0].Name,
+					Rrtype: dns.TypeRRSIG,
+					Class:  dns.ClassINET,
+					Ttl:    300,
+				},
+				TypeCovered: dns.TypeA,
+				Algorithm:   dns.RSASHA256,
+				Labels:      2,
+				OrigTtl:     300,
+				Expiration:  uint32(tt.expiration.Unix()),       //nolint:gosec // DNS timestamp fixture
+				Inception:   uint32(now.Add(-time.Hour).Unix()), //nolint:gosec // DNS timestamp fixture
+				KeyTag:      12345,
+				SignerName:  "example.",
+				Signature:   "ZmFrZXNpZ25hdHVyZQ==",
+			})
+			seedStaleEntry(t, c, answer, netip.Prefix{}, time.Second, time.Hour)
+
+			calls := 0
+			resp := runStaleQuery(t, c, req, servfailHandler(&calls), context.Background())
+			if resp.AuthenticatedData != tt.wantAD {
+				t.Fatalf("AD = %v, want %v", resp.AuthenticatedData, tt.wantAD)
+			}
+		})
+	}
+}
+
+func TestServeStalePrecedesRFC9520FailureHit(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, ServeStale: true})
+	defer c.Stop()
+	req := new(dns.Msg)
+	req.SetQuestion("failure-hit.example.", dns.TypeA)
+	req.SetEdns0(1232, false)
+	seedStaleEntry(t, c, staleTestAnswer(req, "192.0.2.49"), netip.Prefix{}, time.Second, time.Hour)
+
+	failure := new(dns.Msg)
+	failure.SetRcode(req, dns.RcodeServerFailure)
+	c.store.RecordFailure(failure, netip.Prefix{}, FailureProvenance("test"), nil)
+
+	calls := 0
+	resp := runStaleQuery(t, c, req, middleware.HandlerFunc(func(_ context.Context, _ *middleware.Chain) {
+		calls++
+	}), context.Background())
+	if calls != 0 {
+		t.Fatalf("cached failure reached downstream %d times", calls)
+	}
+	if resp.Rcode != dns.RcodeSuccess {
+		t.Fatalf("rcode = %s, want stale success", dns.RcodeToString[resp.Rcode])
+	}
+	if ede := dnsutil.GetEDE(resp); ede == nil || ede.InfoCode != dns.ExtendedErrorCodeStaleAnswer {
+		t.Fatalf("EDE = %+v, want stale answer", ede)
+	}
+}
+
+func TestServeStaleKeepsWireFailureFastPathWithoutCandidate(t *testing.T) {
+	cfg := makeTestConfig()
+	cfg.ServeStale = true
+	c := New(cfg)
+	defer c.Stop()
+	e := edns.New(cfg)
+
+	req := new(dns.Msg)
+	req.SetQuestion("failure-only.example.", dns.TypeA)
+	c.store.RecordFailure(req, netip.Prefix{}, FailureProvenance("test"), nil)
+	if !serveFailureThrough(t, c, e, req.Question[0].Name, false) {
+		t.Fatal("serve-stale without an answer candidate disabled the cached-failure wire path")
+	}
+}
+
+func TestServeStalePrecedesWireBornRFC9520FailureHit(t *testing.T) {
+	cfg := makeTestConfig()
+	cfg.ServeStale = true
+	c := New(cfg)
+	defer c.Stop()
+	e := edns.New(cfg)
+
+	wireReq, req := wireTestRequest(t, "wire-stale.example.", dns.TypeA, false)
+	seedStaleEntry(t, c, staleTestAnswer(req, "192.0.2.57"), netip.Prefix{}, time.Second, time.Hour)
+	c.store.RecordFailure(req, netip.Prefix{}, FailureProvenance("test"), nil)
+
+	beforeFailureWire := wireFailureServed.Value()
+	writer := mock.NewWriter("udp", "198.51.100.9:40000")
+	terminal := middleware.HandlerFunc(func(_ context.Context, _ *middleware.Chain) {
+		t.Fatal("wire-born cached failure reached downstream")
+	})
+	ch := middleware.NewChain([]middleware.Handler{e, c, terminal})
+	ch.ResetWire(writer, wireReq)
+	ch.AllowDirectPack()
+	ch.Next(context.Background())
+
+	if !writer.Written() || writer.Rcode() != dns.RcodeSuccess {
+		t.Fatalf("wire-born stale response = written %v, rcode %s", writer.Written(), dns.RcodeToString[writer.Rcode()])
+	}
+	if wireFailureServed.Value() != beforeFailureWire {
+		t.Fatal("cached SERVFAIL wire path bypassed the stale candidate")
+	}
+	if ede := dnsutil.GetEDE(writer.Msg()); ede == nil || ede.InfoCode != dns.ExtendedErrorCodeStaleAnswer {
+		t.Fatalf("wire-born EDE = %+v, want stale answer", ede)
+	}
+}
+
+func TestServeStalePreservesECSAudience(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, ServeStale: true})
+	defer c.Stop()
+	req := new(dns.Msg)
+	req.SetQuestion("ecs-stale.example.", dns.TypeA)
+	req.SetEdns0(1232, false)
+
+	client := netip.MustParsePrefix("203.0.113.128/25")
+	scope := netip.MustParsePrefix("203.0.113.0/24")
+	seedStaleEntry(t, c, staleTestAnswer(req, "192.0.2.50"), netip.Prefix{}, time.Second, time.Hour)
+	seedStaleEntry(t, c, staleTestAnswer(req, "192.0.2.51"), scope, time.Second, time.Hour)
+
+	resp, _ := c.staleResponse(req, false, client)
+	if resp == nil {
+		t.Fatal("scoped stale candidate was not selected")
+	}
+	a, ok := resp.Answer[0].(*dns.A)
+	if !ok || !a.A.Equal(netip.MustParseAddr("192.0.2.51").AsSlice()) {
+		t.Fatalf("scoped stale answer = %v, want 192.0.2.51", resp.Answer)
+	}
+}
+
+func TestScopedLookupFreshWiderScopeBeatsExpiredNarrowScope(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, ServeStale: true})
+	defer c.Stop()
+	req := new(dns.Msg)
+	req.SetQuestion("ecs-shadow.example.", dns.TypeA)
+
+	client := netip.MustParsePrefix("203.0.113.130/32")
+	narrow := netip.MustParsePrefix("203.0.113.128/26")
+	wide := netip.MustParsePrefix("203.0.113.0/24")
+	seedStaleEntry(t, c, staleTestAnswer(req, "192.0.2.60"), narrow, time.Second, time.Hour)
+	fresh := seedStaleEntry(t, c, staleTestAnswer(req, "192.0.2.61"), wide, time.Second, time.Hour)
+	fresh.stored = time.Now()
+
+	entry, key, scope := c.scopedLookup(req.Question[0], false, client)
+	if entry != fresh || scope != wide {
+		t.Fatalf("scoped lookup = (%p, %v), want fresh /24 (%p, %v)", entry, scope, fresh, wide)
+	}
+
+	writer := mock.NewWriter("udp", "203.0.113.130:53000")
+	ch := middleware.NewChain(nil)
+	ch.Reset(writer, req.Copy())
+	if !c.handleCacheHit(context.Background(), ch, entry, key, scope, nil) {
+		t.Fatal("fresh wider scoped entry was not served as a cache hit")
+	}
+	if got := answerA(writer.Msg()); got != "192.0.2.61" {
+		t.Fatalf("scoped hit answer = %q, want fresh /24 answer 192.0.2.61", got)
+	}
+
+	if stale, _ := c.staleResponse(req, false, client); stale != nil {
+		t.Fatal("expired /26 was selected although a fresh /24 existed")
+	}
+}
+
+func TestServeStaleOnClientDeadline(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, ServeStale: true})
+	defer c.Stop()
+	req := new(dns.Msg)
+	req.SetQuestion("deadline.example.", dns.TypeA)
+	req.SetEdns0(1232, false)
+	seedStaleEntry(t, c, staleTestAnswer(req, "192.0.2.52"), netip.Prefix{}, time.Second, time.Hour)
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	calls := 0
+	resp := runStaleQuery(t, c, req, middleware.HandlerFunc(func(_ context.Context, _ *middleware.Chain) {
+		calls++
+	}), ctx)
+	if calls != 0 {
+		t.Fatalf("expired client request reached downstream %d times", calls)
+	}
+	if resp.Rcode != dns.RcodeSuccess || answerA(resp) != "192.0.2.52" {
+		t.Fatalf("deadline response = rcode %s, answer %q; want retained stale answer",
+			dns.RcodeToString[resp.Rcode], answerA(resp))
+	}
+	if ede := dnsutil.GetEDE(resp); ede == nil || ede.InfoCode != dns.ExtendedErrorCodeStaleAnswer {
+		t.Fatalf("deadline EDE = %+v, want stale-answer", ede)
+	}
+}
+
+func TestServeStaleOnResolutionFailureAfterDeadline(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, ServeStale: true})
+	defer c.Stop()
+	req := new(dns.Msg)
+	req.SetQuestion("deadline-upstream.example.", dns.TypeA)
+	req.SetEdns0(1232, false)
+	seedStaleEntry(t, c, staleTestAnswer(req, "192.0.2.65"), netip.Prefix{}, time.Second, time.Hour)
+
+	deadlineCtx := &controllableDeadlineContext{Context: context.Background()}
+	calls := 0
+	resp := runStaleQuery(t, c, req, middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		calls++
+		deadlineCtx.expired = true
+		failure := new(dns.Msg)
+		failure.SetRcode(ch.Request.Msg(), dns.RcodeServerFailure)
+		_ = ch.Writer.WriteMsg(failure)
+		ch.Cancel()
+	}), deadlineCtx)
+	if calls != 1 {
+		t.Fatalf("downstream calls = %d, want 1", calls)
+	}
+	if resp.Rcode != dns.RcodeSuccess || answerA(resp) != "192.0.2.65" {
+		t.Fatalf("post-deadline response = rcode %s, answer %q; want retained stale answer",
+			dns.RcodeToString[resp.Rcode], answerA(resp))
+	}
+	if ede := dnsutil.GetEDE(resp); ede == nil || ede.InfoCode != dns.ExtendedErrorCodeStaleAnswer {
+		t.Fatalf("post-deadline EDE = %+v, want stale-answer", ede)
+	}
+	if hit, ok := c.store.LookupFailure(req, netip.Prefix{}); ok {
+		t.Fatalf("request-local deadline published RFC 9520 state: %+v", hit)
+	}
+}
+
+func TestServeStaleDeadlineWithoutCandidateKeepsLocalFailure(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, ServeStale: true})
+	defer c.Stop()
+	req := new(dns.Msg)
+	req.SetQuestion("deadline-miss.example.", dns.TypeA)
+	req.SetEdns0(1232, false)
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+	calls := 0
+	resp := runStaleQuery(t, c, req, middleware.HandlerFunc(func(_ context.Context, _ *middleware.Chain) {
+		calls++
+	}), ctx)
+	if calls != 0 {
+		t.Fatalf("expired client request reached downstream %d times", calls)
+	}
+	if resp.Rcode != dns.RcodeServerFailure {
+		t.Fatalf("deadline response rcode = %s, want SERVFAIL", dns.RcodeToString[resp.Rcode])
+	}
+	if ede := dnsutil.GetEDE(resp); ede == nil || ede.InfoCode != dns.ExtendedErrorCodeNoReachableAuthority {
+		t.Fatalf("deadline EDE = %+v, want no-reachable-authority", ede)
+	}
+}
+
+func TestServeStaleDoesNotOverrideClientCancellation(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, ServeStale: true})
+	defer c.Stop()
+	req := new(dns.Msg)
+	req.SetQuestion("canceled.example.", dns.TypeA)
+	seedStaleEntry(t, c, staleTestAnswer(req, "192.0.2.62"), netip.Prefix{}, time.Second, time.Hour)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	calls := 0
+	writer := mock.NewWriter("udp", "192.0.2.1:53000")
+	ch := middleware.NewChain([]middleware.Handler{c, middleware.HandlerFunc(func(_ context.Context, _ *middleware.Chain) {
+		calls++
+	})})
+	ch.Reset(writer, req)
+	ch.Next(ctx)
+	if calls != 0 {
+		t.Fatalf("canceled client request reached downstream %d times", calls)
+	}
+	if writer.Written() {
+		t.Fatal("transport cancellation wrote a stale response")
+	}
+}
+
+func TestBoundRequestToStaleLifetime(t *testing.T) {
+	now := time.Now()
+	tests := []struct {
+		name      string
+		cutUntil  time.Time
+		cutKey    uint64
+		wantUntil time.Time
+		wantKey   uint64
+	}{
+		{
+			name:      "advertised stale lifetime",
+			wantUntil: now.Add(staleAnswerTTL),
+		},
+		{
+			name:      "shorter delegation lease",
+			cutUntil:  now.Add(5 * time.Second),
+			cutKey:    0x8767,
+			wantUntil: now.Add(5 * time.Second),
+			wantKey:   0x8767,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			entry := &CacheEntry{cutUntil: tt.cutUntil, cutKey: tt.cutKey}
+			var meta middleware.ResponseMeta
+			ctx := middleware.WithResponseMeta(context.Background(), &meta)
+			boundRequestToStaleLifetime(ctx, entry, now)
+			gotUntil, gotKey := meta.Cut()
+			if !gotUntil.Equal(tt.wantUntil) || gotKey != tt.wantKey {
+				t.Fatalf("stale bound = (%v, %#x), want (%v, %#x)",
+					gotUntil, gotKey, tt.wantUntil, tt.wantKey)
+			}
+		})
+	}
+}
+
+func TestServeStaleReadPreservesPrefetchCAS(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, ServeStale: true})
+	defer c.Stop()
+	req := new(dns.Msg)
+	req.SetQuestion("refresh.example.", dns.TypeA)
+	entry := seedStaleEntry(t, c, staleTestAnswer(req, "192.0.2.53"), netip.Prefix{}, time.Second, time.Hour)
+
+	if resp, got := c.staleResponse(req, false, netip.Prefix{}); resp == nil || got != entry {
+		t.Fatal("stale read did not return the retained entry")
+	}
+	key := CacheKey{Question: req.Question[0], CD: false}.Hash()
+	if !c.store.ReplaceIfCurrent(
+		key,
+		entry,
+		staleTestAnswer(req, "192.0.2.54"),
+		time.Now().Add(time.Hour),
+		123,
+	) {
+		t.Fatal("stale read disturbed ReplaceIfCurrent pointer CAS")
+	}
+	replacement, ok := c.store.LookupByKeyVerified(key, CacheKey{Question: req.Question[0]})
+	if !ok || replacement == entry {
+		t.Fatal("successful refresh did not replace the stale entry")
+	}
+}

--- a/middleware/cache/store.go
+++ b/middleware/cache/store.go
@@ -128,7 +128,16 @@ func (s *Store) Lookup(req *dns.Msg) (*CacheEntry, bool) {
 // the map key is a non-cryptographic 64-bit xxhash of that preimage, so a
 // hash collision would otherwise serve one query's answer to another.
 func (s *Store) LookupByKey(key uint64) (*CacheEntry, bool) {
-	if entry, ok := s.positive.Get(key); ok {
+	var (
+		entry *CacheEntry
+		ok    bool
+	)
+	if s.cfg.ServeStale {
+		entry, ok = s.positive.retained(key)
+	} else {
+		entry, ok = s.positive.Get(key)
+	}
+	if ok {
 		return entry, true
 	}
 	if entry, ok := s.negative.Get(key); ok {
@@ -145,6 +154,17 @@ func (s *Store) LookupByKey(key uint64) (*CacheEntry, bool) {
 // poison the cache.
 func (s *Store) LookupByKeyVerified(key uint64, want CacheKey) (*CacheEntry, bool) {
 	entry, ok := s.LookupByKey(key)
+	if !ok || !entryMatchesKey(entry, want) {
+		return nil, false
+	}
+	return entry, true
+}
+
+// lookupRetainedPositiveVerified is the serve-stale view of the positive
+// cache. It deliberately bypasses freshness cleanup but still verifies the
+// complete key preimage; policy and response shaping remain the caller's job.
+func (s *Store) lookupRetainedPositiveVerified(key uint64, want CacheKey) (*CacheEntry, bool) {
+	entry, ok := s.positive.retained(key)
 	if !ok || !entryMatchesKey(entry, want) {
 		return nil, false
 	}

--- a/middleware/cache/types.go
+++ b/middleware/cache/types.go
@@ -97,13 +97,25 @@ type CacheEntry struct {
 // remaining returns the entry's effective remaining lifetime at now:
 // the stored TTL minus elapsed time, further bounded by cutUntil.
 func (e *CacheEntry) remaining(now time.Time) time.Duration {
-	rem := e.ttl - now.Sub(e.stored)
+	rem, leaseRem := e.remainingBounds(now)
 	if !e.cutUntil.IsZero() {
-		if cutRem := e.cutUntil.Sub(now); cutRem < rem {
-			rem = cutRem
+		if leaseRem < rem {
+			rem = leaseRem
 		}
 	}
 	return rem
+}
+
+// remainingBounds returns the two independent lifetimes that remaining folds
+// together: the answer TTL and the delegation lease. A zero cutUntil is
+// unbounded and therefore returns zero for leaseRemaining; callers must check
+// cutUntil before interpreting that value as an expired lease.
+func (e *CacheEntry) remainingBounds(now time.Time) (ttlRemaining, leaseRemaining time.Duration) {
+	ttlRemaining = e.ttl - now.Sub(e.stored)
+	if !e.cutUntil.IsZero() {
+		leaseRemaining = e.cutUntil.Sub(now)
+	}
+	return ttlRemaining, leaseRemaining
 }
 
 // NewCacheEntry creates a new cache entry from a DNS message.
@@ -431,6 +443,10 @@ type CacheConfig struct {
 	MinTTL      time.Duration
 	MaxTTL      time.Duration
 	RateLimit   int
+	ServeStale  bool
+	// ServeStaleMaxTTL is measured from the admitted answer TTL's expiry.
+	// Zero leaves cutUntil as the only stale lifetime bound.
+	ServeStaleMaxTTL time.Duration
 
 	// ECSMaxTTL caps the lifetime of cache entries keyed under an
 	// ECS scope. Geo-routed answers tend to go stale faster than
@@ -454,6 +470,9 @@ func (cc CacheConfig) Validate() error {
 	}
 	if cc.MaxTTL < cc.MinTTL {
 		return errors.New("maximum TTL must be greater than minimum TTL")
+	}
+	if cc.ServeStaleMaxTTL < 0 {
+		return errors.New("serve-stale maximum TTL cannot be negative")
 	}
 	return nil
 }


### PR DESCRIPTION
Serve-stale: when recursive resolution ends in SERVFAIL, answer from a cached positive entry whose TTL has already expired rather than handing the client a failure. Lives entirely in the cache middleware, which already wraps failover and the resolver, so a stale answer is only reached after failover has had its turn.

## The security constraint

The delegation lease (`cutUntil`, GHSA-mqfw-f48p-2vc8) is a hard ceiling. Serving past an entry's TTL is the whole point; serving past the parent-granted lease would revive the ghost domains that lease exists to bury. Two guarantees:

- a stale answer is refused once the lease has passed, and
- the TTL it advertises is capped by whatever remains of the lease, so nothing downstream holds the answer longer than the delegation behind it.

## What changed structurally

Expired entries were already retained — the positive cache computes expiry rather than storing it, so an entry outlives its TTL until eviction. Reading them is opt-in per lookup, which means every consumer of the shared lookup now rejects an expired entry itself: the ordinary hit path, the byte-serving fast path, and the scoped (ECS) walk, which keeps searching for a broader fresh scope instead of stopping at an expired narrow one and shadowing it.

Two seams produce a stale answer: a cached RFC 9520 failure about to be replayed, and a fresh SERVFAIL on its way out. Whether to *record* a failure and whether to *answer around* it are different questions and use different predicates — a resolution that exhausted its deadline is the case RFC 8767 exists for and serves stale without being recorded as shared state, while cancellation, work-budget rejections and request-local failures do neither.

## The answer

30-second TTL (RFC 8767 §4), EDE 3 "Stale Answer", AD kept only while every retained signature is still inside its validity period, ECS audiences never crossed, and never built from a denial.

## Deliberately out of scope

Stale denials (NXDOMAIN/NODATA keep their own rungs and provenance); RFC 8767's client-response-timeout trigger, which would need a per-query timer in the dedup path; background refresh after serving stale.

## Configuration

Off by default.

- `serve_stale` — enable the feature.
- `serve_stale_max_ttl` — how long an answer may be reused past its TTL. Left unset it is 24 hours, because a forwarded answer carries no delegation lease and would otherwise have no upper bound at all. Setting it to `0s` explicitly asks for the lease to be the only bound.

New metric `dns_cache_stale_answers_total`. Note that with the feature on, `dns_cache_size{type="positive"}` includes expired entries retained as stale candidates until eviction; this is documented in the README.

## Verification

`make test`, `go test -race ./middleware/cache`, `go vet ./...`, `golangci-lint run` all clean.

Beyond that, the security-critical and previously-unpinned behaviours were mutation-tested: each was broken in a scratch copy to confirm a named test turns red — the lease refusal, the advertised-TTL clamp, the stale-lifetime bound on internal consumers, both ordinary-path expiry guards, the ECS fresh-beats-stale rule, and the deadline serving gate. Mutations that failed to compile were not counted as evidence.