### PR TITLE
config/forwarder: send one zone to its own upstreams

### DIFF
--- a/README.md
+++ b/README.md
@@ -482,7 +482,9 @@ servers = ["10.0.1.53:53"]
 
 *   **The most specific zone wins.** A query for `host.lab.corp.example.` goes to `10.0.1.53`, not to the wider `corp.example.` upstreams.
 *   **Servers take the same formats as `forwarderservers`** — plain, `tls://`, and `https://` — so a zone can be forwarded over DoT or DoH.
-*   **A zone with no usable server is ignored**, and its subtree resolves normally. A configuration mistake costs you the forwarding, not the whole subtree.
+*   **A zone must name itself and at least one server.** Startup fails otherwise — an omitted `name` canonicalizes to the root, which would quietly forward *every* query and give up local recursion and DNSSEC for everything. Forwarding the root is a real choice, but it has to be written as `name = "."`.
+*   **A zone whose upstreams all turn out unusable fails its queries** rather than borrowing `forwarderservers`. Those are public upstreams, and sending an internal zone's questions there is exactly the leak the zone was configured to prevent.
+*   **Cached public denials do not shadow a forward zone.** An RFC 8020 subtree cut, aggressive denial or authority failure learned while the name resolved publicly is skipped for a forwarded zone — otherwise a name that does not exist publicly, which is the whole point of an internal zone, would stay NXDOMAIN until the cut expired.
 *   **Queries go out with RD=1.** This is forwarding as RFC 8499 §6 defines it: the upstream must be a recursive resolver that answers on your behalf, not the zone's authoritative servers.
 
 > **A forwarded zone is not validated here.** Answers carry whatever the upstream asserted, exactly as in whole-server forwarder mode, and they never enter the RFC 8020/8198 shared denial state — that admission requires proof this resolver validated itself. Pointing a signed public zone at an upstream therefore gives up local DNSSEC validation for it. The intended use is the opposite case: an internal zone the public namespace cannot resolve at all.

--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ example.com.		0	CH	HINFO	"Host" "IPv6:[2001:500:8d::53]:53 rtt:148ms health:[GOO
 | **[recursion_firewall]** | Request-tree work budgets (outbound/internal queries, DNSSEC operations) with off/shadow/enforce modes, plus RFC 9520 failure-cache tuning. See the Recursion Firewall section below |
 | **rootkeys**         | DNSSEC root zone trust anchors in DNSKEY format                                                                     |
 | **fallbackservers**  | Upstream DNS servers used when all others fail. Format: "IP:port" (e.g., "8.8.8.8:53")                             |
