### PR TITLE
cache: complete a stale answer's alias chain, and charge it like a hit

### DIFF
--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -802,10 +802,9 @@ func (c *Cache) stopCanceledRequest(
 	err := contextutil.EffectiveError(ctx)
 	if errors.Is(err, context.DeadlineExceeded) {
 		req := ch.Request.Msg()
-		if stale, entry := c.staleResponse(req, req.CheckingDisabled, clientScope); stale != nil {
-			boundRequestToStaleLifetime(ctx, entry, time.Now())
-			staleAnswers.Inc()
-			_ = ch.Writer.WriteMsg(stale)
+		if handled, _ := c.writeStaleResponse(
+			ctx, ch.Writer, req, req.CheckingDisabled, clientScope, ch.Writer.Internal(),
+		); handled {
 			ch.Cancel()
 			return
 		}
@@ -1100,10 +1099,9 @@ func (c *Cache) handleFailureHit(
 	clientScope netip.Prefix,
 	hit FailureHit,
 ) {
-	if resp, entry := c.staleResponse(ch.Request.Msg(), ch.Request.CD(), clientScope); resp != nil {
-		boundRequestToStaleLifetime(ctx, entry, time.Now())
-		staleAnswers.Inc()
-		_ = ch.Writer.WriteMsg(resp)
+	if handled, _ := c.writeStaleResponse(
+		ctx, ch.Writer, ch.Request.Msg(), ch.Request.CD(), clientScope, ch.Writer.Internal(),
+	); handled {
 		ch.Cancel()
 		return
 	}
@@ -1230,7 +1228,7 @@ func (c *Cache) serveHitFromWire(
 	ctx context.Context, ch *middleware.Chain, entry *CacheEntry, spent **rate.Limiter,
 ) bool {
 	w := ch.Writer
-	if w.Internal() {
+	if w.Internal() || isStaleAliasChase(ctx) {
 		return false
 	}
 	if entry == nil || entry.remaining(time.Now()) <= 0 {
@@ -1353,6 +1351,12 @@ func (c *Cache) handleCacheHit(
 	// entry rate-limit token so the later fallback is not charged twice (and
 	// cannot be suppressed by a token spent on a response we did not serve).
 	if entry.remaining(time.Now()) <= 0 {
+		return false
+	}
+	// A stale alias completion may consume a still-fresh target entry, but
+	// RFC 8767 does not allow originally zero-TTL data to become part of the
+	// stale response. Force this rare path through the inspected Msg body.
+	if isStaleAliasChase(ctx) && entry.hasOriginalZeroTTL() {
 		return false
 	}
 
@@ -1828,10 +1832,10 @@ func (w *ResponseWriter) writeResolutionFailure(ctx context.Context, res *dns.Ms
 		if req == nil {
 			req = res
 		}
-		if stale, entry := w.cache.staleResponse(req, w.requestCD, w.clientScope); stale != nil {
-			boundRequestToStaleLifetime(ctx, entry, time.Now())
-			staleAnswers.Inc()
-			return w.ResponseWriter.WriteMsg(stale)
+		if handled, err := w.cache.writeStaleResponse(
+			ctx, w.ResponseWriter, req, w.requestCD, w.clientScope, w.internal,
+		); handled {
+			return err
 		}
 	}
 	return w.ResponseWriter.WriteMsg(out)

--- a/middleware/cache/serve_stale.go
+++ b/middleware/cache/serve_stale.go
@@ -12,12 +12,32 @@ import (
 
 const staleAnswerTTL = 30 * time.Second
 
+type staleAliasChaseKeyType struct{}
+
+var staleAliasChaseKey = &staleAliasChaseKeyType{}
+
+type staleEntryResponse struct {
+	msg      *dns.Msg
+	until    time.Time
+	boundKey uint64
+}
+
+func withStaleAliasChase(ctx context.Context) context.Context {
+	return context.WithValue(ctx, staleAliasChaseKey, true)
+}
+
+func isStaleAliasChase(ctx context.Context) bool {
+	active, _ := ctx.Value(staleAliasChaseKey).(bool)
+	return active
+}
+
 // staleResponse applies the single RFC 8767 policy used by both failure
 // seams. Every applicable scoped key and then the shared key is checked for a
 // fresh entry before any stale answer is returned. Among stale candidates the
-// most-specific eligible scope wins, so stale retention cannot let an expired
-// narrow scope shadow a fresh wider answer or cross ECS audiences.
+// most-specific eligible and complete scope wins, so stale retention cannot
+// let an expired narrow scope shadow a fresh wider answer or cross audiences.
 func (c *Cache) staleResponse(
+	ctx context.Context,
 	req *dns.Msg,
 	requestCD bool,
 	clientScope netip.Prefix,
@@ -28,10 +48,7 @@ func (c *Cache) staleResponse(
 
 	now := time.Now()
 	q := req.Question[0]
-	var (
-		stale      *dns.Msg
-		staleEntry *CacheEntry
-	)
+	candidates := make([]*CacheEntry, 0, 4)
 	if clientScope.IsValid() {
 		for bits := clientScope.Bits(); bits >= 1; bits-- {
 			scope, err := clientScope.Addr().Prefix(bits)
@@ -46,11 +63,7 @@ func (c *Cache) staleResponse(
 			if entry.remaining(now) > 0 {
 				return nil, nil
 			}
-			if stale == nil {
-				if resp := c.staleResponseFromEntry(entry, req, requestCD, now); resp != nil {
-					stale, staleEntry = resp, entry
-				}
-			}
+			candidates = append(candidates, entry)
 		}
 	}
 
@@ -60,13 +73,58 @@ func (c *Cache) staleResponse(
 		if entry.remaining(now) > 0 {
 			return nil, nil
 		}
-		if stale == nil {
-			if resp := c.staleResponseFromEntry(entry, req, requestCD, now); resp != nil {
-				stale, staleEntry = resp, entry
-			}
+		candidates = append(candidates, entry)
+	}
+
+	// Freshness was checked across every applicable scope before any alias
+	// chase is attempted. Now try stale candidates in specificity order; an
+	// incomplete narrow alias that cannot be completed must not suppress a
+	// usable wider candidate.
+	for _, candidateEntry := range candidates {
+		candidate := c.staleResponseFromEntry(candidateEntry, req, requestCD, now)
+		if candidate.msg == nil {
+			continue
+		}
+		resp := c.completeStaleAlias(ctx, candidate, req)
+		if resp != nil {
+			return resp, candidateEntry
 		}
 	}
-	return stale, staleEntry
+	return nil, nil
+}
+
+// writeStaleResponse is the single commit point for a retained answer. A
+// stale response is still a cache answer, so an external query pays the same
+// entry-local rate-limit token as an ordinary hit. Internal alias chases are
+// exempt: charging their target leg would either double-charge one client
+// question or leave the outer response with only a partial alias chain.
+//
+// handled is true both when the response was written and when the limiter
+// refused it. The latter is deliberately terminal and silent, matching the
+// ordinary cache-hit path instead of falling back to the SERVFAIL that made
+// the retained answer eligible.
+func (c *Cache) writeStaleResponse(
+	ctx context.Context,
+	w middleware.ResponseWriter,
+	req *dns.Msg,
+	requestCD bool,
+	clientScope netip.Prefix,
+	internal bool,
+) (handled bool, err error) {
+	resp, entry := c.staleResponse(ctx, req, requestCD, clientScope)
+	if resp == nil {
+		return false, nil
+	}
+
+	if !internal && !isStaleAliasChase(ctx) {
+		if limiter := entry.GetRateLimiter(); limiter != nil && !limiter.Allow() {
+			return true, nil
+		}
+	}
+
+	boundRequestToStaleLifetime(ctx, entry, time.Now())
+	staleAnswers.Inc()
+	return true, w.WriteMsg(resp)
 }
 
 func (c *Cache) staleResponseFromEntry(
@@ -74,27 +132,40 @@ func (c *Cache) staleResponseFromEntry(
 	req *dns.Msg,
 	requestCD bool,
 	now time.Time,
-) *dns.Msg {
+) staleEntryResponse {
 	if entry == nil {
-		return nil
+		return staleEntryResponse{}
 	}
 
 	ttlRemaining, leaseRemaining := entry.remainingBounds(now)
 	if ttlRemaining > 0 {
-		return nil
+		return staleEntryResponse{}
 	}
 	// A zero cut is explicitly unbounded. A real delegation lease is a
 	// non-negotiable security ceiling: never revive an answer after it.
 	if !entry.cutUntil.IsZero() && leaseRemaining <= 0 {
-		return nil
+		return staleEntryResponse{}
 	}
 	if maxStale := c.config.ServeStaleMaxTTL; maxStale > 0 && -ttlRemaining > maxStale {
-		return nil
+		return staleEntryResponse{}
 	}
 
 	resp := entry.storedMsg()
-	if resp == nil || resp.Rcode != dns.RcodeSuccess || len(resp.Answer) == 0 {
-		return nil
+	if resp == nil || resp.Rcode != dns.RcodeSuccess || len(resp.Answer) == 0 || hasZeroTTLRecord(resp) {
+		return staleEntryResponse{}
+	}
+
+	hardUntil := now.Add(staleAnswerTTL)
+	hardKey := uint64(0)
+	if !entry.cutUntil.IsZero() && entry.cutUntil.Before(hardUntil) {
+		hardUntil, hardKey = entry.cutUntil, entry.cutKey
+	}
+	// DNS TTLs have one-second granularity. Rounding a positive sub-second
+	// lease up would outlive the delegation; rounding down would emit TTL 0,
+	// which RFC 8767 section 4 forbids. Decline the stale candidate instead.
+	responseTTL := hardUntil.Sub(now)
+	if responseTTL < time.Second {
+		return staleEntryResponse{}
 	}
 
 	originalRcode := resp.Rcode
@@ -106,13 +177,6 @@ func (c *Cache) staleResponseFromEntry(
 	resp.Authoritative = false
 	resp.CheckingDisabled = requestCD
 
-	responseTTL := staleAnswerTTL
-	if !entry.cutUntil.IsZero() && leaseRemaining < responseTTL {
-		// The ordinary response path never advertises a TTL beyond the
-		// delegation lease. Preserve that ghost-domain guarantee in the
-		// narrow final window where less than RFC 8767's 30 seconds remain.
-		responseTTL = leaseRemaining
-	}
 	setStaleTTLs(resp.Answer, responseTTL)
 	setStaleTTLs(resp.Ns, responseTTL)
 	setStaleTTLs(resp.Extra, responseTTL)
@@ -130,7 +194,143 @@ func (c *Cache) staleResponseFromEntry(
 		dnsutil.SetEDE(resp, dns.ExtendedErrorCodeStaleAnswer, "Stale Answer")
 	}
 
+	return staleEntryResponse{msg: resp, until: hardUntil, boundKey: hardKey}
+}
+
+// completeStaleAlias mirrors the ordinary Msg hit's alias completion. The
+// chase runs with an isolated cut accumulator that still shares the request
+// tree's work ledgers; only records actually merged into the stale answer
+// contribute their lifetime. An incomplete result is rejected rather than
+// returning a misleading NOERROR response containing only an alias.
+func (c *Cache) completeStaleAlias(
+	ctx context.Context,
+	candidate staleEntryResponse,
+	req *dns.Msg,
+) *dns.Msg {
+	resp := candidate.msg
+	if !staleAliasNeedsCompletion(resp) {
+		return resp
+	}
+	depth := cnameChaseDepth(ctx)
+	if depth >= maxCnameChaseDepth {
+		return nil
+	}
+
+	aliasLifetime := time.Until(candidate.until)
+	if aliasLifetime < time.Second {
+		return nil
+	}
+	// Resolver-produced DNAME answers normally carry the synthesized CNAME.
+	// Preserve that behavior for a retained DNAME-only body so the existing
+	// CNAME chase can resolve its target instead of returning a partial reply.
+	if !hasCNAME(resp) {
+		if target := dnsutil.DnameTarget(resp); target != "" {
+			resp.Answer = append(resp.Answer, &dns.CNAME{
+				Hdr: dns.RR_Header{
+					Name:   req.Question[0].Name,
+					Rrtype: dns.TypeCNAME,
+					Class:  req.Question[0].Qclass,
+					Ttl:    uint32(aliasLifetime / time.Second), //nolint:gosec // capped at 30s
+				},
+				Target: target,
+			})
+		}
+	}
+
+	var chaseMeta *middleware.ResponseMeta
+	if parent := middleware.ResponseMetaFrom(ctx); parent != nil {
+		chaseMeta = parent.ForkCut()
+	} else {
+		chaseMeta = new(middleware.ResponseMeta)
+	}
+	chaseMeta.BoundCutFor(candidate.until, candidate.boundKey)
+	chaseCtx := middleware.WithResponseMeta(ctx, chaseMeta)
+	chaseCtx = withStaleAliasChase(chaseCtx)
+	resp = c.additionalAnswer(withCnameChaseDepth(chaseCtx, depth+1), resp)
+	if resp == nil || resp.Rcode != dns.RcodeSuccess ||
+		staleAliasNeedsCompletion(resp) || hasZeroTTLRecord(resp) {
+		return nil
+	}
+
+	// additionalAnswer preserves the TTLs of fresh terminal records. Fold
+	// their shortest advertised lifetime together with every exact lineage
+	// bound accumulated by the chase, then give the whole composed response
+	// one non-zero TTL that cannot outlive any of its parts.
+	hardUntil, hardKey := chaseMeta.Cut()
+	if ttl, found := minimumRecordTTL(resp); found {
+		ttlUntil := time.Now().Add(time.Duration(ttl) * time.Second)
+		if hardUntil.IsZero() || ttlUntil.Before(hardUntil) {
+			hardUntil, hardKey = ttlUntil, 0
+		}
+	}
+	remaining := time.Until(hardUntil)
+	if hardUntil.IsZero() || remaining < time.Second {
+		return nil
+	}
+	setStaleTTLs(resp.Answer, remaining)
+	setStaleTTLs(resp.Ns, remaining)
+	setStaleTTLs(resp.Extra, remaining)
+	if outer := middleware.ResponseMetaFrom(ctx); outer != nil {
+		outer.BoundCutFor(hardUntil, hardKey)
+	}
 	return resp
+}
+
+func staleAliasNeedsCompletion(msg *dns.Msg) bool {
+	if msg == nil || len(msg.Question) != 1 || msg.Rcode == dns.RcodeNameError {
+		return false
+	}
+	q := msg.Question[0]
+	if q.Qtype == dns.TypeCNAME || q.Qtype == dns.TypeDS || respCnameHasType(msg, q.Qtype) {
+		return false
+	}
+	return hasCNAME(msg) || dnsutil.DnameTarget(msg) != ""
+}
+
+func hasCNAME(msg *dns.Msg) bool {
+	if msg == nil {
+		return false
+	}
+	for _, rr := range msg.Answer {
+		if rr.Header().Rrtype == dns.TypeCNAME {
+			return true
+		}
+	}
+	return false
+}
+
+func hasZeroTTLRecord(msg *dns.Msg) bool {
+	if msg == nil {
+		return false
+	}
+	for _, section := range [][]dns.RR{msg.Answer, msg.Ns, msg.Extra} {
+		for _, rr := range section {
+			if rr.Header().Rrtype != dns.TypeOPT && rr.Header().Ttl == 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func minimumRecordTTL(msg *dns.Msg) (uint32, bool) {
+	var minimum uint32
+	found := false
+	for _, section := range [][]dns.RR{msg.Answer, msg.Ns, msg.Extra} {
+		for _, rr := range section {
+			if rr.Header().Rrtype == dns.TypeOPT {
+				continue
+			}
+			if !found || rr.Header().Ttl < minimum {
+				minimum, found = rr.Header().Ttl, true
+			}
+		}
+	}
+	return minimum, found
+}
+
+func (e *CacheEntry) hasOriginalZeroTTL() bool {
+	return hasZeroTTLRecord(e.storedMsg())
 }
 
 func setStaleTTLs(records []dns.RR, ttl time.Duration) {

--- a/middleware/cache/serve_stale.go
+++ b/middleware/cache/serve_stale.go
@@ -81,7 +81,14 @@ func (c *Cache) staleResponse(
 	// incomplete narrow alias that cannot be completed must not suppress a
 	// usable wider candidate.
 	for _, candidateEntry := range candidates {
-		candidate := c.staleResponseFromEntry(candidateEntry, req, requestCD, now)
+		// Each candidate is judged on the clock it is actually reached at,
+		// not the one the walk started on. Completing an earlier candidate's
+		// alias can spend real seconds on a failing sub-resolution, and the
+		// delegation lease is an absolute instant: reusing the opening
+		// timestamp would let a candidate whose lease ran out during that
+		// chase pass the ceiling check and be served after it expired, which
+		// is the revival the ceiling exists to prevent.
+		candidate := c.staleResponseFromEntry(candidateEntry, req, requestCD, time.Now())
 		if candidate.msg == nil {
 			continue
 		}

--- a/middleware/cache/serve_stale.go
+++ b/middleware/cache/serve_stale.go
@@ -118,6 +118,16 @@ func (c *Cache) writeStaleResponse(
 	clientScope netip.Prefix,
 	internal bool,
 ) (handled bool, err error) {
+	// The charge lands after the candidate walk, not before it as on the
+	// ordinary hit path, because the entry to charge is what the walk
+	// returns: which candidate wins is not known until completion has been
+	// attempted, and billing each one as it is tried would charge several
+	// entries for a single question. An accepted residual, on the same
+	// terms as the inline/replay double charge: a refused query has already
+	// paid for one alias completion. It is bounded on both legs — the
+	// resolution that made this answer eligible dominates the cost, and the
+	// chase's own sub-query records its failure under RFC 9520, so the
+	// repeat is a cached-failure hit rather than another walk to the wire.
 	resp, entry := c.staleResponse(ctx, req, requestCD, clientScope)
 	if resp == nil {
 		return false, nil

--- a/middleware/cache/serve_stale_test.go
+++ b/middleware/cache/serve_stale_test.go
@@ -1074,3 +1074,58 @@ func TestServeStaleReadPreservesPrefetchCAS(t *testing.T) {
 		t.Fatal("successful refresh did not replace the stale entry")
 	}
 }
+
+// TestServeStaleReEvaluatesLeaseAfterASlowChase pins the clock each candidate
+// is judged on. Completing an earlier candidate's alias can spend real time on
+// a failing sub-resolution, and the delegation lease is an absolute instant —
+// so a later candidate must be re-checked against the time it is actually
+// reached at, or one whose lease ran out during that chase is served after the
+// ceiling that GHSA-mqfw-f48p-2vc8 put in place.
+func TestServeStaleReEvaluatesLeaseAfterASlowChase(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, ServeStale: true})
+	defer c.Stop()
+	const alias = "slow-chase.example."
+
+	req := new(dns.Msg)
+	req.SetQuestion(alias, dns.TypeA)
+	req.SetEdns0(1232, false)
+
+	client := netip.MustParsePrefix("203.0.113.130/32")
+	scope := netip.MustParsePrefix("203.0.113.0/24")
+
+	// The narrow candidate needs completion, and its chase will be slow and
+	// end in failure — so the loop moves on to the shared candidate.
+	aliasBody := new(dns.Msg)
+	aliasBody.SetReply(req)
+	aliasBody.Answer = []dns.RR{&dns.CNAME{
+		Hdr:    dns.RR_Header{Name: alias, Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+		Target: "slow-target.example.",
+	}}
+	seedStaleEntry(t, c, aliasBody, scope, time.Second, time.Hour)
+
+	// The shared candidate is servable when the walk starts — its lease is
+	// over the one-second floor an advertised TTL needs — and is expired by
+	// the time the chase above returns.
+	const lease = 1200 * time.Millisecond
+	seedStaleEntry(t, c, staleTestAnswer(req, "192.0.2.90"), netip.Prefix{}, time.Second, lease)
+
+	calls := 0
+	c.SetQueryer(&internalQueryer{handlers: []middleware.Handler{c, middleware.HandlerFunc(
+		func(_ context.Context, ch *middleware.Chain) {
+			calls++
+			time.Sleep(lease + 300*time.Millisecond)
+			resp := new(dns.Msg)
+			resp.SetRcode(ch.Request.Msg(), dns.RcodeServerFailure)
+			_ = ch.Writer.WriteMsg(resp)
+			ch.Cancel()
+		},
+	)}})
+
+	resp, _ := c.staleResponse(context.Background(), req, false, client)
+	if calls == 0 {
+		t.Fatal("the alias chase never ran, so no time passed between the candidates")
+	}
+	if resp != nil {
+		t.Fatalf("served an answer whose delegation lease expired during the chase: %v", resp.Answer)
+	}
+}

--- a/middleware/cache/serve_stale_test.go
+++ b/middleware/cache/serve_stale_test.go
@@ -50,10 +50,22 @@ func seedStaleEntry(
 	staleFor time.Duration,
 	leaseRemaining time.Duration,
 ) *CacheEntry {
+	return seedStaleEntryWithRate(t, c, resp, scope, staleFor, leaseRemaining, 0)
+}
+
+func seedStaleEntryWithRate(
+	t *testing.T,
+	c *Cache,
+	resp *dns.Msg,
+	scope netip.Prefix,
+	staleFor time.Duration,
+	leaseRemaining time.Duration,
+	rateLimit int,
+) *CacheEntry {
 	t.Helper()
 	q := resp.Question[0]
 	want := CacheKey{Question: q, CD: resp.CheckingDisabled, Scope: scope}
-	entry := NewCacheEntryWithKey(resp, time.Minute, 0, want.Hash())
+	entry := NewCacheEntryWithKey(resp, time.Minute, rateLimit, want.Hash())
 	if entry == nil {
 		t.Fatal("failed to construct stale cache entry")
 	}
@@ -66,6 +78,19 @@ func seedStaleEntry(
 	return entry
 }
 
+func runStaleQueryWriter(
+	c *Cache,
+	req *dns.Msg,
+	downstream middleware.Handler,
+	ctx context.Context,
+) *mock.Writer {
+	writer := mock.NewWriter("udp", "192.0.2.1:53000")
+	ch := middleware.NewChain([]middleware.Handler{c, downstream})
+	ch.Reset(writer, req)
+	ch.Next(ctx)
+	return writer
+}
+
 func runStaleQuery(
 	t *testing.T,
 	c *Cache,
@@ -74,10 +99,7 @@ func runStaleQuery(
 	ctx context.Context,
 ) *dns.Msg {
 	t.Helper()
-	writer := mock.NewWriter("udp", "192.0.2.1:53000")
-	ch := middleware.NewChain([]middleware.Handler{c, downstream})
-	ch.Reset(writer, req)
-	ch.Next(ctx)
+	writer := runStaleQueryWriter(c, req, downstream, ctx)
 	if !writer.Written() {
 		t.Fatal("query wrote no response")
 	}
@@ -129,6 +151,436 @@ func TestServeStaleOnFreshSERVFAIL(t *testing.T) {
 	}
 	if ede := dnsutil.GetEDE(resp); ede == nil || ede.InfoCode != dns.ExtendedErrorCodeStaleAnswer || ede.ExtraText != "Stale Answer" {
 		t.Fatalf("EDE = %+v, want code 3 Stale Answer", ede)
+	}
+}
+
+func TestServeStaleRateLimitsCachedFailureFallback(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, ServeStale: true, RateLimit: 1})
+	defer c.Stop()
+	req := new(dns.Msg)
+	req.SetQuestion("rate-cached-failure.stale.example.", dns.TypeA)
+	entry := seedStaleEntryWithRate(
+		t, c, staleTestAnswer(req, "192.0.2.80"), netip.Prefix{}, time.Second, time.Hour, 1,
+	)
+	limiter := entry.GetRateLimiter()
+	if limiter == nil {
+		t.Fatal("stale entry carries no rate limiter")
+	}
+	awaitToken(t, limiter)
+
+	failure := new(dns.Msg)
+	failure.SetRcode(req, dns.RcodeServerFailure)
+	c.store.RecordFailure(failure, netip.Prefix{}, FailureProvenance("test"), nil)
+	downstreamCalls := 0
+	downstream := middleware.HandlerFunc(func(_ context.Context, _ *middleware.Chain) {
+		downstreamCalls++
+	})
+
+	first := runStaleQueryWriter(c, req.Copy(), downstream, context.Background())
+	if !first.Written() || first.Rcode() != dns.RcodeSuccess {
+		t.Fatalf("first cached-failure fallback = written %v, rcode %s; want stale success",
+			first.Written(), dns.RcodeToString[first.Rcode()])
+	}
+	second := runStaleQueryWriter(c, req.Copy(), downstream, context.Background())
+	if second.Written() {
+		t.Fatalf("rate-limited cached-failure fallback wrote %s; want silent drop",
+			dns.RcodeToString[second.Rcode()])
+	}
+	if downstreamCalls != 0 {
+		t.Fatalf("cached failure reached downstream %d times, want 0", downstreamCalls)
+	}
+}
+
+func TestServeStaleRateLimitsFreshSERVFAILFallback(t *testing.T) {
+	rfc9520Disabled := false
+	c := New(&config.Config{
+		CacheSize:  1024,
+		ServeStale: true,
+		RateLimit:  1,
+		RFC9520:    &rfc9520Disabled,
+	})
+	defer c.Stop()
+	req := new(dns.Msg)
+	req.SetQuestion("rate-fresh-failure.stale.example.", dns.TypeA)
+	entry := seedStaleEntryWithRate(
+		t, c, staleTestAnswer(req, "192.0.2.81"), netip.Prefix{}, time.Second, time.Hour, 1,
+	)
+	limiter := entry.GetRateLimiter()
+	if limiter == nil {
+		t.Fatal("stale entry carries no rate limiter")
+	}
+	awaitToken(t, limiter)
+
+	downstreamCalls := 0
+	downstream := servfailHandler(&downstreamCalls)
+	first := runStaleQueryWriter(c, req.Copy(), downstream, context.Background())
+	if !first.Written() || first.Rcode() != dns.RcodeSuccess {
+		t.Fatalf("first fresh-SERVFAIL fallback = written %v, rcode %s; want stale success",
+			first.Written(), dns.RcodeToString[first.Rcode()])
+	}
+	second := runStaleQueryWriter(c, req.Copy(), downstream, context.Background())
+	if second.Written() {
+		t.Fatalf("rate-limited fresh-SERVFAIL fallback wrote %s; want silent drop",
+			dns.RcodeToString[second.Rcode()])
+	}
+	if downstreamCalls != 2 {
+		t.Fatalf("fresh resolution calls = %d, want 2", downstreamCalls)
+	}
+}
+
+func TestServeStaleRateLimitsDeadlineFallback(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, ServeStale: true, RateLimit: 1})
+	defer c.Stop()
+	req := new(dns.Msg)
+	req.SetQuestion("rate-deadline.stale.example.", dns.TypeA)
+	entry := seedStaleEntryWithRate(
+		t, c, staleTestAnswer(req, "192.0.2.82"), netip.Prefix{}, time.Second, time.Hour, 1,
+	)
+	limiter := entry.GetRateLimiter()
+	if limiter == nil {
+		t.Fatal("stale entry carries no rate limiter")
+	}
+	awaitToken(t, limiter)
+
+	downstreamCalls := 0
+	downstream := middleware.HandlerFunc(func(_ context.Context, _ *middleware.Chain) {
+		downstreamCalls++
+	})
+	deadlineCtx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-time.Second))
+	defer cancel()
+
+	first := runStaleQueryWriter(c, req.Copy(), downstream, deadlineCtx)
+	if !first.Written() || first.Rcode() != dns.RcodeSuccess {
+		t.Fatalf("first deadline fallback = written %v, rcode %s; want stale success",
+			first.Written(), dns.RcodeToString[first.Rcode()])
+	}
+	second := runStaleQueryWriter(c, req.Copy(), downstream, deadlineCtx)
+	if second.Written() {
+		t.Fatalf("rate-limited deadline fallback wrote %s; want silent drop",
+			dns.RcodeToString[second.Rcode()])
+	}
+	if downstreamCalls != 0 {
+		t.Fatalf("expired requests reached downstream %d times, want 0", downstreamCalls)
+	}
+}
+
+func TestServeStaleCompletesAliasChains(t *testing.T) {
+	tests := []struct {
+		name      string
+		question  string
+		target    string
+		outer     func(*dns.Msg) *dns.Msg
+		wantCNAME int
+		wantDNAME int
+	}{
+		{
+			name:     "CNAME",
+			question: "alias.stale.example.",
+			target:   "target.stale.example.",
+			outer: func(req *dns.Msg) *dns.Msg {
+				resp := new(dns.Msg)
+				resp.SetReply(req)
+				resp.Answer = []dns.RR{&dns.CNAME{
+					Hdr:    dns.RR_Header{Name: req.Question[0].Name, Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+					Target: "target.stale.example.",
+				}}
+				return resp
+			},
+			wantCNAME: 1,
+		},
+		{
+			name:     "DNAME without synthesized CNAME",
+			question: "host.alias.stale.example.",
+			target:   "host.target.stale.example.",
+			outer: func(req *dns.Msg) *dns.Msg {
+				resp := new(dns.Msg)
+				resp.SetReply(req)
+				resp.Answer = []dns.RR{&dns.DNAME{
+					Hdr:    dns.RR_Header{Name: "alias.stale.example.", Rrtype: dns.TypeDNAME, Class: dns.ClassINET, Ttl: 300},
+					Target: "target.stale.example.",
+				}}
+				return resp
+			},
+			wantCNAME: 1,
+			wantDNAME: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := New(&config.Config{CacheSize: 1024, ServeStale: true})
+			defer c.Stop()
+			req := new(dns.Msg)
+			req.SetQuestion(tt.question, dns.TypeA)
+			req.SetEdns0(1232, false)
+
+			targetReq := new(dns.Msg)
+			targetReq.SetQuestion(tt.target, dns.TypeA)
+			target := staleTestAnswer(targetReq, "192.0.2.70")
+			target.Answer[0].Header().Ttl = 2
+			queryer := &stubQueryer{responses: map[string]*dns.Msg{tt.target: target}}
+			c.SetQueryer(queryer)
+			seedStaleEntry(t, c, tt.outer(req), netip.Prefix{}, time.Second, time.Hour)
+
+			calls := 0
+			resp := runStaleQuery(t, c, req, servfailHandler(&calls), context.Background())
+			if calls != 1 || queryer.calls != 1 {
+				t.Fatalf("calls = downstream %d, alias target %d; want 1 each", calls, queryer.calls)
+			}
+			if resp.Rcode != dns.RcodeSuccess || answerA(resp) != "192.0.2.70" {
+				t.Fatalf("completed stale alias = rcode %s, answer %q; want terminal A",
+					dns.RcodeToString[resp.Rcode], answerA(resp))
+			}
+			var cnames, dnames int
+			for _, rr := range resp.Answer {
+				switch rr.Header().Rrtype {
+				case dns.TypeCNAME:
+					cnames++
+				case dns.TypeDNAME:
+					dnames++
+				}
+				if ttl := rr.Header().Ttl; ttl == 0 || ttl > 2 {
+					t.Fatalf("completed stale alias TTL = %d, want 1..2", ttl)
+				}
+			}
+			if cnames != tt.wantCNAME || dnames != tt.wantDNAME {
+				t.Fatalf("completed aliases = %d CNAME/%d DNAME, want %d/%d; answer=%v",
+					cnames, dnames, tt.wantCNAME, tt.wantDNAME, resp.Answer)
+			}
+			if ede := dnsutil.GetEDE(resp); ede == nil || ede.InfoCode != dns.ExtendedErrorCodeStaleAnswer {
+				t.Fatalf("completed stale alias EDE = %+v, want stale-answer", ede)
+			}
+		})
+	}
+}
+
+func TestServeStaleRejectsIncompleteAlias(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, ServeStale: true})
+	defer c.Stop()
+	req := new(dns.Msg)
+	req.SetQuestion("incomplete.stale.example.", dns.TypeA)
+	req.SetEdns0(1232, false)
+	outer := new(dns.Msg)
+	outer.SetReply(req)
+	outer.Answer = []dns.RR{&dns.CNAME{
+		Hdr:    dns.RR_Header{Name: req.Question[0].Name, Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+		Target: "missing.stale.example.",
+	}}
+	queryer := &stubQueryer{responses: map[string]*dns.Msg{}}
+	c.SetQueryer(queryer)
+	seedStaleEntry(t, c, outer, netip.Prefix{}, time.Second, time.Hour)
+
+	calls := 0
+	resp := runStaleQuery(t, c, req, servfailHandler(&calls), context.Background())
+	if resp.Rcode != dns.RcodeServerFailure || len(resp.Answer) != 0 {
+		t.Fatalf("incomplete alias response = rcode %s, answer %v; want original SERVFAIL",
+			dns.RcodeToString[resp.Rcode], resp.Answer)
+	}
+	if queryer.calls != 1 {
+		t.Fatalf("alias target calls = %d, want 1", queryer.calls)
+	}
+}
+
+func TestServeStaleCompletesCNAMEFromStaleTarget(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, ServeStale: true})
+	defer c.Stop()
+	const alias, target = "alias-to-stale.example.", "stale-terminal.example."
+
+	targetReq := new(dns.Msg)
+	targetReq.SetQuestion(target, dns.TypeA)
+	targetEntry := seedStaleEntryWithRate(
+		t, c, staleTestAnswer(targetReq, "192.0.2.74"), netip.Prefix{}, time.Second, 3*time.Second, 1,
+	)
+	targetEntry.cutKey = 0x87670002
+	targetLimiter := targetEntry.GetRateLimiter()
+	if targetLimiter == nil {
+		t.Fatal("stale alias target carries no rate limiter")
+	}
+	awaitToken(t, targetLimiter)
+	if !targetLimiter.Allow() {
+		t.Fatal("failed to drain stale alias target limiter")
+	}
+	targetCalls := 0
+	c.SetQueryer(&internalQueryer{handlers: []middleware.Handler{c, servfailHandler(&targetCalls)}})
+
+	req := new(dns.Msg)
+	req.SetQuestion(alias, dns.TypeA)
+	req.SetEdns0(1232, false)
+	outer := new(dns.Msg)
+	outer.SetReply(req)
+	outer.Answer = []dns.RR{&dns.CNAME{
+		Hdr:    dns.RR_Header{Name: alias, Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+		Target: target,
+	}}
+	seedStaleEntry(t, c, outer, netip.Prefix{}, time.Second, time.Hour)
+
+	outerCalls := 0
+	writer := mock.NewWriter("udp", "192.0.2.1:53000")
+	ch := middleware.NewChain([]middleware.Handler{c, servfailHandler(&outerCalls)})
+	ch.Reset(writer, req)
+	ch.Next(context.Background())
+	if !writer.Written() {
+		t.Fatal("stale-to-stale alias wrote no response")
+	}
+	resp := writer.Msg()
+	if outerCalls != 1 || targetCalls != 1 {
+		t.Fatalf("resolution calls = outer %d, target %d; want 1 each", outerCalls, targetCalls)
+	}
+	if resp.Rcode != dns.RcodeSuccess || answerA(resp) != "192.0.2.74" || len(resp.Answer) != 2 {
+		t.Fatalf("stale-to-stale alias response = rcode %s, answer %v; want CNAME + terminal A",
+			dns.RcodeToString[resp.Rcode], resp.Answer)
+	}
+	for _, rr := range resp.Answer {
+		if ttl := rr.Header().Ttl; ttl == 0 || ttl > 3 {
+			t.Fatalf("stale target lifetime was not folded into alias TTL: %d", ttl)
+		}
+	}
+	if cut, key := ch.Meta.Cut(); cut.IsZero() || cut.After(targetEntry.cutUntil) {
+		t.Fatalf("composed stale alias bound = (%v, %#x), must not outlive target (%v, %#x)",
+			cut, key, targetEntry.cutUntil, targetEntry.cutKey)
+	}
+}
+
+func TestServeStaleRejectsCNAMETerminatingInNODATA(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, ServeStale: true})
+	defer c.Stop()
+	const alias, target = "alias-to-nodata.example.", "nodata-terminal.example."
+
+	req := new(dns.Msg)
+	req.SetQuestion(alias, dns.TypeA)
+	req.SetEdns0(1232, false)
+	outer := new(dns.Msg)
+	outer.SetReply(req)
+	outer.Answer = []dns.RR{&dns.CNAME{
+		Hdr:    dns.RR_Header{Name: alias, Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+		Target: target,
+	}}
+	seedStaleEntry(t, c, outer, netip.Prefix{}, time.Second, time.Hour)
+
+	targetReq := new(dns.Msg)
+	targetReq.SetQuestion(target, dns.TypeA)
+	nodata := new(dns.Msg)
+	nodata.SetReply(targetReq)
+	nodata.Ns = []dns.RR{&dns.SOA{
+		Hdr:     dns.RR_Header{Name: "example.", Rrtype: dns.TypeSOA, Class: dns.ClassINET, Ttl: 300},
+		Ns:      "ns.example.",
+		Mbox:    "hostmaster.example.",
+		Serial:  1,
+		Refresh: 3600,
+		Retry:   600,
+		Expire:  86400,
+		Minttl:  300,
+	}}
+	c.SetQueryer(&stubQueryer{responses: map[string]*dns.Msg{target: nodata}})
+
+	calls := 0
+	resp := runStaleQuery(t, c, req, servfailHandler(&calls), context.Background())
+	if resp.Rcode != dns.RcodeServerFailure || len(resp.Answer) != 0 {
+		t.Fatalf("stale alias NODATA response = rcode %s, answer %v; want original SERVFAIL",
+			dns.RcodeToString[resp.Rcode], resp.Answer)
+	}
+}
+
+func TestServeStaleRejectsOriginallyZeroTTL(t *testing.T) {
+	t.Run("retained answer", func(t *testing.T) {
+		c := New(&config.Config{CacheSize: 1024, ServeStale: true})
+		defer c.Stop()
+		req := new(dns.Msg)
+		req.SetQuestion("zero.stale.example.", dns.TypeA)
+		req.SetEdns0(1232, false)
+		answer := staleTestAnswer(req, "192.0.2.71")
+		answer.Answer[0].Header().Ttl = 0
+		seedStaleEntry(t, c, answer, netip.Prefix{}, time.Second, time.Hour)
+
+		calls := 0
+		resp := runStaleQuery(t, c, req, servfailHandler(&calls), context.Background())
+		if resp.Rcode != dns.RcodeServerFailure {
+			t.Fatalf("zero-TTL stale response rcode = %s, want SERVFAIL", dns.RcodeToString[resp.Rcode])
+		}
+	})
+
+	t.Run("alias terminal", func(t *testing.T) {
+		c := New(&config.Config{CacheSize: 1024, ServeStale: true})
+		defer c.Stop()
+		req := new(dns.Msg)
+		req.SetQuestion("zero-target.stale.example.", dns.TypeA)
+		req.SetEdns0(1232, false)
+		outer := new(dns.Msg)
+		outer.SetReply(req)
+		outer.Answer = []dns.RR{&dns.CNAME{
+			Hdr:    dns.RR_Header{Name: req.Question[0].Name, Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+			Target: "terminal-zero.stale.example.",
+		}}
+		targetReq := new(dns.Msg)
+		targetReq.SetQuestion("terminal-zero.stale.example.", dns.TypeA)
+		target := staleTestAnswer(targetReq, "192.0.2.72")
+		target.Answer[0].Header().Ttl = 0
+		c.SetQueryer(&stubQueryer{responses: map[string]*dns.Msg{
+			"terminal-zero.stale.example.": target,
+		}})
+		seedStaleEntry(t, c, outer, netip.Prefix{}, time.Second, time.Hour)
+
+		calls := 0
+		resp := runStaleQuery(t, c, req, servfailHandler(&calls), context.Background())
+		if resp.Rcode != dns.RcodeServerFailure || len(resp.Answer) != 0 {
+			t.Fatalf("zero-TTL terminal response = rcode %s, answer %v; want original SERVFAIL",
+				dns.RcodeToString[resp.Rcode], resp.Answer)
+		}
+	})
+
+	t.Run("fresh cached alias terminal", func(t *testing.T) {
+		c := New(&config.Config{CacheSize: 1024, ServeStale: true})
+		defer c.Stop()
+		const alias, targetName = "cached-zero-target.stale.example.", "cached-terminal-zero.stale.example."
+
+		targetReq := new(dns.Msg)
+		targetReq.SetQuestion(targetName, dns.TypeA)
+		target := staleTestAnswer(targetReq, "192.0.2.75")
+		target.Answer[0].Header().Ttl = 0
+		c.store.SetFromResponse(target, false, time.Time{})
+		targetKey := CacheKey{Question: targetReq.Question[0]}.Hash()
+		if entry, ok := c.store.LookupByKey(targetKey); !ok || entry.remaining(time.Now()) <= 0 {
+			t.Fatal("zero-TTL target was not admitted under the existing minimum TTL floor")
+		}
+		targetCalls := 0
+		c.SetQueryer(&internalQueryer{handlers: []middleware.Handler{c, servfailHandler(&targetCalls)}})
+
+		req := new(dns.Msg)
+		req.SetQuestion(alias, dns.TypeA)
+		req.SetEdns0(1232, false)
+		outer := new(dns.Msg)
+		outer.SetReply(req)
+		outer.Answer = []dns.RR{&dns.CNAME{
+			Hdr:    dns.RR_Header{Name: alias, Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+			Target: targetName,
+		}}
+		seedStaleEntry(t, c, outer, netip.Prefix{}, time.Second, time.Hour)
+
+		outerCalls := 0
+		resp := runStaleQuery(t, c, req, servfailHandler(&outerCalls), context.Background())
+		if resp.Rcode != dns.RcodeServerFailure || len(resp.Answer) != 0 {
+			t.Fatalf("cached zero-TTL terminal response = rcode %s, answer %v; want original SERVFAIL",
+				dns.RcodeToString[resp.Rcode], resp.Answer)
+		}
+		if targetCalls != 1 {
+			t.Fatalf("zero-TTL cached target reached fallback %d times, want 1", targetCalls)
+		}
+	})
+}
+
+func TestServeStaleRejectsSubsecondDelegationLease(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, ServeStale: true})
+	defer c.Stop()
+	req := new(dns.Msg)
+	req.SetQuestion("subsecond-lease.stale.example.", dns.TypeA)
+	req.SetEdns0(1232, false)
+	seedStaleEntry(t, c, staleTestAnswer(req, "192.0.2.73"), netip.Prefix{}, time.Second, 500*time.Millisecond)
+
+	calls := 0
+	resp := runStaleQuery(t, c, req, servfailHandler(&calls), context.Background())
+	if resp.Rcode != dns.RcodeServerFailure || len(resp.Answer) != 0 {
+		t.Fatalf("subsecond-lease response = rcode %s, answer %v; want original SERVFAIL",
+			dns.RcodeToString[resp.Rcode], resp.Answer)
 	}
 }
 
@@ -411,7 +863,7 @@ func TestServeStalePreservesECSAudience(t *testing.T) {
 	seedStaleEntry(t, c, staleTestAnswer(req, "192.0.2.50"), netip.Prefix{}, time.Second, time.Hour)
 	seedStaleEntry(t, c, staleTestAnswer(req, "192.0.2.51"), scope, time.Second, time.Hour)
 
-	resp, _ := c.staleResponse(req, false, client)
+	resp, _ := c.staleResponse(context.Background(), req, false, client)
 	if resp == nil {
 		t.Fatal("scoped stale candidate was not selected")
 	}
@@ -449,7 +901,7 @@ func TestScopedLookupFreshWiderScopeBeatsExpiredNarrowScope(t *testing.T) {
 		t.Fatalf("scoped hit answer = %q, want fresh /24 answer 192.0.2.61", got)
 	}
 
-	if stale, _ := c.staleResponse(req, false, client); stale != nil {
+	if stale, _ := c.staleResponse(context.Background(), req, false, client); stale != nil {
 		t.Fatal("expired /26 was selected although a fresh /24 existed")
 	}
 }
@@ -604,7 +1056,7 @@ func TestServeStaleReadPreservesPrefetchCAS(t *testing.T) {
 	req.SetQuestion("refresh.example.", dns.TypeA)
 	entry := seedStaleEntry(t, c, staleTestAnswer(req, "192.0.2.53"), netip.Prefix{}, time.Second, time.Hour)
 
-	if resp, got := c.staleResponse(req, false, netip.Prefix{}); resp == nil || got != entry {
+	if resp, got := c.staleResponse(context.Background(), req, false, netip.Prefix{}); resp == nil || got != entry {
 		t.Fatal("stale read did not return the retained entry")
 	}
 	key := CacheKey{Question: req.Question[0], CD: false}.Hash()


### PR DESCRIPTION
Follow-up to #588. Two gaps that pass left open.

## Alias completion

An entry whose answer stops at a CNAME was served flat, so a client asking for an address could get NOERROR carrying nothing but an alias — legal DNS, useless answer. The chain is now completed the way an ordinary cache hit completes one, reusing the existing chase along with its depth and loop bounds. A chain that cannot be completed is refused rather than shipped half-built.

The lifetime composition is the part worth reviewing closely:

- completion runs on a **forked cut** seeded with the stale entry's own bound, so only the records actually merged into the answer contribute their lifetime;
- the composed response then gets a single TTL that cannot outlive any part of it — the shortest of every lineage bound the chase accumulated and the shortest terminal record it merged;
- records the zone published with a zero TTL are kept out of a stale response, as RFC 8767 requires;
- the byte-serving fast path stands aside during a chase so the body can be inspected.

## Rate limiting

A stale answer is still a cache answer, so an external query pays the same entry-local token an ordinary hit pays, with the same silent-drop behaviour on refusal. Internal alias legs are exempt — charging the target would either bill one client question twice or leave the outer answer with a partial chain.

All three failure seams now commit through a single place instead of three copies of the same lines.

## Verification

`make test`, `go test -race ./middleware/cache`, `go vet ./...`, `golangci-lint run`, `gofmt` all clean. 27 serve-stale tests.

Mutation-tested, each confirmed to turn a named test red: accepting an incomplete alias chain (`TestServeStaleRejectsIncompleteAlias`), dropping the terminal-record TTL from the composed bound (`TestServeStaleCompletesAliasChains`), and skipping the limiter for an external stale answer (`TestServeStaleRateLimitsCachedFailureFallback`). Mutations that failed to compile were not counted as evidence.

One guard is deliberately noted as unpinned: removing the depth check in `completeStaleAlias` leaves the suite green. It is redundancy rather than a hole — the underlying chase keeps its own loop check and the depth counter still propagates — but it has no test of its own.

## Known behaviour worth a conscious sign-off

Alias completion resolves the target through `internalExchange`, which can attempt upstream resolution when the target is not cached — precisely when upstream is failing. It is bounded by the shared work ledgers and the depth counter, and in the deadline case the context is already expired so it fails fast, but it can add latency to a stale answer during an outage.