### PR TITLE
test: draw a root test key again when its tag lands on zero

### DIFF
--- a/middleware/resolver/localroot/roottest/roottest.go
+++ b/middleware/resolver/localroot/roottest/roottest.go
@@ -9,11 +9,16 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"time"
 
 	"github.com/miekg/dns"
 )
+
+// errZeroKeyTag reports that key generation kept producing the one tag value
+// a signer refuses. Reaching it means the generator is not random.
+var errZeroKeyTag = errors.New("roottest: could not generate a key with a non-zero tag")
 
 // Serial is the zone serial every default-built zone carries.
 const Serial = 2026082401
@@ -59,17 +64,29 @@ func Build(digest func(rrs []dns.RR, apex string) ([]byte, error)) (*Zone, error
 // BuildZone assembles and seals a zone from the given body lines, whose SOA
 // must carry serial, under a freshly generated key.
 func BuildZone(digest func(rrs []dns.RR, apex string) ([]byte, error), lines []string, serial uint32) (*Zone, error) {
-	key := &dns.DNSKEY{
-		Hdr:       dns.RR_Header{Name: ".", Rrtype: dns.TypeDNSKEY, Class: dns.ClassINET, Ttl: 172800},
-		Flags:     257,
-		Protocol:  3,
-		Algorithm: dns.ECDSAP256SHA256,
+	// A key tag is a checksum over the key's own bytes, so roughly one
+	// generated key in 65536 lands on zero — and miekg's signer rejects a
+	// zero tag outright ("dns: bad key"), which surfaced as a rare, entirely
+	// unrelated-looking test failure. Draw again rather than sign with it.
+	// The loop is bounded: it can only repeat if the generator keeps landing
+	// on that one value out of 65536.
+	for range 8 {
+		key := &dns.DNSKEY{
+			Hdr:       dns.RR_Header{Name: ".", Rrtype: dns.TypeDNSKEY, Class: dns.ClassINET, Ttl: 172800},
+			Flags:     257,
+			Protocol:  3,
+			Algorithm: dns.ECDSAP256SHA256,
+		}
+		priv, err := key.Generate(256)
+		if err != nil {
+			return nil, err
+		}
+		if key.KeyTag() == 0 {
+			continue
+		}
+		return BuildZoneWithKey(digest, lines, serial, key, priv)
 	}
-	priv, err := key.Generate(256)
-	if err != nil {
-		return nil, err
-	}
-	return BuildZoneWithKey(digest, lines, serial, key, priv)
+	return nil, errZeroKeyTag
 }
 
 // BuildZoneWithKey is BuildZone under an existing key, so a test can produce


### PR DESCRIPTION
A DNSKEY's key tag is a checksum over the key's own bytes, so roughly one generated key in 65536 comes out as zero. miekg's signer refuses a zero tag outright (`signAsIs` returns `ErrKey` — "dns: bad key"), and the zone builder every local-root test depends on generates a fresh key per zone.

The result was a rare CI failure in whichever test happened to draw the unlucky key, reported as `build zone: dns: bad key` with no connection to what that test was actually checking. It hit `TestLocalRootLeaseBoundedBySecurityEvidence` on a recent run; the same draw would have failed any of the local-root tests equally.

The builder now draws again rather than signing with a zero-tag key.

**No regression test.** The trigger is one value out of 65536 from a `crypto/rand` generator — a test could neither force it nor reasonably be expected to catch its return, and one that "passed" would be proving nothing.

Test-only change; no production code is touched.