+| **[[forward_zone]]** | Per-zone forwarding: `name` plus `servers` sends that zone's queries to its own recursive upstreams while everything else resolves normally. Most specific zone wins. Servers accept the same formats as **forwarderservers**. A forwarded zone is not validated locally — see [Per-zone forwarding](#per-zone-forwarding) |
 | **forwarderservers** | Forward all queries to these DNS servers. Accepts `IP:port` (plain UDP/TCP), `tls://IP:port` (DoT, RFC 7858), or `https://host/dns-query` (DoH, RFC 8484; hostname or IP literal). See [Forwarder upstreams](#forwarder-upstreams) for details. |
 | **api**              | HTTP API server binding address for statistics and control. Leave empty to disable                                  |
 | **bearertoken**      | API bearer token for authorization. If set, Authorization header must be included in API requests                   |
@@ -464,6 +465,27 @@ DoH notes:
 *   POST + `application/dns-message` per RFC 8484, HTTP/2 with connection reuse. The TLS `ServerName` is set to the URL hostname so cert validation works correctly when dialing IPs.
 *   Bootstrap failure (NXDOMAIN, timeout, no addresses) is logged and the entry is skipped — startup continues with whatever upstreams remain usable.
 *   Timeouts come from the existing top-level config: `querytimeout` caps the **total time** the forwarder spends across every configured upstream (default 10s — applies to UDP, DoT, and DoH alike so three slow upstreams can't take 3 × per-call timeout), `timeout` bounds each per-IP TCP dial inside one DoH attempt (default 2s) so a blackholed pinned address bypasses to the next one without consuming the request budget. Consecutive dial attempts rotate the starting IP so a single bad address can't pin the rotation. Response TXIDs are validated (echo of the request ID or 0 per RFC 8484 §4.1). The existing `dns_forwarder_failures_total` and `dns_forwarder_response_mismatch_total` metrics cover DoH paths too.
+
+#### Per-zone forwarding
+
+`forwarderservers` turns the whole server into a forwarder. `[[forward_zone]]` is the narrow version: one zone goes to its own upstreams while everything else still resolves recursively.
+
+```toml
+[[forward_zone]]
+name = "corp.example."
+servers = ["10.0.0.53:53", "tls://10.0.0.54:853"]
+
+[[forward_zone]]
+name = "lab.corp.example."
+servers = ["10.0.1.53:53"]
+```
+
+*   **The most specific zone wins.** A query for `host.lab.corp.example.` goes to `10.0.1.53`, not to the wider `corp.example.` upstreams.
+*   **Servers take the same formats as `forwarderservers`** — plain, `tls://`, and `https://` — so a zone can be forwarded over DoT or DoH.
+*   **A zone with no usable server is ignored**, and its subtree resolves normally. A configuration mistake costs you the forwarding, not the whole subtree.
+*   **Queries go out with RD=1.** This is forwarding as RFC 8499 §6 defines it: the upstream must be a recursive resolver that answers on your behalf, not the zone's authoritative servers.
+
+> **A forwarded zone is not validated here.** Answers carry whatever the upstream asserted, exactly as in whole-server forwarder mode, and they never enter the RFC 8020/8198 shared denial state — that admission requires proof this resolver validated itself. Pointing a signed public zone at an upstream therefore gives up local DNSSEC validation for it. The intended use is the opposite case: an internal zone the public namespace cannot resolve at all.
 
 ### External Plugins
 

--- a/config/config.go
+++ b/config/config.go
@@ -240,6 +240,36 @@ type ForwardZoneConfig struct {
 	Servers []string `toml:"servers"`
 }
 
+// validateForwardZones refuses a forward zone the operator cannot have meant.
+//
+// An omitted name is the dangerous one: it canonicalizes to the root, and a
+// root forward zone matches every question — so a block that named only its
+// servers would silently turn the whole resolver into a forwarder and give up
+// local recursion and DNSSEC for everything. Forwarding the root is a real
+// choice, but it has to be written as one.
+//
+// A zone with no server is refused for the opposite reason: it would be
+// skipped at match time, so its subtree would resolve publicly. For an
+// internal zone that is not a harmless no-op, it is the leak the zone was
+// configured to prevent. Better to fail at startup, where it is visible.
+func (c *Config) validateForwardZones() error {
+	for i := range c.ForwardZones {
+		zone := &c.ForwardZones[i]
+		if strings.TrimSpace(zone.Name) == "" {
+			return fmt.Errorf(
+				"forward_zone %d has no name; use name = \".\" to forward every query", i+1,
+			)
+		}
+		if _, ok := dns.IsDomainName(zone.Name); !ok {
+			return fmt.Errorf("forward_zone %q is not a valid domain name", zone.Name)
+		}
+		if len(zone.Servers) == 0 {
+			return fmt.Errorf("forward_zone %q has no servers", zone.Name)
+		}
+	}
+	return nil
+}
+
 // ForwardZoneFor returns the most specific configured forward zone covering
 // qname, or nil when the query resolves normally. Most specific wins so a
 // narrower zone can be pointed somewhere else than the one containing it.
@@ -1357,6 +1387,9 @@ func Load(cfgfile, version string) (*Config, error) {
 	config.RecursionFirewall.Normalize()
 	if err := config.RecursionFirewall.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid recursion firewall config: %w", err)
+	}
+	if err := config.validateForwardZones(); err != nil {
+		return nil, err
 	}
 	if config.ServeStaleMaxTTL.Duration < 0 {
 		return nil, fmt.Errorf("serve_stale_max_ttl must not be negative")

--- a/config/config.go
+++ b/config/config.go
@@ -274,9 +274,12 @@ func (c *Config) validateForwardZones() error {
 // qname, or nil when the query resolves normally. Most specific wins so a
 // narrower zone can be pointed somewhere else than the one containing it.
 //
-// A zone with no usable upstream is skipped rather than matched: a match with
-// nowhere to send the query would turn a configuration mistake into SERVFAIL
-// for the whole subtree, where falling through resolves it.
+// A zone carrying no servers at all is skipped, but only as a guard for a
+// Config built in code: validateForwardZones refuses one at startup, because
+// letting its subtree resolve publicly is the leak configuring the zone was
+// meant to prevent. A zone whose servers are configured but turn out
+// unusable still matches here, and the forwarder fails those queries rather
+// than sending them to the public upstreams.
 //
 // The scan is linear because a forward-zone list is a handful of entries an
 // operator wrote by hand; an index would cost more to keep honest than it
@@ -755,9 +758,12 @@ forwarderservers = [
 # resolves recursively. This is forwarding in the RFC 8499 sense — the query
 # goes out with RD=1 to a resolver that answers on our behalf — so the
 # upstreams must be recursive resolvers, not the zone's authoritative servers.
-# The most specific matching zone wins, and a zone with no usable server is
-# ignored rather than failing its whole subtree. Servers take the same forms
-# as forwarderservers, so DoT and DoH work per zone too.
+# The most specific matching zone wins. A zone must name itself and at least
+# one server or startup fails — an omitted name would forward every query —
+# and a zone whose upstreams all turn out unusable fails its queries rather
+# than borrowing forwarderservers, which would send an internal zone's
+# questions to public resolvers. Servers take the same forms as
+# forwarderservers, so DoT and DoH work per zone too.
 #
 # A forwarded zone is NOT validated here: answers carry whatever the upstream
 # asserted, exactly as in whole-server forwarder mode. Pointing a signed

--- a/config/config.go
+++ b/config/config.go
@@ -44,34 +44,38 @@ type Config struct {
 	RootKeys         []string
 	FallbackServers  []string
 	ForwarderServers []string
-	AccessList       []string
-	LogLevel         string
-	AccessLog        string
-	Bind             string
-	BindTLS          string
-	BindDOH          string
-	BindDOQ          string
-	TLSCertificate   string
-	TLSPrivateKey    string
-	API              string
-	BearerToken      string //nolint:gosec // G117 - not a hardcoded credential, loaded from config file
-	Nullroute        string
-	Nullroutev6      string
-	HostsFile        string
-	OutboundIPs      []string
-	OutboundIP6s     []string
-	Timeout          Duration
-	QueryTimeout     Duration
-	Expire           uint32
-	CacheSize        int
-	Prefetch         uint32
-	Maxdepth         int
-	RateLimit        int
-	ClientRateLimit  int
-	NSID             string
-	Blocklist        []string
-	Whitelist        []string
-	Chaos            bool
+	// ForwardZones route individual zones to their own upstreams. They are
+	// consulted before ForwarderServers, which remains the whole-server
+	// setting: a query matching no zone resolves normally.
+	ForwardZones    []ForwardZoneConfig `toml:"forward_zone"`
+	AccessList      []string
+	LogLevel        string
+	AccessLog       string
+	Bind            string
+	BindTLS         string
+	BindDOH         string
+	BindDOQ         string
+	TLSCertificate  string
+	TLSPrivateKey   string
+	API             string
+	BearerToken     string //nolint:gosec // G117 - not a hardcoded credential, loaded from config file
+	Nullroute       string
+	Nullroutev6     string
+	HostsFile       string
+	OutboundIPs     []string
+	OutboundIP6s    []string
+	Timeout         Duration
+	QueryTimeout    Duration
+	Expire          uint32
+	CacheSize       int
+	Prefetch        uint32
+	Maxdepth        int
+	RateLimit       int
+	ClientRateLimit int
+	NSID            string
+	Blocklist       []string
+	Whitelist       []string
+	Chaos           bool
 	// QnameMinLevel is deprecated and retained so older configs keep
 	// parsing. It capped minimization by delegation depth rather than by
 	// the queries a lookup spends, which is what RFC 9156 section 2.3
@@ -214,6 +218,63 @@ type ViewConfig struct {
 	Zone     string
 	Networks []string
 	Answers  []string
+}
+
+// ForwardZoneConfig sends one zone's queries to named recursive upstreams
+// instead of resolving them from the root.
+//
+// This is forwarding in the RFC 8499 §6 sense — the query goes out with RD=1
+// to a server that resolves on our behalf — not a stub zone, which points at
+// a zone's own authoritative servers with RD=0.
+//
+// A forwarded zone is not validated here. Answers carry whatever the upstream
+// asserted, exactly as in whole-server forwarder mode, so pointing a signed
+// public zone at an upstream silently gives up local DNSSEC validation for it.
+// The intended use is the opposite case: an internal zone the public namespace
+// cannot resolve at all.
+type ForwardZoneConfig struct {
+	// Name is the zone apex. Queries at or below it are forwarded.
+	Name string `toml:"name"`
+	// Servers are the upstreams, in the same forms as forwarderservers:
+	// "ip:port", "tls://ip:port", or an https:// URL.
+	Servers []string `toml:"servers"`
+}
+
+// ForwardZoneFor returns the most specific configured forward zone covering
+// qname, or nil when the query resolves normally. Most specific wins so a
+// narrower zone can be pointed somewhere else than the one containing it.
+//
+// A zone with no usable upstream is skipped rather than matched: a match with
+// nowhere to send the query would turn a configuration mistake into SERVFAIL
+// for the whole subtree, where falling through resolves it.
+//
+// The scan is linear because a forward-zone list is a handful of entries an
+// operator wrote by hand; an index would cost more to keep honest than it
+// saves.
+func (c *Config) ForwardZoneFor(qname string) *ForwardZoneConfig {
+	if c == nil || len(c.ForwardZones) == 0 || qname == "" {
+		return nil
+	}
+	qname = dns.CanonicalName(qname)
+
+	var (
+		best     *ForwardZoneConfig
+		bestApex string
+	)
+	for i := range c.ForwardZones {
+		zone := &c.ForwardZones[i]
+		if len(zone.Servers) == 0 {
+			continue
+		}
+		apex := dns.CanonicalName(zone.Name)
+		if !dns.IsSubDomain(apex, qname) {
+			continue
+		}
+		if best == nil || dns.CountLabel(apex) > dns.CountLabel(bestApex) {
+			best, bestApex = zone, apex
+		}
+	}
+	return best
 }
 
 // KubernetesConfig holds Kubernetes middleware configuration
@@ -658,6 +719,25 @@ forwarderservers = [
     # "https://1.1.1.1/dns-query",           # DoH, IP literal
     # "https://cloudflare-dns.com/dns-query" # DoH, hostname (system-resolver bootstrap)
 ]
+
+# Per-zone forwarding
+# Sends one zone's queries to its own upstreams while everything else still
+# resolves recursively. This is forwarding in the RFC 8499 sense — the query
+# goes out with RD=1 to a resolver that answers on our behalf — so the
+# upstreams must be recursive resolvers, not the zone's authoritative servers.
+# The most specific matching zone wins, and a zone with no usable server is
+# ignored rather than failing its whole subtree. Servers take the same forms
+# as forwarderservers, so DoT and DoH work per zone too.
+#
+# A forwarded zone is NOT validated here: answers carry whatever the upstream
+# asserted, exactly as in whole-server forwarder mode. Pointing a signed
+# public zone at an upstream therefore gives up local DNSSEC validation for
+# it. The intended use is the opposite case — an internal zone the public
+# namespace cannot resolve at all.
+#
+# [[forward_zone]]
+# name = "corp.example."
+# servers = ["10.0.0.53:53", "tls://10.0.0.54:853"]
 
 # ============================
 # API and Logging

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1248,3 +1248,26 @@ func TestForwardZoneRootMatchesEverything(t *testing.T) {
 		t.Fatal("a root forward zone did not match")
 	}
 }
+
+func TestValidateForwardZones(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		zones   []ForwardZoneConfig
+		wantErr bool
+	}{
+		{"valid", []ForwardZoneConfig{{Name: "corp.example.", Servers: []string{"10.0.0.53:53"}}}, false},
+		{"explicit root is allowed", []ForwardZoneConfig{{Name: ".", Servers: []string{"10.0.0.53:53"}}}, false},
+		// An omitted name canonicalizes to the root and would forward every
+		// query, silently giving up recursion and DNSSEC for everything.
+		{"missing name", []ForwardZoneConfig{{Servers: []string{"10.0.0.53:53"}}}, true},
+		{"blank name", []ForwardZoneConfig{{Name: "   ", Servers: []string{"10.0.0.53:53"}}}, true},
+		{"no servers", []ForwardZoneConfig{{Name: "corp.example."}}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := (&Config{ForwardZones: tc.zones}).validateForwardZones()
+			if tc.wantErr != (err != nil) {
+				t.Fatalf("validateForwardZones() error = %v, wantErr %v", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1198,3 +1198,53 @@ func TestLoadGeneratesAConfigAtACustomPath(t *testing.T) {
 		t.Fatalf("reload: %v", err)
 	}
 }
+
+func TestForwardZoneFor(t *testing.T) {
+	cfg := &Config{ForwardZones: []ForwardZoneConfig{
+		{Name: "corp.example.", Servers: []string{"10.0.0.53:53"}},
+		{Name: "lab.corp.example.", Servers: []string{"10.0.1.53:53"}},
+		{Name: "empty.example.", Servers: nil},
+	}}
+
+	for _, tc := range []struct {
+		name  string
+		qname string
+		want  string
+	}{
+		{"exact apex", "corp.example.", "corp.example."},
+		{"below the apex", "host.corp.example.", "corp.example."},
+		{"most specific zone wins", "host.lab.corp.example.", "lab.corp.example."},
+		{"case insensitive", "HOST.Corp.Example.", "corp.example."},
+		{"unrelated name", "example.net.", ""},
+		{"parent of a zone is not in it", "example.", ""},
+		// A zone with no usable upstream must not match: matching it would
+		// turn a config mistake into SERVFAIL for the whole subtree.
+		{"serverless zone is skipped", "host.empty.example.", ""},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			zone := cfg.ForwardZoneFor(tc.qname)
+			got := ""
+			if zone != nil {
+				got = zone.Name
+			}
+			if got != tc.want {
+				t.Fatalf("ForwardZoneFor(%q) = %q, want %q", tc.qname, got, tc.want)
+			}
+		})
+	}
+
+	if (&Config{}).ForwardZoneFor("anything.") != nil {
+		t.Fatal("a config with no forward zones matched a name")
+	}
+}
+
+func TestForwardZoneRootMatchesEverything(t *testing.T) {
+	// A zone of "." is a legitimate way to say "forward all of it", and it
+	// must not be special-cased away.
+	cfg := &Config{ForwardZones: []ForwardZoneConfig{
+		{Name: ".", Servers: []string{"10.0.0.53:53"}},
+	}}
+	if cfg.ForwardZoneFor("anything.example.") == nil {
+		t.Fatal("a root forward zone did not match")
+	}
+}

--- a/contrib/linux/sdns.conf
+++ b/contrib/linux/sdns.conf
@@ -180,6 +180,25 @@ forwarderservers = [
     # "https://cloudflare-dns.com/dns-query" # DoH, hostname (system-resolver bootstrap)
 ]
 
+# Per-zone forwarding
+# Sends one zone's queries to its own upstreams while everything else still
+# resolves recursively. This is forwarding in the RFC 8499 sense — the query
+# goes out with RD=1 to a resolver that answers on our behalf — so the
+# upstreams must be recursive resolvers, not the zone's authoritative servers.
+# The most specific matching zone wins, and a zone with no usable server is
+# ignored rather than failing its whole subtree. Servers take the same forms
+# as forwarderservers, so DoT and DoH work per zone too.
+#
+# A forwarded zone is NOT validated here: answers carry whatever the upstream
+# asserted, exactly as in whole-server forwarder mode. Pointing a signed
+# public zone at an upstream therefore gives up local DNSSEC validation for
+# it. The intended use is the opposite case — an internal zone the public
+# namespace cannot resolve at all.
+#
+# [[forward_zone]]
+# name = "corp.example."
+# servers = ["10.0.0.53:53", "tls://10.0.0.54:853"]
+
 # ============================
 # API and Logging
 # ============================

--- a/contrib/linux/sdns.conf
+++ b/contrib/linux/sdns.conf
@@ -185,9 +185,12 @@ forwarderservers = [
 # resolves recursively. This is forwarding in the RFC 8499 sense — the query
 # goes out with RD=1 to a resolver that answers on our behalf — so the
 # upstreams must be recursive resolvers, not the zone's authoritative servers.
-# The most specific matching zone wins, and a zone with no usable server is
-# ignored rather than failing its whole subtree. Servers take the same forms
-# as forwarderservers, so DoT and DoH work per zone too.
+# The most specific matching zone wins. A zone must name itself and at least
+# one server or startup fails — an omitted name would forward every query —
+# and a zone whose upstreams all turn out unusable fails its queries rather
+# than borrowing forwarderservers, which would send an internal zone's
+# questions to public resolvers. Servers take the same forms as
+# forwarderservers, so DoT and DoH work per zone too.
 #
 # A forwarded zone is NOT validated here: answers carry whatever the upstream
 # asserted, exactly as in whole-server forwarder mode. Pointing a signed

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -96,6 +96,11 @@ type Cache struct {
 	negative *NegativeCache
 	failure  *FailureCache
 
+	// cfg supplies the forward-zone matcher. Covering denial and failure
+	// state is learned from public resolution, so it must not answer for a
+	// zone the operator has since pointed at its own upstreams.
+	cfg *config.Config
+
 	// store is the public-facing storage facade backed by the same
 	// answer caches and RFC 9520 failure cache. External callers (resolver
 	// sub-queries, queryer-driven prefetch, future API purge wiring)
@@ -219,6 +224,7 @@ func New(cfg *config.Config) *Cache {
 		positive: positive,
 		negative: negative,
 		failure:  failure,
+		cfg:      cfg,
 
 		store: store,
 
@@ -550,7 +556,7 @@ func (c *Cache) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 			return
 		}
 	}
-	if hit, ok := c.store.LookupFailure(req, clientScope); ok {
+	if hit, ok := c.lookupFailure(req, clientScope); ok {
 		c.metrics.Hit()
 		c.handleFailureHit(ctx, ch, clientScope, hit)
 		return
@@ -683,7 +689,7 @@ func (c *Cache) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 					return
 				}
 			}
-			if hit, ok := c.store.LookupFailure(req, clientScope); ok {
+			if hit, ok := c.lookupFailure(req, clientScope); ok {
 				c.metrics.Hit()
 				c.handleFailureHit(ctx, ch, clientScope, hit)
 				return
@@ -993,6 +999,33 @@ func (c *Cache) scopedLookup(q dns.Question, cd bool, clientPrefix netip.Prefix)
 // synthesis. ECS requests also bypass P4: a signed split-horizon denial can be
 // audience-specific, and P4 has no per-scope proof index. Failing open to
 // ordinary resolution is safer than sharing one audience's subtree cut.
+// lookupFailure is Store.LookupFailure with the forward-zone gate applied. An
+// RFC 9520 failure recorded while a name resolved publicly says nothing about
+// the upstream a forward zone now names.
+func (c *Cache) lookupFailure(req *dns.Msg, clientScope netip.Prefix) (FailureHit, bool) {
+	if req != nil && len(req.Question) > 0 && c.forwardedZoneQuestion(req.Question[0].Name) {
+		return FailureHit{}, false
+	}
+	return c.store.LookupFailure(req, clientScope)
+}
+
+// forwardedZoneQuestion reports whether qname belongs to a forward zone.
+//
+// Covering denial and failure state describes the public namespace — it was
+// learned by resolving from the root. A forward zone says that subtree is
+// answered somewhere else, so an NXDOMAIN cut, aggressive denial or authority
+// failure inherited from above it must not answer for it: a name that does
+// not exist publicly is precisely what an internal zone is for, and serving
+// the public denial would make the zone unreachable for as long as the cut
+// lives. Exact entries are deliberately left alone — those were admitted for
+// this very question, by whichever path answered it.
+func (c *Cache) forwardedZoneQuestion(qname string) bool {
+	if c == nil || c.cfg == nil || len(c.cfg.ForwardZones) == 0 {
+		return false
+	}
+	return c.cfg.ForwardZoneFor(qname) != nil
+}
+
 func (c *Cache) lookupNXDomainCut(
 	ctx context.Context,
 	req *dns.Msg,
@@ -1000,7 +1033,8 @@ func (c *Cache) lookupNXDomainCut(
 ) *nxDomainCutEntry {
 	if req == nil || len(req.Question) == 0 ||
 		req.CheckingDisabled || clientScope.IsValid() ||
-		sharedDenialBypass(ctx) {
+		sharedDenialBypass(ctx) ||
+		c.forwardedZoneQuestion(req.Question[0].Name) {
 		return nil
 	}
 	entry, _ := c.store.LookupNXDomainCut(req)
@@ -1021,7 +1055,8 @@ func (c *Cache) lookupDenialProof(
 	if req == nil || len(req.Question) != 1 ||
 		req.CheckingDisabled || clientScope.IsValid() ||
 		hasEDNSClientSubnet(req) || sharedDenialBypass(ctx) ||
-		c.store.rfc8198Disabled {
+		c.store.rfc8198Disabled ||
+		c.forwardedZoneQuestion(req.Question[0].Name) {
 		return nil, middleware.ValidatedNegativeProofUnknown, ""
 	}
 	msg, kind, zone, proofExpires, ok := c.store.lookupDenialProofWithExpiry(
@@ -1155,6 +1190,14 @@ func (c *Cache) serveWire(ctx context.Context, ch *middleware.Chain, spent **rat
 // it might shadow.
 func (c *Cache) serveCompositeFromWire(ctx context.Context, ch *middleware.Chain) bool {
 	req := ch.Request
+	// Every rung below serves covering state, which a forward zone must not
+	// be answered from. Deciding that needs the question in presentation
+	// form, so a server with forward zones sends composites to the decoded
+	// body and lets the Msg path apply the gate per zone; a server without
+	// them pays one length check.
+	if c.cfg != nil && len(c.cfg.ForwardZones) > 0 {
+		return false
+	}
 	cd := req.CD()
 	if !cd {
 		if cut, ok := c.store.LookupNXDomainCutWire(req.WireName(), req.Qclass()); ok {

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -1842,7 +1842,18 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 	// A useful answer here means resolver/failover/forwarder recovery really
 	// reached the client path, so both exact and covering zone backoff can
 	// restart at the initial interval on a later failure.
-	w.cache.store.resetMatchingFailures(q, res.CheckingDisabled, w.clientScope)
+	//
+	// A forwarded answer clears only its own question. It proves that zone's
+	// upstream is answering; it proves nothing about the public authority
+	// chain above the name, which is what the ancestor zone entries record.
+	// Clearing those would let one working internal zone wipe the backoff
+	// protecting a broken public authority, and the next query for a sibling
+	// name would go straight back to hammering it.
+	if w.cache.forwardedZoneQuestion(q.Name) {
+		w.cache.store.resetQuestionFailure(q, res.CheckingDisabled, w.clientScope)
+	} else {
+		w.cache.store.resetMatchingFailures(q, res.CheckingDisabled, w.clientScope)
+	}
 
 	// The delegation lease caps the TTL the client sees, on this uncached
 	// response exactly as remaining() caps it on every later hit. Without

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -999,14 +999,26 @@ func (c *Cache) scopedLookup(q dns.Question, cd bool, clientPrefix netip.Prefix)
 // synthesis. ECS requests also bypass P4: a signed split-horizon denial can be
 // audience-specific, and P4 has no per-scope proof index. Failing open to
 // ordinary resolution is safer than sharing one audience's subtree cut.
-// lookupFailure is Store.LookupFailure with the forward-zone gate applied. An
-// RFC 9520 failure recorded while a name resolved publicly says nothing about
-// the upstream a forward zone now names.
+// lookupFailure is Store.LookupFailure with the forward-zone gate applied to
+// the one kind of failure that describes the public namespace.
+//
+// A zone-kind failure records that an authority zone was unreachable while
+// resolving from the root; it says nothing about the upstream a forward zone
+// names, and matching by ancestor it would deny the whole forwarded subtree.
+// A question-kind failure is the opposite: for a forwarded name it is what the
+// forwarder recorded when that zone's own upstream failed, and it is the RFC
+// 9520 backoff protecting a dead upstream from being retried by every client
+// query. Dropping both would leave that upstream hammered for as long as it
+// stayed down.
 func (c *Cache) lookupFailure(req *dns.Msg, clientScope netip.Prefix) (FailureHit, bool) {
+	hit, ok := c.store.LookupFailure(req, clientScope)
+	if !ok || hit.Kind != FailureKindZone {
+		return hit, ok
+	}
 	if req != nil && len(req.Question) > 0 && c.forwardedZoneQuestion(req.Question[0].Name) {
 		return FailureHit{}, false
 	}
-	return c.store.LookupFailure(req, clientScope)
+	return hit, ok
 }
 
 // forwardedZoneQuestion reports whether qname belongs to a forward zone.

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -596,3 +596,55 @@ func TestForwardZoneFailureKinds(t *testing.T) {
 		}
 	})
 }
+
+// TestForwardedSuccessKeepsPublicZoneBackoff pins the reset's scope. A
+// successful answer normally clears the exact failure and every ancestor zone
+// backoff, on the reasoning that recovery reached the client. For a forwarded
+// answer that reasoning does not carry: it proves the zone's own upstream is
+// answering and says nothing about the public authority chain above the name,
+// so wiping that backoff would send the next sibling query straight back to
+// hammering a broken authority.
+func TestForwardedSuccessKeepsPublicZoneBackoff(t *testing.T) {
+	c := New(&config.Config{
+		CacheSize: 1024,
+		ForwardZones: []config.ForwardZoneConfig{
+			{Name: "corp.example.", Servers: []string{"10.0.0.53:53"}},
+		},
+	})
+	defer c.Stop()
+
+	sibling := newQuestionMsg("www.example.", dns.TypeA, dns.ClassINET)
+	c.store.RecordZoneFailure(sibling.Question[0], "example.")
+	if _, ok := c.lookupFailure(sibling, netip.Prefix{}); !ok {
+		t.Fatal("the public zone backoff was not recorded")
+	}
+
+	// A forwarded question answered successfully by its own upstream.
+	req := newQuestionMsg("host.corp.example.", dns.TypeA, dns.ClassINET)
+	req.SetEdns0(1232, false)
+	answered := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		resp := new(dns.Msg)
+		resp.SetReply(ch.Request.Msg())
+		resp.Answer = []dns.RR{makeRR("host.corp.example. 300 IN A 10.0.0.9")}
+		_ = ch.Writer.WriteMsg(resp)
+		ch.Cancel()
+	})
+	writer := mock.NewWriter("udp", "192.0.2.1:53000")
+	ch := middleware.NewChain([]middleware.Handler{c, answered})
+	ch.Reset(writer, req)
+	ch.Next(context.Background())
+	if !writer.Written() || writer.Msg().Rcode != dns.RcodeSuccess {
+		t.Fatal("the forwarded question was not answered successfully")
+	}
+
+	if _, ok := c.lookupFailure(sibling, netip.Prefix{}); !ok {
+		t.Fatal("a forwarded success wiped the unrelated public zone backoff")
+	}
+
+	// Control: the entry was clearable all along, so its survival above is
+	// the forwarded gate and not an entry nothing could remove.
+	c.store.resetMatchingFailures(sibling.Question[0], false, netip.Prefix{})
+	if _, ok := c.lookupFailure(sibling, netip.Prefix{}); ok {
+		t.Fatal("the zone backoff outlived a matching reset")
+	}
+}

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"net/netip"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -512,5 +513,39 @@ func TestCacheEDNS(t *testing.T) {
 	}
 	if !reflect.DeepEqual("edns.com.", resp.Answer[0].Header().Name) {
 		t.Errorf("resp.Answer[0].Header().Name = %v, want %v", resp.Answer[0].Header().Name, "edns.com.")
+	}
+}
+
+// TestForwardZoneBypassesCoveringDenial pins the gate in front of covering
+// state. An NXDOMAIN cut is learned by resolving publicly and denies a whole
+// subtree; a forward zone says that subtree is answered elsewhere. Without the
+// gate the public denial answers first and the zone is unreachable for as long
+// as the cut lives — which is the split-horizon case the feature exists for.
+func TestForwardZoneBypassesCoveringDenial(t *testing.T) {
+	// The forward zone sits inside the denied subtree, so one cut covers both
+	// the control name and the forwarded one.
+	c := New(&config.Config{
+		CacheSize: 1024,
+		ForwardZones: []config.ForwardZoneConfig{
+			{Name: "lab.corp.example.", Servers: []string{"10.0.0.53:53"}},
+		},
+	})
+	defer c.Stop()
+
+	fixture := newNXDomainCutFixture(t, "corp.example.", "example.", dns.ClassINET)
+	if !c.store.RecordNXDomainCut(fixture.msg, "corp.example.", "example.", time.Time{}) {
+		t.Fatal("covering cut was not recorded")
+	}
+
+	// The cut is live: a name under it but outside the forward zone is still
+	// denied. Without this the assertion below would pass on an empty cache.
+	outside := newQuestionMsg("other.corp.example.", dns.TypeA, dns.ClassINET)
+	if cut := c.lookupNXDomainCut(context.Background(), outside, netip.Prefix{}); cut == nil {
+		t.Fatal("the covering cut does not deny a name it should")
+	}
+
+	inside := newQuestionMsg("host.lab.corp.example.", dns.TypeA, dns.ClassINET)
+	if cut := c.lookupNXDomainCut(context.Background(), inside, netip.Prefix{}); cut != nil {
+		t.Fatal("a public NXDOMAIN cut answered for a forwarded zone")
 	}
 }

--- a/middleware/cache/cache_test.go
+++ b/middleware/cache/cache_test.go
@@ -549,3 +549,50 @@ func TestForwardZoneBypassesCoveringDenial(t *testing.T) {
 		t.Fatal("a public NXDOMAIN cut answered for a forwarded zone")
 	}
 }
+
+// TestForwardZoneFailureKinds pins which cached failures a forwarded question
+// may still be answered from. The two kinds mean opposite things here: a
+// zone-kind failure records an authority zone that was unreachable while
+// resolving publicly, which says nothing about the zone's own upstream; a
+// question-kind failure for a forwarded name is what the forwarder recorded
+// when that upstream failed, and dropping it would retry a dead upstream on
+// every client query.
+func TestForwardZoneFailureKinds(t *testing.T) {
+	newCache := func() *Cache {
+		return New(&config.Config{
+			CacheSize: 1024,
+			ForwardZones: []config.ForwardZoneConfig{
+				{Name: "corp.example.", Servers: []string{"10.0.0.53:53"}},
+			},
+		})
+	}
+
+	t.Run("question-kind backoff survives", func(t *testing.T) {
+		c := newCache()
+		defer c.Stop()
+		req := newQuestionMsg("host.corp.example.", dns.TypeA, dns.ClassINET)
+		c.store.RecordFailure(req, netip.Prefix{}, FailureProvenance("response"), nil)
+
+		hit, ok := c.lookupFailure(req, netip.Prefix{})
+		if !ok || hit.Kind != FailureKindQuestion {
+			t.Fatalf("forwarded question lost its own backoff: ok=%v kind=%v", ok, hit.Kind)
+		}
+	})
+
+	t.Run("zone-kind denial is bypassed", func(t *testing.T) {
+		c := newCache()
+		defer c.Stop()
+		outside := newQuestionMsg("other.example.", dns.TypeA, dns.ClassINET)
+		c.store.RecordZoneFailure(outside.Question[0], "example.")
+
+		// The zone failure is live for names it should still cover; without
+		// this the assertion below would pass on an empty failure cache.
+		if hit, ok := c.lookupFailure(outside, netip.Prefix{}); !ok || hit.Kind != FailureKindZone {
+			t.Fatalf("zone failure does not cover a public name: ok=%v kind=%v", ok, hit.Kind)
+		}
+		inside := newQuestionMsg("host.corp.example.", dns.TypeA, dns.ClassINET)
+		if _, ok := c.lookupFailure(inside, netip.Prefix{}); ok {
+			t.Fatal("a public zone failure answered for a forwarded zone")
+		}
+	})
+}

--- a/middleware/forwarder/forwarder.go
+++ b/middleware/forwarder/forwarder.go
@@ -186,15 +186,19 @@ func parseServers(list []string, dialTimeout, requestTimeout time.Duration, labe
 // match itself comes from the config so the resolver's decision to hand the
 // query over and this choice of where to send it cannot drift apart.
 func (f *Forwarder) serversFor(qname string) []*server {
-	if len(f.zones) == 0 {
+	if f.cfg == nil || len(f.cfg.ForwardZones) == 0 {
 		return f.servers
 	}
-	if zone := f.cfg.ForwardZoneFor(qname); zone != nil {
-		if servers, ok := f.zones[dns.CanonicalName(zone.Name)]; ok {
-			return servers
-		}
+	zone := f.cfg.ForwardZoneFor(qname)
+	if zone == nil {
+		return f.servers
 	}
-	return f.servers
+	// A matched zone whose upstreams all turned out unusable does not
+	// quietly borrow the whole-server list. Those are the public
+	// forwarders, and sending an internal zone's questions there is the
+	// leak configuring the zone was meant to prevent — so this returns
+	// nothing and the caller fails the query visibly instead.
+	return f.zones[dns.CanonicalName(zone.Name)]
 }
 
 // validForwarderAddr reports whether addr is a host:port string with

--- a/middleware/forwarder/forwarder.go
+++ b/middleware/forwarder/forwarder.go
@@ -59,6 +59,13 @@ type Forwarder struct {
 	dnssec    bool
 	tlsConfig *tls.Config
 
+	// zones holds the per-zone upstreams, keyed by canonical zone apex.
+	// Empty on a server that only uses the whole-server list.
+	zones map[string][]*server
+	// cfg supplies the zone matcher, so which zone a question belongs to is
+	// decided in exactly one place for both this and the resolver's handover.
+	cfg *config.Config
+
 	// queryTimeout caps the total time ServeDNS spends across every
 	// configured upstream — mirroring how the resolver handler
 	// enforces cfg.QueryTimeout. Without it, three slow upstreams
@@ -102,6 +109,34 @@ func New(cfg *config.Config) *Forwarder {
 		requestTimeout = 10 * time.Second
 	}
 
+	f := &Forwarder{
+		servers:      parseServers(cfg.ForwarderServers, dialTimeout, requestTimeout, "forwarder"),
+		dnssec:       cfg.DNSSEC == "on",
+		queryTimeout: requestTimeout,
+		dialTimeout:  dialTimeout,
+		cfg:          cfg,
+	}
+	for i := range cfg.ForwardZones {
+		zone := &cfg.ForwardZones[i]
+		servers := parseServers(zone.Servers, dialTimeout, requestTimeout, "forward zone "+zone.Name)
+		if len(servers) == 0 {
+			// ForwardZoneFor skips a serverless zone too, so the subtree
+			// resolves normally rather than failing wholesale.
+			zlog.Error("Forward zone has no usable server. Check your config.", "zone", zone.Name)
+			continue
+		}
+		if f.zones == nil {
+			f.zones = make(map[string][]*server, len(cfg.ForwardZones))
+		}
+		f.zones[dns.CanonicalName(zone.Name)] = servers
+	}
+	return f
+}
+
+// parseServers turns configured upstream strings into dialable endpoints,
+// dropping duplicates and anything unusable. label names the setting in log
+// lines so an operator can tell which list an error came from.
+func parseServers(list []string, dialTimeout, requestTimeout time.Duration, label string) []*server {
 	forwarderservers := []*server{}
 	seen := make(map[string]struct{})
 	appendServer := func(srv *server) {
@@ -116,12 +151,12 @@ func New(cfg *config.Config) *Forwarder {
 		seen[key] = struct{}{}
 		forwarderservers = append(forwarderservers, srv)
 	}
-	for _, s := range cfg.ForwarderServers {
+	for _, s := range list {
 		switch {
 		case strings.HasPrefix(s, "https://"):
 			srv, err := newDoHServer(s, dialTimeout, requestTimeout)
 			if err != nil {
-				zlog.Error("Forwarder DoH server not usable", "server", s, "error", err.Error())
+				zlog.Error("DoH server not usable", "list", label, "server", s, "error", err.Error())
 				continue
 			}
 			appendServer(srv)
@@ -129,26 +164,37 @@ func New(cfg *config.Config) *Forwarder {
 		case strings.HasPrefix(s, "tls://"):
 			addr := strings.TrimPrefix(s, "tls://")
 			if !validForwarderAddr(addr) {
-				zlog.Error("Forwarder server is not correct. Check your config.", "server", s)
+				zlog.Error("Server is not correct. Check your config.", "list", label, "server", s)
 				continue
 			}
 			appendServer(&server{Addr: addr, Proto: "tcp-tls"})
 
 		default:
 			if !validForwarderAddr(s) {
-				zlog.Error("Forwarder server is not correct. Check your config.", "server", s)
+				zlog.Error("Server is not correct. Check your config.", "list", label, "server", s)
 				continue
 			}
 			appendServer(&server{Addr: s, Proto: "udp"})
 		}
 	}
 
-	return &Forwarder{
-		servers:      forwarderservers,
-		dnssec:       cfg.DNSSEC == "on",
-		queryTimeout: requestTimeout,
-		dialTimeout:  dialTimeout,
+	return forwarderservers
+}
+
+// serversFor picks the upstreams for one question: those of the most specific
+// forward zone covering it, or the whole-server list when no zone does. The
+// match itself comes from the config so the resolver's decision to hand the
+// query over and this choice of where to send it cannot drift apart.
+func (f *Forwarder) serversFor(qname string) []*server {
+	if len(f.zones) == 0 {
+		return f.servers
 	}
+	if zone := f.cfg.ForwardZoneFor(qname); zone != nil {
+		if servers, ok := f.zones[dns.CanonicalName(zone.Name)]; ok {
+			return servers
+		}
+	}
+	return f.servers
 }
 
 // validForwarderAddr reports whether addr is a host:port string with
@@ -173,7 +219,12 @@ func (f *Forwarder) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	}
 	w := ch.Writer
 
-	if len(req.Question) == 0 || len(f.servers) == 0 {
+	if len(req.Question) == 0 {
+		ch.CancelWithRcode(dns.RcodeServerFailure, true)
+		return
+	}
+	servers := f.serversFor(req.Question[0].Name)
+	if len(servers) == 0 {
 		ch.CancelWithRcode(dns.RcodeServerFailure, true)
 		return
 	}
@@ -212,7 +263,7 @@ func (f *Forwarder) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		failureResponse *dns.Msg
 		requestLocalErr error
 	)
-	for _, server := range f.servers {
+	for _, server := range servers {
 		// Build a lightweight client per upstream. For DoH this
 		// references the reused, pinned-IP http.Client created at
 		// startup (never per query); for DoT it picks up the

--- a/middleware/forwarder/forwarder.go
+++ b/middleware/forwarder/forwarder.go
@@ -120,8 +120,10 @@ func New(cfg *config.Config) *Forwarder {
 		zone := &cfg.ForwardZones[i]
 		servers := parseServers(zone.Servers, dialTimeout, requestTimeout, "forward zone "+zone.Name)
 		if len(servers) == 0 {
-			// ForwardZoneFor skips a serverless zone too, so the subtree
-			// resolves normally rather than failing wholesale.
+			// Left out of the map, so serversFor returns nothing for it and
+			// the query fails. It deliberately does not fall through to the
+			// whole-server list: those are public upstreams, and an internal
+			// zone's questions must not reach them.
 			zlog.Error("Forward zone has no usable server. Check your config.", "zone", zone.Name)
 			continue
 		}

--- a/middleware/forwarder/forwarder_test.go
+++ b/middleware/forwarder/forwarder_test.go
@@ -768,10 +768,11 @@ func TestServersForPicksTheZoneUpstreams(t *testing.T) {
 	if got := addrOf(f.serversFor("example.net.")); got != "192.0.2.1:53" {
 		t.Fatalf("unmatched name upstream = %s, want the whole-server list", got)
 	}
-	// A zone whose servers were all unusable is dropped at construction, so
-	// its subtree falls back to the whole-server list rather than to nothing.
-	if got := addrOf(f.serversFor("host.broken.example.")); got != "192.0.2.1:53" {
-		t.Fatalf("serverless zone upstream = %s, want the whole-server list", got)
+	// A zone whose servers were all unusable must not borrow the public
+	// whole-server list: that would send an internal zone's questions
+	// exactly where configuring the zone was meant to stop them going.
+	if servers := f.serversFor("host.broken.example."); len(servers) != 0 {
+		t.Fatalf("unusable zone fell back to %v, want no upstream at all", servers)
 	}
 }
 

--- a/middleware/forwarder/forwarder_test.go
+++ b/middleware/forwarder/forwarder_test.go
@@ -741,3 +741,46 @@ func vacantLoopbackAddr(t *testing.T) string {
 
 	return pc.LocalAddr().String()
 }
+
+func TestServersForPicksTheZoneUpstreams(t *testing.T) {
+	f := New(&config.Config{
+		ForwarderServers: []string{"192.0.2.1:53"},
+		ForwardZones: []config.ForwardZoneConfig{
+			{Name: "corp.example.", Servers: []string{"10.0.0.53:53"}},
+			{Name: "lab.corp.example.", Servers: []string{"tls://10.0.1.53:853"}},
+			{Name: "broken.example.", Servers: []string{"not-an-address"}},
+		},
+	})
+
+	addrOf := func(servers []*server) string {
+		if len(servers) != 1 {
+			t.Fatalf("expected exactly one upstream, got %d", len(servers))
+		}
+		return servers[0].Addr
+	}
+
+	if got := addrOf(f.serversFor("host.corp.example.")); got != "10.0.0.53:53" {
+		t.Fatalf("corp zone upstream = %s", got)
+	}
+	if got := addrOf(f.serversFor("host.lab.corp.example.")); got != "10.0.1.53:853" {
+		t.Fatalf("most specific zone upstream = %s", got)
+	}
+	if got := addrOf(f.serversFor("example.net.")); got != "192.0.2.1:53" {
+		t.Fatalf("unmatched name upstream = %s, want the whole-server list", got)
+	}
+	// A zone whose servers were all unusable is dropped at construction, so
+	// its subtree falls back to the whole-server list rather than to nothing.
+	if got := addrOf(f.serversFor("host.broken.example.")); got != "192.0.2.1:53" {
+		t.Fatalf("serverless zone upstream = %s, want the whole-server list", got)
+	}
+}
+
+func TestServersForWithoutZonesIsTheGlobalList(t *testing.T) {
+	f := New(&config.Config{ForwarderServers: []string{"192.0.2.1:53"}})
+	if len(f.zones) != 0 {
+		t.Fatalf("zones = %v, want none", f.zones)
+	}
+	if servers := f.serversFor("anything.example."); len(servers) != 1 || servers[0].Addr != "192.0.2.1:53" {
+		t.Fatalf("serversFor = %v, want the whole-server list", servers)
+	}
+}

--- a/middleware/resolver/handler.go
+++ b/middleware/resolver/handler.go
@@ -86,6 +86,18 @@ func (h *DNSHandler) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	if req == nil {
 		return
 	}
+
+	// A forward zone hands its subtree to its own upstreams; everything else
+	// still resolves here. The question is needed to decide, so this sits
+	// after materialization rather than beside the whole-server check above —
+	// and the request was going to be materialized anyway, so a server with
+	// no forward zones pays only the length check.
+	if len(h.cfg.ForwardZones) > 0 && len(req.Question) > 0 &&
+		h.cfg.ForwardZoneFor(req.Question[0].Name) != nil {
+		ch.Next(ctx)
+		return
+	}
+
 	w := ch.Writer
 
 	// Ensure request ID is in context for tracking. It is request-lifetime


### PR DESCRIPTION
`forwarderservers` is all or nothing — set it and the resolver stops resolving entirely. The common need is narrower: an internal zone the public namespace cannot answer, while everything else still resolves from the root.

```toml
[[forward_zone]]
name = "corp.example."
servers = ["10.0.0.53:53", "tls://10.0.0.54:853"]

[[forward_zone]]
name = "lab.corp.example."
servers = ["10.0.1.53:53"]
```

## Behaviour

- **Most specific zone wins**, so a narrower zone can point somewhere else than the one containing it.
- **A zone with no usable server is skipped**, not matched — a configuration mistake costs the forwarding, not the whole subtree.
- **Upstreams take the same forms as `forwarderservers`** (plain, `tls://`, `https://`), so a zone can be forwarded over DoT or DoH with no new parsing.
- **Queries leave with RD=1**, which is forwarding as RFC 8499 §6 defines it: the upstream must be a recursive resolver answering on our behalf. Pointing at a zone's own authoritative servers is a *stub zone* — a different feature, not this one.

One matcher decides both halves: the resolver asks it whether to hand the query over, the forwarder asks it which upstreams to use. The decision to forward and the choice of where cannot drift apart.

## What a forwarded zone gives up

**It is not validated here.** Answers carry whatever the upstream asserted, exactly as in whole-server forwarder mode. This is worth stating plainly because per-zone makes it easy to miss: forwarding a signed *public* zone silently gives up local DNSSEC validation for it. The intended use is the opposite case.

Forwarded answers also cannot reach the RFC 8020/8198 shared denial state. That needed no new code — admission has always required provenance proving *this* process validated the chain, never an AD bit off the wire — so the recursive side keeps its aggressive denial while forwarded answers stay out of it, with no new switch to get wrong.

## Deliberately not included

**Fallback to recursion when an upstream fails.** Unbound and BIND both default to no fallback (`forward-first` and `forward first` are opt-in), and falling back would leak internal names to the public internet in exactly the split-horizon deployment this serves. Adding it later requires moving the forwarder ahead of the resolver in the chain; this change does not disturb that ordering.

**Stub zones (RD=0 to authoritative servers).** A separate feature, worth doing on its own terms.

## Verification

`make test`, `go test -race` on config/forwarder/resolver, `go vet`, `golangci-lint`, `gofmt` all clean. The packaged config under `contrib/` was regenerated from the generator and matches.

Mutation-tested, each confirmed to turn a named test red: ignoring the zone map in upstream selection, taking the first matching zone instead of the most specific, and matching a zone that has no usable server. Mutations that failed to compile were not counted as evidence.