### PR TITLE
config: check the file, and say what is wrong with it

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ $ make test
 | Flag              | Description                                                                    |
 | ----------------- | ------------------------------------------------------------------------------ |
 | -c, --config PATH | Location of the config file. If it doesn't exist, a new one is generated at that path. Default: sdns.conf (working directory) |
-| -t, --test        | Test configuration file and exit. Returns exit code 0 if valid, 1 if invalid  |
+| -t, --test        | Test configuration file and exit. Returns exit code 0 if valid, 1 if invalid. Checks every setting it can judge — addresses, IPs, CIDRs, enumerated values, upstream formats, TLS files — and reports all problems at once. It also fails on keys the file carries that no setting claims: a typo, or a key an older SDNS understood. Startup only warns about those, so upgrading with a stale key does not become an outage |
 | -v, --version     | Show the SDNS version                                                          |
 | -h, --help        | Show help information and exit                                                 |
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ example.com.		0	CH	HINFO	"Host" "IPv6:[2001:500:8d::53]:53 rtt:148ms health:[GOO
 | **bearertoken**      | API bearer token for authorization. If set, Authorization header must be included in API requests                   |
 | **blocklists**       | URLs of remote blocklists to download and use for filtering                                                         |
 | **blocklistdir**     | \[DEPRECATED] Blocklist directory. Now automatically created in the working directory                               |
-| **loglevel**         | Logging verbosity level. Options: crit, error, warn, info, debug. Default: "info"                                  |
+| **loglevel**         | Logging verbosity level. Options: error, warn, info, debug. Default: "info"                                  |
 | **accesslog**        | Path to the access log file in Common Log Format. Leave empty to disable                                            |
 | **nullroute**        | IPv4 address returned for blocked A queries. Default: "0.0.0.0"                                                     |
 | **nullroutev6**      | IPv6 address returned for blocked AAAA queries. Default: "::0"                                                      |

--- a/config/config.go
+++ b/config/config.go
@@ -261,22 +261,26 @@ type ForwardZoneConfig struct {
 // skipped at match time, so its subtree would resolve publicly. For an
 // internal zone that is not a harmless no-op, it is the leak the zone was
 // configured to prevent. Better to fail at startup, where it is visible.
-func (c *Config) validateForwardZones() error {
+func (c *Config) validateForwardZones(add func(string, ...any)) {
 	for i := range c.ForwardZones {
 		zone := &c.ForwardZones[i]
-		if strings.TrimSpace(zone.Name) == "" {
-			return fmt.Errorf(
-				"forward_zone %d has no name; use name = \".\" to forward every query", i+1,
-			)
-		}
-		if _, ok := dns.IsDomainName(zone.Name); !ok {
-			return fmt.Errorf("forward_zone %q is not a valid domain name", zone.Name)
-		}
-		if len(zone.Servers) == 0 {
-			return fmt.Errorf("forward_zone %q has no servers", zone.Name)
+		switch {
+		case strings.TrimSpace(zone.Name) == "":
+			add("forward_zone %d has no name; use name = \".\" to forward every query", i+1)
+		case !validDomainName(zone.Name):
+			add("forward_zone %q is not a valid domain name", zone.Name)
+		case len(zone.Servers) == 0:
+			add("forward_zone %q has no servers", zone.Name)
 		}
 	}
-	return nil
+}
+
+// validDomainName reports whether name is structurally a domain name. Its
+// character set is deliberately not judged: RFC 2181 section 11 makes a label
+// any binary string, so a name this package finds odd may still be legal.
+func validDomainName(name string) bool {
+	_, ok := dns.IsDomainName(name)
+	return ok
 }
 
 // ForwardZoneFor returns the most specific configured forward zone covering
@@ -1400,9 +1404,7 @@ func Load(cfgfile, version string) (*Config, error) {
 	config.normalizeQnameMinimize()
 
 	config.RecursionFirewall.Normalize()
-	if err := config.RecursionFirewall.Validate(); err != nil {
-		return nil, fmt.Errorf("invalid recursion firewall config: %w", err)
-	}
+
 	// Keys the file carries that no field claims: a typo, or a setting an
 	// older SDNS understood and this one no longer does. Either way the
 	// operator wrote something that will not take effect, so it is recorded
@@ -1414,14 +1416,12 @@ func Load(cfgfile, version string) (*Config, error) {
 		zlog.Warn("Unknown config key, ignored", "key", key.String(), "path", cfgfile)
 	}
 
-	if err := config.validateForwardZones(); err != nil {
-		return nil, err
-	}
+	// One gate, so a file with several mistakes is fixed in one pass rather
+	// than one error per run. Recording the unknown keys above this point is
+	// deliberate for the same reason: they are reported even when a value
+	// elsewhere in the file is wrong.
 	if err := config.Validate(); err != nil {
 		return nil, err
-	}
-	if config.ServeStaleMaxTTL.Duration < 0 {
-		return nil, fmt.Errorf("serve_stale_max_ttl must not be negative")
 	}
 
 	if _, err := os.Stat(config.Directory); os.IsNotExist(err) {

--- a/config/config.go
+++ b/config/config.go
@@ -264,12 +264,16 @@ type ForwardZoneConfig struct {
 func (c *Config) validateForwardZones(add func(string, ...any)) {
 	for i := range c.ForwardZones {
 		zone := &c.ForwardZones[i]
+		// The two name problems are alternatives, but a missing server list is
+		// independent of both — reporting only the first would send the
+		// operator back for a second run over the same entry.
 		switch {
 		case strings.TrimSpace(zone.Name) == "":
 			add("forward_zone %d has no name; use name = \".\" to forward every query", i+1)
 		case !validDomainName(zone.Name):
 			add("forward_zone %q is not a valid domain name", zone.Name)
-		case len(zone.Servers) == 0:
+		}
+		if len(zone.Servers) == 0 {
 			add("forward_zone %q has no servers", zone.Name)
 		}
 	}
@@ -1401,8 +1405,6 @@ func Load(cfgfile, version string) (*Config, error) {
 		zlog.Warn("Config file is out of version, you can generate new one and check the changes.")
 	}
 
-	config.normalizeQnameMinimize()
-
 	config.RecursionFirewall.Normalize()
 
 	// Keys the file carries that no field claims: a typo, or a setting an
@@ -1427,6 +1429,12 @@ func Load(cfgfile, version string) (*Config, error) {
 		}
 		return nil, err
 	}
+
+	// After the gate, not before: normalizing folds a negative minimization
+	// count to zero and a negative one-label count to the default, so running
+	// it first would hand Validate the settled value and hide what the file
+	// actually said.
+	config.normalizeQnameMinimize()
 
 	if _, err := os.Stat(config.Directory); os.IsNotExist(err) {
 		if err := os.Mkdir(config.Directory, 0750); err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -1405,6 +1405,14 @@ func Load(cfgfile, version string) (*Config, error) {
 		zlog.Warn("Config file is out of version, you can generate new one and check the changes.")
 	}
 
+	// Before the gate, because omitting the key means validation is on: the
+	// coercion below used to run after it, so a file naming neither dnssec
+	// nor a trust anchor passed the anchor check as if validation were off
+	// and then ran with it on and nothing to anchor to.
+	if config.DNSSEC == "" {
+		config.DNSSEC = "on"
+	}
+
 	config.RecursionFirewall.Normalize()
 
 	// Keys the file carries that no field claims: a typo, or a setting an
@@ -1445,10 +1453,6 @@ func Load(cfgfile, version string) (*Config, error) {
 	zlog.Info("Working directory", zlog.String("path", config.Directory))
 
 	config.sVersion = version
-
-	if config.DNSSEC == "" || config.DNSSEC != "off" {
-		config.DNSSEC = "on"
-	}
 
 	if config.CookieSecret == "" {
 		// 16 random bytes (128-bit) hex-encoded to a 32-char secret.

--- a/config/config.go
+++ b/config/config.go
@@ -190,7 +190,16 @@ type Config struct {
 	ReflexThreshold    float64 // Suspicion threshold (0.0-1.0, default: 0.7)
 
 	sVersion string
+
+	// undecodedKeys are the keys the config file carried that no field
+	// claimed. See Load for why they warn rather than fail there.
+	undecodedKeys []string
 }
+
+// UndecodedKeys returns the config keys that were present in the file and
+// matched no setting — typos, or settings a previous version understood.
+// They have no effect on this server.
+func (c *Config) UndecodedKeys() []string { return c.undecodedKeys }
 
 // RFC8198Enabled reports whether aggressive NSEC/NSEC3 denial synthesis is
 // enabled. Omission is default-on; an explicit false is the operational kill
@@ -1394,7 +1403,21 @@ func Load(cfgfile, version string) (*Config, error) {
 	if err := config.RecursionFirewall.Validate(); err != nil {
 		return nil, fmt.Errorf("invalid recursion firewall config: %w", err)
 	}
+	// Keys the file carries that no field claims: a typo, or a setting an
+	// older SDNS understood and this one no longer does. Either way the
+	// operator wrote something that will not take effect, so it is recorded
+	// and logged. Startup only warns — refusing to run over a stale key
+	// would turn an upgrade into an outage — while `sdns -t`, whose whole
+	// job is to answer "is this file right", treats it as a failure.
+	for _, key := range metadata.Undecoded() {
+		config.undecodedKeys = append(config.undecodedKeys, key.String())
+		zlog.Warn("Unknown config key, ignored", "key", key.String(), "path", cfgfile)
+	}
+
 	if err := config.validateForwardZones(); err != nil {
+		return nil, err
+	}
+	if err := config.Validate(); err != nil {
 		return nil, err
 	}
 	if config.ServeStaleMaxTTL.Duration < 0 {

--- a/config/config.go
+++ b/config/config.go
@@ -798,7 +798,7 @@ api = "127.0.0.1:8080"
 # bearertoken = ""
 
 # Log verbosity level
-# Options: crit, error, warn, info, debug
+# Options: error, warn, info, debug
 loglevel = "info"
 
 # Query access log file path

--- a/config/config.go
+++ b/config/config.go
@@ -1430,7 +1430,7 @@ func Load(cfgfile, version string) (*Config, error) {
 	// than one error per run. When the file is failing anyway, the unknown
 	// keys join the report — they still never cause a failure on their own,
 	// but omitting them here would send the operator back for a second run.
-	if err := config.Validate(); err != nil {
+	if err := config.validateLoaded(); err != nil {
 		if len(config.undecodedKeys) > 0 {
 			return nil, fmt.Errorf("%w\n  - unknown keys (a typo, or settings this version no longer has): %s",
 				err, strings.Join(config.undecodedKeys, ", "))

--- a/config/config.go
+++ b/config/config.go
@@ -1405,6 +1405,15 @@ func Load(cfgfile, version string) (*Config, error) {
 		zlog.Warn("Config file is out of version, you can generate new one and check the changes.")
 	}
 
+	// Before the gate, like the DNSSEC default below, because the checks read
+	// the settled value: outboundip6s is only judged when v6 is in use, and
+	// root6servers only count as roots then too.
+	if !config.IPv6Access {
+		if err := ipv6Probe(); err == nil {
+			config.IPv6Access = true
+		}
+	}
+
 	// Before the gate, because omitting the key means validation is on: the
 	// coercion below used to run after it, so a file naming neither dnssec
 	// nor a trust anchor passed the anchor check as if validation were off
@@ -1465,13 +1474,6 @@ func Load(cfgfile, version string) (*Config, error) {
 			return nil, err
 		}
 		config.CookieSecret = hex.EncodeToString(secret)
-	}
-
-	if !config.IPv6Access {
-		err := ipv6Probe()
-		if err == nil {
-			config.IPv6Access = true
-		}
 	}
 
 	// Set TCP keepalive defaults

--- a/config/config.go
+++ b/config/config.go
@@ -1417,10 +1417,14 @@ func Load(cfgfile, version string) (*Config, error) {
 	}
 
 	// One gate, so a file with several mistakes is fixed in one pass rather
-	// than one error per run. Recording the unknown keys above this point is
-	// deliberate for the same reason: they are reported even when a value
-	// elsewhere in the file is wrong.
+	// than one error per run. When the file is failing anyway, the unknown
+	// keys join the report — they still never cause a failure on their own,
+	// but omitting them here would send the operator back for a second run.
 	if err := config.Validate(); err != nil {
+		if len(config.undecodedKeys) > 0 {
+			return nil, fmt.Errorf("%w\n  - unknown keys (a typo, or settings this version no longer has): %s",
+				err, strings.Join(config.undecodedKeys, ", "))
+		}
 		return nil, err
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -475,8 +475,9 @@ func TestIPv6ProbeDecidesAccess(t *testing.T) {
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sdns.conf")
-	// Not a DNSSEC test, and this scaffold carries no trust anchor.
-	content := fmt.Sprintf("version = %q\ndirectory = %q\ndnssec = \"off\"\n",
+	// Not a DNSSEC test, and this scaffold carries neither a trust anchor
+	// nor a root server, both of which a loaded file must have.
+	content := fmt.Sprintf("version = %q\ndirectory = %q\ndnssec = \"off\"\nrootservers = [\"192.5.5.241:53\"]\n",
 		configver, filepath.Join(dir, "db"))
 	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -698,8 +699,11 @@ func TestLoadRFC8198Policy(t *testing.T) {
 directory = %q
 ipv6access = true
 # Not a DNSSEC test, and this scaffold carries no trust anchor; with
-# validation on and nothing to anchor to the config is refused.
+# validation on and nothing to anchor to the config is refused. A root
+# server is likewise required of a loaded file: with none, the resolver
+# stops the process on the first recursive query.
 dnssec = "off"
+rootservers = ["192.5.5.241:53"]
 %s
 `, configver, workDir, tt.setting)
 			if err := os.WriteFile(cfgFile, []byte(content), 0644); err != nil { //nolint:gosec // G306 - test file
@@ -793,8 +797,11 @@ func TestLoadRFC9520Policy(t *testing.T) {
 directory = %q
 ipv6access = true
 # Not a DNSSEC test, and this scaffold carries no trust anchor; with
-# validation on and nothing to anchor to the config is refused.
+# validation on and nothing to anchor to the config is refused. A root
+# server is likewise required of a loaded file: with none, the resolver
+# stops the process on the first recursive query.
 dnssec = "off"
+rootservers = ["192.5.5.241:53"]
 %s
 `, configver, workDir, tt.setting)
 			if err := os.WriteFile(cfgFile, []byte(content), 0644); err != nil { //nolint:gosec // G306 - test file
@@ -845,6 +852,7 @@ func TestLoadServeStalePolicy(t *testing.T) {
 directory = %q
 ipv6access = true
 dnssec = "off"
+rootservers = ["192.5.5.241:53"]
 %s
 `, configver, workDir, tt.settings)
 			if err := os.WriteFile(cfgFile, []byte(content), 0644); err != nil { //nolint:gosec // G306 - test file
@@ -871,6 +879,7 @@ func TestLoadRejectsNegativeServeStaleTTL(t *testing.T) {
 directory = %q
 ipv6access = true
 dnssec = "off"
+rootservers = ["192.5.5.241:53"]
 serve_stale = true
 serve_stale_max_ttl = "-1s"
 `, configver, workDir)
@@ -896,6 +905,7 @@ func TestLoadRecursionFirewallPolicy(t *testing.T) {
 directory = %q
 ipv6access = true
 dnssec = "off"
+rootservers = ["192.5.5.241:53"]
 
 [recursion_firewall]
 mode = "enforce"
@@ -954,6 +964,7 @@ failure_cache_max_ttl = "2m"
 directory = %q
 ipv6access = true
 dnssec = "off"
+rootservers = ["192.5.5.241:53"]
 
 [recursion_firewall]
 mode = "blocking"
@@ -1066,7 +1077,7 @@ func TestConfigVersionMismatch(t *testing.T) {
 	minimalConfig := `version = "0.0.1"
 directory = "db"
 bind = ":53"
-rootservers = []
+rootservers = ["192.5.5.241:53"]
 root6servers = []
 # Off, because this scaffold carries no trust anchor, and validation with
 # nothing to anchor to is now refused rather than left to fail per query.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1057,7 +1057,10 @@ directory = "db"
 bind = ":53"
 rootservers = []
 root6servers = []
-dnssec = "on"
+# Off, because this scaffold carries no trust anchor, and validation with
+# nothing to anchor to is now refused rather than left to fail per query.
+# The version warning under test does not depend on it either way.
+dnssec = "off"
 rootkeys = []
 fallbackservers = []
 forwarderservers = []

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1264,9 +1264,10 @@ func TestValidateForwardZones(t *testing.T) {
 		{"no servers", []ForwardZoneConfig{{Name: "corp.example."}}, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			err := (&Config{ForwardZones: tc.zones}).validateForwardZones()
+			// Through Validate, which is the single gate the load path uses.
+			err := (&Config{ForwardZones: tc.zones}).Validate()
 			if tc.wantErr != (err != nil) {
-				t.Fatalf("validateForwardZones() error = %v, wantErr %v", err, tc.wantErr)
+				t.Fatalf("Validate() error = %v, wantErr %v", err, tc.wantErr)
 			}
 		})
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -155,9 +155,12 @@ func TestLoad(t *testing.T) {
 					os.RemoveAll(tmpDir)                            //nolint:gosec // G104 - test cleanup
 				}
 			},
-			version:     "1.4.0",
-			wantErr:     true,
-			errContains: "error creating working directory",
+			version: "1.4.0",
+			wantErr: true,
+			// Reported at the gate now, with everything else wrong in the
+			// file, rather than by the Mkdir that used to be the first
+			// thing to notice.
+			errContains: "parent directory",
 		},
 		{
 			// The sdns.toml fallback is gone with the releases that used

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -475,7 +475,8 @@ func TestIPv6ProbeDecidesAccess(t *testing.T) {
 
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sdns.conf")
-	content := fmt.Sprintf("version = %q\ndirectory = %q\n",
+	// Not a DNSSEC test, and this scaffold carries no trust anchor.
+	content := fmt.Sprintf("version = %q\ndirectory = %q\ndnssec = \"off\"\n",
 		configver, filepath.Join(dir, "db"))
 	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 		t.Fatalf("write config: %v", err)
@@ -696,6 +697,9 @@ func TestLoadRFC8198Policy(t *testing.T) {
 			content := fmt.Sprintf(`version = %q
 directory = %q
 ipv6access = true
+# Not a DNSSEC test, and this scaffold carries no trust anchor; with
+# validation on and nothing to anchor to the config is refused.
+dnssec = "off"
 %s
 `, configver, workDir, tt.setting)
 			if err := os.WriteFile(cfgFile, []byte(content), 0644); err != nil { //nolint:gosec // G306 - test file
@@ -788,6 +792,9 @@ func TestLoadRFC9520Policy(t *testing.T) {
 			content := fmt.Sprintf(`version = %q
 directory = %q
 ipv6access = true
+# Not a DNSSEC test, and this scaffold carries no trust anchor; with
+# validation on and nothing to anchor to the config is refused.
+dnssec = "off"
 %s
 `, configver, workDir, tt.setting)
 			if err := os.WriteFile(cfgFile, []byte(content), 0644); err != nil { //nolint:gosec // G306 - test file
@@ -837,6 +844,7 @@ func TestLoadServeStalePolicy(t *testing.T) {
 			content := fmt.Sprintf(`version = %q
 directory = %q
 ipv6access = true
+dnssec = "off"
 %s
 `, configver, workDir, tt.settings)
 			if err := os.WriteFile(cfgFile, []byte(content), 0644); err != nil { //nolint:gosec // G306 - test file
@@ -862,6 +870,7 @@ func TestLoadRejectsNegativeServeStaleTTL(t *testing.T) {
 	content := fmt.Sprintf(`version = %q
 directory = %q
 ipv6access = true
+dnssec = "off"
 serve_stale = true
 serve_stale_max_ttl = "-1s"
 `, configver, workDir)
@@ -886,6 +895,7 @@ func TestLoadRecursionFirewallPolicy(t *testing.T) {
 		content := fmt.Sprintf(`version = %q
 directory = %q
 ipv6access = true
+dnssec = "off"
 
 [recursion_firewall]
 mode = "enforce"
@@ -943,6 +953,7 @@ failure_cache_max_ttl = "2m"
 		content := fmt.Sprintf(`version = %q
 directory = %q
 ipv6access = true
+dnssec = "off"
 
 [recursion_firewall]
 mode = "blocking"

--- a/config/openflags_other.go
+++ b/config/openflags_other.go
@@ -1,0 +1,7 @@
+//go:build !unix
+
+package config
+
+// nonBlockingOpen has no counterpart here: Windows has no FIFO that an open
+// can wait on the way a unix one does.
+const nonBlockingOpen = 0

--- a/config/openflags_unix.go
+++ b/config/openflags_unix.go
@@ -1,0 +1,11 @@
+//go:build unix
+
+package config
+
+import "syscall"
+
+// nonBlockingOpen keeps a probe from waiting on the file it is asking about.
+// A FIFO with no reader answers ENXIO instead of holding the open, which is
+// the difference between reporting the problem and becoming it. On anything
+// else it changes nothing.
+const nonBlockingOpen = syscall.O_NONBLOCK

--- a/config/validate.go
+++ b/config/validate.go
@@ -322,6 +322,11 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 			add("rootkeys %q: must be class IN", key)
 		case dnskey.Protocol != 3:
 			add("rootkeys %q: protocol must be 3 (RFC 4034 section 2.1.2)", key)
+		case dnskey.Flags&dnsKeyFlagRevoke != 0:
+			// RFC 5011 section 2.1: an operator may seed a revoked key so
+			// the resolver remembers the revocation across a restart. AutoTA
+			// records it as a tombstone and keeps it out of the active set,
+			// which is exactly what not counting it here does.
 		case dnskey.Flags != 257:
 			// Only key-signing keys enter the verification set.
 			add("rootkeys %q: must be a key-signing key (flags 257), not %d", key, dnskey.Flags)
@@ -413,8 +418,11 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 	// in code, which have no working directory to speak of — requiring one
 	// here would refuse every such caller to co-report a failure that is
 	// already impossible to miss.
+	// The working directory is written for certain — the trust-anchor store
+	// lives there — so it has to take an entry.
+	pending := c.Directory
 	if c.Directory != "" {
-		if err := writableDir(c.Directory); err != nil {
+		if err := writableDir(c.Directory, ""); err != nil {
 			add("directory = %q: %v", c.Directory, err)
 		}
 	}
@@ -429,15 +437,21 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 	// the parent of the default is legitimately not there yet — asking for
 	// it would refuse every first run. A blocklistdir the operator wrote
 	// themselves is nobody's to create, so that one is asked in full.
+	//
+	// Write is not required of it, unlike the working directory. The
+	// middleware reads local lists from there and only logs when it cannot
+	// download into it, so a read-only mount carrying nothing but local
+	// lists is a working setup — and refusing it would stop a server that
+	// runs today.
 	switch {
 	case c.BlockListDir != "":
-		if err := writableDir(c.BlockListDir); err != nil {
+		if err := usableDir(c.BlockListDir, pending); err != nil {
 			add("blocklistdir = %q: %v", c.BlockListDir, err)
 		}
 	case c.Directory != "":
 		derived := filepath.Join(c.Directory, "blacklists")
 		if _, err := os.Lstat(derived); err == nil {
-			if err := writableDir(derived); err != nil {
+			if err := usableDir(derived, ""); err != nil {
 				add("blocklistdir defaults to %q: %v", derived, err)
 			}
 		}
@@ -469,7 +483,7 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 				add("accesslog = %q: names a directory, want a file", c.AccessLog)
 				break
 			}
-			if err := existingDir(literalParent(target)); err != nil {
+			if err := existingDir(literalParent(target), pending); err != nil {
 				add("accesslog = %q: %v", c.AccessLog, err)
 			}
 		case err != nil:
@@ -701,8 +715,16 @@ func (c *Config) validateSubTables(add func(string, ...any)) {
 			}
 		}
 		for _, answer := range view.Answers {
-			if _, err := dns.NewRR(answer); err != nil {
+			// NewRR reports no error for a line that holds no record —
+			// blank, a comment, a directive — and hands back nothing. The
+			// view then answers with one entry fewer than the file lists,
+			// or with none at all.
+			rr, err := dns.NewRR(answer)
+			switch {
+			case err != nil:
 				add("view %s answer %q: %v", label, answer, err)
+			case rr == nil:
+				add("view %s answer %q: is not a record, so the view would not serve it", label, answer)
 			}
 		}
 	}
@@ -860,6 +882,9 @@ func (c *Config) validateECS(add func(string, ...any)) {
 	}
 }
 
+// dnsKeyFlagRevoke is the REVOKE bit of RFC 5011 section 2.1.
+const dnsKeyFlagRevoke = 0x0080
+
 // forwardsRoot reports whether a forward zone takes every query. Matching is
 // the same test ForwardZoneFor makes — a canonical apex of "." covers every
 // name, and a zone with no servers is skipped there — so a name this says is
@@ -961,7 +986,19 @@ func fileKind(mode os.FileMode) string {
 // writableDir reports whether path can serve as a directory the server writes
 // into. Absence is fine — both callers create it — but a plain file sitting at
 // the path is not, because the Mkdir that would follow fails.
-func writableDir(path string) error {
+// pending is the working directory Load creates just after the gate. A parent
+// that is exactly it is treated as present: the server makes it, and then
+// makes what goes inside. Only that one level, because Load uses Mkdir.
+// usableDir is writableDir without asking whether an entry can be made in it.
+func usableDir(path, pending string) error {
+	return dirCheck(path, pending, false)
+}
+
+func writableDir(path, pending string) error {
+	return dirCheck(path, pending, true)
+}
+
+func dirCheck(path, pending string, mustWrite bool) error {
 	// Lstat, so a symlink is judged as itself: a dangling one looks absent to
 	// Stat, and then Mkdir fails on it with EEXIST because the entry is
 	// already there.
@@ -970,7 +1007,7 @@ func writableDir(path string) error {
 		// Created with Mkdir, not MkdirAll, so one missing level is made and
 		// two are not — and Mkdir resolves every component on the way, so a
 		// "missing/../db" fails on the middle one however it cleans up.
-		return existingDir(literalParent(path))
+		return existingDir(literalParent(path), pending)
 	}
 	if err != nil {
 		return err
@@ -988,17 +1025,31 @@ func writableDir(path string) error {
 		// Through the link, because that is the path the server writes to.
 		// Returning here without asking accepted a symlink to a directory
 		// that the same check refuses when it is named directly.
+		if !mustWrite {
+			return nil
+		}
 		return creatable(path)
 	}
 	if !info.IsDir() {
 		return fmt.Errorf("is a file, want a directory")
+	}
+	if !mustWrite {
+		return nil
 	}
 	return creatable(path)
 }
 
 // existingDir reports whether path is a directory that is already there and
 // can be written into.
-func existingDir(path string) error {
+func existingDir(path, pending string) error {
+	if pending != "" && filepath.Clean(path) == filepath.Clean(pending) {
+		// Not there yet, and about to be. Everything under it is created
+		// after that, in the order the server does it.
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			return nil
+		}
+	}
+
 	info, err := os.Stat(path)
 	if err != nil {
 		return fmt.Errorf("parent directory %q: %w", path, err)

--- a/config/validate.go
+++ b/config/validate.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"crypto/ecdh"
+	"crypto/rsa"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -52,24 +53,32 @@ func (c *Config) Validate() error {
 		add("loglevel = %q: must be one of debug, info, warn, error", c.LogLevel)
 	}
 
-	for _, bind := range []struct{ key, value string }{
-		{"bind", c.Bind},
-		{"bindtls", c.BindTLS},
-		{"binddoh", c.BindDOH},
-		{"binddoq", c.BindDOQ},
+	for _, bind := range []struct {
+		key, value string
+		networks   []string
+	}{
+		// The plain listener answers over both; the rest open one apiece.
+		{"bind", c.Bind, []string{"udp", "tcp"}},
+		{"bindtls", c.BindTLS, []string{"tcp"}},
+		{"binddoh", c.BindDOH, []string{"tcp"}},
+		{"binddoq", c.BindDOQ, []string{"udp"}},
 	} {
 		if bind.value == "" {
 			continue
 		}
-		// An empty host is how every listener is told "all interfaces", so
-		// only the port half is required.
-		port, err := hostPort(bind.value)
+		host, port, err := net.SplitHostPort(bind.value)
 		switch {
-		case err != nil:
+		case err != nil || port == "":
 			add("%s = %q: must be host:port", bind.key, bind.value)
 		default:
+			// The host half is deliberately not judged. Empty means every
+			// interface; a literal may name an address this machine does not
+			// hold yet, which is how a floating address is served; and
+			// whether a name resolves is a runtime question of the same
+			// class as whether an upstream answers.
+			_ = host
 			// Port 0 is legal here: it asks the kernel for a free one.
-			if _, err := usablePort(port); err != nil {
+			if _, err := usablePort(port, bind.networks...); err != nil {
 				add("%s = %q: %v", bind.key, bind.value, err)
 			}
 		}
@@ -154,7 +163,7 @@ func (c *Config) Validate() error {
 			// Unlike a listener, an upstream cannot use port 0: nothing
 			// answers there, and the dial failure is per query rather than
 			// at startup.
-			if n, err := usablePort(port); err != nil || n == 0 {
+			if n, err := usablePort(port, "udp"); err != nil || n == 0 {
 				add("%s %q: must have a port to reach, e.g. 192.0.2.1:53", list.key, addr)
 				continue
 			}
@@ -185,8 +194,6 @@ func (c *Config) Validate() error {
 	}{
 		{"timeout", c.Timeout},
 		{"querytimeout", c.QueryTimeout},
-		{"roottcptimeout", c.RootTCPTimeout},
-		{"tldtcptimeout", c.TLDTCPTimeout},
 	} {
 		if d.value.Duration < 0 {
 			add("%s = %q: must not be negative", d.key, d.value.Duration)
@@ -208,7 +215,6 @@ func (c *Config) Validate() error {
 		// value is neither the default nor what was asked for: it leaves the
 		// TCP pool holding nothing, dnstap back on its default interval, and
 		// the metrics limit meaningless.
-		{"tcpmaxconnections", c.TCPMaxConnections},
 		{"dnstapflushinterval", c.DnstapFlushInterval},
 		{"domainmetricslimit", c.DomainMetricsLimit},
 		{"ingressworkers", c.IngressWorkers},
@@ -217,6 +223,25 @@ func (c *Config) Validate() error {
 	} {
 		if n.value < 0 {
 			add("%s = %d: must not be negative", n.key, n.value)
+		}
+	}
+
+	// Only reachable behind tcpkeepalive: the pool is the only reader, and it
+	// is not built at all when the setting is off.
+	if c.TCPKeepalive {
+		for _, d := range []struct {
+			key   string
+			value Duration
+		}{
+			{"roottcptimeout", c.RootTCPTimeout},
+			{"tldtcptimeout", c.TLDTCPTimeout},
+		} {
+			if d.value.Duration < 0 {
+				add("%s = %q: must not be negative", d.key, d.value.Duration)
+			}
+		}
+		if c.TCPMaxConnections < 0 {
+			add("tcpmaxconnections = %d: must not be negative", c.TCPMaxConnections)
 		}
 	}
 
@@ -321,16 +346,32 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 					family = "IPv4"
 				}
 				add("%s %q: must be an %s address", out.key, addr, family)
+				continue
+			}
+			// The resolver binds its outbound sockets to these, and stops
+			// the process outright when one is not an address this machine
+			// holds — after this test has already reported success.
+			// IPv6 is only read when ipv6access is on, so it is only
+			// judged then.
+			if !out.want4 && !c.IPv6Access {
+				continue
+			}
+			if !localAddress(ip) {
+				add("%s %q: is not an address of this machine", out.key, addr)
 			}
 		}
 	}
 
 	if c.API != "" {
-		port, err := hostPort(c.API)
-		if err != nil {
+		host, port, err := net.SplitHostPort(c.API)
+		switch {
+		case err != nil || port == "":
 			add("api = %q: must be host:port", c.API)
-		} else if _, err := usablePort(port); err != nil {
-			add("api = %q: %v", c.API, err)
+		default:
+			_ = host
+			if _, err := usablePort(port, "tcp"); err != nil {
+				add("api = %q: %v", c.API, err)
+			}
 		}
 	}
 
@@ -355,23 +396,47 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 
 	// Opened with O_CREATE, so it need not exist; a directory at the path
 	// makes that open fail and takes the server down at startup.
+	// Opened write-only with O_CREATE. The middleware logs a failure there and
+	// carries on with access logging quietly switched off, so every way of
+	// getting this wrong is silent.
 	if c.AccessLog != "" {
-		switch info, err := os.Stat(c.AccessLog); {
-		case err == nil && info.IsDir():
-			add("accesslog = %q: is a directory, want a file", c.AccessLog)
+		info, err := os.Lstat(c.AccessLog)
+		switch {
 		case os.IsNotExist(err):
-			// It is created on open, but only inside a directory that is
-			// already there. The middleware logs the failure and carries on
-			// with access logging quietly switched off.
+			// Created on open, but only inside a directory already there.
 			if err := existingDir(filepath.Dir(c.AccessLog)); err != nil {
+				add("accesslog = %q: %v", c.AccessLog, err)
+			}
+		case err != nil:
+			add("accesslog = %q: %v", c.AccessLog, err)
+		case info.IsDir():
+			add("accesslog = %q: is a directory, want a file", c.AccessLog)
+		case !info.Mode().IsRegular():
+			// A FIFO would hold the open until a reader arrives, which is a
+			// hung startup rather than a logged failure.
+			add("accesslog = %q: is a %s, want a regular file", c.AccessLog, fileKind(info.Mode()))
+		default:
+			if err := openable(c.AccessLog, os.O_WRONLY); err != nil {
 				add("accesslog = %q: %v", c.AccessLog, err)
 			}
 		}
 	}
 
-	if c.Kubernetes.Enabled && c.Kubernetes.Kubeconfig != "" {
-		if err := regularFile(c.Kubernetes.Kubeconfig); err != nil {
-			add("kubernetes.kubeconfig = %q: %v", c.Kubernetes.Kubeconfig, err)
+	// Demo seeds the registry and switches the middleware on just as Enabled
+	// does, so both open the same settings.
+	if c.Kubernetes.Enabled || c.Kubernetes.Demo {
+		if c.Kubernetes.Enabled && c.Kubernetes.Kubeconfig != "" {
+			if err := regularFile(c.Kubernetes.Kubeconfig); err != nil {
+				add("kubernetes.kubeconfig = %q: %v", c.Kubernetes.Kubeconfig, err)
+			}
+		}
+		// Lowercased and stripped of a trailing dot, then used as the suffix
+		// every lookup is matched against. A name that cannot be one matches
+		// nothing, and the middleware answers for no query at all.
+		if domain := strings.TrimSuffix(strings.ToLower(c.Kubernetes.ClusterDomain), "."); domain != "" {
+			if !validDomainName(domain) {
+				add("kubernetes.cluster_domain = %q: is not a valid domain name", c.Kubernetes.ClusterDomain)
+			}
 		}
 	}
 
@@ -402,7 +467,7 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 		case err != nil || host == "" || port == "":
 			add("hyperlocal_root_sources %q: must be host:port", raw)
 		default:
-			if n, err := usablePort(port); err != nil || n == 0 {
+			if n, err := usablePort(port, "tcp"); err != nil || n == 0 {
 				add("hyperlocal_root_sources %q: must have a port to reach", raw)
 			}
 		}
@@ -418,7 +483,10 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 	if c.QnameMaxMinimizeCount != nil && *c.QnameMaxMinimizeCount < 0 {
 		add("qname_max_minimize_count = %d: must not be negative (0 turns minimization off)", *c.QnameMaxMinimizeCount)
 	}
-	if c.QnameMinLevel < 0 {
+	// Only when it is the value actually read: with the new key set, the
+	// deprecated one is never consulted, so judging it would refuse a config
+	// whose live setting is fine.
+	if c.QnameMaxMinimizeCount == nil && c.QnameMinLevel < 0 {
 		add("qname_min_level = %d: must not be negative", c.QnameMinLevel)
 	}
 	if c.QnameMinimizeOneLabel < 0 {
@@ -512,7 +580,7 @@ func (c *Config) validateNameLists(add func(string, ...any)) {
 			// An explicit port is dialled like any other; out of range or
 			// zero fails at connect and the list simply never loads.
 			if port := parsed.Port(); port != "" {
-				if n, err := usablePort(port); err != nil || n == 0 {
+				if n, err := usablePort(port, "tcp"); err != nil || n == 0 {
 					add("blocklists %q: port %q has nothing to connect to", u, port)
 				}
 			}
@@ -697,6 +765,32 @@ func (c *Config) validateECS(add func(string, ...any)) {
 	}
 }
 
+// localAddress reports whether ip is one this machine holds. The resolver
+// makes the same test before binding an outbound socket to it and stops the
+// process when it fails, so a config test that skipped it would report success
+// on a file the server refuses.
+func localAddress(ip net.IP) bool {
+	addrs, err := net.InterfaceAddrs()
+	if err != nil {
+		// Nothing to compare against; leave the judgement to the runtime
+		// rather than invent a failure.
+		return true
+	}
+	for _, a := range addrs {
+		switch v := a.(type) {
+		case *net.IPNet:
+			if v.IP.Equal(ip) {
+				return true
+			}
+		case *net.IPAddr:
+			if v.IP.Equal(ip) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func validCIDR(s string) bool {
 	_, _, err := net.ParseCIDR(s)
 	return err == nil
@@ -722,7 +816,23 @@ func regularFile(path string) error {
 	if !info.Mode().IsRegular() {
 		return fmt.Errorf("is a %s, want a regular file", fileKind(info.Mode()))
 	}
-	return nil
+	// Type alone does not make it readable, and every consumer here opens the
+	// file: a certificate, a hosts file and a plugin all fail later on a mode
+	// this test would have passed. Startup runs under the same identity, so
+	// the open answers the question that matters.
+	return openable(path, os.O_RDONLY)
+}
+
+// openable reports whether path can be opened with the given flags, without
+// creating or truncating anything.
+func openable(path string, flag int) error {
+	// The path is the operator's own config value, opened to answer whether
+	// the server will be able to use it.
+	f, err := os.OpenFile(path, flag, 0) //nolint:gosec // G304 - the path under test is the input
+	if err != nil {
+		return err
+	}
+	return f.Close()
 }
 
 func fileKind(mode os.FileMode) string {
@@ -743,7 +853,10 @@ func fileKind(mode os.FileMode) string {
 // into. Absence is fine — both callers create it — but a plain file sitting at
 // the path is not, because the Mkdir that would follow fails.
 func writableDir(path string) error {
-	info, err := os.Stat(path)
+	// Lstat, so a symlink is judged as itself: a dangling one looks absent to
+	// Stat, and then Mkdir fails on it with EEXIST because the entry is
+	// already there.
+	info, err := os.Lstat(path)
 	if os.IsNotExist(err) {
 		// Created with Mkdir, not MkdirAll, so one missing level is made
 		// and two are not.
@@ -751,6 +864,18 @@ func writableDir(path string) error {
 	}
 	if err != nil {
 		return err
+	}
+	if info.Mode()&os.ModeSymlink != 0 {
+		// A symlink that resolves to a directory is usable; one that does
+		// not is the case Mkdir cannot get past.
+		target, terr := os.Stat(path)
+		if terr != nil {
+			return fmt.Errorf("is a symlink that does not resolve: %w", terr)
+		}
+		if !target.IsDir() {
+			return fmt.Errorf("is a symlink to a file, want a directory")
+		}
+		return nil
 	}
 	if !info.IsDir() {
 		return fmt.Errorf("is a file, want a directory")
@@ -796,8 +921,16 @@ func anchorKeyProblem(key *dns.DNSKEY) error {
 	switch {
 	case errors.Is(err, dns.ErrAlg):
 		return fmt.Errorf("algorithm %d (%s) cannot be verified with", key.Algorithm, name)
-	case errors.Is(err, dns.ErrKey):
-		return fmt.Errorf("public key is not usable for algorithm %d (%s)", key.Algorithm, name)
+	case err == nil, errors.Is(err, expectedProbeFailure(key.Algorithm)):
+		// The key was loaded and used, and only the throwaway signature was
+		// rejected — which is all this is asking.
+	default:
+		// Anything else means the key itself stopped the verifier. Listing
+		// the failures to reject would miss the ones the crypto packages add
+		// over time: Go now refuses an RSA key under 1024 bits with a policy
+		// error that is neither a parse failure nor a signature mismatch, and
+		// an anchor like that fails every real verification the same way.
+		return fmt.Errorf("public key is not usable for algorithm %d (%s): %v", key.Algorithm, name, err)
 	}
 
 	// The probe cannot see this on its own. A throwaway signature decodes to
@@ -818,6 +951,19 @@ func anchorKeyProblem(key *dns.DNSKEY) error {
 	return nil
 }
 
+// expectedProbeFailure is the one error a usable key of this algorithm may
+// produce against a signature that is deliberately wrong. Naming what success
+// looks like rather than enumerating failures keeps a key the crypto packages
+// reject for a new reason from passing as usable.
+func expectedProbeFailure(alg uint8) error {
+	switch alg {
+	case dns.RSAMD5, dns.RSASHA1, dns.RSASHA1NSEC3SHA1, dns.RSASHA256, dns.RSASHA512:
+		return rsa.ErrVerification
+	}
+	// ECDSA and the Edwards curves fail a bad signature inside miekg itself.
+	return dns.ErrSig
+}
+
 // ecdhCurve returns the curve behind a DNSSEC ECDSA algorithm, or nil for
 // every other algorithm. crypto/ecdh is used only as a point checker here —
 // it validates on-curve-ness on parse, which is the part the signature probe
@@ -834,18 +980,6 @@ func ecdhCurve(alg uint8) ecdh.Curve {
 	return nil
 }
 
-// hostPort splits addr and returns its port half, requiring one to be present.
-func hostPort(addr string) (string, error) {
-	_, port, err := net.SplitHostPort(addr)
-	if err != nil {
-		return "", err
-	}
-	if port == "" {
-		return "", fmt.Errorf("no port")
-	}
-	return port, nil
-}
-
 // usablePort resolves a port the way the net package does and returns the
 // number it lands on. SplitHostPort only separates the halves — it never reads
 // them — so ":65536" survives it and then fails at bind time, and an upstream
@@ -858,17 +992,23 @@ func hostPort(addr string) (string, error) {
 // tried because sdns listens on each and the two tables can differ; accepting
 // a name either one knows can only avoid refusing a config that works.
 //
+// The networks a caller passes are the ones the endpoint actually opens, so a
+// service name is judged the way it will be looked up: bind serves UDP and TCP
+// both, DoQ is UDP, and the TLS, DoH and API listeners are TCP.
+//
 // Callers that cannot use port 0 test the returned number rather than the
 // string: "00" and "+0" both resolve to zero and would slip past a comparison
 // against "0".
-func usablePort(port string) (int, error) {
-	n, err := net.LookupPort("udp", port)
-	if err != nil {
-		if n, err = net.LookupPort("tcp", port); err != nil {
-			return 0, fmt.Errorf("port %q is not one this host can use", port)
+func usablePort(port string, networks ...string) (int, error) {
+	var resolved int
+	for _, network := range networks {
+		n, err := net.LookupPort(network, port)
+		if err != nil {
+			return 0, fmt.Errorf("port %q is not one this host can use for %s", port, network)
 		}
+		resolved = n
 	}
-	return n, nil
+	return resolved, nil
 }
 
 // validIPPort reports whether addr is an IP literal with a usable port.
@@ -879,7 +1019,7 @@ func validIPPort(addr string) bool {
 	if err != nil || port == "" {
 		return false
 	}
-	if n, err := usablePort(port); err != nil || n == 0 {
+	if n, err := usablePort(port, "udp"); err != nil || n == 0 {
 		return false
 	}
 	return net.ParseIP(host) != nil
@@ -899,7 +1039,7 @@ func validUpstream(addr string) error {
 			return fmt.Errorf("not a usable DoH URL")
 		}
 		if port := u.Port(); port != "" {
-			n, err := usablePort(port)
+			n, err := usablePort(port, "tcp")
 			if err != nil {
 				return err
 			}
@@ -919,4 +1059,55 @@ func validUpstream(addr string) error {
 		}
 		return nil
 	}
+}
+
+// validateLoaded is Validate plus the requirements that only a configuration
+// file has to meet. A Config built in code — a test, an embedder — supplies
+// what it needs directly and legitimately leaves the rest empty, so these
+// cannot live in Validate itself. They belong to the same report all the same:
+// finding them one run later is exactly what the single gate exists to avoid.
+func (c *Config) validateLoaded() error {
+	var problems []string
+	add := func(format string, args ...any) {
+		problems = append(problems, fmt.Sprintf(format, args...))
+	}
+
+	// Load creates this directory and then works inside it; empty reaches
+	// os.Mkdir("") a few lines on and fails there, past the report.
+	if strings.TrimSpace(c.Directory) == "" {
+		add("directory: required, and this file leaves it empty")
+	}
+
+	// With no root to start from and nothing standing in for one, the
+	// resolver stops the process on the first recursive query rather than
+	// answering it. A global forwarder takes every query before the resolver
+	// sees it, and a forward zone for the root covers the same ground.
+	if len(c.RootServers) == 0 && len(c.Root6Servers) == 0 &&
+		len(c.ForwarderServers) == 0 && !c.forwardsRoot() {
+		add("rootservers: no root server, forwarder or root forward zone, so the first recursive query would stop the server")
+	}
+
+	if err := c.Validate(); err != nil {
+		if len(problems) == 0 {
+			return err
+		}
+		// One list, in the shape Validate already reports.
+		return fmt.Errorf("%w\n  - %s", err, strings.Join(problems, "\n  - "))
+	}
+	if len(problems) == 0 {
+		return nil
+	}
+	return fmt.Errorf("invalid configuration:\n  - %s", strings.Join(problems, "\n  - "))
+}
+
+// forwardsRoot reports whether a forward zone hands the whole namespace to its
+// own upstreams, which leaves nothing for the resolver to recurse for.
+func (c *Config) forwardsRoot() bool {
+	for i := range c.ForwardZones {
+		zone := &c.ForwardZones[i]
+		if dns.CanonicalName(strings.TrimSpace(zone.Name)) == "." && len(zone.Servers) > 0 {
+			return true
+		}
+	}
+	return false
 }

--- a/config/validate.go
+++ b/config/validate.go
@@ -1055,7 +1055,19 @@ func readable(dir string) error {
 	}
 	defer f.Close() //nolint:errcheck // nothing was written
 
-	if _, err := f.ReadDir(1); err != nil && !errors.Is(err, io.EOF) {
+	entries, err := f.ReadDir(1)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	if len(entries) == 0 {
+		// Nothing to walk into, which is a fine state for a list directory.
+		return nil
+	}
+
+	// Listing is not walking. A directory carrying read but not execute
+	// hands back its entry names and then refuses to stat any of them —
+	// which is exactly where the middleware's walk stops, loading nothing.
+	if _, err := os.Lstat(filepath.Join(dir, entries[0].Name())); err != nil {
 		return err
 	}
 	return nil
@@ -1071,7 +1083,22 @@ func samePath(a, b string) bool {
 	if cleansPathComponents || (!hasDotDot(a) && !hasDotDot(b)) {
 		return filepath.Clean(a) == filepath.Clean(b)
 	}
-	return a == b
+	// Components as written, because a ".." among them only resolves once
+	// what precedes it exists. A trailing separator is not one of those
+	// components, though — mkdir and open both take a path with one — so it
+	// is dropped before the comparison rather than making two spellings of
+	// the same place look different.
+	return trimTrailingSeparators(a) == trimTrailingSeparators(b)
+}
+
+// trimTrailingSeparators drops the separators at the end of path, keeping a
+// lone root as itself.
+func trimTrailingSeparators(path string) string {
+	i := len(path)
+	for i > 1 && os.IsPathSeparator(path[i-1]) {
+		i--
+	}
+	return path[:i]
 }
 
 // hasDotDot reports whether path has a ".." among its components. Bytes, not

--- a/config/validate.go
+++ b/config/validate.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"crypto"
 	"crypto/ecdh"
 	"crypto/ed25519"
 	"crypto/rsa"
@@ -8,12 +9,12 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"math/big"
 	"net"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/miekg/dns"
 )
@@ -409,8 +410,10 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 		info, err := os.Stat(c.AccessLog)
 		switch {
 		case os.IsNotExist(err):
-			// Created on open, but only inside a directory already there.
-			if err := existingDir(filepath.Dir(c.AccessLog)); err != nil {
+			// Created on open, but only inside a directory already there —
+			// and for a symlink that is the target's directory, not the
+			// link's, since the open follows the link before creating.
+			if err := existingDir(filepath.Dir(accessLogTarget(c.AccessLog))); err != nil {
 				add("accesslog = %q: %v", c.AccessLog, err)
 			}
 		case err != nil:
@@ -897,7 +900,10 @@ func writableDir(path string) error {
 		if !target.IsDir() {
 			return fmt.Errorf("is a symlink to a file, want a directory")
 		}
-		return nil
+		// Through the link, because that is the path the server writes to.
+		// Returning here without asking accepted a symlink to a directory
+		// that the same check refuses when it is named directly.
+		return creatable(path)
 	}
 	if !info.IsDir() {
 		return fmt.Errorf("is a file, want a directory")
@@ -921,6 +927,24 @@ func existingDir(path string) error {
 	return nil
 }
 
+// accessLogTarget resolves one level of symlink, so a dangling link is judged
+// where the file would actually be made. Stat reports such a link as absent,
+// which read as an ordinary missing file and had the link's own directory
+// checked instead of the target's.
+func accessLogTarget(path string) string {
+	if info, err := os.Lstat(path); err != nil || info.Mode()&os.ModeSymlink == 0 {
+		return path
+	}
+	target, err := os.Readlink(path)
+	if err != nil {
+		return path
+	}
+	if filepath.IsAbs(target) {
+		return target
+	}
+	return filepath.Join(filepath.Dir(path), target)
+}
+
 // creatable reports whether this process can make an entry in dir. Mode bits
 // alone do not answer it — ownership, group membership and the mount's own
 // flags all decide — so the question is put the only portable way there is,
@@ -933,11 +957,15 @@ func creatable(dir string) error {
 	if err != nil {
 		return err
 	}
+	// Set up straight after creating it, so no later failure can leave the
+	// probe behind. Neither result changes the answer: the directory took an
+	// entry, which is the whole question.
 	name := f.Name()
-	if err := f.Close(); err != nil {
-		return err
-	}
-	return os.Remove(name)
+	defer func() {
+		_ = f.Close()
+		_ = os.Remove(name)
+	}()
+	return nil
 }
 
 // anchorKeyProblem reports why this key cannot be verified with, or nil when
@@ -983,7 +1011,7 @@ func anchorKeyProblem(key *dns.DNSKEY) error {
 	// public point — so a curve key of the right length that is not a point
 	// on the curve comes back as a bad signature and looks usable.
 	if key.Algorithm == dns.ED25519 {
-		if err := edwardsCanonical(key.PublicKey); err != nil {
+		if err := ed25519Usable(key.PublicKey); err != nil {
 			return fmt.Errorf("public key is not usable for algorithm %d (%s): %v", key.Algorithm, name, err)
 		}
 	}
@@ -1015,21 +1043,38 @@ func expectedProbeFailure(alg uint8) error {
 	return dns.ErrSig
 }
 
-// edwards25519P is 2^255 - 19, the field the curve is defined over.
-var edwards25519P = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 255), big.NewInt(19))
+// ed25519 probe inputs. The signature is deliberately wrong, so the only
+// question the verifier can answer is whether the key itself is usable.
+var (
+	ed25519ProbeMessage = []byte("sdns config test")
+	ed25519ProbeOptions = &ed25519.Options{Hash: crypto.Hash(0)}
+)
 
-// edwardsCanonical reports whether an Ed25519 public key is encoded the way a
-// decoder will accept. RFC 8032 section 5.1.3 recovers the y-coordinate by
-// clearing the sign bit and fails when what is left is not less than p, so
-// this is the decoder's own rule rather than one invented here.
-//
-// It does not make the key valid: a canonical y that is not a point on the
-// curve still gets through, and the standard library exposes nothing that
-// would catch it — ed25519.Verify answers false for such a key exactly as it
-// does for a good key and a bad signature, which is why the probe above
-// cannot tell them apart. Catching that case needs Edwards arithmetic this
-// package has no business carrying.
-func edwardsCanonical(publicKey string) error {
+// ed25519BadSignature is what VerifyWithOptions reports when the key is fine
+// and only the signature is wrong. It is measured from a key generated here
+// rather than written out as a string, so if a future Go release rewords it
+// both sides move together — a hardcoded message would turn this check too
+// strict, which is the failure worth avoiding.
+var ed25519BadSignature = sync.OnceValue(func() string {
+	pub, _, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		return ""
+	}
+	e := ed25519.VerifyWithOptions(pub, ed25519ProbeMessage,
+		make([]byte, ed25519.SignatureSize), ed25519ProbeOptions)
+	if e == nil {
+		return ""
+	}
+	return e.Error()
+})
+
+// ed25519Usable reports whether an Ed25519 public key is one the verifier can
+// work with. Unlike ed25519.Verify, which answers false for a bad key and a
+// bad signature alike, VerifyWithOptions separates them: a key that is not a
+// point on the curve — or is encoded above the field prime — is reported as a
+// bad public key, while a usable key reports only that the signature is
+// wrong. Accepting nothing but the latter makes this fail closed.
+func ed25519Usable(publicKey string) error {
 	raw, err := base64.StdEncoding.DecodeString(publicKey)
 	if err != nil {
 		return fmt.Errorf("not base64: %w", err)
@@ -1038,14 +1083,16 @@ func edwardsCanonical(publicKey string) error {
 		return fmt.Errorf("is %d bytes, want %d", len(raw), ed25519.PublicKeySize)
 	}
 
-	// Little-endian, with the top bit carrying the sign of x.
-	y := make([]byte, len(raw))
-	for i := range raw {
-		y[len(raw)-1-i] = raw[i]
+	want := ed25519BadSignature()
+	if want == "" {
+		// Nothing to compare against; leave the judgement to the runtime
+		// rather than invent a failure.
+		return nil
 	}
-	y[0] &= 0x7f
-	if new(big.Int).SetBytes(y).Cmp(edwards25519P) >= 0 {
-		return fmt.Errorf("y-coordinate is not below 2^255-19, so no decoder accepts it")
+	e := ed25519.VerifyWithOptions(raw, ed25519ProbeMessage,
+		make([]byte, ed25519.SignatureSize), ed25519ProbeOptions)
+	if e != nil && e.Error() != want {
+		return e
 	}
 	return nil
 }

--- a/config/validate.go
+++ b/config/validate.go
@@ -17,6 +17,8 @@ import (
 	"sync"
 
 	"github.com/miekg/dns"
+
+	"github.com/semihalev/sdns/internal/emptyzones"
 )
 
 // Validate reports what is wrong with a loaded configuration.
@@ -140,6 +142,11 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	root6 := c.Root6Servers
+	if !c.IPv6Access {
+		root6 = nil
+	}
+
 	// The resolver takes IPv4 from rootservers and IPv6 from root6servers,
 	// and silently drops anything in the wrong list. A misplaced address
 	// therefore leaves a shorter root set than the operator wrote, or an
@@ -150,7 +157,9 @@ func (c *Config) Validate() error {
 		want   string // "4", "6", or "" for either
 	}{
 		{"rootservers", c.RootServers, "4"},
-		{"root6servers", c.Root6Servers, "6"},
+		// Only read behind ipv6access, so a stale entry on a host without
+		// v6 has no effect and must not stop the server.
+		{"root6servers", root6, "6"},
 		{"fallbackservers", c.FallbackServers, ""},
 	} {
 		for _, addr := range list.values {
@@ -413,7 +422,7 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 			// Created on open, but only inside a directory already there —
 			// and for a symlink that is the target's directory, not the
 			// link's, since the open follows the link before creating.
-			if err := existingDir(filepath.Dir(accessLogTarget(c.AccessLog))); err != nil {
+			if err := existingDir(filepath.Dir(filepath.Clean(accessLogTarget(c.AccessLog)))); err != nil {
 				add("accesslog = %q: %v", c.AccessLog, err)
 			}
 		case err != nil:
@@ -569,16 +578,23 @@ func (c *Config) validateNameLists(add func(string, ...any)) {
 		values   []string
 		wildcard bool
 	}{
+		// Only the blocklist reads the star: set() strips "*." and files the
+		// rest as a wildcard block. The whitelist is stored verbatim and
+		// matched up the hierarchy, so "*.example.com" there becomes a key
+		// with a literal star label that no query ever produces — and the
+		// operator who wrote it, meaning to exempt the subdomains, gets
+		// nothing. Whitelisting "example.com" already covers them.
 		{"blocklist", c.Blocklist, true},
-		{"whitelist", c.Whitelist, true},
+		{"whitelist", c.Whitelist, false},
 		{"emptyzones", c.EmptyZones, false},
 	} {
 		for _, entry := range list.values {
 			name := entry
-			// "*.example.com" blocks subdomains only; the star is the
-			// blocklist's own syntax, not part of the name.
 			if list.wildcard {
 				name = strings.TrimPrefix(name, "*.")
+			} else if strings.HasPrefix(name, "*.") {
+				add("%s %q: the leading \"*.\" is blocklist syntax and is not read here; write the name itself, which already covers its subdomains", list.key, entry)
+				continue
 			}
 			if name == "" {
 				add("%s entry %q is empty", list.key, entry)
@@ -586,6 +602,13 @@ func (c *Config) validateNameLists(add func(string, ...any)) {
 			}
 			if _, ok := dns.IsDomainName(name); !ok {
 				add("%s %q: not a valid domain name", list.key, entry)
+				continue
+			}
+			// An empty zone outside the locally-served tree is dropped, and
+			// a list where every entry is dropped falls back to all of them
+			// — so the operator gets the opposite of a narrowed list.
+			if list.key == "emptyzones" && !emptyzones.Covers(name) {
+				add("emptyzones %q: is not one of the locally-served zones (RFC 6303), so it is dropped", entry)
 			}
 		}
 	}
@@ -884,8 +907,9 @@ func writableDir(path string) error {
 	info, err := os.Lstat(path)
 	if os.IsNotExist(err) {
 		// Created with Mkdir, not MkdirAll, so one missing level is made
-		// and two are not.
-		return existingDir(filepath.Dir(path))
+		// and two are not. Clean first: Dir("/parent/db/") is "/parent/db",
+		// the path itself, which would look like a parent that is not there.
+		return existingDir(filepath.Dir(filepath.Clean(path)))
 	}
 	if err != nil {
 		return err

--- a/config/validate.go
+++ b/config/validate.go
@@ -969,22 +969,38 @@ func endsInSeparator(path string) bool {
 	return strings.HasSuffix(path, "/") || strings.HasSuffix(path, string(os.PathSeparator))
 }
 
-// accessLogTarget resolves one level of symlink, so a dangling link is judged
-// where the file would actually be made. Stat reports such a link as absent,
-// which read as an ordinary missing file and had the link's own directory
-// checked instead of the target's.
+// accessLogTarget resolves the symlink chain the open would follow, so a link
+// is judged where the file would actually be made. Stat reports a dangling
+// link as absent, which read as an ordinary missing file and had the link's
+// own directory checked instead of the target's.
+//
+// The trailing separator is carried across each hop by hand. Join cleans it
+// away, and it is the whole difference between a name the open creates and one
+// it refuses — a relative "real.log/" would otherwise arrive here looking like
+// an ordinary file name.
 func accessLogTarget(path string) string {
-	if info, err := os.Lstat(path); err != nil || info.Mode()&os.ModeSymlink == 0 {
-		return path
+	// Deeper than any real layout, and bounded so a link that points at
+	// itself cannot spin.
+	for range 16 {
+		info, err := os.Lstat(path)
+		if err != nil || info.Mode()&os.ModeSymlink == 0 {
+			return path
+		}
+		target, err := os.Readlink(path)
+		if err != nil {
+			return path
+		}
+		if filepath.IsAbs(target) {
+			path = target
+			continue
+		}
+		next := filepath.Join(filepath.Dir(path), target)
+		if endsInSeparator(target) {
+			next += string(os.PathSeparator)
+		}
+		path = next
 	}
-	target, err := os.Readlink(path)
-	if err != nil {
-		return path
-	}
-	if filepath.IsAbs(target) {
-		return target
-	}
-	return filepath.Join(filepath.Dir(path), target)
+	return path
 }
 
 // creatable reports whether this process can make an entry in dir. Mode bits

--- a/config/validate.go
+++ b/config/validate.go
@@ -962,14 +962,18 @@ func validCIDR(s string) bool {
 	if err != nil {
 		return false
 	}
-	// An IPv4-mapped prefix is filed under IPv6 by internal/ipset, while a
-	// client arriving over IPv4 is unmapped and looked up under IPv4 — so
-	// the entry sits in a table nothing searches. ECS compares prefix to
-	// address directly, where the families disagree just as flatly. Either
-	// way it is a rule that matches nobody, and as the only access-list
-	// entry it would leave an empty allow set. The operator wants the plain
-	// form: 192.0.2.0/24.
-	return !p.Addr().Is4In6()
+	// A prefix that stays inside the IPv4-mapped range once masked is filed
+	// under IPv6 by internal/ipset, while a client arriving over IPv4 is
+	// unmapped and looked up under IPv4 — so the entry sits in a table
+	// nothing searches. ECS compares prefix to address directly, where the
+	// families disagree just as flatly. Either way it matches nobody, and as
+	// the only access-list entry it would leave an empty allow set. The
+	// operator wants the plain form: 192.0.2.0/24.
+	//
+	// Masked, not as written: "::ffff:192.0.2.0/64" covers ::/64, which real
+	// IPv6 clients fall inside. Only /96 and narrower stay mapped, and only
+	// those are dead.
+	return !p.Masked().Addr().Is4In6()
 }
 
 // regularFile reports whether path is something the server can open and read.

--- a/config/validate.go
+++ b/config/validate.go
@@ -293,11 +293,20 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 	// record that is not a DNSKEY panics an unchecked type assertion during
 	// verification, and a key that is merely not a root KSK leaves the
 	// anchor set empty so every DNSSEC answer fails on unavailable anchors.
+	// Every record is parsed whatever the settings — NewResolver stops the
+	// process on one that will not — but nothing looks at what a record
+	// means unless validation or the hyperlocal root asks it to. Judging the
+	// meaning regardless would refuse a stale key that has no effect.
+	anchorsUsed := c.DNSSEC == "on" || c.HyperlocalRoot
+
 	anchors := 0
 	for _, key := range c.RootKeys {
 		rr, err := dns.NewRR(key)
 		if err != nil {
 			add("rootkeys %q: %v", key, err)
+			continue
+		}
+		if !anchorsUsed {
 			continue
 		}
 		dnskey, ok := rr.(*dns.DNSKEY)
@@ -327,13 +336,15 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 		}
 	}
 	switch {
-	case anchors == 0 && c.DNSSEC == "on" && len(c.ForwarderServers) == 0:
+	case anchors == 0 && c.DNSSEC == "on" && len(c.ForwarderServers) == 0 && !c.forwardsRoot():
 		// AutoTA needs a seed and will not take one from disk when the live
 		// set is empty, so this does not heal on its own: every iterative
 		// validation fails closed from the first query. A global forwarder
-		// skips the resolver entirely and so needs no anchor of its own.
+		// skips the resolver entirely and so needs no anchor of its own —
+		// and neither does a forward zone at the root, which hands every
+		// query to its upstreams by the same early return.
 		add("rootkeys: dnssec is on with no usable root trust anchor, so every validated answer would fail")
-	case anchors == 0 && len(c.RootKeys) > 0:
+	case anchorsUsed && anchors == 0 && len(c.RootKeys) > 0:
 		add("rootkeys: none of the configured keys is a usable root trust anchor")
 	}
 
@@ -345,6 +356,11 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 		{"outboundips", c.OutboundIPs, true},
 		{"outboundip6s", c.OutboundIP6s, false},
 	} {
+		// Read only behind ipv6access, so on a host without v6 the whole
+		// list has no effect — not just the locality of its entries.
+		if !out.want4 && !c.IPv6Access {
+			continue
+		}
 		for _, addr := range out.values {
 			ip := net.ParseIP(addr)
 			if ip == nil {
@@ -364,11 +380,6 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 			// The resolver binds its outbound sockets to these, and stops
 			// the process outright when one is not an address this machine
 			// holds — after this test has already reported success.
-			// IPv6 is only read when ipv6access is on, so it is only
-			// judged then.
-			if !out.want4 && !c.IPv6Access {
-				continue
-			}
 			if !localAddress(ip) {
 				add("%s %q: is not an address of this machine", out.key, addr)
 			}
@@ -395,15 +406,33 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 	// in code, which have no working directory to speak of — requiring one
 	// here would refuse every such caller to co-report a failure that is
 	// already impossible to miss.
-	for _, dir := range []struct{ key, path string }{
-		{"directory", c.Directory},
-		{"blocklistdir", c.BlockListDir},
-	} {
-		if dir.path == "" {
-			continue
+	if c.Directory != "" {
+		if err := writableDir(c.Directory); err != nil {
+			add("directory = %q: %v", c.Directory, err)
 		}
-		if err := writableDir(dir.path); err != nil {
-			add("%s = %q: %v", dir.key, dir.path, err)
+	}
+
+	// An empty blocklistdir is the normal case, not an unset one: the
+	// middleware fills it in under the working directory, and a plain file
+	// or an unwritable directory there leaves both the downloaded and the
+	// local lists quietly unloaded.
+	//
+	// Only what is already at the derived path can be judged, though. Load
+	// creates the working directory after this gate, so on a fresh install
+	// the parent of the default is legitimately not there yet — asking for
+	// it would refuse every first run. A blocklistdir the operator wrote
+	// themselves is nobody's to create, so that one is asked in full.
+	switch {
+	case c.BlockListDir != "":
+		if err := writableDir(c.BlockListDir); err != nil {
+			add("blocklistdir = %q: %v", c.BlockListDir, err)
+		}
+	case c.Directory != "":
+		derived := filepath.Join(c.Directory, "blacklists")
+		if _, err := os.Lstat(derived); err == nil {
+			if err := writableDir(derived); err != nil {
+				add("blocklistdir defaults to %q: %v", derived, err)
+			}
 		}
 	}
 
@@ -433,7 +462,7 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 				add("accesslog = %q: names a directory, want a file", c.AccessLog)
 				break
 			}
-			if err := existingDir(filepath.Dir(filepath.Clean(target))); err != nil {
+			if err := existingDir(literalParent(target)); err != nil {
 				add("accesslog = %q: %v", c.AccessLog, err)
 			}
 		case err != nil:
@@ -824,6 +853,20 @@ func (c *Config) validateECS(add func(string, ...any)) {
 	}
 }
 
+// forwardsRoot reports whether a forward zone takes every query. Matching is
+// the same test ForwardZoneFor makes — a canonical apex of "." covers every
+// name, and a zone with no servers is skipped there — so a name this says is
+// the root is one the handler will actually forward on.
+func (c *Config) forwardsRoot() bool {
+	for i := range c.ForwardZones {
+		zone := &c.ForwardZones[i]
+		if len(zone.Servers) > 0 && dns.CanonicalName(zone.Name) == "." {
+			return true
+		}
+	}
+	return false
+}
+
 // localAddress reports whether ip is one this machine holds. The resolver
 // makes the same test before binding an outbound socket to it and stops the
 // process when it fails, so a config test that skipped it would report success
@@ -917,10 +960,10 @@ func writableDir(path string) error {
 	// already there.
 	info, err := os.Lstat(path)
 	if os.IsNotExist(err) {
-		// Created with Mkdir, not MkdirAll, so one missing level is made
-		// and two are not. Clean first: Dir("/parent/db/") is "/parent/db",
-		// the path itself, which would look like a parent that is not there.
-		return existingDir(filepath.Dir(filepath.Clean(path)))
+		// Created with Mkdir, not MkdirAll, so one missing level is made and
+		// two are not — and Mkdir resolves every component on the way, so a
+		// "missing/../db" fails on the middle one however it cleans up.
+		return existingDir(literalParent(path))
 	}
 	if err != nil {
 		return err
@@ -960,6 +1003,31 @@ func existingDir(path string) error {
 		return fmt.Errorf("parent directory %q: %w", path, err)
 	}
 	return nil
+}
+
+// literalParent returns everything before the last element of path, with the
+// components left exactly as written.
+//
+// filepath.Dir cannot be used for this: it cleans, so "missing/../access.log"
+// comes back as "." and looks like it lives somewhere that exists — while the
+// open, which resolves each component in turn, fails on the "missing" that is
+// not there. Trailing separators are dropped first, so a path written as a
+// directory still yields its own parent rather than itself.
+func literalParent(path string) string {
+	i := len(path)
+	for i > 0 && os.IsPathSeparator(path[i-1]) {
+		i--
+	}
+	for i > 0 && !os.IsPathSeparator(path[i-1]) {
+		i--
+	}
+	for i > 1 && os.IsPathSeparator(path[i-1]) {
+		i--
+	}
+	if i == 0 {
+		return "."
+	}
+	return path[:i]
 }
 
 // endsInSeparator reports whether path is written as a directory. Both

--- a/config/validate.go
+++ b/config/validate.go
@@ -1,0 +1,193 @@
+package config
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strings"
+)
+
+// Validate reports what is wrong with a loaded configuration.
+//
+// Every problem is collected and reported together. An operator fixing a
+// config file wants the whole list, not one error per run — and a DNS server
+// that refuses to start is a visible failure, where one that starts with a
+// setting it silently ignored is not.
+//
+// The rules only reject what cannot be right: an address that does not parse,
+// a value outside an enumerated set, a file that is not there. Anything this
+// package cannot judge — whether an upstream answers, whether a certificate
+// matches its key — belongs to the component that uses it.
+func (c *Config) Validate() error {
+	var problems []string
+	add := func(format string, args ...any) {
+		problems = append(problems, fmt.Sprintf(format, args...))
+	}
+
+	switch c.DNSSEC {
+	case "", "on", "off":
+	default:
+		// Anything but "off" silently became "on", so a typo here turned
+		// validation on when the operator meant to turn it off.
+		add("dnssec = %q: must be \"on\" or \"off\"", c.DNSSEC)
+	}
+
+	switch c.LogLevel {
+	case "", "crit", "debug", "info", "warn", "error":
+	default:
+		add("loglevel = %q: must be one of crit, debug, info, warn, error", c.LogLevel)
+	}
+
+	for _, bind := range []struct{ key, value string }{
+		{"bind", c.Bind},
+		{"bindtls", c.BindTLS},
+		{"binddoh", c.BindDOH},
+		{"binddoq", c.BindDOQ},
+	} {
+		if bind.value == "" {
+			continue
+		}
+		// An empty host is how every listener is told "all interfaces", so
+		// only the port half is required.
+		if _, port, err := net.SplitHostPort(bind.value); err != nil || port == "" {
+			add("%s = %q: must be host:port", bind.key, bind.value)
+		}
+	}
+
+	if c.BindTLS != "" || c.BindDOH != "" || c.BindDOQ != "" {
+		if c.TLSCertificate == "" || c.TLSPrivateKey == "" {
+			add("tlscertificate and tlsprivatekey are required when bindtls, binddoh or binddoq is set")
+		} else {
+			for _, f := range []struct{ key, path string }{
+				{"tlscertificate", c.TLSCertificate},
+				{"tlsprivatekey", c.TLSPrivateKey},
+			} {
+				if _, err := os.Stat(f.path); err != nil {
+					add("%s = %q: %v", f.key, f.path, err)
+				}
+			}
+		}
+	}
+
+	for _, ip := range []struct{ key, value string }{
+		{"nullroute", c.Nullroute},
+		{"nullroutev6", c.Nullroutev6},
+	} {
+		if ip.value != "" && net.ParseIP(ip.value) == nil {
+			add("%s = %q: must be an IP address", ip.key, ip.value)
+		}
+	}
+
+	for i, entry := range c.AccessList {
+		if entry == "" {
+			add("accesslist entry %d is empty", i+1)
+			continue
+		}
+		if _, _, err := net.ParseCIDR(entry); err == nil {
+			continue
+		}
+		if net.ParseIP(entry) == nil {
+			add("accesslist %q: must be an IP address or CIDR block", entry)
+		}
+	}
+
+	for _, list := range []struct {
+		key    string
+		values []string
+	}{
+		{"rootservers", c.RootServers},
+		{"root6servers", c.Root6Servers},
+		{"fallbackservers", c.FallbackServers},
+	} {
+		for _, addr := range list.values {
+			if !validIPPort(addr) {
+				add("%s %q: must be an IP address and port, e.g. 192.0.2.1:53", list.key, addr)
+			}
+		}
+	}
+
+	for _, addr := range c.ForwarderServers {
+		if err := validUpstream(addr); err != nil {
+			add("forwarderservers %q: %v", addr, err)
+		}
+	}
+	for i := range c.ForwardZones {
+		zone := &c.ForwardZones[i]
+		for _, addr := range zone.Servers {
+			if err := validUpstream(addr); err != nil {
+				add("forward_zone %q server %q: %v", zone.Name, addr, err)
+			}
+		}
+	}
+
+	for _, d := range []struct {
+		key   string
+		value Duration
+	}{
+		{"timeout", c.Timeout},
+		{"querytimeout", c.QueryTimeout},
+		{"roottcptimeout", c.RootTCPTimeout},
+		{"tldtcptimeout", c.TLDTCPTimeout},
+	} {
+		if d.value.Duration < 0 {
+			add("%s = %q: must not be negative", d.key, d.value.Duration)
+		}
+	}
+
+	for _, n := range []struct {
+		key   string
+		value int
+	}{
+		{"cachesize", c.CacheSize},
+		{"maxdepth", c.Maxdepth},
+		{"ratelimit", c.RateLimit},
+		{"clientratelimit", c.ClientRateLimit},
+		{"maxconcurrentqueries", c.MaxConcurrentQueries},
+	} {
+		if n.value < 0 {
+			add("%s = %d: must not be negative", n.key, n.value)
+		}
+	}
+
+	if len(problems) == 0 {
+		return nil
+	}
+	return fmt.Errorf("invalid configuration:\n  - %s", strings.Join(problems, "\n  - "))
+}
+
+// validIPPort reports whether addr is an IP literal with a port. Authority and
+// fallback servers are dialled directly, so a hostname there would need a
+// resolver this one may not have yet.
+func validIPPort(addr string) bool {
+	host, port, err := net.SplitHostPort(addr)
+	if err != nil || port == "" {
+		return false
+	}
+	return net.ParseIP(host) != nil
+}
+
+// validUpstream reports whether addr is one of the three forms a forwarder
+// upstream may take. It mirrors what middleware/forwarder accepts, so a config
+// that passes here is one the forwarder can actually use.
+func validUpstream(addr string) error {
+	switch {
+	case strings.HasPrefix(addr, "https://"):
+		// DoH may name a host: it is bootstrapped once at startup.
+		u, err := url.Parse(addr)
+		if err != nil || u.Host == "" {
+			return fmt.Errorf("not a usable DoH URL")
+		}
+		return nil
+	case strings.HasPrefix(addr, "tls://"):
+		if !validIPPort(strings.TrimPrefix(addr, "tls://")) {
+			return fmt.Errorf("DoT needs an IP address and port, e.g. tls://192.0.2.1:853")
+		}
+		return nil
+	default:
+		if !validIPPort(addr) {
+			return fmt.Errorf("must be an IP address and port, a tls:// address, or an https:// URL")
+		}
+		return nil
+	}
+}

--- a/config/validate.go
+++ b/config/validate.go
@@ -513,16 +513,23 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 			add("accesslog = %q: %v", c.AccessLog, err)
 		case info.IsDir():
 			add("accesslog = %q: is a directory, want a file", c.AccessLog)
-		default:
-			// Judged by opening it, not by its type. A character device is
-			// the usual container spelling — /dev/null, or /dev/stdout to
-			// fold the log into the container's own output — and os.OpenFile
-			// takes both. So does a pipe: /dev/stdout is one whenever the
-			// container's output is piped, and reopening it through /dev/fd
-			// waits for nobody.
+		case info.Mode()&os.ModeNamedPipe != 0:
+			// Left alone on purpose. Opening a pipe to see whether it can be
+			// opened is not a free question: a reader waiting on it — cat, a
+			// log collector, the container runtime behind /dev/stdout — sees
+			// EOF the moment the last writer closes, and a probe that opens
+			// and closes is exactly that. The reader exits, and the open the
+			// middleware makes a moment later then waits forever for it.
 			//
-			// What does wait is a FIFO on disk with no reader, and the open
-			// below refuses that rather than joining it.
+			// So this check would cause the hang it was looking for. Whether
+			// a reader is attached is a fact about the running system, not
+			// about the file, and it belongs to the runtime the same way
+			// whether an upstream answers does.
+
+		default:
+			// Judged by opening it, not by its type: a character device is
+			// the usual container spelling — /dev/null, or /dev/stdout when
+			// the output is a file — and os.OpenFile takes it.
 			if err := openable(c.AccessLog, os.O_WRONLY); err != nil {
 				add("accesslog = %q: %v", c.AccessLog, err)
 			}
@@ -1008,14 +1015,19 @@ func regularFile(path string) error {
 	return openable(path, os.O_RDONLY)
 }
 
+// openFile is os.OpenFile, as a variable so a test can record which paths this
+// package opens. What it does not open matters as much as what it does: a pipe
+// is left untouched, and only a recording of the calls can pin that.
+var openFile = os.OpenFile
+
 // openable reports whether path can be opened with the given flags, without
 // creating or truncating anything.
 func openable(path string, flag int) error {
 	// The path is the operator's own config value, opened to answer whether
-	// the server will be able to use it — and opened so that it never waits:
-	// a FIFO with no reader answers ENXIO here instead of holding the open
-	// until one arrives.
-	f, err := os.OpenFile(path, flag|nonBlockingOpen, 0) //nolint:gosec // G304 - the path under test is the input
+	// the server will be able to use it — and opened so that it never waits.
+	// Pipes do not reach here, but a character device can hold an open too:
+	// a serial line waits for carrier.
+	f, err := openFile(path, flag|nonBlockingOpen, 0) //nolint:gosec // G304 - the path under test is the input
 	if err != nil {
 		return err
 	}
@@ -1097,7 +1109,7 @@ func dirCheck(path, pending string, mustWrite bool) error {
 // blocklist middleware walks the directory and, when it cannot, logs once and
 // loads no local list at all.
 func readable(dir string) error {
-	f, err := os.Open(dir) //nolint:gosec // G304 - the path under test is the input
+	f, err := openFile(dir, os.O_RDONLY, 0) //nolint:gosec // G304 - the path under test is the input
 	if err != nil {
 		return err
 	}

--- a/config/validate.go
+++ b/config/validate.go
@@ -1,11 +1,15 @@
 package config
 
 import (
+	"crypto/ecdh"
+	"encoding/base64"
 	"errors"
 	"fmt"
+	"math"
 	"net"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/miekg/dns"
@@ -65,7 +69,7 @@ func (c *Config) Validate() error {
 			add("%s = %q: must be host:port", bind.key, bind.value)
 		default:
 			// Port 0 is legal here: it asks the kernel for a free one.
-			if err := usablePort(port); err != nil {
+			if _, err := usablePort(port); err != nil {
 				add("%s = %q: %v", bind.key, bind.value, err)
 			}
 		}
@@ -150,7 +154,7 @@ func (c *Config) Validate() error {
 			// Unlike a listener, an upstream cannot use port 0: nothing
 			// answers there, and the dial failure is per query rather than
 			// at startup.
-			if err := usablePort(port); err != nil || port == "0" {
+			if n, err := usablePort(port); err != nil || n == 0 {
 				add("%s %q: must have a port to reach, e.g. 192.0.2.1:53", list.key, addr)
 				continue
 			}
@@ -325,13 +329,18 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 		port, err := hostPort(c.API)
 		if err != nil {
 			add("api = %q: must be host:port", c.API)
-		} else if err := usablePort(port); err != nil {
+		} else if _, err := usablePort(port); err != nil {
 			add("api = %q: %v", c.API, err)
 		}
 	}
 
 	// Both are created when absent, so only a plain file already sitting at
 	// the path is a problem — the Mkdir that follows would fail on it.
+	// An empty path is left alone. Load fails loudly on os.Mkdir("") a few
+	// lines further on, and Validate is also called on configurations built
+	// in code, which have no working directory to speak of — requiring one
+	// here would refuse every such caller to co-report a failure that is
+	// already impossible to miss.
 	for _, dir := range []struct{ key, path string }{
 		{"directory", c.Directory},
 		{"blocklistdir", c.BlockListDir},
@@ -347,8 +356,16 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 	// Opened with O_CREATE, so it need not exist; a directory at the path
 	// makes that open fail and takes the server down at startup.
 	if c.AccessLog != "" {
-		if info, err := os.Stat(c.AccessLog); err == nil && info.IsDir() {
+		switch info, err := os.Stat(c.AccessLog); {
+		case err == nil && info.IsDir():
 			add("accesslog = %q: is a directory, want a file", c.AccessLog)
+		case os.IsNotExist(err):
+			// It is created on open, but only inside a directory that is
+			// already there. The middleware logs the failure and carries on
+			// with access logging quietly switched off.
+			if err := existingDir(filepath.Dir(c.AccessLog)); err != nil {
+				add("accesslog = %q: %v", c.AccessLog, err)
+			}
 		}
 	}
 
@@ -385,8 +402,8 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 		case err != nil || host == "" || port == "":
 			add("hyperlocal_root_sources %q: must be host:port", raw)
 		default:
-			if err := usablePort(port); err != nil {
-				add("hyperlocal_root_sources %q: %v", raw, err)
+			if n, err := usablePort(port); err != nil || n == 0 {
+				add("hyperlocal_root_sources %q: must have a port to reach", raw)
 			}
 		}
 	}
@@ -422,10 +439,23 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 		add("prefetch = %d: is a percentage of the original TTL and must be 0 (off) or between 10 and 90", c.Prefetch)
 	}
 
-	if c.ReflexThreshold != 0 && (c.ReflexThreshold < 0 || c.ReflexThreshold > 1) {
-		// Out of range is silently replaced by the default, so an operator
-		// who wrote 42 believes they set a threshold they did not.
-		add("reflexthreshold = %v: must be between 0 and 1", c.ReflexThreshold)
+	// Only when the feature is on: reflex.New returns before reading the
+	// threshold otherwise, so a stale value under a disabled feature has no
+	// effect and must not stop the server.
+	//
+	// NaN is called out separately because it slips through a range test —
+	// every comparison against it is false, including the ones the middleware
+	// itself makes, so it lands on the same silent default as an out-of-range
+	// value.
+	if c.ReflexEnabled {
+		switch {
+		case math.IsNaN(float64(c.ReflexThreshold)):
+			add("reflexthreshold is not a number; must be between 0 and 1")
+		case c.ReflexThreshold != 0 && (c.ReflexThreshold < 0 || c.ReflexThreshold > 1):
+			// Out of range is silently replaced by the default, so an operator
+			// who wrote 42 believes they set a threshold they did not.
+			add("reflexthreshold = %v: must be between 0 and 1", c.ReflexThreshold)
+		}
 	}
 
 	for name, plugin := range c.Plugins {
@@ -478,6 +508,14 @@ func (c *Config) validateNameLists(add func(string, ...any)) {
 			// The updater fetches with an http.Client, so any other scheme
 			// fails on an unsupported protocol and the list never loads.
 			add("blocklists %q: scheme %q cannot be fetched; use http or https", u, parsed.Scheme)
+		default:
+			// An explicit port is dialled like any other; out of range or
+			// zero fails at connect and the list simply never loads.
+			if port := parsed.Port(); port != "" {
+				if n, err := usablePort(port); err != nil || n == 0 {
+					add("blocklists %q: port %q has nothing to connect to", u, port)
+				}
+			}
 		}
 	}
 }
@@ -536,6 +574,9 @@ func (c *Config) validateDNS64(add func(string, ...any)) {
 	}
 
 	validPrefixBits := map[int]bool{32: true, 40: true, 48: true, 56: true, 64: true, 96: true}
+	// Whether the prefix set the runtime ends up with contains the well-known
+	// one, which is what decides if exclude_a_networks is read at all.
+	wellKnown, usablePrefixes := false, 0
 	for _, raw := range c.DNS64.Prefixes {
 		prefix := strings.TrimSpace(raw)
 		_, network, err := net.ParseCIDR(prefix)
@@ -556,20 +597,38 @@ func (c *Config) validateDNS64(add func(string, ...any)) {
 		// already covers it.
 		if bits == 96 && len(network.IP) >= 9 && network.IP[8] != 0 {
 			add("dns64 prefix %q: byte 8 must be zero (RFC 6052 section 2.2 reserved)", prefix)
+			continue
 		}
+		usablePrefixes++
+		if network.String() == wellKnownPrefix {
+			wellKnown = true
+		}
+	}
+	// With no usable prefix the runtime falls back to the well-known one, so
+	// the exclude list is read either way.
+	if usablePrefixes == 0 {
+		wellKnown = true
 	}
 	// The exclude lists are family-specific at runtime and the wrong family
 	// is dropped with a log line nobody reads, so the exclusion the operator
 	// wrote silently does not apply. Family is decided by mask length, not
 	// To4(): ParseCIDR returns a 4-byte mask for IPv4 and 16 for IPv6, and
 	// an IPv4-mapped IPv6 range would fool the address test.
+	// Only consulted under the well-known prefix (RFC 6147 section 5.1.4):
+	// with a custom prefix the runtime skips the parse entirely, so a stale
+	// entry here has no effect and must not stop the server.
+	excludeA := c.DNS64.ExcludeANetworks
+	if !wellKnown {
+		excludeA = nil
+	}
+
 	for _, list := range []struct {
 		key    string
 		values []string
 		mask   int // 0 for either family
 	}{
 		{"dns64 client_networks", c.DNS64.ClientNetworks, 0},
-		{"dns64 exclude_a_networks", c.DNS64.ExcludeANetworks, net.IPv4len},
+		{"dns64 exclude_a_networks", excludeA, net.IPv4len},
 		{"dns64 exclude_aaaa_networks", c.DNS64.ExcludeAAAANetworks, net.IPv6len},
 	} {
 		for _, raw := range list.values {
@@ -600,6 +659,10 @@ func (c *Config) validateDNS64(add func(string, ...any)) {
 		}
 	}
 }
+
+// wellKnownPrefix is the NAT64 prefix from RFC 6052 section 2.1, in the
+// canonical spelling net.IPNet.String produces.
+const wellKnownPrefix = "64:ff9b::/96"
 
 func (c *Config) validateECS(add func(string, ...any)) {
 	if !c.ECS.Enabled {
@@ -651,7 +714,29 @@ func regularFile(path string) error {
 	if info.IsDir() {
 		return fmt.Errorf("is a directory, want a file")
 	}
+	// Not merely "not a directory": a FIFO passes that test and then blocks
+	// the reader, and a socket or device node fails it in its own way. Mode
+	// is checked rather than the file being opened, because a config test
+	// run by a different user than the service would read permissions that
+	// are not the ones that matter.
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("is a %s, want a regular file", fileKind(info.Mode()))
+	}
 	return nil
+}
+
+func fileKind(mode os.FileMode) string {
+	switch {
+	case mode&os.ModeNamedPipe != 0:
+		return "named pipe"
+	case mode&os.ModeSocket != 0:
+		return "socket"
+	case mode&os.ModeDevice != 0:
+		return "device"
+	case mode&os.ModeSymlink != 0:
+		return "symlink"
+	}
+	return "special file"
 }
 
 // writableDir reports whether path can serve as a directory the server writes
@@ -660,13 +745,27 @@ func regularFile(path string) error {
 func writableDir(path string) error {
 	info, err := os.Stat(path)
 	if os.IsNotExist(err) {
-		return nil
+		// Created with Mkdir, not MkdirAll, so one missing level is made
+		// and two are not.
+		return existingDir(filepath.Dir(path))
 	}
 	if err != nil {
 		return err
 	}
 	if !info.IsDir() {
 		return fmt.Errorf("is a file, want a directory")
+	}
+	return nil
+}
+
+// existingDir reports whether path is a directory that is already there.
+func existingDir(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("parent directory %q: %w", path, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("parent %q is a file, want a directory", path)
 	}
 	return nil
 }
@@ -700,6 +799,38 @@ func anchorKeyProblem(key *dns.DNSKEY) error {
 	case errors.Is(err, dns.ErrKey):
 		return fmt.Errorf("public key is not usable for algorithm %d (%s)", key.Algorithm, name)
 	}
+
+	// The probe cannot see this on its own. A throwaway signature decodes to
+	// r = s = 0, and ecdsa.Verify rejects that before it ever looks at the
+	// public point — so a curve key of the right length that is not a point
+	// on the curve comes back as a bad signature and looks usable.
+	if curve := ecdhCurve(key.Algorithm); curve != nil {
+		raw, decodeErr := base64.StdEncoding.DecodeString(key.PublicKey)
+		if decodeErr != nil {
+			return fmt.Errorf("public key is not base64: %v", decodeErr)
+		}
+		// DNSKEY carries the coordinates bare (RFC 6605 section 4); the
+		// 0x04 tag is what NewPublicKey expects on an uncompressed point.
+		if _, err := curve.NewPublicKey(append([]byte{4}, raw...)); err != nil {
+			return fmt.Errorf("public key is not usable for algorithm %d (%s): %v", key.Algorithm, name, err)
+		}
+	}
+	return nil
+}
+
+// ecdhCurve returns the curve behind a DNSSEC ECDSA algorithm, or nil for
+// every other algorithm. crypto/ecdh is used only as a point checker here —
+// it validates on-curve-ness on parse, which is the part the signature probe
+// above cannot reach. Ed25519 and Ed448 have no equivalent parse-time test in
+// the standard library, so a non-canonical point there is still only caught
+// when a real signature is verified.
+func ecdhCurve(alg uint8) ecdh.Curve {
+	switch alg {
+	case dns.ECDSAP256SHA256:
+		return ecdh.P256()
+	case dns.ECDSAP384SHA384:
+		return ecdh.P384()
+	}
 	return nil
 }
 
@@ -715,20 +846,29 @@ func hostPort(addr string) (string, error) {
 	return port, nil
 }
 
-// usablePort reports whether the net package can turn this port into one it
-// will actually use. SplitHostPort only separates the halves — it never reads
+// usablePort resolves a port the way the net package does and returns the
+// number it lands on. SplitHostPort only separates the halves — it never reads
 // them — so ":65536" survives it and then fails at bind time, and an upstream
 // with a port that big fails on every dial instead.
 //
-// LookupPort is the same call the net package makes when it dials or listens,
-// which is why it is used here rather than a numeric range check: it also
-// accepts the service names ("domain", "https") that a plain number test would
-// wrongly reject, and ":domain" does listen on 53.
-func usablePort(port string) error {
-	if _, err := net.LookupPort("udp", port); err != nil {
-		return fmt.Errorf("port %q is not one this host can use", port)
+// LookupPort is the call the net package itself makes when it dials or
+// listens, which is why it is used here rather than a numeric range check: it
+// also accepts the service names ("domain", "https") that a plain number test
+// would wrongly reject, and ":domain" does listen on 53. Both protocols are
+// tried because sdns listens on each and the two tables can differ; accepting
+// a name either one knows can only avoid refusing a config that works.
+//
+// Callers that cannot use port 0 test the returned number rather than the
+// string: "00" and "+0" both resolve to zero and would slip past a comparison
+// against "0".
+func usablePort(port string) (int, error) {
+	n, err := net.LookupPort("udp", port)
+	if err != nil {
+		if n, err = net.LookupPort("tcp", port); err != nil {
+			return 0, fmt.Errorf("port %q is not one this host can use", port)
+		}
 	}
-	return nil
+	return n, nil
 }
 
 // validIPPort reports whether addr is an IP literal with a usable port.
@@ -736,10 +876,10 @@ func usablePort(port string) error {
 // would need a resolver this one may not have yet.
 func validIPPort(addr string) bool {
 	host, port, err := net.SplitHostPort(addr)
-	if err != nil || port == "" || port == "0" {
+	if err != nil || port == "" {
 		return false
 	}
-	if err := usablePort(port); err != nil {
+	if n, err := usablePort(port); err != nil || n == 0 {
 		return false
 	}
 	return net.ParseIP(host) != nil
@@ -759,8 +899,12 @@ func validUpstream(addr string) error {
 			return fmt.Errorf("not a usable DoH URL")
 		}
 		if port := u.Port(); port != "" {
-			if err := usablePort(port); err != nil {
+			n, err := usablePort(port)
+			if err != nil {
 				return err
+			}
+			if n == 0 {
+				return fmt.Errorf("port 0 has nothing to connect to")
 			}
 		}
 		return nil

--- a/config/validate.go
+++ b/config/validate.go
@@ -59,8 +59,15 @@ func (c *Config) Validate() error {
 		}
 		// An empty host is how every listener is told "all interfaces", so
 		// only the port half is required.
-		if _, port, err := net.SplitHostPort(bind.value); err != nil || port == "" {
+		port, err := hostPort(bind.value)
+		switch {
+		case err != nil:
 			add("%s = %q: must be host:port", bind.key, bind.value)
+		default:
+			// Port 0 is legal here: it asks the kernel for a free one.
+			if err := usablePort(port); err != nil {
+				add("%s = %q: %v", bind.key, bind.value, err)
+			}
 		}
 	}
 
@@ -120,6 +127,13 @@ func (c *Config) Validate() error {
 			ip := net.ParseIP(host)
 			if ip == nil {
 				add("%s %q: must be an IP address and port, e.g. 192.0.2.1:53", list.key, addr)
+				continue
+			}
+			// Unlike a listener, an upstream cannot use port 0: nothing
+			// answers there, and the dial failure is per query rather than
+			// at startup.
+			if err := usablePort(port); err != nil || port == "0" {
+				add("%s %q: must have a port to reach, e.g. 192.0.2.1:53", list.key, addr)
 				continue
 			}
 			is4 := ip.To4() != nil
@@ -240,17 +254,25 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 		case dnskey.Flags != 257:
 			// Only key-signing keys enter the verification set.
 			add("rootkeys %q: must be a key-signing key (flags 257), not %d", key, dnskey.Flags)
-		case !verifiableAlgorithm(dnskey):
-			// Nothing rejects this at startup: the anchor is loaded, and
-			// then every signature made with it fails, so validation is off
-			// while the file still says it is on.
-			add("rootkeys %q: algorithm %d (%s) cannot be verified with",
-				key, dnskey.Algorithm, dns.AlgorithmToString[dnskey.Algorithm])
 		default:
+			// Nothing rejects an unusable key at startup: the anchor is
+			// loaded, and then every signature it is asked to verify fails,
+			// so validation is off while the file still says it is on.
+			if problem := anchorKeyProblem(dnskey); problem != nil {
+				add("rootkeys %q: %v", key, problem)
+				continue
+			}
 			anchors++
 		}
 	}
-	if len(c.RootKeys) > 0 && anchors == 0 {
+	switch {
+	case anchors == 0 && c.DNSSEC == "on" && len(c.ForwarderServers) == 0:
+		// AutoTA needs a seed and will not take one from disk when the live
+		// set is empty, so this does not heal on its own: every iterative
+		// validation fails closed from the first query. A global forwarder
+		// skips the resolver entirely and so needs no anchor of its own.
+		add("rootkeys: dnssec is on with no usable root trust anchor, so every validated answer would fail")
+	case anchors == 0 && len(c.RootKeys) > 0:
 		add("rootkeys: none of the configured keys is a usable root trust anchor")
 	}
 
@@ -281,8 +303,11 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 	}
 
 	if c.API != "" {
-		if _, port, err := net.SplitHostPort(c.API); err != nil || port == "" {
+		port, err := hostPort(c.API)
+		if err != nil {
 			add("api = %q: must be host:port", c.API)
+		} else if err := usablePort(port); err != nil {
+			add("api = %q: %v", c.API, err)
 		}
 	}
 
@@ -292,12 +317,24 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 		}
 	}
 
-	for _, addr := range c.HyperlocalRootSources {
+	for _, raw := range c.HyperlocalRootSources {
+		// The manager trims each source and drops the ones left empty,
+		// falling back to its built-in list, so neither surrounding space
+		// nor a blank entry is a problem to report.
+		addr := strings.TrimSpace(raw)
+		if addr == "" {
+			continue
+		}
 		// Hostnames are expected here: the built-in sources are the root
 		// servers' names.
 		host, port, err := net.SplitHostPort(addr)
-		if err != nil || host == "" || port == "" {
-			add("hyperlocal_root_sources %q: must be host:port", addr)
+		switch {
+		case err != nil || host == "" || port == "":
+			add("hyperlocal_root_sources %q: must be host:port", raw)
+		default:
+			if err := usablePort(port); err != nil {
+				add("hyperlocal_root_sources %q: %v", raw, err)
+			}
 		}
 	}
 
@@ -398,11 +435,18 @@ func (c *Config) validateSubTables(add func(string, ...any)) {
 	//
 	// The family test is the mask length, not To4(): an IPv4-mapped range
 	// like ::ffff:0:0/96 has a non-nil To4() and is a legal Pref64 input.
+	//
+	// dns64 reads every one of its lists through TrimSpace, so surrounding
+	// space is not a problem there and rejecting it would refuse a config the
+	// server runs today. The ecs list below is parsed raw, so it is not
+	// trimmed here either — each list is judged the way its own reader reads
+	// it.
 	validPrefixBits := map[int]bool{32: true, 40: true, 48: true, 56: true, 64: true, 96: true}
-	for _, prefix := range c.DNS64.Prefixes {
+	for _, raw := range c.DNS64.Prefixes {
+		prefix := strings.TrimSpace(raw)
 		_, network, err := net.ParseCIDR(prefix)
 		if err != nil {
-			add("dns64 prefix %q: must be a CIDR block", prefix)
+			add("dns64 prefix %q: must be a CIDR block", raw)
 			continue
 		}
 		if len(network.Mask) != net.IPv6len {
@@ -428,17 +472,22 @@ func (c *Config) validateSubTables(add func(string, ...any)) {
 	for _, list := range []struct {
 		key    string
 		values []string
-		mask   int // 0 for either family
+		mask   int  // 0 for either family
+		trim   bool // whether this list's reader trims before parsing
 	}{
-		{"dns64 client_networks", c.DNS64.ClientNetworks, 0},
-		{"dns64 exclude_a_networks", c.DNS64.ExcludeANetworks, net.IPv4len},
-		{"dns64 exclude_aaaa_networks", c.DNS64.ExcludeAAAANetworks, net.IPv6len},
-		{"ecs client_networks", c.ECS.ClientNetworks, 0},
+		{"dns64 client_networks", c.DNS64.ClientNetworks, 0, true},
+		{"dns64 exclude_a_networks", c.DNS64.ExcludeANetworks, net.IPv4len, true},
+		{"dns64 exclude_aaaa_networks", c.DNS64.ExcludeAAAANetworks, net.IPv6len, true},
+		{"ecs client_networks", c.ECS.ClientNetworks, 0, false},
 	} {
-		for _, network := range list.values {
+		for _, raw := range list.values {
+			network := raw
+			if list.trim {
+				network = strings.TrimSpace(raw)
+			}
 			_, parsed, err := net.ParseCIDR(network)
 			if err != nil {
-				add("%s %q: must be a CIDR block", list.key, network)
+				add("%s %q: must be a CIDR block", list.key, raw)
 				continue
 			}
 			if list.mask != 0 && len(parsed.Mask) != list.mask {
@@ -446,13 +495,19 @@ func (c *Config) validateSubTables(add func(string, ...any)) {
 				if list.mask == net.IPv6len {
 					family = "IPv6"
 				}
-				add("%s %q: must be %s", list.key, network, family)
+				add("%s %q: must be %s", list.key, raw, family)
 			}
 		}
 	}
-	for _, zone := range c.DNS64.ExcludeZones {
+	for _, raw := range c.DNS64.ExcludeZones {
+		// Trimmed, lowercased, and given a trailing dot before use, and a
+		// blank entry is skipped — so none of those is worth reporting.
+		zone := strings.TrimSpace(strings.ToLower(raw))
+		if zone == "" {
+			continue
+		}
 		if _, ok := dns.IsDomainName(zone); !ok {
-			add("dns64 exclude_zones %q: not a valid domain name", zone)
+			add("dns64 exclude_zones %q: not a valid domain name", raw)
 		}
 	}
 
@@ -477,14 +532,17 @@ func validCIDR(s string) bool {
 	return err == nil
 }
 
-// verifiableAlgorithm reports whether signatures made with this key's algorithm
-// can be verified. The answer is asked of the DNSSEC library rather than kept
-// as a list here, because the set belongs to that library and moves with it —
-// a list written today would claim ED448 works, and it does not.
+// anchorKeyProblem reports why this key cannot be verified with, or nil when
+// it can. Both the set of usable algorithms and the shape each one demands of
+// its public key belong to the DNSSEC library, so the library is asked rather
+// than kept in step with by hand: a list written here would claim ED448 works,
+// and it does not.
 //
-// A signature this throwaway fails for many reasons; only ErrAlg means the
-// algorithm itself is the problem, so every other outcome counts as usable.
-func verifiableAlgorithm(key *dns.DNSKEY) bool {
+// A signature this throwaway fails for many reasons, and only these two are
+// about the key. Every other outcome — a crypto mismatch, a bad signature —
+// means the algorithm was recognised and the key parsed, which is all that is
+// being asked. Real keys of every supported algorithm reach those outcomes.
+func anchorKeyProblem(key *dns.DNSKEY) error {
 	probe := &dns.RRSIG{
 		Hdr:         dns.RR_Header{Name: key.Hdr.Name, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET},
 		TypeCovered: dns.TypeDNSKEY,
@@ -494,15 +552,55 @@ func verifiableAlgorithm(key *dns.DNSKEY) bool {
 		SignerName:  key.Hdr.Name,
 		Signature:   "AA==",
 	}
-	return !errors.Is(probe.Verify(key, []dns.RR{key}), dns.ErrAlg)
+
+	err := probe.Verify(key, []dns.RR{key})
+	name := dns.AlgorithmToString[key.Algorithm]
+	switch {
+	case errors.Is(err, dns.ErrAlg):
+		return fmt.Errorf("algorithm %d (%s) cannot be verified with", key.Algorithm, name)
+	case errors.Is(err, dns.ErrKey):
+		return fmt.Errorf("public key is not usable for algorithm %d (%s)", key.Algorithm, name)
+	}
+	return nil
 }
 
-// validIPPort reports whether addr is an IP literal with a port. Authority and
-// fallback servers are dialled directly, so a hostname there would need a
-// resolver this one may not have yet.
+// hostPort splits addr and returns its port half, requiring one to be present.
+func hostPort(addr string) (string, error) {
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		return "", err
+	}
+	if port == "" {
+		return "", fmt.Errorf("no port")
+	}
+	return port, nil
+}
+
+// usablePort reports whether the net package can turn this port into one it
+// will actually use. SplitHostPort only separates the halves — it never reads
+// them — so ":65536" survives it and then fails at bind time, and an upstream
+// with a port that big fails on every dial instead.
+//
+// LookupPort is the same call the net package makes when it dials or listens,
+// which is why it is used here rather than a numeric range check: it also
+// accepts the service names ("domain", "https") that a plain number test would
+// wrongly reject, and ":domain" does listen on 53.
+func usablePort(port string) error {
+	if _, err := net.LookupPort("udp", port); err != nil {
+		return fmt.Errorf("port %q is not one this host can use", port)
+	}
+	return nil
+}
+
+// validIPPort reports whether addr is an IP literal with a usable port.
+// Authority and fallback servers are dialled directly, so a hostname there
+// would need a resolver this one may not have yet.
 func validIPPort(addr string) bool {
 	host, port, err := net.SplitHostPort(addr)
-	if err != nil || port == "" {
+	if err != nil || port == "" || port == "0" {
+		return false
+	}
+	if err := usablePort(port); err != nil {
 		return false
 	}
 	return net.ParseIP(host) != nil

--- a/config/validate.go
+++ b/config/validate.go
@@ -79,19 +79,37 @@ func (c *Config) Validate() error {
 				{"tlscertificate", c.TLSCertificate},
 				{"tlsprivatekey", c.TLSPrivateKey},
 			} {
-				if _, err := os.Stat(f.path); err != nil {
+				if err := regularFile(f.path); err != nil {
 					add("%s = %q: %v", f.key, f.path, err)
 				}
 			}
 		}
 	}
 
-	for _, ip := range []struct{ key, value string }{
-		{"nullroute", c.Nullroute},
-		{"nullroutev6", c.Nullroutev6},
+	// Blocked names answer A from the first and AAAA from the second. Swap
+	// them and the A record packs the IPv6 address's nil To4() as 0.0.0.0,
+	// while the AAAA carries an IPv4-mapped address — a wrong answer rather
+	// than a failure, so nothing downstream complains.
+	for _, ip := range []struct {
+		key, value string
+		want4      bool
+	}{
+		{"nullroute", c.Nullroute, true},
+		{"nullroutev6", c.Nullroutev6, false},
 	} {
-		if ip.value != "" && net.ParseIP(ip.value) == nil {
+		if ip.value == "" {
+			continue
+		}
+		parsed := net.ParseIP(ip.value)
+		switch {
+		case parsed == nil:
 			add("%s = %q: must be an IP address", ip.key, ip.value)
+		case (parsed.To4() != nil) != ip.want4:
+			family := "IPv6"
+			if ip.want4 {
+				family = "IPv4"
+			}
+			add("%s = %q: must be %s", ip.key, ip.value, family)
 		}
 	}
 
@@ -165,7 +183,6 @@ func (c *Config) Validate() error {
 		{"querytimeout", c.QueryTimeout},
 		{"roottcptimeout", c.RootTCPTimeout},
 		{"tldtcptimeout", c.TLDTCPTimeout},
-		{"ecs.cache_limit_ttl", c.ECS.CacheLimitTTL},
 	} {
 		if d.value.Duration < 0 {
 			add("%s = %q: must not be negative", d.key, d.value.Duration)
@@ -176,6 +193,8 @@ func (c *Config) Validate() error {
 		key   string
 		value int
 	}{
+		// Zero keeps its "use the default" meaning; a size the cache would
+		// silently raise is caught below.
 		{"cachesize", c.CacheSize},
 		{"maxdepth", c.Maxdepth},
 		{"ratelimit", c.RateLimit},
@@ -311,13 +330,47 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 		}
 	}
 
+	// Both are created when absent, so only a plain file already sitting at
+	// the path is a problem — the Mkdir that follows would fail on it.
+	for _, dir := range []struct{ key, path string }{
+		{"directory", c.Directory},
+		{"blocklistdir", c.BlockListDir},
+	} {
+		if dir.path == "" {
+			continue
+		}
+		if err := writableDir(dir.path); err != nil {
+			add("%s = %q: %v", dir.key, dir.path, err)
+		}
+	}
+
+	// Opened with O_CREATE, so it need not exist; a directory at the path
+	// makes that open fail and takes the server down at startup.
+	if c.AccessLog != "" {
+		if info, err := os.Stat(c.AccessLog); err == nil && info.IsDir() {
+			add("accesslog = %q: is a directory, want a file", c.AccessLog)
+		}
+	}
+
+	if c.Kubernetes.Enabled && c.Kubernetes.Kubeconfig != "" {
+		if err := regularFile(c.Kubernetes.Kubeconfig); err != nil {
+			add("kubernetes.kubeconfig = %q: %v", c.Kubernetes.Kubeconfig, err)
+		}
+	}
+
 	if c.HostsFile != "" {
-		if _, err := os.Stat(c.HostsFile); err != nil {
+		if err := regularFile(c.HostsFile); err != nil {
 			add("hostsfile = %q: %v", c.HostsFile, err)
 		}
 	}
 
-	for _, raw := range c.HyperlocalRootSources {
+	// Only read when the feature is on, so a stale source left behind by an
+	// operator who turned hyperlocal off does not stop the server.
+	sources := c.HyperlocalRootSources
+	if !c.HyperlocalRoot {
+		sources = nil
+	}
+	for _, raw := range sources {
 		// The manager trims each source and drops the ones left empty,
 		// falling back to its built-in list, so neither surrounding space
 		// nor a blank entry is a problem to report.
@@ -341,8 +394,32 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 	// The cache refuses anything above 90 and then disables prefetch
 	// entirely, so 91-100 passed this test and silently turned the feature
 	// off. The low end is clamped up to 10 rather than refused.
-	if c.Prefetch > 90 {
-		add("prefetch = %d: is a percentage of the original TTL and must not exceed 90", c.Prefetch)
+	// Negatives here are settled away rather than refused: a negative
+	// minimization count folds to zero, which turns minimization off, and a
+	// negative one-label count falls back to the default. Both leave the
+	// server running something the file does not say.
+	if c.QnameMaxMinimizeCount != nil && *c.QnameMaxMinimizeCount < 0 {
+		add("qname_max_minimize_count = %d: must not be negative (0 turns minimization off)", *c.QnameMaxMinimizeCount)
+	}
+	if c.QnameMinLevel < 0 {
+		add("qname_min_level = %d: must not be negative", c.QnameMinLevel)
+	}
+	if c.QnameMinimizeOneLabel < 0 {
+		add("qname_minimize_one_label = %d: must not be negative", c.QnameMinimizeOneLabel)
+	}
+
+	// The cache raises anything under 1024 to 1024 without saying so, so a
+	// file naming a smaller cache does not describe the server that runs.
+	// Zero still means "use the default".
+	if c.CacheSize > 0 && c.CacheSize < 1024 {
+		add("cachesize = %d: must be 0 (default) or at least 1024", c.CacheSize)
+	}
+
+	// A percentage of the original TTL, and the cache moves anything outside
+	// 10..90 without saying so: above 90 it turns prefetch off entirely, and
+	// 1..9 it raises to 10. Zero is the documented way to disable it.
+	if c.Prefetch > 90 || (c.Prefetch > 0 && c.Prefetch < 10) {
+		add("prefetch = %d: is a percentage of the original TTL and must be 0 (off) or between 10 and 90", c.Prefetch)
 	}
 
 	if c.ReflexThreshold != 0 && (c.ReflexThreshold < 0 || c.ReflexThreshold > 1) {
@@ -356,7 +433,7 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 			add("plugin %q has no path", name)
 			continue
 		}
-		if _, err := os.Stat(plugin.Path); err != nil {
+		if err := regularFile(plugin.Path); err != nil {
 			add("plugin %q path %q: %v", name, plugin.Path, err)
 		}
 	}
@@ -393,7 +470,9 @@ func (c *Config) validateNameLists(add func(string, ...any)) {
 	for _, u := range c.BlockLists {
 		parsed, err := url.Parse(u)
 		switch {
-		case err != nil || parsed.Host == "":
+		// Hostname, not Host: "http://:80/list" has the latter and nothing
+		// to connect to.
+		case err != nil || parsed.Hostname() == "":
 			add("blocklists %q: must be an http:// or https:// URL", u)
 		case parsed.Scheme != "http" && parsed.Scheme != "https":
 			// The updater fetches with an http.Client, so any other scheme
@@ -441,6 +520,21 @@ func (c *Config) validateSubTables(add func(string, ...any)) {
 	// server runs today. The ecs list below is parsed raw, so it is not
 	// trimmed here either — each list is judged the way its own reader reads
 	// it.
+	//
+	// All of it is gated on enabled, because both constructors return before
+	// reading another field when the feature is off. A config that has run
+	// for years with a stale value under a disabled section must keep
+	// starting; refusing it would turn an upgrade into an outage over a
+	// setting that has no effect either way.
+	c.validateDNS64(add)
+	c.validateECS(add)
+}
+
+func (c *Config) validateDNS64(add func(string, ...any)) {
+	if !c.DNS64.Enabled {
+		return
+	}
+
 	validPrefixBits := map[int]bool{32: true, 40: true, 48: true, 56: true, 64: true, 96: true}
 	for _, raw := range c.DNS64.Prefixes {
 		prefix := strings.TrimSpace(raw)
@@ -472,20 +566,15 @@ func (c *Config) validateSubTables(add func(string, ...any)) {
 	for _, list := range []struct {
 		key    string
 		values []string
-		mask   int  // 0 for either family
-		trim   bool // whether this list's reader trims before parsing
+		mask   int // 0 for either family
 	}{
-		{"dns64 client_networks", c.DNS64.ClientNetworks, 0, true},
-		{"dns64 exclude_a_networks", c.DNS64.ExcludeANetworks, net.IPv4len, true},
-		{"dns64 exclude_aaaa_networks", c.DNS64.ExcludeAAAANetworks, net.IPv6len, true},
-		{"ecs client_networks", c.ECS.ClientNetworks, 0, false},
+		{"dns64 client_networks", c.DNS64.ClientNetworks, 0},
+		{"dns64 exclude_a_networks", c.DNS64.ExcludeANetworks, net.IPv4len},
+		{"dns64 exclude_aaaa_networks", c.DNS64.ExcludeAAAANetworks, net.IPv6len},
 	} {
 		for _, raw := range list.values {
-			network := raw
-			if list.trim {
-				network = strings.TrimSpace(raw)
-			}
-			_, parsed, err := net.ParseCIDR(network)
+			// Every dns64 list is read through TrimSpace.
+			_, parsed, err := net.ParseCIDR(strings.TrimSpace(raw))
 			if err != nil {
 				add("%s %q: must be a CIDR block", list.key, raw)
 				continue
@@ -510,6 +599,20 @@ func (c *Config) validateSubTables(add func(string, ...any)) {
 			add("dns64 exclude_zones %q: not a valid domain name", raw)
 		}
 	}
+}
+
+func (c *Config) validateECS(add func(string, ...any)) {
+	if !c.ECS.Enabled {
+		return
+	}
+
+	// internal/ecs hands each entry straight to netip.ParsePrefix, so unlike
+	// the dns64 lists above this one is judged exactly as written.
+	for _, network := range c.ECS.ClientNetworks {
+		if !validCIDR(network) {
+			add("ecs client_networks %q: must be a CIDR block", network)
+		}
+	}
 
 	for _, bits := range []struct {
 		key   string
@@ -525,11 +628,47 @@ func (c *Config) validateSubTables(add func(string, ...any)) {
 			add("%s = %d: must not exceed %d", bits.key, bits.value, bits.max)
 		}
 	}
+
+	if c.ECS.CacheLimitTTL.Duration < 0 {
+		add("ecs.cache_limit_ttl = %q: must not be negative", c.ECS.CacheLimitTTL.Duration)
+	}
 }
 
 func validCIDR(s string) bool {
 	_, _, err := net.ParseCIDR(s)
 	return err == nil
+}
+
+// regularFile reports whether path is something the server can open and read.
+// Existence alone is not enough: a directory satisfies Stat and then fails at
+// the read, which for a certificate and key means the TLS listener stops
+// startup after this test has already reported success.
+func regularFile(path string) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return fmt.Errorf("is a directory, want a file")
+	}
+	return nil
+}
+
+// writableDir reports whether path can serve as a directory the server writes
+// into. Absence is fine — both callers create it — but a plain file sitting at
+// the path is not, because the Mkdir that would follow fails.
+func writableDir(path string) error {
+	info, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("is a file, want a directory")
+	}
+	return nil
 }
 
 // anchorKeyProblem reports why this key cannot be verified with, or nil when
@@ -612,10 +751,17 @@ func validIPPort(addr string) bool {
 func validUpstream(addr string) error {
 	switch {
 	case strings.HasPrefix(addr, "https://"):
-		// DoH may name a host: it is bootstrapped once at startup.
+		// DoH may name a host: it is bootstrapped once at startup. What the
+		// forwarder actually uses is Hostname(), not Host — "https://:443/x"
+		// has a Host and no hostname, and is dropped during bootstrap.
 		u, err := url.Parse(addr)
-		if err != nil || u.Host == "" {
+		if err != nil || u.Hostname() == "" {
 			return fmt.Errorf("not a usable DoH URL")
+		}
+		if port := u.Port(); port != "" {
+			if err := usablePort(port); err != nil {
+				return err
+			}
 		}
 		return nil
 	case strings.HasPrefix(addr, "tls://"):

--- a/config/validate.go
+++ b/config/validate.go
@@ -513,16 +513,16 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 			add("accesslog = %q: %v", c.AccessLog, err)
 		case info.IsDir():
 			add("accesslog = %q: is a directory, want a file", c.AccessLog)
-		case info.Mode()&os.ModeNamedPipe != 0:
-			// The one kind that cannot be probed: opening a FIFO write-only
-			// waits for a reader, so asking would hang the config test the
-			// way it would hang startup.
-			add("accesslog = %q: is a named pipe, which the open would wait on", c.AccessLog)
 		default:
-			// Anything else is judged by opening it rather than by its type.
-			// A character device is the usual container spelling —
-			// /dev/null, or /dev/stdout to fold the log into the container's
-			// own output — and os.OpenFile takes both.
+			// Judged by opening it, not by its type. A character device is
+			// the usual container spelling — /dev/null, or /dev/stdout to
+			// fold the log into the container's own output — and os.OpenFile
+			// takes both. So does a pipe: /dev/stdout is one whenever the
+			// container's output is piped, and reopening it through /dev/fd
+			// waits for nobody.
+			//
+			// What does wait is a FIFO on disk with no reader, and the open
+			// below refuses that rather than joining it.
 			if err := openable(c.AccessLog, os.O_WRONLY); err != nil {
 				add("accesslog = %q: %v", c.AccessLog, err)
 			}
@@ -1012,8 +1012,10 @@ func regularFile(path string) error {
 // creating or truncating anything.
 func openable(path string, flag int) error {
 	// The path is the operator's own config value, opened to answer whether
-	// the server will be able to use it.
-	f, err := os.OpenFile(path, flag, 0) //nolint:gosec // G304 - the path under test is the input
+	// the server will be able to use it — and opened so that it never waits:
+	// a FIFO with no reader answers ENXIO here instead of holding the open
+	// until one arrives.
+	f, err := os.OpenFile(path, flag|nonBlockingOpen, 0) //nolint:gosec // G304 - the path under test is the input
 	if err != nil {
 		return err
 	}

--- a/config/validate.go
+++ b/config/validate.go
@@ -35,10 +35,16 @@ func (c *Config) Validate() error {
 		add("dnssec = %q: must be \"on\" or \"off\"", c.DNSSEC)
 	}
 
+	// Exactly what startup accepts: the four levels, plus omission, which is
+	// filled in as "info" before the logger sees it. Anything else stops the
+	// server there, so a config test that disagreed would send the operator
+	// to production with a file that cannot start. "crit" was documented for
+	// years but never existed — the logger has no such level and startup
+	// rejects it.
 	switch c.LogLevel {
-	case "", "crit", "debug", "info", "warn", "error":
+	case "", "debug", "info", "warn", "error":
 	default:
-		add("loglevel = %q: must be one of crit, debug, info, warn, error", c.LogLevel)
+		add("loglevel = %q: must be one of debug, info, warn, error", c.LogLevel)
 	}
 
 	for _, bind := range []struct{ key, value string }{
@@ -81,30 +87,43 @@ func (c *Config) Validate() error {
 		}
 	}
 
-	for i, entry := range c.AccessList {
-		if entry == "" {
-			add("accesslist entry %d is empty", i+1)
-			continue
-		}
-		if _, _, err := net.ParseCIDR(entry); err == nil {
-			continue
-		}
-		if net.ParseIP(entry) == nil {
-			add("accesslist %q: must be an IP address or CIDR block", entry)
+	for _, entry := range c.AccessList {
+		// The access list is parsed with netip.ParsePrefix and nothing else,
+		// so a bare address is dropped at startup. Accepting one here would
+		// pass a file whose only entry is discarded — leaving an empty allow
+		// set, which blocks every client.
+		if !validCIDR(entry) {
+			add("accesslist %q: must be a CIDR block, e.g. 192.0.2.0/24 or 192.0.2.1/32", entry)
 		}
 	}
 
+	// The resolver takes IPv4 from rootservers and IPv6 from root6servers,
+	// and silently drops anything in the wrong list. A misplaced address
+	// therefore leaves a shorter root set than the operator wrote, or an
+	// empty one.
 	for _, list := range []struct {
 		key    string
 		values []string
+		want   string // "4", "6", or "" for either
 	}{
-		{"rootservers", c.RootServers},
-		{"root6servers", c.Root6Servers},
-		{"fallbackservers", c.FallbackServers},
+		{"rootservers", c.RootServers, "4"},
+		{"root6servers", c.Root6Servers, "6"},
+		{"fallbackservers", c.FallbackServers, ""},
 	} {
 		for _, addr := range list.values {
-			if !validIPPort(addr) {
+			host, port, err := net.SplitHostPort(addr)
+			if err != nil || port == "" {
 				add("%s %q: must be an IP address and port, e.g. 192.0.2.1:53", list.key, addr)
+				continue
+			}
+			ip := net.ParseIP(host)
+			if ip == nil {
+				add("%s %q: must be an IP address and port, e.g. 192.0.2.1:53", list.key, addr)
+				continue
+			}
+			is4 := ip.To4() != nil
+			if (list.want == "4" && !is4) || (list.want == "6" && is4) {
+				add("%s %q: must be an IPv%s address", list.key, addr, list.want)
 			}
 		}
 	}
@@ -165,17 +184,40 @@ func (c *Config) Validate() error {
 // validateTrustAndIdentity covers the settings that decide who this resolver
 // trusts and what address it speaks from.
 func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
+	// Syntax alone does not make a usable root anchor, and every way of
+	// getting it wrong fails somewhere the operator will not connect to
+	// this file: a malformed record is fatal at resolver construction, a
+	// record that is not a DNSKEY panics an unchecked type assertion during
+	// verification, and a key that is merely not a root KSK leaves the
+	// anchor set empty so every DNSSEC answer fails on unavailable anchors.
+	anchors := 0
 	for _, key := range c.RootKeys {
-		// A bad anchor is fatal at resolver construction, so without this
-		// the config test passes and the server then refuses to start.
 		rr, err := dns.NewRR(key)
 		if err != nil {
 			add("rootkeys %q: %v", key, err)
 			continue
 		}
-		if _, ok := rr.(*dns.DNSKEY); !ok {
+		dnskey, ok := rr.(*dns.DNSKEY)
+		if !ok {
 			add("rootkeys %q: must be a DNSKEY record", key)
+			continue
 		}
+		switch {
+		case dns.CanonicalName(dnskey.Hdr.Name) != ".":
+			add("rootkeys %q: must be owned by the root zone", key)
+		case dnskey.Hdr.Class != dns.ClassINET:
+			add("rootkeys %q: must be class IN", key)
+		case dnskey.Protocol != 3:
+			add("rootkeys %q: protocol must be 3 (RFC 4034 section 2.1.2)", key)
+		case dnskey.Flags != 257:
+			// Only key-signing keys enter the verification set.
+			add("rootkeys %q: must be a key-signing key (flags 257), not %d", key, dnskey.Flags)
+		default:
+			anchors++
+		}
+	}
+	if len(c.RootKeys) > 0 && anchors == 0 {
+		add("rootkeys: none of the configured keys is a usable root trust anchor")
 	}
 
 	for _, out := range []struct {
@@ -225,11 +267,11 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 		}
 	}
 
-	// Prefetch is a percentage of the original TTL. Above 100 the refresh
-	// trigger sits beyond the whole lifetime, so every hit prefetches — the
-	// documented range is 10-90 and only the low end is clamped in code.
-	if c.Prefetch > 100 {
-		add("prefetch = %d: is a percentage, so it cannot exceed 100", c.Prefetch)
+	// The cache refuses anything above 90 and then disables prefetch
+	// entirely, so 91-100 passed this test and silently turned the feature
+	// off. The low end is clamped up to 10 rather than refused.
+	if c.Prefetch > 90 {
+		add("prefetch = %d: is a percentage of the original TTL and must not exceed 90", c.Prefetch)
 	}
 
 	if c.ReflexThreshold != 0 && (c.ReflexThreshold < 0 || c.ReflexThreshold > 1) {
@@ -310,10 +352,34 @@ func (c *Config) validateSubTables(add func(string, ...any)) {
 		}
 	}
 
+	// These are the rules middleware/dns64 applies at startup. A prefix that
+	// only looks like IPv6 is dropped there, and if it was the only one the
+	// resolver falls back to 64:ff9b::/96 — so a config test that accepted
+	// it would report success while traffic went to a different NAT64
+	// prefix than the file names.
+	//
+	// The family test is the mask length, not To4(): an IPv4-mapped range
+	// like ::ffff:0:0/96 has a non-nil To4() and is a legal Pref64 input.
+	validPrefixBits := map[int]bool{32: true, 40: true, 48: true, 56: true, 64: true, 96: true}
 	for _, prefix := range c.DNS64.Prefixes {
-		ip, _, err := net.ParseCIDR(prefix)
-		if err != nil || ip.To4() != nil {
-			add("dns64 prefix %q: must be an IPv6 CIDR block", prefix)
+		_, network, err := net.ParseCIDR(prefix)
+		if err != nil {
+			add("dns64 prefix %q: must be a CIDR block", prefix)
+			continue
+		}
+		if len(network.Mask) != net.IPv6len {
+			add("dns64 prefix %q: is IPv4, want IPv6", prefix)
+			continue
+		}
+		bits, _ := network.Mask.Size()
+		if !validPrefixBits[bits] {
+			add("dns64 prefix %q: length /%d invalid; must be /32, /40, /48, /56, /64, or /96", prefix, bits)
+			continue
+		}
+		// RFC 6052 §2.2 reserves byte 8; at /96 the operator's prefix
+		// already covers it.
+		if bits == 96 && len(network.IP) >= 9 && network.IP[8] != 0 {
+			add("dns64 prefix %q: byte 8 must be zero (RFC 6052 section 2.2 reserved)", prefix)
 		}
 	}
 	for _, list := range []struct {

--- a/config/validate.go
+++ b/config/validate.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/url"
@@ -150,6 +151,7 @@ func (c *Config) Validate() error {
 		{"querytimeout", c.QueryTimeout},
 		{"roottcptimeout", c.RootTCPTimeout},
 		{"tldtcptimeout", c.TLDTCPTimeout},
+		{"ecs.cache_limit_ttl", c.ECS.CacheLimitTTL},
 	} {
 		if d.value.Duration < 0 {
 			add("%s = %q: must not be negative", d.key, d.value.Duration)
@@ -165,12 +167,38 @@ func (c *Config) Validate() error {
 		{"ratelimit", c.RateLimit},
 		{"clientratelimit", c.ClientRateLimit},
 		{"maxconcurrentqueries", c.MaxConcurrentQueries},
+		// Each of these treats zero as "use the default", so a negative
+		// value is neither the default nor what was asked for: it leaves the
+		// TCP pool holding nothing, dnstap back on its default interval, and
+		// the metrics limit meaningless.
+		{"tcpmaxconnections", c.TCPMaxConnections},
+		{"dnstapflushinterval", c.DnstapFlushInterval},
+		{"domainmetricslimit", c.DomainMetricsLimit},
+		{"ingressworkers", c.IngressWorkers},
+		{"ingressqueue", c.IngressQueue},
+		{"ingresstcpconns", c.IngressTCPConns},
 	} {
 		if n.value < 0 {
 			add("%s = %d: must not be negative", n.key, n.value)
 		}
 	}
 
+	// Everything the load path used to check on its own runs here too, so one
+	// pass reports every problem in the file rather than one problem per run.
+	//
+	// An empty firewall mode is the operator omitting the section; Normalize
+	// fills it in before the load path reaches here, so only a mode that
+	// survived normalization is judged. Validating "" would fail every Config
+	// built in code rather than read from a file.
+	if c.RecursionFirewall.Mode != "" {
+		if err := c.RecursionFirewall.Validate(); err != nil {
+			add("invalid recursion firewall config: %v", err)
+		}
+	}
+	if c.ServeStaleMaxTTL.Duration < 0 {
+		add("serve_stale_max_ttl must not be negative (got %q)", c.ServeStaleMaxTTL.Duration)
+	}
+	c.validateForwardZones(add)
 	c.validateTrustAndIdentity(add)
 	c.validateNameLists(add)
 	c.validateSubTables(add)
@@ -212,6 +240,12 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 		case dnskey.Flags != 257:
 			// Only key-signing keys enter the verification set.
 			add("rootkeys %q: must be a key-signing key (flags 257), not %d", key, dnskey.Flags)
+		case !verifiableAlgorithm(dnskey):
+			// Nothing rejects this at startup: the anchor is loaded, and
+			// then every signature made with it fails, so validation is off
+			// while the file still says it is on.
+			add("rootkeys %q: algorithm %d (%s) cannot be verified with",
+				key, dnskey.Algorithm, dns.AlgorithmToString[dnskey.Algorithm])
 		default:
 			anchors++
 		}
@@ -321,8 +355,13 @@ func (c *Config) validateNameLists(add func(string, ...any)) {
 
 	for _, u := range c.BlockLists {
 		parsed, err := url.Parse(u)
-		if err != nil || parsed.Host == "" || parsed.Scheme == "" {
-			add("blocklists %q: must be a URL", u)
+		switch {
+		case err != nil || parsed.Host == "":
+			add("blocklists %q: must be an http:// or https:// URL", u)
+		case parsed.Scheme != "http" && parsed.Scheme != "https":
+			// The updater fetches with an http.Client, so any other scheme
+			// fails on an unsupported protocol and the list never loads.
+			add("blocklists %q: scheme %q cannot be fetched; use http or https", u, parsed.Scheme)
 		}
 	}
 }
@@ -335,11 +374,10 @@ func (c *Config) validateSubTables(add func(string, ...any)) {
 		if label == "" {
 			label = fmt.Sprintf("#%d", i+1)
 		}
-		if view.Zone != "" {
-			if _, ok := dns.IsDomainName(view.Zone); !ok {
-				add("view %s: zone is not a valid domain name", label)
-			}
-		}
+		// zone is a free-form label. The middleware only carries it into log
+		// lines; matching is done by the networks and the answers' own owner
+		// names. Validating it as a domain would reject descriptive labels
+		// that work today and stop the server on upgrade.
 		for _, network := range view.Networks {
 			if !validCIDR(network) {
 				add("view %s network %q: must be a CIDR block", label, network)
@@ -382,18 +420,33 @@ func (c *Config) validateSubTables(add func(string, ...any)) {
 			add("dns64 prefix %q: byte 8 must be zero (RFC 6052 section 2.2 reserved)", prefix)
 		}
 	}
+	// The exclude lists are family-specific at runtime and the wrong family
+	// is dropped with a log line nobody reads, so the exclusion the operator
+	// wrote silently does not apply. Family is decided by mask length, not
+	// To4(): ParseCIDR returns a 4-byte mask for IPv4 and 16 for IPv6, and
+	// an IPv4-mapped IPv6 range would fool the address test.
 	for _, list := range []struct {
 		key    string
 		values []string
+		mask   int // 0 for either family
 	}{
-		{"dns64 client_networks", c.DNS64.ClientNetworks},
-		{"dns64 exclude_a_networks", c.DNS64.ExcludeANetworks},
-		{"dns64 exclude_aaaa_networks", c.DNS64.ExcludeAAAANetworks},
-		{"ecs client_networks", c.ECS.ClientNetworks},
+		{"dns64 client_networks", c.DNS64.ClientNetworks, 0},
+		{"dns64 exclude_a_networks", c.DNS64.ExcludeANetworks, net.IPv4len},
+		{"dns64 exclude_aaaa_networks", c.DNS64.ExcludeAAAANetworks, net.IPv6len},
+		{"ecs client_networks", c.ECS.ClientNetworks, 0},
 	} {
 		for _, network := range list.values {
-			if !validCIDR(network) {
+			_, parsed, err := net.ParseCIDR(network)
+			if err != nil {
 				add("%s %q: must be a CIDR block", list.key, network)
+				continue
+			}
+			if list.mask != 0 && len(parsed.Mask) != list.mask {
+				family := "IPv4"
+				if list.mask == net.IPv6len {
+					family = "IPv6"
+				}
+				add("%s %q: must be %s", list.key, network, family)
 			}
 		}
 	}
@@ -422,6 +475,26 @@ func (c *Config) validateSubTables(add func(string, ...any)) {
 func validCIDR(s string) bool {
 	_, _, err := net.ParseCIDR(s)
 	return err == nil
+}
+
+// verifiableAlgorithm reports whether signatures made with this key's algorithm
+// can be verified. The answer is asked of the DNSSEC library rather than kept
+// as a list here, because the set belongs to that library and moves with it —
+// a list written today would claim ED448 works, and it does not.
+//
+// A signature this throwaway fails for many reasons; only ErrAlg means the
+// algorithm itself is the problem, so every other outcome counts as usable.
+func verifiableAlgorithm(key *dns.DNSKEY) bool {
+	probe := &dns.RRSIG{
+		Hdr:         dns.RR_Header{Name: key.Hdr.Name, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET},
+		TypeCovered: dns.TypeDNSKEY,
+		Algorithm:   key.Algorithm,
+		OrigTtl:     key.Hdr.Ttl,
+		KeyTag:      key.KeyTag(),
+		SignerName:  key.Hdr.Name,
+		Signature:   "AA==",
+	}
+	return !errors.Is(probe.Verify(key, []dns.RR{key}), dns.ErrAlg)
 }
 
 // validIPPort reports whether addr is an IP literal with a port. Authority and

--- a/config/validate.go
+++ b/config/validate.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"math"
 	"net"
+	"net/netip"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -448,15 +449,24 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 	// download into it, so a read-only mount carrying nothing but local
 	// lists is a working setup — and refusing it would stop a server that
 	// runs today.
+	//
+	// Whether it has to be written depends on what is being loaded into it:
+	// a remote list is downloaded into the directory with os.Create, so with
+	// one configured a read-only mount loads nothing at all.
+	dirCheck := usableDir
+	if len(c.BlockLists) > 0 {
+		dirCheck = writableDir
+	}
+
 	switch {
 	case c.BlockListDir != "":
-		if err := usableDir(c.BlockListDir, pending); err != nil {
+		if err := dirCheck(c.BlockListDir, pending); err != nil {
 			add("blocklistdir = %q: %v", c.BlockListDir, err)
 		}
 	case c.Directory != "":
 		derived := filepath.Join(c.Directory, "blacklists")
 		if _, err := os.Lstat(derived); err == nil {
-			if err := usableDir(derived, ""); err != nil {
+			if err := dirCheck(derived, ""); err != nil {
 				add("blocklistdir defaults to %q: %v", derived, err)
 			}
 		}
@@ -930,8 +940,17 @@ func localAddress(ip net.IP) bool {
 	return false
 }
 
+// validCIDR reports whether a prefix is one the access list, the views and
+// the ECS policy will take. All three reach netip.ParsePrefix — the first two
+// through internal/ipset — and it is stricter than net.ParseCIDR about the
+// bits after the slash: "10.0.0.0/08" parses there and not here, so accepting
+// it would pass a file whose only access-list entry is then dropped, leaving
+// an empty allow set that blocks every client.
+//
+// dns64 is not one of these callers. It parses with net.ParseCIDR and takes
+// the leading zero, so its lists are judged with that instead.
 func validCIDR(s string) bool {
-	_, _, err := net.ParseCIDR(s)
+	_, err := netip.ParsePrefix(s)
 	return err == nil
 }
 

--- a/config/validate.go
+++ b/config/validate.go
@@ -422,7 +422,18 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 			// Created on open, but only inside a directory already there —
 			// and for a symlink that is the target's directory, not the
 			// link's, since the open follows the link before creating.
-			if err := existingDir(filepath.Dir(filepath.Clean(accessLogTarget(c.AccessLog)))); err != nil {
+			target := accessLogTarget(c.AccessLog)
+
+			// A trailing separator says the path is a directory, and the
+			// open refuses it outright. Unlike a directory setting, where
+			// the separator means nothing and is cleaned away, here it
+			// changes what the name asks for — so it is reported as the
+			// wrong kind of name rather than as a missing parent.
+			if endsInSeparator(c.AccessLog) || endsInSeparator(target) {
+				add("accesslog = %q: names a directory, want a file", c.AccessLog)
+				break
+			}
+			if err := existingDir(filepath.Dir(filepath.Clean(target))); err != nil {
 				add("accesslog = %q: %v", c.AccessLog, err)
 			}
 		case err != nil:
@@ -949,6 +960,13 @@ func existingDir(path string) error {
 		return fmt.Errorf("parent directory %q: %w", path, err)
 	}
 	return nil
+}
+
+// endsInSeparator reports whether path is written as a directory. Both
+// spellings are checked because a config carried between platforms may use
+// either, and the open rejects the name on both.
+func endsInSeparator(path string) bool {
+	return strings.HasSuffix(path, "/") || strings.HasSuffix(path, string(os.PathSeparator))
 }
 
 // accessLogTarget resolves one level of symlink, so a dangling link is judged

--- a/config/validate.go
+++ b/config/validate.go
@@ -60,7 +60,8 @@ func (c *Config) Validate() error {
 		// The plain listener answers over both; the rest open one apiece.
 		{"bind", c.Bind, []string{"udp", "tcp"}},
 		{"bindtls", c.BindTLS, []string{"tcp"}},
-		{"binddoh", c.BindDOH, []string{"tcp"}},
+		// DoH brings its HTTP/3 listener with it, on UDP at the same address.
+		{"binddoh", c.BindDOH, []string{"udp", "tcp"}},
 		{"binddoq", c.BindDOQ, []string{"udp"}},
 	} {
 		if bind.value == "" {
@@ -163,7 +164,7 @@ func (c *Config) Validate() error {
 			// Unlike a listener, an upstream cannot use port 0: nothing
 			// answers there, and the dial failure is per query rather than
 			// at startup.
-			if n, err := usablePort(port, "udp"); err != nil || n == 0 {
+			if n, err := usablePort(port, "udp", "tcp"); err != nil || n == 0 {
 				add("%s %q: must have a port to reach, e.g. 192.0.2.1:53", list.key, addr)
 				continue
 			}
@@ -400,7 +401,10 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 	// carries on with access logging quietly switched off, so every way of
 	// getting this wrong is silent.
 	if c.AccessLog != "" {
-		info, err := os.Lstat(c.AccessLog)
+		// Stat, not Lstat: OpenFile follows a symlink, so a link to a
+		// writable file is usable and rejecting it would refuse a setup that
+		// works today.
+		info, err := os.Stat(c.AccessLog)
 		switch {
 		case os.IsNotExist(err):
 			// Created on open, but only inside a directory already there.
@@ -433,8 +437,13 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 		// Lowercased and stripped of a trailing dot, then used as the suffix
 		// every lookup is matched against. A name that cannot be one matches
 		// nothing, and the middleware answers for no query at all.
-		if domain := strings.TrimSuffix(strings.ToLower(c.Kubernetes.ClusterDomain), "."); domain != "" {
-			if !validDomainName(domain) {
+		//
+		// The runtime strips one trailing dot and then puts one back, so
+		// "cluster.local.." becomes a suffix with a doubled dot that no
+		// query can match. Judging the value after the same single strip
+		// would let that through, so the raw value is judged instead.
+		if raw := strings.ToLower(c.Kubernetes.ClusterDomain); raw != "" {
+			if !validDomainName(strings.TrimSuffix(raw, ".")) || strings.HasSuffix(raw, "..") {
 				add("kubernetes.cluster_domain = %q: is not a valid domain name", c.Kubernetes.ClusterDomain)
 			}
 		}
@@ -489,8 +498,19 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 	if c.QnameMaxMinimizeCount == nil && c.QnameMinLevel < 0 {
 		add("qname_min_level = %d: must not be negative", c.QnameMinLevel)
 	}
-	if c.QnameMinimizeOneLabel < 0 {
-		add("qname_minimize_one_label = %d: must not be negative", c.QnameMinimizeOneLabel)
+	// One label at a time is only meaningful while minimization is on, and
+	// the runtime settles the pair together: a count above the maximum is
+	// quietly lowered to it, and with minimization off the field is not read
+	// at all. Judging the fields separately reported a value that has no
+	// effect and missed one that is silently changed.
+	if maxCount, _ := c.QnameMinimizeParams(); maxCount > 0 {
+		switch {
+		case c.QnameMinimizeOneLabel < 0:
+			add("qname_minimize_one_label = %d: must not be negative", c.QnameMinimizeOneLabel)
+		case c.QnameMinimizeOneLabel > maxCount:
+			add("qname_minimize_one_label = %d: must not exceed qname_max_minimize_count (%d), which is what it is lowered to",
+				c.QnameMinimizeOneLabel, maxCount)
+		}
 	}
 
 	// The cache raises anything under 1024 to 1024 without saying so, so a
@@ -880,10 +900,11 @@ func writableDir(path string) error {
 	if !info.IsDir() {
 		return fmt.Errorf("is a file, want a directory")
 	}
-	return nil
+	return creatable(path)
 }
 
-// existingDir reports whether path is a directory that is already there.
+// existingDir reports whether path is a directory that is already there and
+// can be written into.
 func existingDir(path string) error {
 	info, err := os.Stat(path)
 	if err != nil {
@@ -892,7 +913,29 @@ func existingDir(path string) error {
 	if !info.IsDir() {
 		return fmt.Errorf("parent %q is a file, want a directory", path)
 	}
+	if err := creatable(path); err != nil {
+		return fmt.Errorf("parent directory %q: %w", path, err)
+	}
 	return nil
+}
+
+// creatable reports whether this process can make an entry in dir. Mode bits
+// alone do not answer it — ownership, group membership and the mount's own
+// flags all decide — so the question is put the only portable way there is,
+// by creating something and taking it straight back out. The server creates
+// its working directory here anyway, and a check that skipped this passed a
+// read-only parent whose failure surfaces one run later for the working
+// directory, and not at all for the access log.
+func creatable(dir string) error {
+	f, err := os.CreateTemp(dir, ".sdns-config-test-*")
+	if err != nil {
+		return err
+	}
+	name := f.Name()
+	if err := f.Close(); err != nil {
+		return err
+	}
+	return os.Remove(name)
 }
 
 // anchorKeyProblem reports why this key cannot be verified with, or nil when
@@ -999,10 +1042,17 @@ func ecdhCurve(alg uint8) ecdh.Curve {
 // Callers that cannot use port 0 test the returned number rather than the
 // string: "00" and "+0" both resolve to zero and would slip past a comparison
 // against "0".
+// lookupPort is net.LookupPort, as a variable so a test can record which
+// networks each caller asks about. The service tables on a developer machine
+// are not partitioned by protocol, so recording the question is the only way
+// to pin that a DoT upstream is judged over TCP and a listener over what it
+// actually opens.
+var lookupPort = net.LookupPort
+
 func usablePort(port string, networks ...string) (int, error) {
 	var resolved int
 	for _, network := range networks {
-		n, err := net.LookupPort(network, port)
+		n, err := lookupPort(network, port)
 		if err != nil {
 			return 0, fmt.Errorf("port %q is not one this host can use for %s", port, network)
 		}
@@ -1014,12 +1064,12 @@ func usablePort(port string, networks ...string) (int, error) {
 // validIPPort reports whether addr is an IP literal with a usable port.
 // Authority and fallback servers are dialled directly, so a hostname there
 // would need a resolver this one may not have yet.
-func validIPPort(addr string) bool {
+func validIPPort(addr string, networks ...string) bool {
 	host, port, err := net.SplitHostPort(addr)
 	if err != nil || port == "" {
 		return false
 	}
-	if n, err := usablePort(port, "udp"); err != nil || n == 0 {
+	if n, err := usablePort(port, networks...); err != nil || n == 0 {
 		return false
 	}
 	return net.ParseIP(host) != nil
@@ -1049,12 +1099,14 @@ func validUpstream(addr string) error {
 		}
 		return nil
 	case strings.HasPrefix(addr, "tls://"):
-		if !validIPPort(strings.TrimPrefix(addr, "tls://")) {
+		if !validIPPort(strings.TrimPrefix(addr, "tls://"), "tcp") {
 			return fmt.Errorf("DoT needs an IP address and port, e.g. tls://192.0.2.1:853")
 		}
 		return nil
 	default:
-		if !validIPPort(addr) {
+		// Plain DNS asks over UDP and comes back over TCP when an answer
+		// does not fit, so the port has to work for both.
+		if !validIPPort(addr, "udp", "tcp") {
 			return fmt.Errorf("must be an IP address and port, a tls:// address, or an https:// URL")
 		}
 		return nil
@@ -1078,13 +1130,19 @@ func (c *Config) validateLoaded() error {
 		add("directory: required, and this file leaves it empty")
 	}
 
-	// With no root to start from and nothing standing in for one, the
-	// resolver stops the process on the first recursive query rather than
-	// answering it. A global forwarder takes every query before the resolver
-	// sees it, and a forward zone for the root covers the same ground.
-	if len(c.RootServers) == 0 && len(c.Root6Servers) == 0 &&
-		len(c.ForwarderServers) == 0 && !c.forwardsRoot() {
-		add("rootservers: no root server, forwarder or root forward zone, so the first recursive query would stop the server")
+	// A root server is required of every file, forwarders included. The
+	// resolver is constructed either way and its background goroutine primes
+	// the root as soon as the middleware is ready — an empty list stops the
+	// process there, before any query arrives. Forwarding only keeps the
+	// resolver out of the query path, not out of the process.
+	roots6 := len(c.Root6Servers)
+	if !c.IPv6Access {
+		// The resolver only takes the v6 list when v6 is in use, so a file
+		// carrying nothing else has an empty root set at runtime.
+		roots6 = 0
+	}
+	if len(c.RootServers) == 0 && roots6 == 0 {
+		add("rootservers: none configured, and priming an empty root list stops the server at startup")
 	}
 
 	if err := c.Validate(); err != nil {
@@ -1098,16 +1156,4 @@ func (c *Config) validateLoaded() error {
 		return nil
 	}
 	return fmt.Errorf("invalid configuration:\n  - %s", strings.Join(problems, "\n  - "))
-}
-
-// forwardsRoot reports whether a forward zone hands the whole namespace to its
-// own upstreams, which leaves nothing for the resolver to recurse for.
-func (c *Config) forwardsRoot() bool {
-	for i := range c.ForwardZones {
-		zone := &c.ForwardZones[i]
-		if dns.CanonicalName(strings.TrimSpace(zone.Name)) == "." && len(zone.Servers) > 0 {
-			return true
-		}
-	}
-	return false
 }

--- a/config/validate.go
+++ b/config/validate.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
+	"io"
 	"math"
 	"net"
 	"net/url"
@@ -322,11 +323,15 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 			add("rootkeys %q: must be class IN", key)
 		case dnskey.Protocol != 3:
 			add("rootkeys %q: protocol must be 3 (RFC 4034 section 2.1.2)", key)
-		case dnskey.Flags&dnsKeyFlagRevoke != 0:
+		case dnskey.Flags&dnsKeyFlagRevoke != 0 && dnskey.Flags&^dnsKeyFlagRevoke == 257:
 			// RFC 5011 section 2.1: an operator may seed a revoked key so
 			// the resolver remembers the revocation across a restart. AutoTA
 			// records it as a tombstone and keeps it out of the active set,
 			// which is exactly what not counting it here does.
+			//
+			// The REVOKE bit rides on top of the key-signing flags; on its
+			// own it is not a KSK, and AutoTA drops such a record before it
+			// ever looks at the bit.
 		case dnskey.Flags != 257:
 			// Only key-signing keys enter the verification set.
 			add("rootkeys %q: must be a key-signing key (flags 257), not %d", key, dnskey.Flags)
@@ -1026,7 +1031,7 @@ func dirCheck(path, pending string, mustWrite bool) error {
 		// Returning here without asking accepted a symlink to a directory
 		// that the same check refuses when it is named directly.
 		if !mustWrite {
-			return nil
+			return readable(path)
 		}
 		return creatable(path)
 	}
@@ -1034,15 +1039,62 @@ func dirCheck(path, pending string, mustWrite bool) error {
 		return fmt.Errorf("is a file, want a directory")
 	}
 	if !mustWrite {
-		return nil
+		return readable(path)
 	}
 	return creatable(path)
+}
+
+// readable reports whether this process can list dir. Stat says nothing about
+// that — a directory with no permission bits at all satisfies it — while the
+// blocklist middleware walks the directory and, when it cannot, logs once and
+// loads no local list at all.
+func readable(dir string) error {
+	f, err := os.Open(dir) //nolint:gosec // G304 - the path under test is the input
+	if err != nil {
+		return err
+	}
+	defer f.Close() //nolint:errcheck // nothing was written
+
+	if _, err := f.ReadDir(1); err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	return nil
+}
+
+// samePath reports whether two spellings name the same place.
+//
+// Cleaning answers that on Windows, which collapses ".." itself. Where the
+// components are walked instead, a ".." only resolves once what comes before
+// it exists — so "missing/../db" is not the directory the server is about to
+// create, however it cleans up, and the two are compared as written.
+func samePath(a, b string) bool {
+	if cleansPathComponents || (!hasDotDot(a) && !hasDotDot(b)) {
+		return filepath.Clean(a) == filepath.Clean(b)
+	}
+	return a == b
+}
+
+// hasDotDot reports whether path has a ".." among its components. Bytes, not
+// runes: separators are ASCII, and narrowing a multi-byte rune to a byte can
+// land on one by accident.
+func hasDotDot(path string) bool {
+	start := 0
+	for i := 0; i <= len(path); i++ {
+		if i < len(path) && !os.IsPathSeparator(path[i]) {
+			continue
+		}
+		if path[start:i] == ".." {
+			return true
+		}
+		start = i + 1
+	}
+	return false
 }
 
 // existingDir reports whether path is a directory that is already there and
 // can be written into.
 func existingDir(path, pending string) error {
-	if pending != "" && filepath.Clean(path) == filepath.Clean(pending) {
+	if pending != "" && samePath(path, pending) {
 		// Not there yet, and about to be. Everything under it is created
 		// after that, in the order the server does it.
 		if _, err := os.Stat(path); os.IsNotExist(err) {

--- a/config/validate.go
+++ b/config/validate.go
@@ -513,11 +513,16 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 			add("accesslog = %q: %v", c.AccessLog, err)
 		case info.IsDir():
 			add("accesslog = %q: is a directory, want a file", c.AccessLog)
-		case !info.Mode().IsRegular():
-			// A FIFO would hold the open until a reader arrives, which is a
-			// hung startup rather than a logged failure.
-			add("accesslog = %q: is a %s, want a regular file", c.AccessLog, fileKind(info.Mode()))
+		case info.Mode()&os.ModeNamedPipe != 0:
+			// The one kind that cannot be probed: opening a FIFO write-only
+			// waits for a reader, so asking would hang the config test the
+			// way it would hang startup.
+			add("accesslog = %q: is a named pipe, which the open would wait on", c.AccessLog)
 		default:
+			// Anything else is judged by opening it rather than by its type.
+			// A character device is the usual container spelling —
+			// /dev/null, or /dev/stdout to fold the log into the container's
+			// own output — and os.OpenFile takes both.
 			if err := openable(c.AccessLog, os.O_WRONLY); err != nil {
 				add("accesslog = %q: %v", c.AccessLog, err)
 			}
@@ -1121,25 +1126,29 @@ func readable(dir string) error {
 // it exists — so "missing/../db" is not the directory the server is about to
 // create, however it cleans up, and the two are compared as written.
 func samePath(a, b string) bool {
-	if cleansPathComponents || (!hasDotDot(a) && !hasDotDot(b)) {
-		return filepath.Clean(a) == filepath.Clean(b)
-	}
-	// Components as written, because a ".." among them only resolves once
-	// what precedes it exists. A trailing separator is not one of those
-	// components, though — mkdir and open both take a path with one — so it
-	// is dropped before the comparison rather than making two spellings of
-	// the same place look different.
-	//
-	// Where the part before the last element does exist, though, the system
-	// resolves it and so does this: "/tmp/there/../db" and "/tmp/db" are one
-	// place when "there" is there, and the pending directory would otherwise
-	// be missed for one spelling of it.
+	// Made absolute first, because a relative spelling resolves against the
+	// working directory of the process: nothing chdirs, so "db" and
+	// "<cwd>/db" are one place and were being called two.
+	a, b = absKeepingComponents(a), absKeepingComponents(b)
+
+	// Where the part before the last element is there, the system resolves
+	// it — through symlinks, through ".." — and so does this. It is what
+	// makes "/var/db" and "/private/var/db" one place on a Mac, and
+	// "there/../db" and "db" one place anywhere.
 	if ra, ok := resolveParent(a); ok {
 		if rb, ok := resolveParent(b); ok {
-			return ra == rb
+			return equalPaths(ra, rb)
 		}
 	}
-	return trimTrailingSeparators(a) == trimTrailingSeparators(b)
+
+	// Nothing to resolve against, so the spellings answer for themselves.
+	// Cleaning is right where the system cleans; where components are
+	// walked, a ".." among them has not resolved yet and the two are only
+	// the same if they are written the same.
+	if cleansPathComponents || (!hasDotDot(a) && !hasDotDot(b)) {
+		return equalPaths(filepath.Clean(a), filepath.Clean(b))
+	}
+	return equalPaths(trimTrailingSeparators(a), trimTrailingSeparators(b))
 }
 
 // resolveParent rewrites path with everything before its last element
@@ -1154,6 +1163,29 @@ func resolveParent(path string) (string, bool) {
 		return "", false
 	}
 	return filepath.Join(resolved, filepath.Base(trimmed)), true
+}
+
+// absKeepingComponents resolves a relative path against the working directory
+// without cleaning it. filepath.Abs cleans, and that would drop the ".."
+// components the comparison below still has to see.
+func absKeepingComponents(path string) string {
+	if path == "" || filepath.IsAbs(path) {
+		return path
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		return path
+	}
+	return joinKeepingComponents(cwd, path)
+}
+
+// equalPaths compares two already-normalised paths the way the filesystem
+// does. Windows does not distinguish case, so neither does this there.
+func equalPaths(a, b string) bool {
+	if cleansPathComponents {
+		return strings.EqualFold(a, b)
+	}
+	return a == b
 }
 
 // trimTrailingSeparators drops the separators at the end of path, keeping a
@@ -1514,13 +1546,25 @@ func ecdhCurve(alg uint8) ecdh.Curve {
 var lookupPort = net.LookupPort
 
 func usablePort(port string, networks ...string) (int, error) {
-	var resolved int
+	resolved, first := 0, true
 	for _, network := range networks {
 		n, err := lookupPort(network, port)
 		if err != nil {
 			return 0, fmt.Errorf("port %q is not one this host can use for %s", port, network)
 		}
-		resolved = n
+		if first {
+			resolved, first = n, false
+			continue
+		}
+		if n != resolved {
+			// A service name can sit at different numbers in the two
+			// tables — "raid-am" is 2007 over UDP and 2013 over TCP on a
+			// Mac. A setting that opens both would answer on one and wait
+			// for the fallback on the other, which is the same split that
+			// makes port 0 unusable there.
+			return 0, fmt.Errorf("port %q resolves to %d for %s and %d for the other transport this setting opens; name a number",
+				port, n, network, resolved)
+		}
 	}
 	return resolved, nil
 }

--- a/config/validate.go
+++ b/config/validate.go
@@ -337,6 +337,12 @@ func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
 		}
 	}
 	switch {
+	case anchors == 0 && c.HyperlocalRoot:
+		// The manager verifies every transfer against these and gives up on
+		// each refresh while there are none, so the feature never produces a
+		// snapshot at all. Forwarding does not excuse it: the manager runs
+		// whatever the query path does.
+		add("rootkeys: hyperlocal_root has no trust anchor to verify a transfer against, so it can never load the zone")
 	case anchors == 0 && c.DNSSEC == "on" && len(c.ForwarderServers) == 0 && !c.forwardsRoot():
 		// AutoTA needs a seed and will not take one from disk when the live
 		// set is empty, so this does not heal on its own: every iterative
@@ -1051,33 +1057,51 @@ func endsInSeparator(path string) bool {
 // link as absent, which read as an ordinary missing file and had the link's
 // own directory checked instead of the target's.
 //
-// The trailing separator is carried across each hop by hand. Join cleans it
-// away, and it is the whole difference between a name the open creates and one
-// it refuses — a relative "real.log/" would otherwise arrive here looking like
-// an ordinary file name.
+// The bound is above what any system will follow — Linux gives up at forty,
+// this machine at around thirty — so a chain that reaches it is one the stat
+// above has already refused with ELOOP. It is here to end the loop on a link
+// that points at itself, not to judge length.
 func accessLogTarget(path string) string {
-	// Deeper than any real layout, and bounded so a link that points at
-	// itself cannot spin.
-	for range 16 {
+	const maxHops = 64
+
+	for range maxHops {
 		info, err := os.Lstat(path)
 		if err != nil || info.Mode()&os.ModeSymlink == 0 {
 			return path
 		}
-		target, err := os.Readlink(path)
+		link, err := os.Readlink(path)
 		if err != nil {
 			return path
 		}
-		if filepath.IsAbs(target) {
-			path = target
+		if filepath.IsAbs(link) {
+			path = link
 			continue
 		}
-		next := filepath.Join(filepath.Dir(path), target)
-		if endsInSeparator(target) {
-			next += string(os.PathSeparator)
-		}
-		path = next
+		path = joinKeepingComponents(literalParent(path), link)
 	}
 	return path
+}
+
+// joinKeepingComponents puts a relative symlink target under the directory
+// holding the link.
+//
+// filepath.Join cleans, and on a system that resolves a path one component at
+// a time that loses the answer: a target of "missing/../real.log" becomes
+// "real.log" and looks like it lives somewhere that exists, while the open
+// follows the target as written and fails on the "missing" that is not there.
+// Windows collapses ".." itself, so cleaning is what it does and Join is
+// right there.
+func joinKeepingComponents(dir, target string) string {
+	if runtime.GOOS == "windows" {
+		return filepath.Join(dir, target)
+	}
+	if dir == "" {
+		return target
+	}
+	if os.IsPathSeparator(dir[len(dir)-1]) {
+		return dir + target
+	}
+	return dir + string(os.PathSeparator) + target
 }
 
 // creatable reports whether this process can make an entry in dir. Mode bits

--- a/config/validate.go
+++ b/config/validate.go
@@ -86,9 +86,17 @@ func (c *Config) Validate() error {
 			// whether a name resolves is a runtime question of the same
 			// class as whether an upstream answers.
 			_ = host
-			// Port 0 is legal here: it asks the kernel for a free one.
-			if _, err := usablePort(port, bind.networks...); err != nil {
+			n, err := usablePort(port, bind.networks...)
+			switch {
+			case err != nil:
 				add("%s = %q: %v", bind.key, bind.value, err)
+			case n == 0 && len(bind.networks) > 1:
+				// Port 0 asks the kernel for a free one, and each socket
+				// asks separately: the two transports of this setting would
+				// land on different ports, so a truncated UDP answer has no
+				// TCP to fall back to — and DoH would advertise ":0" as its
+				// HTTP/3 port. Fine where the setting opens one socket.
+				add("%s = %q: port 0 gives each transport a different port; name one", bind.key, bind.value)
 			}
 		}
 	}
@@ -950,8 +958,18 @@ func localAddress(ip net.IP) bool {
 // dns64 is not one of these callers. It parses with net.ParseCIDR and takes
 // the leading zero, so its lists are judged with that instead.
 func validCIDR(s string) bool {
-	_, err := netip.ParsePrefix(s)
-	return err == nil
+	p, err := netip.ParsePrefix(s)
+	if err != nil {
+		return false
+	}
+	// An IPv4-mapped prefix is filed under IPv6 by internal/ipset, while a
+	// client arriving over IPv4 is unmapped and looked up under IPv4 — so
+	// the entry sits in a table nothing searches. ECS compares prefix to
+	// address directly, where the families disagree just as flatly. Either
+	// way it is a rule that matches nobody, and as the only access-list
+	// entry it would leave an empty allow set. The operator wants the plain
+	// form: 192.0.2.0/24.
+	return !p.Addr().Is4In6()
 }
 
 // regularFile reports whether path is something the server can open and read.
@@ -1107,7 +1125,31 @@ func samePath(a, b string) bool {
 	// components, though — mkdir and open both take a path with one — so it
 	// is dropped before the comparison rather than making two spellings of
 	// the same place look different.
+	//
+	// Where the part before the last element does exist, though, the system
+	// resolves it and so does this: "/tmp/there/../db" and "/tmp/db" are one
+	// place when "there" is there, and the pending directory would otherwise
+	// be missed for one spelling of it.
+	if ra, ok := resolveParent(a); ok {
+		if rb, ok := resolveParent(b); ok {
+			return ra == rb
+		}
+	}
 	return trimTrailingSeparators(a) == trimTrailingSeparators(b)
+}
+
+// resolveParent rewrites path with everything before its last element
+// resolved through the filesystem, and reports whether that part exists. The
+// last element is left alone: it is the one that may not be there yet.
+func resolveParent(path string) (string, bool) {
+	trimmed := trimTrailingSeparators(path)
+	parent := literalParent(trimmed)
+
+	resolved, err := filepath.EvalSymlinks(parent)
+	if err != nil {
+		return "", false
+	}
+	return filepath.Join(resolved, filepath.Base(trimmed)), true
 }
 
 // trimTrailingSeparators drops the separators at the end of path, keeping a

--- a/config/validate.go
+++ b/config/validate.go
@@ -1012,6 +1012,17 @@ func existingDir(path string) error {
 	return nil
 }
 
+// cleansPathComponents is whether the system collapses ".." itself before it
+// touches the filesystem. Windows does; unix resolves a path one component at
+// a time.
+//
+// It is a variable rather than a check at each site so a test on either
+// platform can exercise both rules — this file has been wrong about the one
+// it does not run twice, and only Windows CI noticed. Which rule is the
+// default here cannot be tested locally, since any assertion would compare
+// this expression against itself; that half stays CI's job.
+var cleansPathComponents = runtime.GOOS == "windows"
+
 // literalParent returns everything before the last element of path.
 //
 // Which parent that is depends on how the system resolves a path. Unix walks
@@ -1025,7 +1036,7 @@ func existingDir(path string) error {
 // Trailing separators are dropped either way, so a path written as a
 // directory yields its own parent rather than itself.
 func literalParent(path string) string {
-	if runtime.GOOS == "windows" {
+	if cleansPathComponents {
 		return filepath.Dir(filepath.Clean(path))
 	}
 
@@ -1092,8 +1103,17 @@ func accessLogTarget(path string) string {
 // Windows collapses ".." itself, so cleaning is what it does and Join is
 // right there.
 func joinKeepingComponents(dir, target string) string {
-	if runtime.GOOS == "windows" {
-		return filepath.Join(dir, target)
+	if cleansPathComponents {
+		joined := filepath.Join(dir, target)
+		// Join cleans, and that takes the trailing separator with it — the
+		// one thing that says the target names a directory, which the open
+		// refuses. The unix branch below keeps it by not cleaning at all, so
+		// this is the only place it has to be put back, and Windows CI is
+		// the only thing that exercises it.
+		if endsInSeparator(target) && !endsInSeparator(joined) {
+			joined += string(os.PathSeparator)
+		}
+		return joined
 	}
 	if dir == "" {
 		return target

--- a/config/validate.go
+++ b/config/validate.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -1005,15 +1006,23 @@ func existingDir(path string) error {
 	return nil
 }
 
-// literalParent returns everything before the last element of path, with the
-// components left exactly as written.
+// literalParent returns everything before the last element of path.
 //
-// filepath.Dir cannot be used for this: it cleans, so "missing/../access.log"
-// comes back as "." and looks like it lives somewhere that exists — while the
-// open, which resolves each component in turn, fails on the "missing" that is
-// not there. Trailing separators are dropped first, so a path written as a
-// directory still yields its own parent rather than itself.
+// Which parent that is depends on how the system resolves a path. Unix walks
+// it one component at a time, so "missing/../access.log" fails on the
+// "missing" that is not there and the parent has to keep the components as
+// written — filepath.Dir cleans, and would answer "." for a path nothing can
+// open. Windows collapses ".." itself before touching the filesystem, so
+// there the cleaned parent is the one that decides, and keeping the
+// components would refuse a path the OS is perfectly happy with.
+//
+// Trailing separators are dropped either way, so a path written as a
+// directory yields its own parent rather than itself.
 func literalParent(path string) string {
+	if runtime.GOOS == "windows" {
+		return filepath.Dir(filepath.Clean(path))
+	}
+
 	i := len(path)
 	for i > 0 && os.IsPathSeparator(path[i-1]) {
 		i--

--- a/config/validate.go
+++ b/config/validate.go
@@ -2,11 +2,13 @@ package config
 
 import (
 	"crypto/ecdh"
+	"crypto/ed25519"
 	"crypto/rsa"
 	"encoding/base64"
 	"errors"
 	"fmt"
 	"math"
+	"math/big"
 	"net"
 	"net/url"
 	"os"
@@ -980,6 +982,12 @@ func anchorKeyProblem(key *dns.DNSKEY) error {
 	// r = s = 0, and ecdsa.Verify rejects that before it ever looks at the
 	// public point — so a curve key of the right length that is not a point
 	// on the curve comes back as a bad signature and looks usable.
+	if key.Algorithm == dns.ED25519 {
+		if err := edwardsCanonical(key.PublicKey); err != nil {
+			return fmt.Errorf("public key is not usable for algorithm %d (%s): %v", key.Algorithm, name, err)
+		}
+	}
+
 	if curve := ecdhCurve(key.Algorithm); curve != nil {
 		raw, decodeErr := base64.StdEncoding.DecodeString(key.PublicKey)
 		if decodeErr != nil {
@@ -1005,6 +1013,41 @@ func expectedProbeFailure(alg uint8) error {
 	}
 	// ECDSA and the Edwards curves fail a bad signature inside miekg itself.
 	return dns.ErrSig
+}
+
+// edwards25519P is 2^255 - 19, the field the curve is defined over.
+var edwards25519P = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 255), big.NewInt(19))
+
+// edwardsCanonical reports whether an Ed25519 public key is encoded the way a
+// decoder will accept. RFC 8032 section 5.1.3 recovers the y-coordinate by
+// clearing the sign bit and fails when what is left is not less than p, so
+// this is the decoder's own rule rather than one invented here.
+//
+// It does not make the key valid: a canonical y that is not a point on the
+// curve still gets through, and the standard library exposes nothing that
+// would catch it — ed25519.Verify answers false for such a key exactly as it
+// does for a good key and a bad signature, which is why the probe above
+// cannot tell them apart. Catching that case needs Edwards arithmetic this
+// package has no business carrying.
+func edwardsCanonical(publicKey string) error {
+	raw, err := base64.StdEncoding.DecodeString(publicKey)
+	if err != nil {
+		return fmt.Errorf("not base64: %w", err)
+	}
+	if len(raw) != ed25519.PublicKeySize {
+		return fmt.Errorf("is %d bytes, want %d", len(raw), ed25519.PublicKeySize)
+	}
+
+	// Little-endian, with the top bit carrying the sign of x.
+	y := make([]byte, len(raw))
+	for i := range raw {
+		y[len(raw)-1-i] = raw[i]
+	}
+	y[0] &= 0x7f
+	if new(big.Int).SetBytes(y).Cmp(edwards25519P) >= 0 {
+		return fmt.Errorf("y-coordinate is not below 2^255-19, so no decoder accepts it")
+	}
+	return nil
 }
 
 // ecdhCurve returns the curve behind a DNSSEC ECDSA algorithm, or nil for

--- a/config/validate.go
+++ b/config/validate.go
@@ -6,6 +6,8 @@ import (
 	"net/url"
 	"os"
 	"strings"
+
+	"github.com/miekg/dns"
 )
 
 // Validate reports what is wrong with a loaded configuration.
@@ -150,10 +152,210 @@ func (c *Config) Validate() error {
 		}
 	}
 
+	c.validateTrustAndIdentity(add)
+	c.validateNameLists(add)
+	c.validateSubTables(add)
+
 	if len(problems) == 0 {
 		return nil
 	}
 	return fmt.Errorf("invalid configuration:\n  - %s", strings.Join(problems, "\n  - "))
+}
+
+// validateTrustAndIdentity covers the settings that decide who this resolver
+// trusts and what address it speaks from.
+func (c *Config) validateTrustAndIdentity(add func(string, ...any)) {
+	for _, key := range c.RootKeys {
+		// A bad anchor is fatal at resolver construction, so without this
+		// the config test passes and the server then refuses to start.
+		rr, err := dns.NewRR(key)
+		if err != nil {
+			add("rootkeys %q: %v", key, err)
+			continue
+		}
+		if _, ok := rr.(*dns.DNSKEY); !ok {
+			add("rootkeys %q: must be a DNSKEY record", key)
+		}
+	}
+
+	for _, out := range []struct {
+		key    string
+		values []string
+		want4  bool
+	}{
+		{"outboundips", c.OutboundIPs, true},
+		{"outboundip6s", c.OutboundIP6s, false},
+	} {
+		for _, addr := range out.values {
+			ip := net.ParseIP(addr)
+			if ip == nil {
+				add("%s %q: must be an IP address", out.key, addr)
+				continue
+			}
+			// Putting a v6 address in the v4 list is a mistake the resolver
+			// cannot act on, and nothing downstream says so.
+			if is4 := ip.To4() != nil; is4 != out.want4 {
+				family := "IPv6"
+				if out.want4 {
+					family = "IPv4"
+				}
+				add("%s %q: must be an %s address", out.key, addr, family)
+			}
+		}
+	}
+
+	if c.API != "" {
+		if _, port, err := net.SplitHostPort(c.API); err != nil || port == "" {
+			add("api = %q: must be host:port", c.API)
+		}
+	}
+
+	if c.HostsFile != "" {
+		if _, err := os.Stat(c.HostsFile); err != nil {
+			add("hostsfile = %q: %v", c.HostsFile, err)
+		}
+	}
+
+	for _, addr := range c.HyperlocalRootSources {
+		// Hostnames are expected here: the built-in sources are the root
+		// servers' names.
+		host, port, err := net.SplitHostPort(addr)
+		if err != nil || host == "" || port == "" {
+			add("hyperlocal_root_sources %q: must be host:port", addr)
+		}
+	}
+
+	// Prefetch is a percentage of the original TTL. Above 100 the refresh
+	// trigger sits beyond the whole lifetime, so every hit prefetches — the
+	// documented range is 10-90 and only the low end is clamped in code.
+	if c.Prefetch > 100 {
+		add("prefetch = %d: is a percentage, so it cannot exceed 100", c.Prefetch)
+	}
+
+	if c.ReflexThreshold != 0 && (c.ReflexThreshold < 0 || c.ReflexThreshold > 1) {
+		// Out of range is silently replaced by the default, so an operator
+		// who wrote 42 believes they set a threshold they did not.
+		add("reflexthreshold = %v: must be between 0 and 1", c.ReflexThreshold)
+	}
+
+	for name, plugin := range c.Plugins {
+		if plugin.Path == "" {
+			add("plugin %q has no path", name)
+			continue
+		}
+		if _, err := os.Stat(plugin.Path); err != nil {
+			add("plugin %q path %q: %v", name, plugin.Path, err)
+		}
+	}
+}
+
+// validateNameLists covers the settings that name zones or hosts.
+func (c *Config) validateNameLists(add func(string, ...any)) {
+	for _, list := range []struct {
+		key      string
+		values   []string
+		wildcard bool
+	}{
+		{"blocklist", c.Blocklist, true},
+		{"whitelist", c.Whitelist, true},
+		{"emptyzones", c.EmptyZones, false},
+	} {
+		for _, entry := range list.values {
+			name := entry
+			// "*.example.com" blocks subdomains only; the star is the
+			// blocklist's own syntax, not part of the name.
+			if list.wildcard {
+				name = strings.TrimPrefix(name, "*.")
+			}
+			if name == "" {
+				add("%s entry %q is empty", list.key, entry)
+				continue
+			}
+			if _, ok := dns.IsDomainName(name); !ok {
+				add("%s %q: not a valid domain name", list.key, entry)
+			}
+		}
+	}
+
+	for _, u := range c.BlockLists {
+		parsed, err := url.Parse(u)
+		if err != nil || parsed.Host == "" || parsed.Scheme == "" {
+			add("blocklists %q: must be a URL", u)
+		}
+	}
+}
+
+// validateSubTables covers the settings that live under their own headings.
+func (c *Config) validateSubTables(add func(string, ...any)) {
+	for i := range c.Views {
+		view := &c.Views[i]
+		label := view.Zone
+		if label == "" {
+			label = fmt.Sprintf("#%d", i+1)
+		}
+		if view.Zone != "" {
+			if _, ok := dns.IsDomainName(view.Zone); !ok {
+				add("view %s: zone is not a valid domain name", label)
+			}
+		}
+		for _, network := range view.Networks {
+			if !validCIDR(network) {
+				add("view %s network %q: must be a CIDR block", label, network)
+			}
+		}
+		for _, answer := range view.Answers {
+			if _, err := dns.NewRR(answer); err != nil {
+				add("view %s answer %q: %v", label, answer, err)
+			}
+		}
+	}
+
+	for _, prefix := range c.DNS64.Prefixes {
+		ip, _, err := net.ParseCIDR(prefix)
+		if err != nil || ip.To4() != nil {
+			add("dns64 prefix %q: must be an IPv6 CIDR block", prefix)
+		}
+	}
+	for _, list := range []struct {
+		key    string
+		values []string
+	}{
+		{"dns64 client_networks", c.DNS64.ClientNetworks},
+		{"dns64 exclude_a_networks", c.DNS64.ExcludeANetworks},
+		{"dns64 exclude_aaaa_networks", c.DNS64.ExcludeAAAANetworks},
+		{"ecs client_networks", c.ECS.ClientNetworks},
+	} {
+		for _, network := range list.values {
+			if !validCIDR(network) {
+				add("%s %q: must be a CIDR block", list.key, network)
+			}
+		}
+	}
+	for _, zone := range c.DNS64.ExcludeZones {
+		if _, ok := dns.IsDomainName(zone); !ok {
+			add("dns64 exclude_zones %q: not a valid domain name", zone)
+		}
+	}
+
+	for _, bits := range []struct {
+		key   string
+		value uint8
+		max   uint8
+	}{
+		{"ecs forward_v4", c.ECS.ForwardV4Max, 32},
+		{"ecs min_scope_v4", c.ECS.MinScopeV4, 32},
+		{"ecs forward_v6", c.ECS.ForwardV6Max, 128},
+		{"ecs min_scope_v6", c.ECS.MinScopeV6, 128},
+	} {
+		if bits.value > bits.max {
+			add("%s = %d: must not exceed %d", bits.key, bits.value, bits.max)
+		}
+	}
+}
+
+func validCIDR(s string) bool {
+	_, _, err := net.ParseCIDR(s)
+	return err == nil
 }
 
 // validIPPort reports whether addr is an IP literal with a port. Authority and

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -1699,3 +1699,42 @@ func TestValidateAccessLogLongChain(t *testing.T) {
 		t.Fatal("Validate() accepted a chain no system will follow")
 	}
 }
+
+// TestPathHandlingOnBothPlatforms exercises the branch this platform does not
+// take. Path resolution differs — Windows collapses ".." before it touches
+// the filesystem, unix walks the components — and each rule has been wrong
+// once, caught only by the other platform's CI.
+func TestPathHandlingOnBothPlatforms(t *testing.T) {
+	original := cleansPathComponents
+	defer func() { cleansPathComponents = original }()
+
+	dir := t.TempDir()
+	sep := string(filepath.Separator)
+
+	// A relative symlink target that names a directory has to stay
+	// directory-shaped through the join, whichever way the join works.
+	link := filepath.Join(dir, "access.log")
+	if err := os.Symlink("real.log"+sep, link); err != nil {
+		t.Skipf("symlink: %v", err)
+	}
+	for _, cleans := range []bool{false, true} {
+		cleansPathComponents = cleans
+		if err := (&Config{AccessLog: link}).Validate(); err == nil ||
+			!strings.Contains(err.Error(), "names a directory") {
+			t.Fatalf("cleansPathComponents=%v: Validate() = %v, want the shape kept", cleans, err)
+		}
+	}
+
+	// A path with a missing component: refused where components are walked,
+	// accepted where ".." is collapsed first — mirroring what open and mkdir
+	// do on each.
+	missing := dir + sep + "missing" + sep + ".." + sep + "db"
+	cleansPathComponents = false
+	if err := (&Config{Directory: missing}).Validate(); err == nil {
+		t.Fatal("walking components: Validate() accepted a missing component")
+	}
+	cleansPathComponents = true
+	if err := (&Config{Directory: missing}).Validate(); err != nil {
+		t.Fatalf("collapsing \"..\": Validate() = %v, want the path accepted", err)
+	}
+}

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -2070,3 +2070,72 @@ func TestValidateRejectsMappedPrefixes(t *testing.T) {
 		t.Fatalf("Validate() rejected ordinary prefixes: %v", err)
 	}
 }
+
+// TestValidatePortNameMustAgreeAcrossTransports pins the split a service name
+// can carry. "raid-am" is 2007 over UDP and 2013 over TCP on a Mac, so a
+// setting that opens both would answer on one number and wait for the
+// fallback on the other — the same break that makes port 0 unusable there.
+func TestValidatePortNameMustAgreeAcrossTransports(t *testing.T) {
+	original := lookupPort
+	defer func() { lookupPort = original }()
+
+	// Pinned rather than borrowed from this machine: which names disagree is
+	// a property of /etc/services, not of the rule under test.
+	lookupPort = func(network, port string) (int, error) {
+		if port != "split" {
+			return original(network, port)
+		}
+		if network == "udp" {
+			return 2007, nil
+		}
+		return 2013, nil
+	}
+
+	// bind opens both, so the disagreement matters.
+	if err := (&Config{Bind: ":split"}).Validate(); err == nil {
+		t.Fatal("Validate() accepted a name that is a different port on each transport")
+	}
+
+	// DoQ opens UDP alone, so there is nothing to disagree with.
+	dir := t.TempDir()
+	cert := filepath.Join(dir, "cert.pem")
+	key := filepath.Join(dir, "key.pem")
+	for _, p := range []string{cert, key} {
+		if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	single := &Config{BindDOQ: ":split", TLSCertificate: cert, TLSPrivateKey: key}
+	if err := single.Validate(); err != nil {
+		t.Fatalf("Validate() refused a one-transport listener: %v", err)
+	}
+
+	// A name both tables agree on is fine everywhere.
+	if err := (&Config{Bind: ":domain"}).Validate(); err != nil {
+		t.Fatalf("Validate() refused a name both transports know: %v", err)
+	}
+}
+
+// TestValidateRelativeAndAbsoluteAreOnePlace pins that a relative working
+// directory and an absolute log path under it are recognised as the same
+// place. Nothing chdirs, so "db" resolves against the process's directory —
+// and on a first run the log's parent is one the server is about to make.
+func TestValidateRelativeAndAbsoluteAreOnePlace(t *testing.T) {
+	dir := t.TempDir()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(cwd) //nolint:errcheck // restoring the test's own directory
+
+	cfg := &Config{
+		Directory: "db",
+		AccessLog: filepath.Join(dir, "db", "access.log"),
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() called two spellings of one directory different: %v", err)
+	}
+}

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -122,10 +123,10 @@ func TestValidateReportsEveryProblem(t *testing.T) {
 func TestLoadRecordsUndecodedKeys(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sdns.conf")
-	body := "version = \"" + configver + "\"\n" +
-		"directory = \"" + filepath.Join(dir, "db") + "\"\n" +
-		"forwardservers = [\"1.1.1.1:53\"]\n" +
-		"maxdepth_old = 30\n"
+	body := fmt.Sprintf(
+		"version = %q\ndirectory = %q\nforwardservers = [\"1.1.1.1:53\"]\nmaxdepth_old = 30\n",
+		configver, filepath.Join(dir, "db"),
+	)
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -147,9 +148,10 @@ func TestLoadRecordsUndecodedKeys(t *testing.T) {
 func TestLoadRejectsUnusableValues(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sdns.conf")
-	body := "version = \"" + configver + "\"\n" +
-		"directory = \"" + filepath.Join(dir, "db") + "\"\n" +
-		"nullroute = \"not-an-ip\"\n"
+	body := fmt.Sprintf(
+		"version = %q\ndirectory = %q\nnullroute = \"not-an-ip\"\n",
+		configver, filepath.Join(dir, "db"),
+	)
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -278,5 +280,32 @@ func TestValidateRootKeyAlgorithm(t *testing.T) {
 				t.Fatalf("Validate() = %v, want the algorithm named as the problem", err)
 			}
 		})
+	}
+}
+
+// TestLoadReportsUnknownKeysAlongsideValueProblems pins the second half of the
+// one-pass promise. The keys are recorded before the gate, but Load returns no
+// Config when validation fails — so without this they reached the operator
+// only as a log line, and fixing the value meant a second run to discover the
+// key.
+func TestLoadReportsUnknownKeysAlongsideValueProblems(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sdns.conf")
+	body := fmt.Sprintf(
+		"version = %q\ndirectory = %q\nnullroute = \"not-an-ip\"\nmaxdepth_old = 30\n",
+		configver, filepath.Join(dir, "db"),
+	)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Load(path, "test")
+	if err == nil {
+		t.Fatal("Load() accepted a config with an unusable value")
+	}
+	for _, want := range []string{"nullroute", "maxdepth_old"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("Load() = %v\nmissing %q — the operator would need a second run", err, want)
+		}
 	}
 }

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -6,9 +6,7 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
-	"syscall"
 	"testing"
 	"time"
 )
@@ -784,23 +782,6 @@ func TestValidateCreatedPathsNeedTheirParent(t *testing.T) {
 	if err := (&Config{AccessLog: filepath.Join(dir, "gone", "a.log")}).Validate(); err == nil ||
 		!strings.Contains(err.Error(), "accesslog") {
 		t.Fatalf("Validate() = %v, want the missing access log directory reported", err)
-	}
-}
-
-func TestValidateRejectsSpecialFiles(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("no mkfifo on windows")
-	}
-	dir := t.TempDir()
-	fifo := filepath.Join(dir, "fifo")
-	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
-		t.Skipf("mkfifo: %v", err)
-	}
-	// Not a directory, and still not something to read a certificate from —
-	// opening it would block startup.
-	if err := (&Config{HostsFile: fifo}).Validate(); err == nil ||
-		!strings.Contains(err.Error(), "named pipe") {
-		t.Fatalf("Validate() = %v, want the FIFO rejected", err)
 	}
 }
 

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -39,9 +39,9 @@ func TestValidateRejectsUnusableValues(t *testing.T) {
 		// /49 is a valid IPv6 CIDR and an invalid Pref64: the runtime drops
 		// it and falls back to 64:ff9b::/96, sending traffic somewhere else
 		// entirely than the file says.
-		{"dns64 prefix length", Config{DNS64: DNS64Config{Prefixes: []string{"2001:db8::/49"}}}, "dns64 prefix"},
+		{"dns64 prefix length", Config{DNS64: DNS64Config{Enabled: true, Prefixes: []string{"2001:db8::/49"}}}, "dns64 prefix"},
 		// Byte 8 is the high half of the fifth group, inside a /96.
-		{"dns64 reserved byte", Config{DNS64: DNS64Config{Prefixes: []string{"2001:db8:0:0:ff00::/96"}}}, "byte 8"},
+		{"dns64 reserved byte", Config{DNS64: DNS64Config{Enabled: true, Prefixes: []string{"2001:db8:0:0:ff00::/96"}}}, "byte 8"},
 		// 91-100 passed before and then silently disabled prefetch.
 		{"prefetch above the cache ceiling", Config{Prefetch: 95}, "prefetch"},
 		{"root server", Config{RootServers: []string{"hello world"}}, "rootservers"},
@@ -58,15 +58,15 @@ func TestValidateRejectsUnusableValues(t *testing.T) {
 		{"root key wrong type", Config{RootKeys: []string{". 172800 IN A 192.0.2.1"}}, "rootkeys"},
 		{"outbound family", Config{OutboundIPs: []string{"2001:db8::1"}}, "outboundips"},
 		{"api address", Config{API: "not an address"}, "api"},
-		{"hyperlocal source", Config{HyperlocalRootSources: []string{"no-port"}}, "hyperlocal_root_sources"},
+		{"hyperlocal source", Config{HyperlocalRoot: true, HyperlocalRootSources: []string{"no-port"}}, "hyperlocal_root_sources"},
 		// Out of range is silently replaced by the default, so the operator
 		// believes they set a threshold they did not.
 		{"reflex threshold", Config{ReflexThreshold: 42}, "reflexthreshold"},
 		{"prefetch percentage", Config{Prefetch: 250}, "prefetch"},
 		{"view network", Config{Views: []ViewConfig{{Zone: "a.", Networks: []string{"nope"}}}}, "network"},
 		{"view answer", Config{Views: []ViewConfig{{Zone: "a.", Answers: []string{"not an rr"}}}}, "answer"},
-		{"dns64 prefix", Config{DNS64: DNS64Config{Prefixes: []string{"192.0.2.0/24"}}}, "dns64 prefix"},
-		{"ecs scope", Config{ECS: ECSConfig{ForwardV4Max: 33}}, "ecs forward_v4"},
+		{"dns64 prefix", Config{DNS64: DNS64Config{Enabled: true, Prefixes: []string{"192.0.2.0/24"}}}, "dns64 prefix"},
+		{"ecs scope", Config{ECS: ECSConfig{Enabled: true, ForwardV4Max: 33}}, "ecs forward_v4"},
 		{"blocklist url", Config{BlockLists: []string{"not-a-url"}}, "blocklists"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -210,9 +210,11 @@ func TestValidateFamilySpecificLists(t *testing.T) {
 		// The runtime keeps these by mask length and drops the wrong family
 		// with a log line, so the exclusion quietly does not apply.
 		{"exclude_a takes IPv4", Config{DNS64: DNS64Config{
+			Enabled:          true,
 			ExcludeANetworks: []string{"2001:db8::/32"},
 		}}, "exclude_a_networks"},
 		{"exclude_aaaa takes IPv6", Config{DNS64: DNS64Config{
+			Enabled:             true,
 			ExcludeAAAANetworks: []string{"192.0.2.0/24"},
 		}}, "exclude_aaaa_networks"},
 		// The updater fetches with an http.Client, so anything else never loads.
@@ -232,7 +234,7 @@ func TestValidateFamilySpecificLists(t *testing.T) {
 	}
 
 	// Both families are legal where the runtime accepts either.
-	both := &Config{DNS64: DNS64Config{ClientNetworks: []string{"192.0.2.0/24", "2001:db8::/32"}}}
+	both := &Config{DNS64: DNS64Config{Enabled: true, ClientNetworks: []string{"192.0.2.0/24", "2001:db8::/32"}}}
 	if err := both.Validate(); err != nil {
 		t.Fatalf("Validate() rejected a mixed-family client_networks list: %v", err)
 	}
@@ -240,6 +242,7 @@ func TestValidateFamilySpecificLists(t *testing.T) {
 
 func TestValidateNegativeECSCacheLimit(t *testing.T) {
 	cfg := &Config{}
+	cfg.ECS.Enabled = true
 	cfg.ECS.CacheLimitTTL.Duration = -time.Second
 	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "cache_limit_ttl") {
 		t.Fatalf("Validate() = %v, want the negative ECS cache limit rejected", err)
@@ -410,20 +413,220 @@ func TestValidatePortRange(t *testing.T) {
 func TestValidateMirrorsRuntimeTrimming(t *testing.T) {
 	trimmed := &Config{
 		DNS64: DNS64Config{
+			Enabled:             true,
 			Prefixes:            []string{" 64:ff9b::/96 "},
 			ClientNetworks:      []string{" 192.0.2.0/24 "},
 			ExcludeANetworks:    []string{" 10.0.0.0/8 "},
 			ExcludeAAAANetworks: []string{" 2001:db8::/32 "},
 			ExcludeZones:        []string{" Example.COM ", ""},
 		},
+		HyperlocalRoot:        true,
 		HyperlocalRootSources: []string{" 192.0.2.1:53 ", ""},
 	}
 	if err := trimmed.Validate(); err != nil {
 		t.Fatalf("Validate() rejected values the runtime trims and uses: %v", err)
 	}
 
-	raw := &Config{ECS: ECSConfig{ClientNetworks: []string{" 192.0.2.0/24 "}}}
+	raw := &Config{ECS: ECSConfig{Enabled: true, ClientNetworks: []string{" 192.0.2.0/24 "}}}
 	if err := raw.Validate(); err == nil {
 		t.Fatal("Validate() accepted an untrimmed ecs network; ecs parses it raw and would fail")
+	}
+}
+
+// TestValidateSkipsDisabledFeatures pins the upgrade path. Both constructors
+// return before reading another field when the feature is off, so a stale
+// value under a disabled section has no effect — and refusing to start over it
+// would turn an upgrade into an outage.
+func TestValidateSkipsDisabledFeatures(t *testing.T) {
+	stale := &Config{
+		DNS64: DNS64Config{
+			Enabled:             false,
+			Prefixes:            []string{"not-a-prefix", "2001:db8::/49"},
+			ClientNetworks:      []string{"nonsense"},
+			ExcludeANetworks:    []string{"2001:db8::/32"},
+			ExcludeAAAANetworks: []string{"192.0.2.0/24"},
+			ExcludeZones:        []string{"\\"},
+		},
+		ECS: ECSConfig{
+			Enabled:        false,
+			ForwardV4Max:   99,
+			ClientNetworks: []string{"nonsense"},
+		},
+		HyperlocalRoot:        false,
+		HyperlocalRootSources: []string{"no-port-at-all"},
+	}
+	if err := stale.Validate(); err != nil {
+		t.Fatalf("Validate() refused a config whose broken values are all under disabled features: %v", err)
+	}
+
+	// Turning the feature on is what makes them count.
+	on := *stale
+	on.DNS64.Enabled = true
+	on.ECS.Enabled = true
+	on.HyperlocalRoot = true
+	err := on.Validate()
+	if err == nil {
+		t.Fatal("Validate() accepted broken values under enabled features")
+	}
+	for _, want := range []string{"dns64 prefix", "ecs forward_v4", "hyperlocal_root_sources"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("Validate() = %v\nmissing a problem for %q", err, want)
+		}
+	}
+}
+
+func TestValidatePathKinds(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "a-file")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// A directory satisfies Stat and then fails at the read, taking the TLS
+	// listener down after this test reported success.
+	tlsCfg := &Config{
+		BindTLS:        ":853",
+		TLSCertificate: dir,
+		TLSPrivateKey:  dir,
+	}
+	err := tlsCfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "is a directory") {
+		t.Fatalf("Validate() = %v, want the certificate directory rejected", err)
+	}
+
+	if err := (&Config{HostsFile: dir}).Validate(); err == nil ||
+		!strings.Contains(err.Error(), "is a directory") {
+		t.Fatalf("Validate() = %v, want a directory rejected as hostsfile", err)
+	}
+
+	// Absent is fine — the server creates it — but a file at the path is not,
+	// because the Mkdir that follows fails on it.
+	if err := (&Config{Directory: filepath.Join(dir, "not-there")}).Validate(); err != nil {
+		t.Fatalf("Validate() rejected a directory the server would create: %v", err)
+	}
+	if err := (&Config{Directory: file}).Validate(); err == nil ||
+		!strings.Contains(err.Error(), "want a directory") {
+		t.Fatalf("Validate() = %v, want a file rejected as directory", err)
+	}
+
+	// Opened with O_CREATE, so absence is fine and a directory is not.
+	if err := (&Config{AccessLog: filepath.Join(dir, "new.log")}).Validate(); err != nil {
+		t.Fatalf("Validate() rejected an access log the server would create: %v", err)
+	}
+	if err := (&Config{AccessLog: dir}).Validate(); err == nil ||
+		!strings.Contains(err.Error(), "accesslog") {
+		t.Fatalf("Validate() = %v, want a directory rejected as accesslog", err)
+	}
+
+	// Only read when the integration is on.
+	off := &Config{}
+	off.Kubernetes.Kubeconfig = filepath.Join(dir, "missing.yaml")
+	if err := off.Validate(); err != nil {
+		t.Fatalf("Validate() read kubeconfig with kubernetes disabled: %v", err)
+	}
+	on := *off
+	on.Kubernetes.Enabled = true
+	if err := on.Validate(); err == nil || !strings.Contains(err.Error(), "kubeconfig") {
+		t.Fatalf("Validate() = %v, want the missing kubeconfig reported", err)
+	}
+}
+
+func TestValidateNullrouteFamilies(t *testing.T) {
+	// Blocked names answer A from nullroute and AAAA from nullroutev6, so a
+	// swap produces a wrong answer rather than a failure.
+	if err := (&Config{Nullroute: "::1"}).Validate(); err == nil ||
+		!strings.Contains(err.Error(), "must be IPv4") {
+		t.Fatalf("Validate() = %v, want an IPv6 nullroute rejected", err)
+	}
+	if err := (&Config{Nullroutev6: "0.0.0.0"}).Validate(); err == nil ||
+		!strings.Contains(err.Error(), "must be IPv6") {
+		t.Fatalf("Validate() = %v, want an IPv4 nullroutev6 rejected", err)
+	}
+	// What the generated config ships.
+	if err := (&Config{Nullroute: "0.0.0.0", Nullroutev6: "::0"}).Validate(); err != nil {
+		t.Fatalf("Validate() rejected the shipped null routes: %v", err)
+	}
+}
+
+func TestValidateSilentlyAdjustedNumbers(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  Config
+		want bool // accept?
+	}{
+		// The cache raises anything under 1024, so the file described a
+		// server that never ran.
+		{"cachesize below the floor", Config{CacheSize: 1}, false},
+		{"cachesize zero means default", Config{CacheSize: 0}, true},
+		{"cachesize at the floor", Config{CacheSize: 1024}, true},
+		// 1-9 is raised to 10, and above 90 turns prefetch off entirely.
+		{"prefetch below the floor", Config{Prefetch: 1}, false},
+		{"prefetch zero is off", Config{Prefetch: 0}, true},
+		{"prefetch at the floor", Config{Prefetch: 10}, true},
+		{"prefetch at the ceiling", Config{Prefetch: 90}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.cfg.Validate(); (err == nil) != tc.want {
+				t.Fatalf("Validate() accepted = %v, want %v (err = %v)", err == nil, tc.want, err)
+			}
+		})
+	}
+}
+
+// TestLoadValidatesQnameBeforeNormalizing pins the ordering. Normalizing folds
+// a negative count to zero — which turns minimization off — so running it
+// first handed Validate the settled value and hid what the file said.
+func TestLoadValidatesQnameBeforeNormalizing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sdns.conf")
+	body := fmt.Sprintf(
+		"version = %q\ndirectory = %q\nqname_max_minimize_count = -1\n",
+		configver, filepath.Join(dir, "db"),
+	)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(path, "test"); err == nil ||
+		!strings.Contains(err.Error(), "qname_max_minimize_count") {
+		t.Fatalf("Load() = %v, want the negative minimization count reported", err)
+	}
+}
+
+func TestValidateForwardZoneReportsNameAndServers(t *testing.T) {
+	err := (&Config{ForwardZones: []ForwardZoneConfig{{Name: ""}}}).Validate()
+	if err == nil {
+		t.Fatal("Validate() accepted a forward zone with no name and no servers")
+	}
+	for _, want := range []string{"has no name", "has no servers"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("Validate() = %v\nmissing %q — one entry, one run", err, want)
+		}
+	}
+}
+
+func TestValidateURLsNeedAHostname(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  Config
+	}{
+		// Host is ":443" and Hostname is empty; the forwarder bootstraps
+		// Hostname and drops this at startup.
+		{"DoH without a hostname", Config{ForwarderServers: []string{"https://:443/dns-query"}}},
+		{"DoH port out of range", Config{ForwarderServers: []string{"https://example.com:99999/dns-query"}}},
+		{"blocklist without a hostname", Config{BlockLists: []string{"http://:80/list"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.cfg.Validate(); err == nil {
+				t.Fatalf("Validate() accepted %+v", tc.cfg)
+			}
+		})
+	}
+
+	ok := &Config{
+		ForwarderServers: []string{"https://cloudflare-dns.com/dns-query", "https://1.1.1.1:443/dns-query"},
+		BlockLists:       []string{"https://example.com/list"},
+	}
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("Validate() rejected usable URLs: %v", err)
 	}
 }

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -1,0 +1,123 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestValidateRejectsUnusableValues(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		// "maybe" used to become "on": a typo silently switched validation
+		// on when the operator meant to switch it off.
+		{"dnssec enum", Config{DNSSEC: "maybe"}, "dnssec"},
+		{"log level", Config{LogLevel: "verbose"}, "loglevel"},
+		{"bind address", Config{Bind: "not an address"}, "bind"},
+		{"nullroute", Config{Nullroute: "not-an-ip"}, "nullroute"},
+		{"accesslist", Config{AccessList: []string{"999.999.999.999/99"}}, "accesslist"},
+		{"root server", Config{RootServers: []string{"hello world"}}, "rootservers"},
+		{"root server without port", Config{RootServers: []string{"192.0.2.1"}}, "rootservers"},
+		{"forwarder upstream", Config{ForwarderServers: []string{"nonsense"}}, "forwarderservers"},
+		{"DoT needs an IP", Config{ForwarderServers: []string{"tls://dns.example.com:853"}}, "forwarderservers"},
+		{"forward zone upstream", Config{ForwardZones: []ForwardZoneConfig{
+			{Name: "corp.example.", Servers: []string{"nonsense"}},
+		}}, "forward_zone"},
+		{"negative size", Config{CacheSize: -1}, "cachesize"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			if err == nil {
+				t.Fatalf("Validate() accepted %+v", tc.cfg)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Validate() = %v, want a problem naming %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateAcceptsUsableValues(t *testing.T) {
+	cfg := Config{
+		DNSSEC:           "on",
+		LogLevel:         "info",
+		Bind:             ":53",
+		Nullroute:        "0.0.0.0",
+		Nullroutev6:      "::0",
+		AccessList:       []string{"0.0.0.0/0", "::0/0", "192.0.2.1"},
+		RootServers:      []string{"192.5.5.241:53"},
+		Root6Servers:     []string{"[2001:500:2f::f]:53"},
+		ForwarderServers: []string{"1.1.1.1:53", "tls://1.1.1.1:853", "https://cloudflare-dns.com/dns-query"},
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() rejected a usable configuration: %v", err)
+	}
+}
+
+// TestValidateReportsEveryProblem pins the whole-list behaviour: an operator
+// fixing a file wants every problem at once, not one per run.
+func TestValidateReportsEveryProblem(t *testing.T) {
+	err := (&Config{
+		DNSSEC:    "maybe",
+		Bind:      "nope",
+		Nullroute: "also-nope",
+	}).Validate()
+	if err == nil {
+		t.Fatal("Validate() accepted three broken settings")
+	}
+	for _, want := range []string{"dnssec", "bind", "nullroute"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("Validate() = %v, missing a problem for %q", err, want)
+		}
+	}
+}
+
+// TestLoadRecordsUndecodedKeys pins the upgrade path: a key this version no
+// longer has, or a typo, takes no effect and must be reported rather than
+// silently ignored. Load only records it — refusing to start over a stale key
+// would turn an upgrade into an outage — and `sdns -t` fails on it.
+func TestLoadRecordsUndecodedKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sdns.conf")
+	body := "version = \"" + configver + "\"\n" +
+		"directory = \"" + filepath.Join(dir, "db") + "\"\n" +
+		"forwardservers = [\"1.1.1.1:53\"]\n" +
+		"maxdepth_old = 30\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path, "test")
+	if err != nil {
+		t.Fatalf("Load() failed on a config whose values are all usable: %v", err)
+	}
+	got := strings.Join(cfg.UndecodedKeys(), ",")
+	for _, want := range []string{"forwardservers", "maxdepth_old"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("UndecodedKeys() = %q, missing %q", got, want)
+		}
+	}
+}
+
+// TestLoadRejectsUnusableValues pins that Validate is actually wired into the
+// load path. Without this, the checks could be correct and never run.
+func TestLoadRejectsUnusableValues(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sdns.conf")
+	body := "version = \"" + configver + "\"\n" +
+		"directory = \"" + filepath.Join(dir, "db") + "\"\n" +
+		"nullroute = \"not-an-ip\"\n"
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Load(path, "test"); err == nil {
+		t.Fatal("Load() accepted a config with an unusable value")
+	} else if !strings.Contains(err.Error(), "nullroute") {
+		t.Fatalf("Load() = %v, want the problem to name nullroute", err)
+	}
+}

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"math"
 	"os"
@@ -948,7 +949,7 @@ func TestLoadRequiresWhatOnlyAFileNeeds(t *testing.T) {
 		want string
 	}{
 		{"no working directory", "directory = \"\"\nrootservers = [\"192.5.5.241:53\"]\n", "leaves it empty"},
-		{"nothing to recurse from", "rootservers = []\n", "no root server"},
+		{"nothing to recurse from", "rootservers = []\n", "rootservers: none configured"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()
@@ -968,8 +969,11 @@ func TestLoadRequiresWhatOnlyAFileNeeds(t *testing.T) {
 		})
 	}
 
-	// A forwarder takes every query before the resolver sees it, so it needs
-	// no root of its own.
+	// Forwarding is not an exemption. The resolver is built either way and
+	// its background goroutine primes the root as soon as the middleware is
+	// ready, so an empty list stops the process before a query arrives —
+	// keeping the resolver out of the query path is not keeping it out of
+	// the process.
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sdns.conf")
 	body := fmt.Sprintf("version = %q\ndirectory = %q\ndnssec = \"off\"\nforwarderservers = [\"1.1.1.1:53\"]\n",
@@ -977,8 +981,9 @@ func TestLoadRequiresWhatOnlyAFileNeeds(t *testing.T) {
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := Load(path, "test"); err != nil {
-		t.Fatalf("Load() refused a forwarder-only config: %v", err)
+	if _, err := Load(path, "test"); err == nil ||
+		!strings.Contains(err.Error(), "rootservers") {
+		t.Fatalf("Load() = %v, want a forwarder-only config still to need a root", err)
 	}
 }
 
@@ -1041,5 +1046,187 @@ func TestUsablePortUsesTheNetworksGiven(t *testing.T) {
 	// port that cannot resolve — every caller names at least one.
 	if n, err := usablePort("65536", "udp"); err == nil {
 		t.Fatalf("usablePort() = %d, want an out-of-range port refused", n)
+	}
+}
+
+// TestLoadSettlesIPv6BeforeJudgingIt pins the ordering. The probe decides
+// whether the v6 lists are read at all, so running it after the gate meant
+// outboundip6s went unjudged on a host that then used it, and a file whose
+// only roots are v6 passed on a host that then had none.
+func TestLoadSettlesIPv6BeforeJudgingIt(t *testing.T) {
+	original := ipv6Probe
+	defer func() { ipv6Probe = original }()
+
+	write := func(t *testing.T, body string) string {
+		t.Helper()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "sdns.conf")
+		content := fmt.Sprintf("version = %q\ndirectory = %q\ndnssec = \"off\"\n%s",
+			configver, filepath.Join(dir, "db"), body)
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+
+	// With v6 reachable the v6-only outbound address is read, and a
+	// non-local one stops the resolver.
+	ipv6Probe = func() error { return nil }
+	if _, err := Load(write(t, "rootservers = [\"192.5.5.241:53\"]\noutboundip6s = [\"2001:db8::1\"]\n"), "test"); err == nil {
+		t.Fatal("Load() accepted a non-local outbound v6 address on a v6 host")
+	}
+
+	// Without v6 the same file is fine, because nothing reads the list.
+	ipv6Probe = func() error { return errors.New("no v6") }
+	if _, err := Load(write(t, "rootservers = [\"192.5.5.241:53\"]\noutboundip6s = [\"2001:db8::1\"]\n"), "test"); err != nil {
+		t.Fatalf("Load() judged outboundip6s on a host without v6: %v", err)
+	}
+
+	// v6-only roots are the whole root set on a v6 host, and none of it
+	// without.
+	v6Only := "root6servers = [\"[2001:500:2f::f]:53\"]\n"
+	ipv6Probe = func() error { return nil }
+	if _, err := Load(write(t, v6Only), "test"); err != nil {
+		t.Fatalf("Load() refused v6-only roots on a v6 host: %v", err)
+	}
+	ipv6Probe = func() error { return errors.New("no v6") }
+	if _, err := Load(write(t, v6Only), "test"); err == nil ||
+		!strings.Contains(err.Error(), "rootservers") {
+		t.Fatalf("Load() = %v, want v6-only roots to leave nothing on a v4 host", err)
+	}
+}
+
+func TestValidateAccessLogFollowsSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real.log")
+	if err := os.WriteFile(target, []byte(""), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(dir, "link.log")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink: %v", err)
+	}
+	// OpenFile follows the link, so a link to a writable file is usable and
+	// refusing it would stop a setup that runs today.
+	if err := (&Config{AccessLog: link}).Validate(); err != nil {
+		t.Fatalf("Validate() rejected an access log symlink to a writable file: %v", err)
+	}
+}
+
+func TestValidateClusterDomainTrailingDots(t *testing.T) {
+	for _, tc := range []struct {
+		domain string
+		want   bool
+	}{
+		{"cluster.local", true},
+		{"cluster.local.", true},
+		// One dot is stripped and one put back, so this becomes a suffix
+		// with a doubled dot that no query can match.
+		{"cluster.local..", false},
+		{"bad..domain", false},
+	} {
+		t.Run(tc.domain, func(t *testing.T) {
+			cfg := &Config{}
+			cfg.Kubernetes.Enabled = true
+			cfg.Kubernetes.ClusterDomain = tc.domain
+			if err := cfg.Validate(); (err == nil) != tc.want {
+				t.Fatalf("Validate() accepted = %v, want %v (err = %v)", err == nil, tc.want, err)
+			}
+		})
+	}
+}
+
+func TestValidateQnameEffectivePair(t *testing.T) {
+	count := func(n int) *int { return &n }
+
+	for _, tc := range []struct {
+		name string
+		cfg  Config
+		want bool
+	}{
+		// Quietly lowered to the maximum, so the file describes a server
+		// that never ran.
+		{"one-label above the maximum", Config{
+			QnameMaxMinimizeCount: count(3), QnameMinimizeOneLabel: 10,
+		}, false},
+		{"one-label at the maximum", Config{
+			QnameMaxMinimizeCount: count(3), QnameMinimizeOneLabel: 3,
+		}, true},
+		// With minimization off the field is never read, so a stale value
+		// there must not stop the server.
+		{"minimization off", Config{
+			QnameMaxMinimizeCount: count(0), QnameMinimizeOneLabel: -1,
+		}, true},
+		{"negative while on", Config{
+			QnameMaxMinimizeCount: count(5), QnameMinimizeOneLabel: -1,
+		}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.cfg.Validate(); (err == nil) != tc.want {
+				t.Fatalf("Validate() accepted = %v, want %v (err = %v)", err == nil, tc.want, err)
+			}
+		})
+	}
+}
+
+func TestValidateUpstreamProtocols(t *testing.T) {
+	// DoT is dialled over TCP only; plain DNS asks over UDP and retries over
+	// TCP when an answer does not fit, so both tables have to know the port.
+	ok := &Config{
+		RootServers:      []string{"192.5.5.241:domain"},
+		ForwarderServers: []string{"tls://1.1.1.1:853", "1.1.1.1:53"},
+	}
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("Validate() rejected upstreams both tables know: %v", err)
+	}
+	// Port 0 has nothing to reach on either.
+	for _, cfg := range []Config{
+		{ForwarderServers: []string{"tls://1.1.1.1:0"}},
+		{ForwarderServers: []string{"1.1.1.1:0"}},
+	} {
+		if err := cfg.Validate(); err == nil {
+			t.Fatalf("Validate() accepted %+v", cfg.ForwarderServers)
+		}
+	}
+}
+
+// TestPortNetworksPerCaller pins which protocols each setting is judged over.
+// This platform's service tables answer the same for udp and tcp, so no value
+// can distinguish them; recording the question can.
+func TestPortNetworksPerCaller(t *testing.T) {
+	original := lookupPort
+	defer func() { lookupPort = original }()
+
+	var asked []string
+	lookupPort = func(network, port string) (int, error) {
+		asked = append(asked, network)
+		return original(network, port)
+	}
+
+	for _, tc := range []struct {
+		name string
+		cfg  Config
+		want []string
+	}{
+		// The plain listener answers over both; DoH brings HTTP/3 with it.
+		{"bind", Config{Bind: ":53"}, []string{"udp", "tcp"}},
+		{"binddoh", Config{BindDOH: ":443", TLSCertificate: "x", TLSPrivateKey: "x"}, []string{"udp", "tcp"}},
+		{"binddoq", Config{BindDOQ: ":853", TLSCertificate: "x", TLSPrivateKey: "x"}, []string{"udp"}},
+		{"bindtls", Config{BindTLS: ":853", TLSCertificate: "x", TLSPrivateKey: "x"}, []string{"tcp"}},
+		{"api", Config{API: "127.0.0.1:8080"}, []string{"tcp"}},
+		// Plain DNS retries over TCP when an answer does not fit.
+		{"rootservers", Config{RootServers: []string{"192.5.5.241:53"}}, []string{"udp", "tcp"}},
+		// DoT is TCP only.
+		{"DoT upstream", Config{ForwarderServers: []string{"tls://1.1.1.1:853"}}, []string{"tcp"}},
+		{"plain upstream", Config{ForwarderServers: []string{"1.1.1.1:53"}}, []string{"udp", "tcp"}},
+		{"blocklist", Config{BlockLists: []string{"http://example.com:8080/list"}}, []string{"tcp"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			asked = nil
+			_ = tc.cfg.Validate()
+			if strings.Join(asked, ",") != strings.Join(tc.want, ",") {
+				t.Fatalf("asked %v, want %v", asked, tc.want)
+			}
+		})
 	}
 }

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -250,34 +250,55 @@ func TestValidateNegativeECSCacheLimit(t *testing.T) {
 // caught here. Nothing downstream rejects it: NewResolver only fails on a
 // record that will not parse, so an anchor like this loads and then silently
 // fails every signature it is asked to verify.
+//
+// The accepted cases carry real key material. Truncated material is what an
+// earlier version of this test used, and it passed — the check was only
+// reading the algorithm, so a key of the right algorithm and the wrong shape
+// went through.
 func TestValidateRootKeyAlgorithm(t *testing.T) {
-	const material = "AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3"
+	// The live root KSK (key id 20326) and a generated P-256 key.
+	const (
+		rsaSHA256 = "AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3+/4RgWOq7HrxRixHlFlExOLAJr5emLvN7SWXgnLh4+B5xQlNVz8Og8kvArMtNROxVQuCaSnIDdD5LKyWbRd2n9WGe2R8PzgCmr3EgVLrjyBxWezF0jLHwVN8efS3rCj/EWgvIWgb9tarpVUDK/b58Da+sqqls3eNbuv7pr+eoZG+SrDK6nWeL3c6H5Apxz7LjVc1uTIdsIXxuOLYA4/ilBmSVIzuDWfdRUfhHdY6+cn8HFRm+2hM8AnXGXws9555KrUB5qihylGa8subX2Nn6UwNR1AkUTV74bU="
+		ecdsaP256 = "FS/jjwld5fQ2hD31w4Odohy65Je3eGSYDvJgKO0qBBEFRC5fa6GvcWdLyn0sj49unyBRv3nAHAH0UtAyYLZi7w=="
+		truncated = "AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3"
+	)
 
 	for _, tc := range []struct {
-		name string
-		alg  string
-		want bool
+		name     string
+		alg      string
+		material string
+		want     string // substring of the expected problem, "" to accept
 	}{
-		{"DSA is gone from the library", "3", false},
-		{"ECC-GOST is gone too", "12", false},
-		{"unassigned codepoint", "200", false},
+		{"DSA is gone from the library", "3", truncated, "cannot be verified with"},
+		{"ECC-GOST is gone too", "12", truncated, "cannot be verified with"},
+		{"unassigned codepoint", "200", truncated, "cannot be verified with"},
 		// Asked of the library, not assumed: ED448 has a name and a number
 		// and still cannot be verified with.
-		{"ED448 has a name but no verifier", "16", false},
-		{"RSASHA256 is what the root uses", "8", true},
-		{"ECDSAP256SHA256 is the successor", "13", true},
+		{"ED448 has a name but no verifier", "16", truncated, "cannot be verified with"},
+		// A supported algorithm carrying material of the wrong shape. P-256
+		// wants 64 bytes; this is 42. The resolver loads it and then fails
+		// every signature, so it is no more usable than a dead algorithm.
+		{"P-256 with material of the wrong size", "13", truncated, "public key is not usable"},
+		{"RSASHA256 with a short modulus", "8", truncated, "public key is not usable"},
+		{"RSASHA256 is what the root uses", "8", rsaSHA256, ""},
+		{"ECDSAP256SHA256 is the successor", "13", ecdsaP256, ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := &Config{RootKeys: []string{
-				". 172800 IN DNSKEY 257 3 " + tc.alg + " " + material,
+				". 172800 IN DNSKEY 257 3 " + tc.alg + " " + tc.material,
 			}}
 			err := cfg.Validate()
-			usable := err == nil
-			if usable != tc.want {
-				t.Fatalf("Validate() accepted = %v, want %v (err = %v)", usable, tc.want, err)
+			if tc.want == "" {
+				if err != nil {
+					t.Fatalf("Validate() rejected a usable anchor: %v", err)
+				}
+				return
 			}
-			if !tc.want && !strings.Contains(err.Error(), "cannot be verified with") {
-				t.Fatalf("Validate() = %v, want the algorithm named as the problem", err)
+			if err == nil {
+				t.Fatalf("Validate() accepted an anchor nothing can verify with")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Validate() = %v, want a problem naming %q", err, tc.want)
 			}
 		})
 	}
@@ -307,5 +328,102 @@ func TestLoadReportsUnknownKeysAlongsideValueProblems(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("Load() = %v\nmissing %q — the operator would need a second run", err, want)
 		}
+	}
+}
+
+// TestValidateRequiresAnchorsWhenValidating pins the case that has no symptom
+// until a query arrives. AutoTA needs a seed and refuses to take one from disk
+// when the live set is empty, so this does not heal: every validated answer
+// fails closed from the first query onward.
+func TestValidateRequiresAnchorsWhenValidating(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  Config
+		want bool // whether Validate should accept
+	}{
+		{"validating with nothing to anchor to", Config{DNSSEC: "on"}, false},
+		// A global forwarder skips the resolver entirely (handler.go returns
+		// before it materializes), so it needs no anchor of its own.
+		{"forwarder needs no anchor", Config{
+			DNSSEC:           "on",
+			ForwarderServers: []string{"1.1.1.1:53"},
+		}, true},
+		// A forward zone only hands over its own subtree; everything else
+		// still recurses here and still needs an anchor.
+		{"forward zone still recurses elsewhere", Config{
+			DNSSEC:       "on",
+			ForwardZones: []ForwardZoneConfig{{Name: "corp.example.", Servers: []string{"1.1.1.1:53"}}},
+		}, false},
+		{"dnssec off needs no anchor", Config{DNSSEC: "off"}, true},
+		// Omitted means off: the resolver reads cfg.DNSSEC == "on".
+		{"dnssec omitted needs no anchor", Config{}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			if (err == nil) != tc.want {
+				t.Fatalf("Validate() accepted = %v, want %v (err = %v)", err == nil, tc.want, err)
+			}
+			if !tc.want && !strings.Contains(err.Error(), "no usable root trust anchor") {
+				t.Fatalf("Validate() = %v, want the missing anchor named", err)
+			}
+		})
+	}
+}
+
+// TestValidatePortRange pins that a port is checked as a port. SplitHostPort
+// only separates the halves, so ":65536" reached the listener and failed at
+// bind time, and an upstream with such a port failed on every dial instead.
+func TestValidatePortRange(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  Config
+		want bool
+	}{
+		{"listener port above range", Config{Bind: ":65536"}, false},
+		{"listener port negative", Config{Bind: ":-1"}, false},
+		{"api port above range", Config{API: "127.0.0.1:99999"}, false},
+		{"upstream port above range", Config{RootServers: []string{"192.0.2.1:99999"}}, false},
+		{"forwarder port above range", Config{ForwarderServers: []string{"1.1.1.1:70000"}}, false},
+		// Nothing answers on port 0, and the dial fails per query rather
+		// than at startup.
+		{"upstream port zero", Config{RootServers: []string{"192.0.2.1:0"}}, false},
+		// Asked of the net package, not of a number range: ":domain" really
+		// does listen on 53, so a numeric test here would refuse a config
+		// that works.
+		{"listener service name", Config{Bind: ":domain"}, true},
+		{"listener port zero asks for a free one", Config{Bind: ":0"}, true},
+		{"ordinary listener", Config{Bind: ":53"}, true},
+		{"ordinary upstream", Config{RootServers: []string{"192.0.2.1:53"}}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.cfg.Validate(); (err == nil) != tc.want {
+				t.Fatalf("Validate() accepted = %v, want %v (err = %v)", err == nil, tc.want, err)
+			}
+		})
+	}
+}
+
+// TestValidateMirrorsRuntimeTrimming pins which lists tolerate surrounding
+// space. dns64 reads every list through TrimSpace and the hyperlocal manager
+// trims and drops blanks, so rejecting those would refuse configs the server
+// runs today. The ecs list is parsed raw, so it is judged raw.
+func TestValidateMirrorsRuntimeTrimming(t *testing.T) {
+	trimmed := &Config{
+		DNS64: DNS64Config{
+			Prefixes:            []string{" 64:ff9b::/96 "},
+			ClientNetworks:      []string{" 192.0.2.0/24 "},
+			ExcludeANetworks:    []string{" 10.0.0.0/8 "},
+			ExcludeAAAANetworks: []string{" 2001:db8::/32 "},
+			ExcludeZones:        []string{" Example.COM ", ""},
+		},
+		HyperlocalRootSources: []string{" 192.0.2.1:53 ", ""},
+	}
+	if err := trimmed.Validate(); err != nil {
+		t.Fatalf("Validate() rejected values the runtime trims and uses: %v", err)
+	}
+
+	raw := &Config{ECS: ECSConfig{ClientNetworks: []string{" 192.0.2.0/24 "}}}
+	if err := raw.Validate(); err == nil {
+		t.Fatal("Validate() accepted an untrimmed ecs network; ecs parses it raw and would fail")
 	}
 }

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -992,34 +992,6 @@ func TestValidateAccessLogTargetKinds(t *testing.T) {
 		t.Fatalf("Validate() rejected a writable access log: %v", err)
 	}
 
-	// Opened write-only; a read-only file fails there and logging quietly
-	// switches off.
-	ro := filepath.Join(dir, "ro.log")
-	if err := os.WriteFile(ro, []byte(""), 0o400); err != nil {
-		t.Fatal(err)
-	}
-	if os.Getuid() == 0 {
-		return // root opens it regardless
-	}
-	if err := (&Config{AccessLog: ro}).Validate(); err == nil {
-		t.Fatal("Validate() accepted an access log it cannot write")
-	}
-}
-
-func TestValidateUnreadableFile(t *testing.T) {
-	if os.Getuid() == 0 {
-		t.Skip("root reads regardless of mode")
-	}
-	dir := t.TempDir()
-	path := filepath.Join(dir, "cert.pem")
-	if err := os.WriteFile(path, []byte("x"), 0o000); err != nil {
-		t.Fatal(err)
-	}
-	// A regular file, and still not one this process can read — every
-	// consumer here opens it, so the type test alone was not enough.
-	if err := (&Config{HostsFile: path}).Validate(); err == nil {
-		t.Fatal("Validate() accepted a file it cannot read")
-	}
 }
 
 func TestValidateDanglingSymlinkDirectory(t *testing.T) {

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -126,7 +126,7 @@ func TestLoadRecordsUndecodedKeys(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sdns.conf")
 	body := fmt.Sprintf(
-		"version = %q\ndirectory = %q\ndnssec = \"off\"\nforwardservers = [\"1.1.1.1:53\"]\nmaxdepth_old = 30\n",
+		"version = %q\ndirectory = %q\ndnssec = \"off\"\nrootservers = [\"192.5.5.241:53\"]\nforwardservers = [\"1.1.1.1:53\"]\nmaxdepth_old = 30\n",
 		configver, filepath.Join(dir, "db"),
 	)
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
@@ -151,7 +151,7 @@ func TestLoadRejectsUnusableValues(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sdns.conf")
 	body := fmt.Sprintf(
-		"version = %q\ndirectory = %q\nnullroute = \"not-an-ip\"\n",
+		"version = %q\ndirectory = %q\nrootservers = [\"192.5.5.241:53\"]\nnullroute = \"not-an-ip\"\n",
 		configver, filepath.Join(dir, "db"),
 	)
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
@@ -221,7 +221,7 @@ func TestValidateFamilySpecificLists(t *testing.T) {
 		}}, "exclude_aaaa_networks"},
 		// The updater fetches with an http.Client, so anything else never loads.
 		{"blocklist scheme", Config{BlockLists: []string{"ftp://example.com/list"}}, "http"},
-		{"negative tcp pool", Config{TCPMaxConnections: -1}, "tcpmaxconnections"},
+		{"negative tcp pool", Config{TCPKeepalive: true, TCPMaxConnections: -1}, "tcpmaxconnections"},
 		{"negative dnstap interval", Config{DnstapFlushInterval: -1}, "dnstapflushinterval"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -318,7 +318,7 @@ func TestLoadReportsUnknownKeysAlongsideValueProblems(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sdns.conf")
 	body := fmt.Sprintf(
-		"version = %q\ndirectory = %q\nnullroute = \"not-an-ip\"\nmaxdepth_old = 30\n",
+		"version = %q\ndirectory = %q\nrootservers = [\"192.5.5.241:53\"]\nnullroute = \"not-an-ip\"\nmaxdepth_old = 30\n",
 		configver, filepath.Join(dir, "db"),
 	)
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
@@ -585,7 +585,7 @@ func TestLoadValidatesQnameBeforeNormalizing(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sdns.conf")
 	body := fmt.Sprintf(
-		"version = %q\ndirectory = %q\nqname_max_minimize_count = -1\n",
+		"version = %q\ndirectory = %q\ndnssec = \"off\"\nrootservers = [\"192.5.5.241:53\"]\nqname_max_minimize_count = -1\n",
 		configver, filepath.Join(dir, "db"),
 	)
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
@@ -646,7 +646,7 @@ func TestLoadTreatsOmittedDNSSECAsOn(t *testing.T) {
 		t.Helper()
 		dir := t.TempDir()
 		path := filepath.Join(dir, "sdns.conf")
-		content := fmt.Sprintf("version = %q\ndirectory = %q\n%s",
+		content := fmt.Sprintf("version = %q\ndirectory = %q\nrootservers = [\"192.5.5.241:53\"]\n%s",
 			configver, filepath.Join(dir, "db"), body)
 		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 			t.Fatal(err)
@@ -793,5 +793,281 @@ func TestValidateBlocklistPort(t *testing.T) {
 	}
 	if err := (&Config{BlockLists: []string{"http://example.com:8080/list"}}).Validate(); err != nil {
 		t.Fatalf("Validate() rejected a usable blocklist URL: %v", err)
+	}
+}
+
+// TestValidateRootKeyPolicyErrors pins that a key the crypto packages refuse
+// for their own reasons is not mistaken for a signature mismatch. Go rejects
+// an RSA key under 1024 bits with a key-size policy error that is neither a
+// parse failure nor a verification failure, and an anchor like that fails
+// every real verification the same way.
+func TestValidateRootKeyPolicyErrors(t *testing.T) {
+	// RFC 3110 key material: exponent length, exponent, modulus.
+	rsaKey := func(modulusBytes int) string {
+		buf := []byte{3, 1, 0, 1}
+		mod := make([]byte, modulusBytes)
+		for i := range mod {
+			mod[i] = 0xff
+		}
+		mod[modulusBytes-1] = 0x8d
+		return base64.StdEncoding.EncodeToString(append(buf, mod...))
+	}
+
+	small := &Config{RootKeys: []string{". 172800 IN DNSKEY 257 3 8 " + rsaKey(64)}}
+	err := small.Validate()
+	if err == nil || !strings.Contains(err.Error(), "not usable") {
+		t.Fatalf("Validate() = %v, want the 512-bit RSA anchor rejected", err)
+	}
+
+	// A key of a size the crypto package will work with still passes.
+	big := &Config{RootKeys: []string{". 172800 IN DNSKEY 257 3 8 " + rsaKey(256)}}
+	if err := big.Validate(); err != nil {
+		t.Fatalf("Validate() rejected a 2048-bit RSA anchor: %v", err)
+	}
+}
+
+func TestValidateOutboundAddressesMustBeLocal(t *testing.T) {
+	// The resolver stops the process when it cannot bind to one of these.
+	notMine := &Config{OutboundIPs: []string{"192.0.2.1"}}
+	if err := notMine.Validate(); err == nil ||
+		!strings.Contains(err.Error(), "not an address of this machine") {
+		t.Fatalf("Validate() = %v, want a non-local outbound address rejected", err)
+	}
+
+	// Loopback is always here, and is what the check should accept.
+	mine := &Config{OutboundIPs: []string{"127.0.0.1"}}
+	if err := mine.Validate(); err != nil {
+		t.Fatalf("Validate() rejected a local address: %v", err)
+	}
+
+	// The v6 list is only read when ipv6access is on.
+	off := &Config{OutboundIP6s: []string{"2001:db8::1"}}
+	if err := off.Validate(); err != nil {
+		t.Fatalf("Validate() read outboundip6s with ipv6access off: %v", err)
+	}
+	on := &Config{IPv6Access: true, OutboundIP6s: []string{"2001:db8::1"}}
+	if err := on.Validate(); err == nil {
+		t.Fatal("Validate() accepted a non-local outbound v6 address with ipv6access on")
+	}
+}
+
+// TestValidateShadowedQnameSetting pins that the deprecated key is judged only
+// when it is the one being read. With the new key set, QnameMinimizeParams
+// never consults it, so refusing a stale value there would stop a server whose
+// live setting is fine.
+func TestValidateShadowedQnameSetting(t *testing.T) {
+	zero := 0
+	shadowed := &Config{QnameMinLevel: -1, QnameMaxMinimizeCount: &zero}
+	if err := shadowed.Validate(); err != nil {
+		t.Fatalf("Validate() judged a shadowed deprecated setting: %v", err)
+	}
+
+	alone := &Config{QnameMinLevel: -1}
+	if err := alone.Validate(); err == nil ||
+		!strings.Contains(err.Error(), "qname_min_level") {
+		t.Fatalf("Validate() = %v, want the live deprecated setting judged", err)
+	}
+}
+
+func TestValidateTCPPoolSettingsFollowKeepalive(t *testing.T) {
+	stale := &Config{TCPMaxConnections: -1}
+	stale.RootTCPTimeout.Duration = -time.Second
+	if err := stale.Validate(); err != nil {
+		t.Fatalf("Validate() read TCP pool settings with keepalive off: %v", err)
+	}
+
+	on := *stale
+	on.TCPKeepalive = true
+	err := on.Validate()
+	if err == nil {
+		t.Fatal("Validate() accepted negative TCP pool settings with keepalive on")
+	}
+	for _, want := range []string{"tcpmaxconnections", "roottcptimeout"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("Validate() = %v\nmissing %q", err, want)
+		}
+	}
+}
+
+func TestValidateKubernetesDemoCountsAsEnabled(t *testing.T) {
+	demo := &Config{}
+	demo.Kubernetes.Demo = true
+	demo.Kubernetes.ClusterDomain = "bad..domain"
+	if err := demo.Validate(); err == nil ||
+		!strings.Contains(err.Error(), "cluster_domain") {
+		t.Fatalf("Validate() = %v, want the demo cluster domain judged", err)
+	}
+
+	off := &Config{}
+	off.Kubernetes.ClusterDomain = "bad..domain"
+	if err := off.Validate(); err != nil {
+		t.Fatalf("Validate() judged the cluster domain with kubernetes off: %v", err)
+	}
+
+	// Trailing dot and case are normalized before use, so both are fine.
+	ok := &Config{}
+	ok.Kubernetes.Enabled = true
+	ok.Kubernetes.ClusterDomain = "Cluster.Local."
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("Validate() rejected a normalizable cluster domain: %v", err)
+	}
+}
+
+// TestValidateLeavesListenerHostAlone pins a deliberate absence. A literal may
+// name an address this machine does not hold yet — that is how a floating
+// address is served, and rejecting it would refuse a working HA config — and
+// whether a name resolves is a runtime question of the same class as whether
+// an upstream answers.
+func TestValidateLeavesListenerHostAlone(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  Config
+		want bool
+	}{
+		{"empty host is every interface", Config{Bind: ":53"}, true},
+		{"IP literal", Config{Bind: "127.0.0.1:53"}, true},
+		{"IPv6 literal", Config{Bind: "[::1]:53"}, true},
+		{"an address not held yet", Config{Bind: "192.0.2.1:53"}, true},
+		{"a name is left to listen time", Config{Bind: "localhost:53"}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.cfg.Validate(); (err == nil) != tc.want {
+				t.Fatalf("Validate() accepted = %v, want %v (err = %v)", err == nil, tc.want, err)
+			}
+		})
+	}
+}
+
+// TestLoadRequiresWhatOnlyAFileNeeds pins the requirements that cannot live in
+// Validate, because a Config built in code legitimately leaves them empty.
+// They still have to reach the same report.
+func TestLoadRequiresWhatOnlyAFileNeeds(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{"no working directory", "directory = \"\"\nrootservers = [\"192.5.5.241:53\"]\n", "leaves it empty"},
+		{"nothing to recurse from", "rootservers = []\n", "no root server"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "sdns.conf")
+			body := fmt.Sprintf("version = %q\ndnssec = \"off\"\n%s", configver, tc.body)
+			if !strings.Contains(tc.body, "directory = ") {
+				body = fmt.Sprintf("version = %q\ndirectory = %q\ndnssec = \"off\"\n%s",
+					configver, filepath.Join(dir, "db"), tc.body)
+			}
+			if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			_, err := Load(path, "test")
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Load() = %v, want a problem naming %q", err, tc.want)
+			}
+		})
+	}
+
+	// A forwarder takes every query before the resolver sees it, so it needs
+	// no root of its own.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sdns.conf")
+	body := fmt.Sprintf("version = %q\ndirectory = %q\ndnssec = \"off\"\nforwarderservers = [\"1.1.1.1:53\"]\n",
+		configver, filepath.Join(dir, "db"))
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(path, "test"); err != nil {
+		t.Fatalf("Load() refused a forwarder-only config: %v", err)
+	}
+}
+
+func TestValidateAccessLogTargetKinds(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "a.log")
+	if err := os.WriteFile(file, []byte(""), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&Config{AccessLog: file}).Validate(); err != nil {
+		t.Fatalf("Validate() rejected a writable access log: %v", err)
+	}
+
+	// Opened write-only; a read-only file fails there and logging quietly
+	// switches off.
+	ro := filepath.Join(dir, "ro.log")
+	if err := os.WriteFile(ro, []byte(""), 0o400); err != nil {
+		t.Fatal(err)
+	}
+	if os.Getuid() == 0 {
+		return // root opens it regardless
+	}
+	if err := (&Config{AccessLog: ro}).Validate(); err == nil {
+		t.Fatal("Validate() accepted an access log it cannot write")
+	}
+}
+
+func TestValidateUnreadableFile(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root reads regardless of mode")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "cert.pem")
+	if err := os.WriteFile(path, []byte("x"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	// A regular file, and still not one this process can read — every
+	// consumer here opens it, so the type test alone was not enough.
+	if err := (&Config{HostsFile: path}).Validate(); err == nil {
+		t.Fatal("Validate() accepted a file it cannot read")
+	}
+}
+
+func TestValidateDanglingSymlinkDirectory(t *testing.T) {
+	dir := t.TempDir()
+	link := filepath.Join(dir, "db")
+	if err := os.Symlink(filepath.Join(dir, "nowhere"), link); err != nil {
+		t.Skipf("symlink: %v", err)
+	}
+	// Stat calls this absent, but the directory entry is there, so the Mkdir
+	// that follows fails with EEXIST.
+	if err := (&Config{Directory: link}).Validate(); err == nil ||
+		!strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("Validate() = %v, want the dangling symlink reported", err)
+	}
+
+	// One that resolves to a directory is usable.
+	target := filepath.Join(dir, "real")
+	if err := os.Mkdir(target, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	good := filepath.Join(dir, "good")
+	if err := os.Symlink(target, good); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&Config{Directory: good}).Validate(); err != nil {
+		t.Fatalf("Validate() rejected a symlink to a directory: %v", err)
+	}
+}
+
+// TestUsablePortUsesTheNetworksGiven pins that the protocols a caller passes
+// actually reach LookupPort. The service tables on this platform are not
+// partitioned by protocol, so no config-level test can tell "udp" from "tcp"
+// here; asking for a network that cannot exist proves the argument is used.
+func TestUsablePortUsesTheNetworksGiven(t *testing.T) {
+	if _, err := usablePort("53", "udp", "tcp"); err != nil {
+		t.Fatalf("usablePort() rejected 53 on udp and tcp: %v", err)
+	}
+	// A numeric port is network-independent and short-circuits, so the proof
+	// has to use a service name: looking one up needs a network that exists.
+	if _, err := usablePort("domain", "nonsense"); err == nil {
+		t.Fatal("usablePort() ignored the network it was given")
+	}
+	if _, err := usablePort("domain", "udp", "tcp"); err != nil {
+		t.Fatalf("usablePort() rejected a service name both protocols know: %v", err)
+	}
+	// No networks means nothing to check, which is not a silent pass for a
+	// port that cannot resolve — every caller names at least one.
+	if n, err := usablePort("65536", "udp"); err == nil {
+		t.Fatalf("usablePort() = %d, want an out-of-range port refused", n)
 	}
 }

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -1609,32 +1609,17 @@ func TestValidateDefaultBlocklistDir(t *testing.T) {
 	}
 }
 
-// TestValidatePathsKeepTheirComponents pins that a parent is taken from the
-// path as written. filepath.Dir cleans, so "missing/../x" comes back as "."
-// and looks like it lives somewhere that exists — while the open and the
-// mkdir both resolve each component and fail on the one that is not there.
-func TestValidatePathsKeepTheirComponents(t *testing.T) {
+// TestValidateAcceptsPathsWhoseComponentsExist is the half that holds
+// everywhere. The ".." cases differ by platform and live in the unix file,
+// because Windows collapses ".." before it touches the filesystem.
+func TestValidateAcceptsPathsWhoseComponentsExist(t *testing.T) {
 	dir := t.TempDir()
-
-	// Built by hand: filepath.Join cleans too, so the components would not
-	// survive to be judged.
-	sep := string(filepath.Separator)
-	logPath := dir + sep + "missing" + sep + ".." + sep + "access.log"
-	if err := (&Config{AccessLog: logPath}).Validate(); err == nil ||
-		!strings.Contains(err.Error(), "accesslog") {
-		t.Fatalf("Validate() = %v, want the missing component reported", err)
-	}
-
-	dbPath := dir + sep + "missing" + sep + ".." + sep + "db"
-	if err := (&Config{Directory: dbPath}).Validate(); err == nil ||
-		!strings.Contains(err.Error(), "directory") {
-		t.Fatalf("Validate() = %v, want the missing component reported", err)
-	}
-
-	// The same shape with the component present is fine.
 	if err := os.Mkdir(filepath.Join(dir, "there"), 0o750); err != nil {
 		t.Fatal(err)
 	}
+	sep := string(filepath.Separator)
+	// Built by hand: filepath.Join cleans too, so the components would not
+	// survive to be judged.
 	okPath := dir + sep + "there" + sep + ".." + sep + "db"
 	if err := (&Config{Directory: okPath}).Validate(); err != nil {
 		t.Fatalf("Validate() rejected a path whose components all exist: %v", err)

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -28,6 +28,22 @@ func TestValidateRejectsUnusableValues(t *testing.T) {
 			{Name: "corp.example.", Servers: []string{"nonsense"}},
 		}}, "forward_zone"},
 		{"negative size", Config{CacheSize: -1}, "cachesize"},
+		// A bad anchor is fatal at resolver construction, so -t passing here
+		// meant the server then refused to start.
+		{"root key", Config{RootKeys: []string{"this is not a DNSKEY"}}, "rootkeys"},
+		{"root key wrong type", Config{RootKeys: []string{". 172800 IN A 192.0.2.1"}}, "rootkeys"},
+		{"outbound family", Config{OutboundIPs: []string{"2001:db8::1"}}, "outboundips"},
+		{"api address", Config{API: "not an address"}, "api"},
+		{"hyperlocal source", Config{HyperlocalRootSources: []string{"no-port"}}, "hyperlocal_root_sources"},
+		// Out of range is silently replaced by the default, so the operator
+		// believes they set a threshold they did not.
+		{"reflex threshold", Config{ReflexThreshold: 42}, "reflexthreshold"},
+		{"prefetch percentage", Config{Prefetch: 250}, "prefetch"},
+		{"view network", Config{Views: []ViewConfig{{Zone: "a.", Networks: []string{"nope"}}}}, "network"},
+		{"view answer", Config{Views: []ViewConfig{{Zone: "a.", Answers: []string{"not an rr"}}}}, "answer"},
+		{"dns64 prefix", Config{DNS64: DNS64Config{Prefixes: []string{"192.0.2.0/24"}}}, "dns64 prefix"},
+		{"ecs scope", Config{ECS: ECSConfig{ForwardV4Max: 33}}, "ecs forward_v4"},
+		{"blocklist url", Config{BlockLists: []string{"not-a-url"}}, "blocklists"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.cfg.Validate()

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -34,7 +34,7 @@ func TestValidateRejectsUnusableValues(t *testing.T) {
 		// Documented for years, never implemented: startup rejects it.
 		{"crit log level", Config{LogLevel: "crit"}, "loglevel"},
 		{"root server family", Config{RootServers: []string{"[2001:db8::1]:53"}}, "rootservers"},
-		{"root6 server family", Config{Root6Servers: []string{"192.0.2.1:53"}}, "root6servers"},
+		{"root6 server family", Config{IPv6Access: true, Root6Servers: []string{"192.0.2.1:53"}}, "root6servers"},
 		{"root key not a KSK", Config{RootKeys: []string{
 			". 172800 IN DNSKEY 256 3 8 AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3",
 		}}, "key-signing key"},
@@ -1333,6 +1333,76 @@ func TestValidateLeavesNoProbeBehind(t *testing.T) {
 			if strings.HasPrefix(e.Name(), ".sdns-config-test-") {
 				t.Fatalf("probe file left behind in %s: %s", d, e.Name())
 			}
+		}
+	}
+}
+
+func TestValidateRoot6ServersFollowIPv6Access(t *testing.T) {
+	// The resolver reads this list only behind ipv6access, so a stale entry
+	// on a host without v6 has no effect and must not stop the server.
+	stale := &Config{RootServers: []string{"192.5.5.241:53"}, Root6Servers: []string{"nonsense"}}
+	if err := stale.Validate(); err != nil {
+		t.Fatalf("Validate() read root6servers with ipv6access off: %v", err)
+	}
+
+	on := *stale
+	on.IPv6Access = true
+	if err := on.Validate(); err == nil || !strings.Contains(err.Error(), "root6servers") {
+		t.Fatalf("Validate() = %v, want root6servers judged when v6 is in use", err)
+	}
+}
+
+// TestValidateWildcardBelongsToTheBlocklist pins which list reads the star.
+// set() strips "*." and files the rest as a wildcard block; the whitelist is
+// stored verbatim and matched up the hierarchy, so a star there is a literal
+// label no query produces — and the operator who wrote it, meaning to exempt
+// the subdomains, gets nothing.
+func TestValidateWildcardBelongsToTheBlocklist(t *testing.T) {
+	if err := (&Config{Blocklist: []string{"*.example.com"}}).Validate(); err != nil {
+		t.Fatalf("Validate() rejected a wildcard block: %v", err)
+	}
+
+	err := (&Config{Whitelist: []string{"*.example.com"}}).Validate()
+	if err == nil || !strings.Contains(err.Error(), "blocklist syntax") {
+		t.Fatalf("Validate() = %v, want the wildcard whitelist entry rejected", err)
+	}
+
+	// The name itself is what works there, and it covers the subdomains.
+	if err := (&Config{Whitelist: []string{"example.com"}}).Validate(); err != nil {
+		t.Fatalf("Validate() rejected a plain whitelist entry: %v", err)
+	}
+}
+
+func TestValidateTrailingSlashDirectory(t *testing.T) {
+	dir := t.TempDir()
+	// Dir("/parent/db/") is "/parent/db" — the path itself, which read as a
+	// parent that is not there. os.Mkdir takes the trailing slash fine.
+	withSlash := filepath.Join(dir, "db") + string(filepath.Separator)
+	if err := (&Config{Directory: withSlash}).Validate(); err != nil {
+		t.Fatalf("Validate() rejected a directory written with a trailing slash: %v", err)
+	}
+	// And the real case still fails: two missing levels, one Mkdir.
+	if err := (&Config{Directory: filepath.Join(dir, "a", "b")}).Validate(); err == nil {
+		t.Fatal("Validate() accepted a directory whose parent is missing")
+	}
+}
+
+func TestValidateEmptyZonesMustBeServedLocally(t *testing.T) {
+	// Outside the tree: the middleware drops it, and a list where every
+	// entry is dropped falls back to all of them.
+	outside := &Config{EmptyZones: []string{"example.com."}}
+	if err := outside.Validate(); err == nil ||
+		!strings.Contains(err.Error(), "locally-served") {
+		t.Fatalf("Validate() = %v, want an unserved empty zone reported", err)
+	}
+
+	for _, zone := range []string{
+		"10.in-addr.arpa.",
+		"10.IN-ADDR.ARPA",      // canonicalized before the walk
+		"sub.10.in-addr.arpa.", // covered by its parent, as Match walks suffixes
+	} {
+		if err := (&Config{EmptyZones: []string{zone}}).Validate(); err != nil {
+			t.Fatalf("Validate() rejected %q: %v", zone, err)
 		}
 	}
 }

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -1730,3 +1730,110 @@ func TestPathHandlingOnBothPlatforms(t *testing.T) {
 	}
 
 }
+
+// TestLoadAcceptsPathsUnderThePendingDirectory pins the first-run case. Load
+// creates the working directory just after this gate, so a path whose parent
+// is that directory is one the server will be able to make — refusing it made
+// a fresh install impossible to start.
+func TestLoadAcceptsPathsUnderThePendingDirectory(t *testing.T) {
+	dir := t.TempDir()
+	work := filepath.Join(dir, "sdns") // does not exist yet
+
+	for _, tc := range []struct {
+		name string
+		body string
+	}{
+		{"access log", fmt.Sprintf("accesslog = %q\n", filepath.Join(work, "access.log"))},
+		{"explicit blocklistdir", fmt.Sprintf("blocklistdir = %q\n", filepath.Join(work, "lists"))},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := t.TempDir()
+			w := filepath.Join(d, "sdns")
+			body := strings.ReplaceAll(tc.body, work, w)
+			path := filepath.Join(d, "sdns.conf")
+			content := fmt.Sprintf("version = %q\ndirectory = %q\ndnssec = \"off\"\n"+
+				"rootservers = [\"192.5.5.241:53\"]\n%s", configver, w, body)
+			if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := Load(path, "test"); err != nil {
+				t.Fatalf("Load() refused a path under the directory it creates: %v", err)
+			}
+		})
+	}
+
+	// One level only: Load uses Mkdir, so a directory below that is nobody's
+	// to create.
+	deep := &Config{Directory: work, AccessLog: filepath.Join(work, "sub", "access.log")}
+	if err := deep.Validate(); err == nil {
+		t.Fatal("Validate() accepted a path two levels below a directory that is not there")
+	}
+}
+
+func TestValidateBlocklistDirNeedNotBeWritable(t *testing.T) {
+	dir := t.TempDir()
+	lists := filepath.Join(dir, "lists")
+	if err := os.Mkdir(lists, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&Config{BlockListDir: lists}).Validate(); err != nil {
+		t.Fatalf("Validate() rejected a usable blocklist directory: %v", err)
+	}
+
+	// It still has to be a directory.
+	file := filepath.Join(dir, "afile")
+	if err := os.WriteFile(file, []byte(""), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&Config{BlockListDir: file}).Validate(); err == nil {
+		t.Fatal("Validate() accepted a plain file as the blocklist directory")
+	}
+}
+
+// TestValidateRevokedAnchorIsAllowed pins RFC 5011 section 2.1 seeding. AutoTA
+// records an admin-configured revoked key as a tombstone so the revocation
+// survives a restart, and keeps it out of the active set — so it is a legal
+// entry that does not count as an anchor.
+func TestValidateRevokedAnchorIsAllowed(t *testing.T) {
+	const revoked = ". 172800 IN DNSKEY 385 3 13 " + testP256
+	const active = ". 172800 IN DNSKEY 257 3 13 " + testP256
+
+	both := &Config{DNSSEC: "on", RootKeys: []string{revoked, active}}
+	if err := both.Validate(); err != nil {
+		t.Fatalf("Validate() refused a config seeding a revoked key alongside an active one: %v", err)
+	}
+
+	// On its own it leaves nothing to validate with, which the anchor rule
+	// reports — the revoked key itself is not the problem.
+	alone := &Config{DNSSEC: "on", RootKeys: []string{revoked}}
+	err := alone.Validate()
+	if err == nil || !strings.Contains(err.Error(), "no usable root trust anchor") {
+		t.Fatalf("Validate() = %v, want the empty active set reported", err)
+	}
+	if strings.Contains(err.Error(), "key-signing key") {
+		t.Fatalf("Validate() = %v, want the revoked key itself accepted", err)
+	}
+}
+
+func TestValidateViewAnswerMustBeARecord(t *testing.T) {
+	for _, answer := range []string{"", "   ", "; a comment", "$TTL 300"} {
+		cfg := &Config{Views: []ViewConfig{{
+			Zone:     "office",
+			Networks: []string{"192.0.2.0/24"},
+			Answers:  []string{answer},
+		}}}
+		if err := cfg.Validate(); err == nil ||
+			!strings.Contains(err.Error(), "is not a record") {
+			t.Fatalf("Validate(%q) = %v, want a line holding no record reported", answer, err)
+		}
+	}
+
+	ok := &Config{Views: []ViewConfig{{
+		Zone:     "office",
+		Networks: []string{"192.0.2.0/24"},
+		Answers:  []string{"printer.local. 300 IN A 192.0.2.10"},
+	}}}
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("Validate() rejected a real record: %v", err)
+	}
+}

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -20,6 +20,28 @@ func TestValidateRejectsUnusableValues(t *testing.T) {
 		{"bind address", Config{Bind: "not an address"}, "bind"},
 		{"nullroute", Config{Nullroute: "not-an-ip"}, "nullroute"},
 		{"accesslist", Config{AccessList: []string{"999.999.999.999/99"}}, "accesslist"},
+		// The access list is parsed with netip.ParsePrefix alone, so a bare
+		// address is dropped at startup — and if it is the only entry the
+		// allow set ends up empty, blocking every client.
+		{"accesslist bare IP", Config{AccessList: []string{"192.0.2.1"}}, "accesslist"},
+		// Documented for years, never implemented: startup rejects it.
+		{"crit log level", Config{LogLevel: "crit"}, "loglevel"},
+		{"root server family", Config{RootServers: []string{"[2001:db8::1]:53"}}, "rootservers"},
+		{"root6 server family", Config{Root6Servers: []string{"192.0.2.1:53"}}, "root6servers"},
+		{"root key not a KSK", Config{RootKeys: []string{
+			". 172800 IN DNSKEY 256 3 8 AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3",
+		}}, "key-signing key"},
+		{"root key wrong owner", Config{RootKeys: []string{
+			"example. 172800 IN DNSKEY 257 3 8 AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3",
+		}}, "root zone"},
+		// /49 is a valid IPv6 CIDR and an invalid Pref64: the runtime drops
+		// it and falls back to 64:ff9b::/96, sending traffic somewhere else
+		// entirely than the file says.
+		{"dns64 prefix length", Config{DNS64: DNS64Config{Prefixes: []string{"2001:db8::/49"}}}, "dns64 prefix"},
+		// Byte 8 is the high half of the fifth group, inside a /96.
+		{"dns64 reserved byte", Config{DNS64: DNS64Config{Prefixes: []string{"2001:db8:0:0:ff00::/96"}}}, "byte 8"},
+		// 91-100 passed before and then silently disabled prefetch.
+		{"prefetch above the cache ceiling", Config{Prefetch: 95}, "prefetch"},
 		{"root server", Config{RootServers: []string{"hello world"}}, "rootservers"},
 		{"root server without port", Config{RootServers: []string{"192.0.2.1"}}, "rootservers"},
 		{"forwarder upstream", Config{ForwarderServers: []string{"nonsense"}}, "forwarderservers"},
@@ -64,7 +86,7 @@ func TestValidateAcceptsUsableValues(t *testing.T) {
 		Bind:             ":53",
 		Nullroute:        "0.0.0.0",
 		Nullroutev6:      "::0",
-		AccessList:       []string{"0.0.0.0/0", "::0/0", "192.0.2.1"},
+		AccessList:       []string{"0.0.0.0/0", "::0/0", "192.0.2.1/32"},
 		RootServers:      []string{"192.5.5.241:53"},
 		Root6Servers:     []string{"[2001:500:2f::f]:53"},
 		ForwarderServers: []string{"1.1.1.1:53", "tls://1.1.1.1:853", "https://cloudflare-dns.com/dns-query"},

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -1891,6 +1891,22 @@ func TestValidatePendingDirectoryKeepsPathRules(t *testing.T) {
 		t.Fatalf("Validate() refused a log under the pending directory: %v", err)
 	}
 
+	// The same place with a trailing separator on the directory. This has to
+	// hold for a path carrying "..", which is the spelling compared as
+	// written: mkdir and open both accept the separator, so dropping it is
+	// the difference between naming the same place and naming two.
+	if err := os.Mkdir(filepath.Join(dir, "there"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	viaDotDot := dir + sep + "there" + sep + ".." + sep + "db"
+	trailing := &Config{
+		Directory: viaDotDot + sep,
+		AccessLog: viaDotDot + sep + "access.log",
+	}
+	if err := trailing.Validate(); err != nil {
+		t.Fatalf("Validate() refused a directory written with a trailing separator: %v", err)
+	}
+
 	// Spelled through a component that is not there. Where components are
 	// walked, the open fails on it whatever the shortcut thinks; where ".."
 	// is collapsed first, it is the same place and fine.

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -1431,3 +1431,73 @@ func TestValidateAccessLogTrailingSlash(t *testing.T) {
 		t.Fatalf("Validate() rejected a directory written with a trailing slash: %v", err)
 	}
 }
+
+// TestValidateAccessLogSymlinkShape pins the two ways a link can name a
+// directory without looking like one. Join cleans a trailing separator off a
+// relative target, and a chain hides the shape of its final hop — in both
+// cases os.OpenFile refuses the name and access logging silently goes off.
+func TestValidateAccessLogSymlinkShape(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		links [][2]string // link name -> target, in creation order
+		log   string
+	}{
+		{"relative target names a directory", [][2]string{
+			{"access.log", "real.log/"},
+		}, "access.log"},
+		{"chain ending in a directory-shaped hop", [][2]string{
+			{"mid.log", "end.log/"},
+			{"a.log", "mid.log"},
+		}, "a.log"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			for _, l := range tc.links {
+				if err := os.Symlink(l[1], filepath.Join(dir, l[0])); err != nil {
+					t.Skipf("symlink: %v", err)
+				}
+			}
+			path := filepath.Join(dir, tc.log)
+			if err := (&Config{AccessLog: path}).Validate(); err == nil ||
+				!strings.Contains(err.Error(), "accesslog") {
+				t.Fatalf("Validate() = %v, want the directory-shaped target refused", err)
+			}
+		})
+	}
+
+	// A chain that ends at a name the open can create is still fine.
+	dir := t.TempDir()
+	if err := os.Symlink("real.log", filepath.Join(dir, "mid.log")); err != nil {
+		t.Skipf("symlink: %v", err)
+	}
+	if err := os.Symlink("mid.log", filepath.Join(dir, "a.log")); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&Config{AccessLog: filepath.Join(dir, "a.log")}).Validate(); err != nil {
+		t.Fatalf("Validate() rejected a chain whose target can be created: %v", err)
+	}
+}
+
+// TestValidateAccessLogSymlinkLoop pins the bound on the chase. A link that
+// points at itself would otherwise be followed forever.
+func TestValidateAccessLogSymlinkLoop(t *testing.T) {
+	dir := t.TempDir()
+	self := filepath.Join(dir, "loop.log")
+	if err := os.Symlink("loop.log", self); err != nil {
+		t.Skipf("symlink: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- (&Config{AccessLog: self}).Validate() }()
+
+	select {
+	case err := <-done:
+		// Whatever it decides, it has to decide. The open cannot use this
+		// name either, so an error is the honest answer.
+		if err == nil {
+			t.Fatal("Validate() accepted a symlink pointing at itself")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Validate() did not return on a self-referencing symlink")
+	}
+}

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -406,7 +406,10 @@ func TestValidatePortRange(t *testing.T) {
 		// does listen on 53, so a numeric test here would refuse a config
 		// that works.
 		{"listener service name", Config{Bind: ":domain"}, true},
-		{"listener port zero asks for a free one", Config{Bind: ":0"}, true},
+		// bind opens UDP and TCP separately, so port 0 would land them on
+		// different ports; a single-transport listener is free to ask.
+		{"port zero on a two-transport listener", Config{Bind: ":0"}, false},
+
 		{"ordinary listener", Config{Bind: ":53"}, true},
 		{"ordinary upstream", Config{RootServers: []string{"192.0.2.1:53"}}, true},
 	} {
@@ -732,11 +735,12 @@ func TestValidatePortZeroSpellings(t *testing.T) {
 			t.Fatalf("Validate() accepted upstream port %q", spelling)
 		}
 	}
-	// The same spellings are fine on a listener, where zero asks the kernel
-	// for a free port.
-	for _, spelling := range []string{"0", "00"} {
-		if err := (&Config{Bind: ":" + spelling}).Validate(); err != nil {
-			t.Fatalf("Validate() rejected listener port %q: %v", spelling, err)
+	// A listener that opens one transport may still ask the kernel for a
+	// free port; one that opens two may not, since each socket asks
+	// separately and they would not agree.
+	for _, spelling := range []string{"0", "00", "+0"} {
+		if err := (&Config{Bind: ":" + spelling}).Validate(); err == nil {
+			t.Fatalf("Validate() accepted port %q on a two-transport listener", spelling)
 		}
 	}
 }
@@ -1968,6 +1972,78 @@ func TestValidateCIDRMatchesEachConsumer(t *testing.T) {
 		Views:      []ViewConfig{{Zone: "a", Networks: []string{"192.0.2.0/24"}}},
 		ECS:        ECSConfig{Enabled: true, ClientNetworks: []string{"192.0.2.0/24"}},
 	}
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("Validate() rejected ordinary prefixes: %v", err)
+	}
+}
+
+// TestValidatePortZeroFollowsTransportCount pins where asking the kernel for a
+// free port is safe. Each socket asks separately, so a setting that opens two
+// transports would get two different ports — a truncated UDP answer with no
+// TCP to fall back to, and DoH advertising ":0" as its HTTP/3 port. A setting
+// that opens one socket has nothing to disagree with.
+func TestValidatePortZeroFollowsTransportCount(t *testing.T) {
+	dir := t.TempDir()
+	cert := filepath.Join(dir, "cert.pem")
+	key := filepath.Join(dir, "key.pem")
+	for _, p := range []string{cert, key} {
+		if err := os.WriteFile(p, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	for _, tc := range []struct {
+		name string
+		cfg  Config
+		want bool
+	}{
+		{"bind opens udp and tcp", Config{Bind: ":0"}, false},
+		{"doh brings http/3 with it", Config{
+			BindDOH: ":0", TLSCertificate: cert, TLSPrivateKey: key,
+		}, false},
+		{"dot is tcp alone", Config{
+			BindTLS: ":0", TLSCertificate: cert, TLSPrivateKey: key,
+		}, true},
+		{"doq is udp alone", Config{
+			BindDOQ: ":0", TLSCertificate: cert, TLSPrivateKey: key,
+		}, true},
+		{"the api is tcp alone", Config{API: "127.0.0.1:0"}, true},
+		// A named port is fine everywhere.
+		{"bind with a real port", Config{Bind: ":53"}, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.cfg.Validate(); (err == nil) != tc.want {
+				t.Fatalf("Validate() accepted = %v, want %v (err = %v)", err == nil, tc.want, err)
+			}
+		})
+	}
+}
+
+// TestValidateRejectsMappedPrefixes pins that an IPv4-mapped prefix is refused
+// where it would match nobody. internal/ipset files it under IPv6 while an
+// IPv4 client is unmapped and looked up under IPv4, and ECS compares prefix to
+// address where the families disagree — either way the rule is dead, and as
+// the only access-list entry it leaves an allow set that blocks everyone.
+func TestValidateRejectsMappedPrefixes(t *testing.T) {
+	const mapped = "::ffff:192.0.2.0/120"
+
+	for _, tc := range []struct {
+		name string
+		cfg  Config
+	}{
+		{"accesslist", Config{AccessList: []string{mapped}}},
+		{"view network", Config{Views: []ViewConfig{{Zone: "a", Networks: []string{mapped}}}}},
+		{"ecs client_networks", Config{ECS: ECSConfig{Enabled: true, ClientNetworks: []string{mapped}}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.cfg.Validate(); err == nil {
+				t.Fatalf("Validate() accepted %q, which matches no client", mapped)
+			}
+		})
+	}
+
+	// The plain forms both work, including a genuine IPv6 prefix.
+	ok := &Config{AccessList: []string{"192.0.2.0/24", "2001:db8::/32", "::0/0"}}
 	if err := ok.Validate(); err != nil {
 		t.Fatalf("Validate() rejected ordinary prefixes: %v", err)
 	}

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"crypto/ed25519"
 	"encoding/base64"
 	"errors"
 	"fmt"
@@ -1228,5 +1229,32 @@ func TestPortNetworksPerCaller(t *testing.T) {
 				t.Fatalf("asked %v, want %v", asked, tc.want)
 			}
 		})
+	}
+}
+
+// TestValidateEd25519Encoding pins the part of Ed25519 key validity that can
+// be checked without Edwards arithmetic: RFC 8032 section 5.1.3 recovers y by
+// clearing the sign bit and fails unless what is left is below 2^255-19.
+// A canonical y that is not on the curve is still accepted, and the comment on
+// edwardsCanonical says so — the standard library offers nothing that would
+// catch it.
+func TestValidateEd25519Encoding(t *testing.T) {
+	// y = 2^255 - 1, which is above the field prime.
+	const nonCanonical = "7////////////////////////////////////////38="
+	cfg := &Config{RootKeys: []string{". 172800 IN DNSKEY 257 3 15 " + nonCanonical}}
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "not usable") {
+		t.Fatalf("Validate() = %v, want the non-canonical Ed25519 key rejected", err)
+	}
+
+	// Every real key encodes a y below the prime, so none of these may trip.
+	for i := 0; i < 200; i++ {
+		pub, _, err := ed25519.GenerateKey(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		key := ". 172800 IN DNSKEY 257 3 15 " + base64.StdEncoding.EncodeToString(pub)
+		if err := (&Config{RootKeys: []string{key}}).Validate(); err != nil {
+			t.Fatalf("Validate() rejected a generated Ed25519 anchor: %v", err)
+		}
 	}
 }

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -1842,3 +1842,70 @@ func TestValidateViewAnswerMustBeARecord(t *testing.T) {
 		t.Fatalf("Validate() rejected a real record: %v", err)
 	}
 }
+
+// TestValidateRevokedAnchorStillNeedsKSKFlags pins that the REVOKE bit rides
+// on top of the key-signing flags rather than replacing them. AutoTA drops a
+// record without the KSK bit before it ever looks at the bit, so accepting one
+// here would pass a key the resolver silently ignores.
+func TestValidateRevokedAnchorStillNeedsKSKFlags(t *testing.T) {
+	active := ". 172800 IN DNSKEY 257 3 13 " + testP256
+
+	for _, tc := range []struct {
+		name  string
+		flags string
+		want  bool // whether Validate should accept
+	}{
+		{"revoked key-signing key", "385", true},   // 257 | REVOKE
+		{"revoke bit on its own", "128", false},    // no KSK bit
+		{"revoked zone-signing key", "384", false}, // 256 | REVOKE
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{DNSSEC: "on", RootKeys: []string{
+				". 172800 IN DNSKEY " + tc.flags + " 3 13 " + testP256,
+				active,
+			}}
+			if err := cfg.Validate(); (err == nil) != tc.want {
+				t.Fatalf("Validate() accepted = %v, want %v (err = %v)", err == nil, tc.want, err)
+			}
+		})
+	}
+
+	// And an ordinary anchor still counts, which the flag arithmetic must
+	// not swallow.
+	if err := (&Config{DNSSEC: "on", RootKeys: []string{active}}).Validate(); err != nil {
+		t.Fatalf("Validate() rejected a plain key-signing key: %v", err)
+	}
+}
+
+// TestValidatePendingDirectoryKeepsPathRules pins that the shortcut for the
+// directory Load is about to create does not quietly equate two spellings
+// that the platform treats differently.
+func TestValidatePendingDirectoryKeepsPathRules(t *testing.T) {
+	dir := t.TempDir()
+	sep := string(filepath.Separator)
+	work := filepath.Join(dir, "sdns")
+
+	// Same place, spelled the same: the shortcut applies.
+	plain := &Config{Directory: work, AccessLog: filepath.Join(work, "access.log")}
+	if err := plain.Validate(); err != nil {
+		t.Fatalf("Validate() refused a log under the pending directory: %v", err)
+	}
+
+	// Spelled through a component that is not there. Where components are
+	// walked, the open fails on it whatever the shortcut thinks; where ".."
+	// is collapsed first, it is the same place and fine.
+	viaMissing := &Config{
+		Directory: work,
+		AccessLog: dir + sep + "sdns" + sep + "gone" + sep + ".." + sep + "access.log",
+	}
+	err := viaMissing.Validate()
+	if cleansPathComponents {
+		if err != nil {
+			t.Fatalf("collapsing \"..\": Validate() = %v, want it accepted", err)
+		}
+		return
+	}
+	if err == nil {
+		t.Fatal("walking components: Validate() accepted a path through a missing component")
+	}
+}

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -2027,6 +2027,28 @@ func TestValidatePortZeroFollowsTransportCount(t *testing.T) {
 func TestValidateRejectsMappedPrefixes(t *testing.T) {
 	const mapped = "::ffff:192.0.2.0/120"
 
+	// Width decides it. A prefix wide enough to leave the mapped range is a
+	// real IPv6 rule that genuine clients fall inside, and refusing it would
+	// stop a config that works.
+	for _, tc := range []struct {
+		prefix string
+		want   bool // whether Validate should accept
+	}{
+		{"::ffff:192.0.2.0/120", false}, // stays ::ffff:192.0.2.0/120
+		{"::ffff:192.0.2.0/104", false}, // stays ::ffff:192.0.0.0/104
+		{"::ffff:192.0.2.0/96", false},  // stays ::ffff:0.0.0.0/96
+		{"::ffff:192.0.2.0/95", true},   // becomes ::fffe:0:0/95
+		{"::ffff:192.0.2.0/64", true},   // becomes ::/64, which holds ::1
+		{"::ffff:192.0.2.0/0", true},    // becomes ::/0
+	} {
+		t.Run(tc.prefix, func(t *testing.T) {
+			cfg := &Config{AccessList: []string{tc.prefix}}
+			if err := cfg.Validate(); (err == nil) != tc.want {
+				t.Fatalf("Validate() accepted = %v, want %v (err = %v)", err == nil, tc.want, err)
+			}
+		})
+	}
+
 	for _, tc := range []struct {
 		name string
 		cfg  Config

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -1700,10 +1700,14 @@ func TestValidateAccessLogLongChain(t *testing.T) {
 	}
 }
 
-// TestPathHandlingOnBothPlatforms exercises the branch this platform does not
-// take. Path resolution differs — Windows collapses ".." before it touches
-// the filesystem, unix walks the components — and each rule has been wrong
-// once, caught only by the other platform's CI.
+// TestPathHandlingOnBothPlatforms exercises the join branch this platform does
+// not take. It covers the part that is pure string handling — whether a
+// directory-shaped target stays directory-shaped — because that is the half a
+// flag can decide.
+//
+// What a missing component means cannot be simulated: the answer comes from
+// Stat, which collapses ".." on Windows however this package joins the path.
+// That half lives in the unix file, where it is the platform's own rule.
 func TestPathHandlingOnBothPlatforms(t *testing.T) {
 	original := cleansPathComponents
 	defer func() { cleansPathComponents = original }()
@@ -1725,16 +1729,4 @@ func TestPathHandlingOnBothPlatforms(t *testing.T) {
 		}
 	}
 
-	// A path with a missing component: refused where components are walked,
-	// accepted where ".." is collapsed first — mirroring what open and mkdir
-	// do on each.
-	missing := dir + sep + "missing" + sep + ".." + sep + "db"
-	cleansPathComponents = false
-	if err := (&Config{Directory: missing}).Validate(); err == nil {
-		t.Fatal("walking components: Validate() accepted a missing component")
-	}
-	cleansPathComponents = true
-	if err := (&Config{Directory: missing}).Validate(); err != nil {
-		t.Fatalf("collapsing \"..\": Validate() = %v, want the path accepted", err)
-	}
 }

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestValidateRejectsUnusableValues(t *testing.T) {
@@ -157,5 +158,125 @@ func TestLoadRejectsUnusableValues(t *testing.T) {
 		t.Fatal("Load() accepted a config with an unusable value")
 	} else if !strings.Contains(err.Error(), "nullroute") {
 		t.Fatalf("Load() = %v, want the problem to name nullroute", err)
+	}
+}
+
+// TestValidateReportsAcrossFormerlySeparateChecks pins the promise the README
+// makes. These four used to return one at a time from the load path, so a file
+// with several mistakes took several runs to fix.
+func TestValidateReportsAcrossFormerlySeparateChecks(t *testing.T) {
+	cfg := &Config{
+		DNSSEC:       "maybe",
+		ForwardZones: []ForwardZoneConfig{{Name: "corp.example."}},
+	}
+	cfg.RecursionFirewall.Mode = "sideways"
+	cfg.ServeStaleMaxTTL.Duration = -time.Second
+
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("Validate() accepted four broken settings")
+	}
+	for _, want := range []string{
+		"dnssec", "forward_zone", "recursion firewall", "serve_stale_max_ttl",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("Validate() = %v\nmissing a problem for %q", err, want)
+		}
+	}
+}
+
+// TestValidateLeavesViewZoneAlone pins that the view label is not judged as a
+// domain name. The middleware only carries it into log lines, so validating it
+// would stop the server on upgrade for labels that work today.
+func TestValidateLeavesViewZoneAlone(t *testing.T) {
+	cfg := &Config{Views: []ViewConfig{{
+		Zone:     "office clients (floor 3)",
+		Networks: []string{"192.0.2.0/24"},
+		Answers:  []string{"printer.local. 300 IN A 192.0.2.10"},
+	}}}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() rejected a free-form view label: %v", err)
+	}
+}
+
+func TestValidateFamilySpecificLists(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cfg  Config
+		want string
+	}{
+		// The runtime keeps these by mask length and drops the wrong family
+		// with a log line, so the exclusion quietly does not apply.
+		{"exclude_a takes IPv4", Config{DNS64: DNS64Config{
+			ExcludeANetworks: []string{"2001:db8::/32"},
+		}}, "exclude_a_networks"},
+		{"exclude_aaaa takes IPv6", Config{DNS64: DNS64Config{
+			ExcludeAAAANetworks: []string{"192.0.2.0/24"},
+		}}, "exclude_aaaa_networks"},
+		// The updater fetches with an http.Client, so anything else never loads.
+		{"blocklist scheme", Config{BlockLists: []string{"ftp://example.com/list"}}, "http"},
+		{"negative tcp pool", Config{TCPMaxConnections: -1}, "tcpmaxconnections"},
+		{"negative dnstap interval", Config{DnstapFlushInterval: -1}, "dnstapflushinterval"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.cfg.Validate()
+			if err == nil {
+				t.Fatalf("Validate() accepted %+v", tc.cfg)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Validate() = %v, want a problem naming %q", err, tc.want)
+			}
+		})
+	}
+
+	// Both families are legal where the runtime accepts either.
+	both := &Config{DNS64: DNS64Config{ClientNetworks: []string{"192.0.2.0/24", "2001:db8::/32"}}}
+	if err := both.Validate(); err != nil {
+		t.Fatalf("Validate() rejected a mixed-family client_networks list: %v", err)
+	}
+}
+
+func TestValidateNegativeECSCacheLimit(t *testing.T) {
+	cfg := &Config{}
+	cfg.ECS.CacheLimitTTL.Duration = -time.Second
+	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "cache_limit_ttl") {
+		t.Fatalf("Validate() = %v, want the negative ECS cache limit rejected", err)
+	}
+}
+
+// TestValidateRootKeyAlgorithm pins that an anchor the verifier cannot use is
+// caught here. Nothing downstream rejects it: NewResolver only fails on a
+// record that will not parse, so an anchor like this loads and then silently
+// fails every signature it is asked to verify.
+func TestValidateRootKeyAlgorithm(t *testing.T) {
+	const material = "AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3"
+
+	for _, tc := range []struct {
+		name string
+		alg  string
+		want bool
+	}{
+		{"DSA is gone from the library", "3", false},
+		{"ECC-GOST is gone too", "12", false},
+		{"unassigned codepoint", "200", false},
+		// Asked of the library, not assumed: ED448 has a name and a number
+		// and still cannot be verified with.
+		{"ED448 has a name but no verifier", "16", false},
+		{"RSASHA256 is what the root uses", "8", true},
+		{"ECDSAP256SHA256 is the successor", "13", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{RootKeys: []string{
+				". 172800 IN DNSKEY 257 3 " + tc.alg + " " + material,
+			}}
+			err := cfg.Validate()
+			usable := err == nil
+			if usable != tc.want {
+				t.Fatalf("Validate() accepted = %v, want %v (err = %v)", usable, tc.want, err)
+			}
+			if !tc.want && !strings.Contains(err.Error(), "cannot be verified with") {
+				t.Fatalf("Validate() = %v, want the algorithm named as the problem", err)
+			}
+		})
 	}
 }

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"math/big"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1232,29 +1233,106 @@ func TestPortNetworksPerCaller(t *testing.T) {
 	}
 }
 
-// TestValidateEd25519Encoding pins the part of Ed25519 key validity that can
-// be checked without Edwards arithmetic: RFC 8032 section 5.1.3 recovers y by
-// clearing the sign bit and fails unless what is left is below 2^255-19.
-// A canonical y that is not on the curve is still accepted, and the comment on
-// edwardsCanonical says so — the standard library offers nothing that would
-// catch it.
-func TestValidateEd25519Encoding(t *testing.T) {
-	// y = 2^255 - 1, which is above the field prime.
-	const nonCanonical = "7////////////////////////////////////////38="
-	cfg := &Config{RootKeys: []string{". 172800 IN DNSKEY 257 3 15 " + nonCanonical}}
-	if err := cfg.Validate(); err == nil || !strings.Contains(err.Error(), "not usable") {
-		t.Fatalf("Validate() = %v, want the non-canonical Ed25519 key rejected", err)
+// TestValidateEd25519Points pins that a key the verifier cannot work with is
+// refused. ed25519.Verify answers false for a bad key and a bad signature
+// alike, which is why the shared probe cannot tell them apart; VerifyWithOptions
+// separates them, so nothing but "the signature is wrong" is accepted here.
+func TestValidateEd25519Points(t *testing.T) {
+	anchor := func(raw []byte) *Config {
+		return &Config{RootKeys: []string{
+			". 172800 IN DNSKEY 257 3 15 " + base64.StdEncoding.EncodeToString(raw),
+		}}
+	}
+	// Little-endian y, sign bit clear.
+	yEncoding := func(y *big.Int) []byte {
+		be := y.Bytes()
+		raw := make([]byte, ed25519.PublicKeySize)
+		for i, b := range be {
+			raw[len(be)-1-i] = b
+		}
+		return raw
+	}
+	p := new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 255), big.NewInt(19))
+
+	for _, tc := range []struct {
+		name string
+		key  []byte
+	}{
+		// Below the field prime, so it decodes — and still not a point on
+		// the curve. This is the case a canonical-encoding test misses.
+		{"canonical y=2, not on the curve", yEncoding(big.NewInt(2))},
+		// p+2: above the prime, so no decoder accepts it.
+		{"non-canonical y=p+2", yEncoding(new(big.Int).Add(p, big.NewInt(2)))},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := anchor(tc.key).Validate()
+			if err == nil || !strings.Contains(err.Error(), "not usable") {
+				t.Fatalf("Validate() = %v, want the key refused", err)
+			}
+		})
 	}
 
-	// Every real key encodes a y below the prime, so none of these may trip.
+	// Every real key must pass, so a check that were too strict shows here.
 	for i := 0; i < 200; i++ {
 		pub, _, err := ed25519.GenerateKey(nil)
 		if err != nil {
 			t.Fatal(err)
 		}
-		key := ". 172800 IN DNSKEY 257 3 15 " + base64.StdEncoding.EncodeToString(pub)
-		if err := (&Config{RootKeys: []string{key}}).Validate(); err != nil {
+		if err := anchor(pub).Validate(); err != nil {
 			t.Fatalf("Validate() rejected a generated Ed25519 anchor: %v", err)
+		}
+	}
+}
+
+func TestValidateAccessLogDanglingSymlink(t *testing.T) {
+	dir := t.TempDir()
+	// The link points into a directory that is not there, so the open that
+	// creates the file fails — but Stat calls the link itself absent, which
+	// read as an ordinary missing file.
+	link := filepath.Join(dir, "a.log")
+	if err := os.Symlink(filepath.Join(dir, "gone", "real.log"), link); err != nil {
+		t.Skipf("symlink: %v", err)
+	}
+	if err := (&Config{AccessLog: link}).Validate(); err == nil ||
+		!strings.Contains(err.Error(), "accesslog") {
+		t.Fatalf("Validate() = %v, want the dangling access log symlink reported", err)
+	}
+
+	// One whose target directory exists is fine: the open creates it there.
+	good := filepath.Join(dir, "good.log")
+	if err := os.Symlink(filepath.Join(dir, "real.log"), good); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&Config{AccessLog: good}).Validate(); err != nil {
+		t.Fatalf("Validate() rejected a symlink whose target can be created: %v", err)
+	}
+}
+
+// TestValidateLeavesNoProbeBehind pins that the writability check undoes its
+// own side effect. It creates an entry to answer a question mode bits cannot,
+// and nothing it creates may outlive the call.
+func TestValidateLeavesNoProbeBehind(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "db")
+	if err := os.Mkdir(target, 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 5; i++ {
+		if err := (&Config{Directory: target, AccessLog: filepath.Join(target, "a.log")}).Validate(); err != nil {
+			t.Fatalf("Validate() failed on a writable directory: %v", err)
+		}
+	}
+
+	for _, d := range []string{dir, target} {
+		entries, err := os.ReadDir(d)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, e := range entries {
+			if strings.HasPrefix(e.Name(), ".sdns-config-test-") {
+				t.Fatalf("probe file left behind in %s: %s", d, e.Name())
+			}
 		}
 	}
 }

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -1925,3 +1925,50 @@ func TestValidatePendingDirectoryKeepsPathRules(t *testing.T) {
 		t.Fatal("walking components: Validate() accepted a path through a missing component")
 	}
 }
+
+// TestValidateCIDRMatchesEachConsumer pins which parser judges which list.
+// The access list, the views and the ECS policy all reach netip.ParsePrefix,
+// which refuses a leading zero in the bits after the slash; dns64 parses with
+// net.ParseCIDR, which takes it. Judging them all the same way would either
+// pass an access-list entry the runtime drops — leaving an empty allow set
+// that blocks every client — or refuse a dns64 prefix that works.
+func TestValidateCIDRMatchesEachConsumer(t *testing.T) {
+	const leadingZero = "10.0.0.0/08"
+
+	for _, tc := range []struct {
+		name string
+		cfg  Config
+	}{
+		{"accesslist", Config{AccessList: []string{leadingZero}}},
+		{"view network", Config{Views: []ViewConfig{{Zone: "a", Networks: []string{leadingZero}}}}},
+		{"ecs client_networks", Config{ECS: ECSConfig{Enabled: true, ClientNetworks: []string{leadingZero}}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if err := tc.cfg.Validate(); err == nil {
+				t.Fatalf("Validate() accepted %q, which the runtime drops", leadingZero)
+			}
+		})
+	}
+
+	// dns64 reads its lists with net.ParseCIDR, so the same spelling works
+	// there and must not be refused.
+	dns64 := &Config{DNS64: DNS64Config{
+		Enabled:          true,
+		Prefixes:         []string{"64:ff9b::/96"},
+		ClientNetworks:   []string{leadingZero},
+		ExcludeANetworks: []string{leadingZero},
+	}}
+	if err := dns64.Validate(); err != nil {
+		t.Fatalf("Validate() refused a dns64 network its own parser takes: %v", err)
+	}
+
+	// And the ordinary spelling passes everywhere.
+	ok := &Config{
+		AccessList: []string{"10.0.0.0/8", "::0/0"},
+		Views:      []ViewConfig{{Zone: "a", Networks: []string{"192.0.2.0/24"}}},
+		ECS:        ECSConfig{Enabled: true, ClientNetworks: []string{"192.0.2.0/24"}},
+	}
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("Validate() rejected ordinary prefixes: %v", err)
+	}
+}

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -1406,3 +1406,28 @@ func TestValidateEmptyZonesMustBeServedLocally(t *testing.T) {
 		}
 	}
 }
+
+// TestValidateAccessLogTrailingSlash pins that a file path keeps the meaning
+// of its trailing separator. Cleaning it away — which a directory path wants —
+// took the parent from one level too high and passed a name os.OpenFile
+// refuses, leaving access logging quietly switched off.
+func TestValidateAccessLogTrailingSlash(t *testing.T) {
+	dir := t.TempDir()
+
+	for _, suffix := range []string{"/", string(os.PathSeparator)} {
+		path := filepath.Join(dir, "new.log") + suffix
+		err := (&Config{AccessLog: path}).Validate()
+		if err == nil || !strings.Contains(err.Error(), "accesslog") {
+			t.Fatalf("Validate(%q) = %v, want the directory-shaped name refused", path, err)
+		}
+	}
+
+	// Without the separator the same target is fine: the open creates it.
+	if err := (&Config{AccessLog: filepath.Join(dir, "new.log")}).Validate(); err != nil {
+		t.Fatalf("Validate() rejected an access log the server would create: %v", err)
+	}
+	// And a directory path still tolerates its own trailing separator.
+	if err := (&Config{Directory: filepath.Join(dir, "db") + "/"}).Validate(); err != nil {
+		t.Fatalf("Validate() rejected a directory written with a trailing slash: %v", err)
+	}
+}

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -1,10 +1,14 @@
 package config
 
 import (
+	"encoding/base64"
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -61,7 +65,7 @@ func TestValidateRejectsUnusableValues(t *testing.T) {
 		{"hyperlocal source", Config{HyperlocalRoot: true, HyperlocalRootSources: []string{"no-port"}}, "hyperlocal_root_sources"},
 		// Out of range is silently replaced by the default, so the operator
 		// believes they set a threshold they did not.
-		{"reflex threshold", Config{ReflexThreshold: 42}, "reflexthreshold"},
+		{"reflex threshold", Config{ReflexEnabled: true, ReflexThreshold: 42}, "reflexthreshold"},
 		{"prefetch percentage", Config{Prefetch: 250}, "prefetch"},
 		{"view network", Config{Views: []ViewConfig{{Zone: "a.", Networks: []string{"nope"}}}}, "network"},
 		{"view answer", Config{Views: []ViewConfig{{Zone: "a.", Answers: []string{"not an rr"}}}}, "answer"},
@@ -124,7 +128,7 @@ func TestLoadRecordsUndecodedKeys(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "sdns.conf")
 	body := fmt.Sprintf(
-		"version = %q\ndirectory = %q\nforwardservers = [\"1.1.1.1:53\"]\nmaxdepth_old = 30\n",
+		"version = %q\ndirectory = %q\ndnssec = \"off\"\nforwardservers = [\"1.1.1.1:53\"]\nmaxdepth_old = 30\n",
 		configver, filepath.Join(dir, "db"),
 	)
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
@@ -358,8 +362,11 @@ func TestValidateRequiresAnchorsWhenValidating(t *testing.T) {
 			ForwardZones: []ForwardZoneConfig{{Name: "corp.example.", Servers: []string{"1.1.1.1:53"}}},
 		}, false},
 		{"dnssec off needs no anchor", Config{DNSSEC: "off"}, true},
-		// Omitted means off: the resolver reads cfg.DNSSEC == "on".
-		{"dnssec omitted needs no anchor", Config{}, true},
+		// A bare Config is not what Load produces: Load fills the omitted
+		// value in as "on" before the gate, which TestLoadTreatsOmittedDNSSECAsOn
+		// covers. Here the empty string is left permissive so a Config built
+		// in code is still usable without a trust anchor.
+		{"dnssec omitted on a hand-built config", Config{}, true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			err := tc.cfg.Validate()
@@ -628,5 +635,182 @@ func TestValidateURLsNeedAHostname(t *testing.T) {
 	}
 	if err := ok.Validate(); err != nil {
 		t.Fatalf("Validate() rejected usable URLs: %v", err)
+	}
+}
+
+// TestLoadTreatsOmittedDNSSECAsOn pins the effective value, not the written
+// one. Load fills an omitted dnssec in as "on", so a file naming neither it
+// nor a trust anchor runs with validation on and nothing to anchor to — every
+// validated answer then fails closed. The defaulting used to run after the
+// gate, which is how the anchor check saw "off" and let the file through.
+func TestLoadTreatsOmittedDNSSECAsOn(t *testing.T) {
+	write := func(t *testing.T, body string) string {
+		t.Helper()
+		dir := t.TempDir()
+		path := filepath.Join(dir, "sdns.conf")
+		content := fmt.Sprintf("version = %q\ndirectory = %q\n%s",
+			configver, filepath.Join(dir, "db"), body)
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+
+	if _, err := Load(write(t, ""), "test"); err == nil ||
+		!strings.Contains(err.Error(), "no usable root trust anchor") {
+		t.Fatalf("Load() = %v, want a file with neither dnssec nor rootkeys refused", err)
+	}
+
+	// Written off is honoured, and so is a file that carries an anchor.
+	if _, err := Load(write(t, "dnssec = \"off\"\n"), "test"); err != nil {
+		t.Fatalf("Load() refused a file that turns validation off: %v", err)
+	}
+}
+
+// TestValidateRootKeyOnCurve pins the gap the signature probe cannot see. A
+// throwaway signature decodes to r = s = 0 and ecdsa.Verify rejects that
+// before looking at the public point, so a curve key of the right length that
+// is not on the curve came back as a bad signature and looked usable.
+func TestValidateRootKeyOnCurve(t *testing.T) {
+	zeros := func(n int) string { return base64.StdEncoding.EncodeToString(make([]byte, n)) }
+
+	for _, tc := range []struct {
+		name string
+		alg  string
+		key  string
+	}{
+		{"P-256 right length, not on the curve", "13", zeros(64)},
+		{"P-384 right length, not on the curve", "14", zeros(96)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{RootKeys: []string{". 172800 IN DNSKEY 257 3 " + tc.alg + " " + tc.key}}
+			err := cfg.Validate()
+			if err == nil || !strings.Contains(err.Error(), "not usable") {
+				t.Fatalf("Validate() = %v, want the off-curve key rejected", err)
+			}
+		})
+	}
+
+	// A real key of the same algorithm must still pass.
+	const realP256 = "FS/jjwld5fQ2hD31w4Odohy65Je3eGSYDvJgKO0qBBEFRC5fa6GvcWdLyn0sj49unyBRv3nAHAH0UtAyYLZi7w=="
+	ok := &Config{RootKeys: []string{". 172800 IN DNSKEY 257 3 13 " + realP256}}
+	if err := ok.Validate(); err != nil {
+		t.Fatalf("Validate() rejected a real P-256 anchor: %v", err)
+	}
+}
+
+func TestValidateReflexGateAndNaN(t *testing.T) {
+	// reflex.New returns before reading the threshold when the feature is
+	// off, so a stale value there must not stop the server.
+	if err := (&Config{ReflexThreshold: 42}).Validate(); err != nil {
+		t.Fatalf("Validate() read the reflex threshold with the feature off: %v", err)
+	}
+	// Every comparison against NaN is false, including the middleware's own,
+	// so it lands on the silent default exactly like an out-of-range value.
+	nan := &Config{ReflexEnabled: true, ReflexThreshold: math.NaN()}
+	if err := nan.Validate(); err == nil || !strings.Contains(err.Error(), "not a number") {
+		t.Fatalf("Validate() = %v, want NaN rejected", err)
+	}
+	if err := (&Config{ReflexEnabled: true, ReflexThreshold: 0.7}).Validate(); err != nil {
+		t.Fatalf("Validate() rejected a usable threshold: %v", err)
+	}
+}
+
+func TestValidatePortZeroSpellings(t *testing.T) {
+	// LookupPort resolves "00" and "+0" to zero, so a comparison against the
+	// literal string "0" let them through.
+	for _, spelling := range []string{"0", "00", "+0"} {
+		cfg := &Config{RootServers: []string{"192.0.2.1:" + spelling}}
+		if err := cfg.Validate(); err == nil {
+			t.Fatalf("Validate() accepted upstream port %q", spelling)
+		}
+	}
+	// The same spellings are fine on a listener, where zero asks the kernel
+	// for a free port.
+	for _, spelling := range []string{"0", "00"} {
+		if err := (&Config{Bind: ":" + spelling}).Validate(); err != nil {
+			t.Fatalf("Validate() rejected listener port %q: %v", spelling, err)
+		}
+	}
+}
+
+func TestValidateDNS64ExcludeANeedsWellKnownPrefix(t *testing.T) {
+	// exclude_a_networks is only consulted under the well-known prefix
+	// (RFC 6147 section 5.1.4); with a custom prefix the runtime never parses
+	// it, so a stale entry there must not stop the server.
+	custom := &Config{DNS64: DNS64Config{
+		Enabled:          true,
+		Prefixes:         []string{"2001:db8::/32"},
+		ExcludeANetworks: []string{"nonsense"},
+	}}
+	if err := custom.Validate(); err != nil {
+		t.Fatalf("Validate() read exclude_a_networks under a custom prefix: %v", err)
+	}
+
+	// With the well-known prefix in the set it is read, so it is judged.
+	wellKnown := &Config{DNS64: DNS64Config{
+		Enabled:          true,
+		Prefixes:         []string{"2001:db8::/32", "64:ff9b::/96"},
+		ExcludeANetworks: []string{"nonsense"},
+	}}
+	if err := wellKnown.Validate(); err == nil ||
+		!strings.Contains(err.Error(), "exclude_a_networks") {
+		t.Fatalf("Validate() = %v, want the exclude list judged under the well-known prefix", err)
+	}
+
+	// No prefixes at all means the runtime falls back to the well-known one.
+	fallback := &Config{DNS64: DNS64Config{
+		Enabled:          true,
+		ExcludeANetworks: []string{"nonsense"},
+	}}
+	if err := fallback.Validate(); err == nil {
+		t.Fatal("Validate() skipped exclude_a_networks when the default prefix applies")
+	}
+}
+
+func TestValidateCreatedPathsNeedTheirParent(t *testing.T) {
+	dir := t.TempDir()
+
+	// Created with Mkdir, not MkdirAll: one missing level is made, two are not.
+	if err := (&Config{Directory: filepath.Join(dir, "one")}).Validate(); err != nil {
+		t.Fatalf("Validate() rejected a directory Mkdir would create: %v", err)
+	}
+	if err := (&Config{Directory: filepath.Join(dir, "one", "two")}).Validate(); err == nil ||
+		!strings.Contains(err.Error(), "parent") {
+		t.Fatalf("Validate() = %v, want the missing parent reported", err)
+	}
+
+	// The access log is created on open, but only inside an existing directory.
+	if err := (&Config{AccessLog: filepath.Join(dir, "gone", "a.log")}).Validate(); err == nil ||
+		!strings.Contains(err.Error(), "accesslog") {
+		t.Fatalf("Validate() = %v, want the missing access log directory reported", err)
+	}
+}
+
+func TestValidateRejectsSpecialFiles(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no mkfifo on windows")
+	}
+	dir := t.TempDir()
+	fifo := filepath.Join(dir, "fifo")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("mkfifo: %v", err)
+	}
+	// Not a directory, and still not something to read a certificate from —
+	// opening it would block startup.
+	if err := (&Config{HostsFile: fifo}).Validate(); err == nil ||
+		!strings.Contains(err.Error(), "named pipe") {
+		t.Fatalf("Validate() = %v, want the FIFO rejected", err)
+	}
+}
+
+func TestValidateBlocklistPort(t *testing.T) {
+	for _, u := range []string{"http://example.com:99999/list", "http://example.com:0/list"} {
+		if err := (&Config{BlockLists: []string{u}}).Validate(); err == nil {
+			t.Fatalf("Validate() accepted %q", u)
+		}
+	}
+	if err := (&Config{BlockLists: []string{"http://example.com:8080/list"}}).Validate(); err != nil {
+		t.Fatalf("Validate() rejected a usable blocklist URL: %v", err)
 	}
 }

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -1736,23 +1736,26 @@ func TestPathHandlingOnBothPlatforms(t *testing.T) {
 // is that directory is one the server will be able to make — refusing it made
 // a fresh install impossible to start.
 func TestLoadAcceptsPathsUnderThePendingDirectory(t *testing.T) {
-	dir := t.TempDir()
-	work := filepath.Join(dir, "sdns") // does not exist yet
-
 	for _, tc := range []struct {
 		name string
-		body string
+		// key is filled in with the path to place under the pending
+		// directory. Built here rather than substituted into a prepared
+		// string: %q escapes a Windows path, so a later ReplaceAll on the
+		// raw form silently matches nothing.
+		key string
 	}{
-		{"access log", fmt.Sprintf("accesslog = %q\n", filepath.Join(work, "access.log"))},
-		{"explicit blocklistdir", fmt.Sprintf("blocklistdir = %q\n", filepath.Join(work, "lists"))},
+		{"access log", "accesslog"},
+		{"explicit blocklistdir", "blocklistdir"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			d := t.TempDir()
-			w := filepath.Join(d, "sdns")
-			body := strings.ReplaceAll(tc.body, work, w)
-			path := filepath.Join(d, "sdns.conf")
+			dir := t.TempDir()
+			work := filepath.Join(dir, "sdns") // does not exist yet
+			inside := filepath.Join(work, "thing")
+
+			path := filepath.Join(dir, "sdns.conf")
 			content := fmt.Sprintf("version = %q\ndirectory = %q\ndnssec = \"off\"\n"+
-				"rootservers = [\"192.5.5.241:53\"]\n%s", configver, w, body)
+				"rootservers = [\"192.5.5.241:53\"]\n%s = %q\n",
+				configver, work, tc.key, inside)
 			if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 				t.Fatal(err)
 			}
@@ -1764,6 +1767,8 @@ func TestLoadAcceptsPathsUnderThePendingDirectory(t *testing.T) {
 
 	// One level only: Load uses Mkdir, so a directory below that is nobody's
 	// to create.
+	dir := t.TempDir()
+	work := filepath.Join(dir, "sdns")
 	deep := &Config{Directory: work, AccessLog: filepath.Join(work, "sub", "access.log")}
 	if err := deep.Validate(); err == nil {
 		t.Fatal("Validate() accepted a path two levels below a directory that is not there")

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -35,10 +35,10 @@ func TestValidateRejectsUnusableValues(t *testing.T) {
 		{"crit log level", Config{LogLevel: "crit"}, "loglevel"},
 		{"root server family", Config{RootServers: []string{"[2001:db8::1]:53"}}, "rootservers"},
 		{"root6 server family", Config{IPv6Access: true, Root6Servers: []string{"192.0.2.1:53"}}, "root6servers"},
-		{"root key not a KSK", Config{RootKeys: []string{
+		{"root key not a KSK", Config{DNSSEC: "on", RootKeys: []string{
 			". 172800 IN DNSKEY 256 3 8 AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3",
 		}}, "key-signing key"},
-		{"root key wrong owner", Config{RootKeys: []string{
+		{"root key wrong owner", Config{DNSSEC: "on", RootKeys: []string{
 			"example. 172800 IN DNSKEY 257 3 8 AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3",
 		}}, "root zone"},
 		// /49 is a valid IPv6 CIDR and an invalid Pref64: the runtime drops
@@ -60,7 +60,7 @@ func TestValidateRejectsUnusableValues(t *testing.T) {
 		// A bad anchor is fatal at resolver construction, so -t passing here
 		// meant the server then refused to start.
 		{"root key", Config{RootKeys: []string{"this is not a DNSKEY"}}, "rootkeys"},
-		{"root key wrong type", Config{RootKeys: []string{". 172800 IN A 192.0.2.1"}}, "rootkeys"},
+		{"root key wrong type", Config{DNSSEC: "on", RootKeys: []string{". 172800 IN A 192.0.2.1"}}, "rootkeys"},
 		{"outbound family", Config{OutboundIPs: []string{"2001:db8::1"}}, "outboundips"},
 		{"api address", Config{API: "not an address"}, "api"},
 		{"hyperlocal source", Config{HyperlocalRoot: true, HyperlocalRootSources: []string{"no-port"}}, "hyperlocal_root_sources"},
@@ -292,7 +292,7 @@ func TestValidateRootKeyAlgorithm(t *testing.T) {
 		{"ECDSAP256SHA256 is the successor", "13", ecdsaP256, ""},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := &Config{RootKeys: []string{
+			cfg := &Config{DNSSEC: "on", RootKeys: []string{
 				". 172800 IN DNSKEY 257 3 " + tc.alg + " " + tc.material,
 			}}
 			err := cfg.Validate()
@@ -684,7 +684,7 @@ func TestValidateRootKeyOnCurve(t *testing.T) {
 		{"P-384 right length, not on the curve", "14", zeros(96)},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			cfg := &Config{RootKeys: []string{". 172800 IN DNSKEY 257 3 " + tc.alg + " " + tc.key}}
+			cfg := &Config{DNSSEC: "on", RootKeys: []string{". 172800 IN DNSKEY 257 3 " + tc.alg + " " + tc.key}}
 			err := cfg.Validate()
 			if err == nil || !strings.Contains(err.Error(), "not usable") {
 				t.Fatalf("Validate() = %v, want the off-curve key rejected", err)
@@ -694,7 +694,7 @@ func TestValidateRootKeyOnCurve(t *testing.T) {
 
 	// A real key of the same algorithm must still pass.
 	const realP256 = "FS/jjwld5fQ2hD31w4Odohy65Je3eGSYDvJgKO0qBBEFRC5fa6GvcWdLyn0sj49unyBRv3nAHAH0UtAyYLZi7w=="
-	ok := &Config{RootKeys: []string{". 172800 IN DNSKEY 257 3 13 " + realP256}}
+	ok := &Config{DNSSEC: "on", RootKeys: []string{". 172800 IN DNSKEY 257 3 13 " + realP256}}
 	if err := ok.Validate(); err != nil {
 		t.Fatalf("Validate() rejected a real P-256 anchor: %v", err)
 	}
@@ -816,14 +816,14 @@ func TestValidateRootKeyPolicyErrors(t *testing.T) {
 		return base64.StdEncoding.EncodeToString(append(buf, mod...))
 	}
 
-	small := &Config{RootKeys: []string{". 172800 IN DNSKEY 257 3 8 " + rsaKey(64)}}
+	small := &Config{DNSSEC: "on", RootKeys: []string{". 172800 IN DNSKEY 257 3 8 " + rsaKey(64)}}
 	err := small.Validate()
 	if err == nil || !strings.Contains(err.Error(), "not usable") {
 		t.Fatalf("Validate() = %v, want the 512-bit RSA anchor rejected", err)
 	}
 
 	// A key of a size the crypto package will work with still passes.
-	big := &Config{RootKeys: []string{". 172800 IN DNSKEY 257 3 8 " + rsaKey(256)}}
+	big := &Config{DNSSEC: "on", RootKeys: []string{". 172800 IN DNSKEY 257 3 8 " + rsaKey(256)}}
 	if err := big.Validate(); err != nil {
 		t.Fatalf("Validate() rejected a 2048-bit RSA anchor: %v", err)
 	}
@@ -1239,7 +1239,7 @@ func TestPortNetworksPerCaller(t *testing.T) {
 // separates them, so nothing but "the signature is wrong" is accepted here.
 func TestValidateEd25519Points(t *testing.T) {
 	anchor := func(raw []byte) *Config {
-		return &Config{RootKeys: []string{
+		return &Config{DNSSEC: "on", RootKeys: []string{
 			". 172800 IN DNSKEY 257 3 15 " + base64.StdEncoding.EncodeToString(raw),
 		}}
 	}
@@ -1499,5 +1499,144 @@ func TestValidateAccessLogSymlinkLoop(t *testing.T) {
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("Validate() did not return on a self-referencing symlink")
+	}
+}
+
+// TestValidateRootKeysOnlyWhereUsed pins that a record's meaning is judged
+// only where something reads it. NewResolver parses every rootkey whatever
+// the settings, but nothing asks what one means unless validation or the
+// hyperlocal root does — so a stale entry under dnssec = "off" has no effect
+// and must not stop the server.
+func TestValidateRootKeysOnlyWhereUsed(t *testing.T) {
+	stale := []string{". 172800 IN A 192.0.2.1"} // parses, and is not a DNSKEY
+
+	off := &Config{DNSSEC: "off", RootKeys: stale}
+	if err := off.Validate(); err != nil {
+		t.Fatalf("Validate() judged a rootkey nothing reads: %v", err)
+	}
+
+	// A record that will not parse is fatal at construction either way.
+	broken := &Config{DNSSEC: "off", RootKeys: []string{"this is not a record"}}
+	if err := broken.Validate(); err == nil {
+		t.Fatal("Validate() accepted a rootkey that will not parse")
+	}
+
+	// Both readers bring the meaning back into play.
+	for _, cfg := range []*Config{
+		{DNSSEC: "on", RootKeys: stale},
+		{DNSSEC: "off", HyperlocalRoot: true, RootKeys: stale},
+	} {
+		if err := cfg.Validate(); err == nil ||
+			!strings.Contains(err.Error(), "must be a DNSKEY") {
+			t.Fatalf("Validate() = %v, want the record judged when it is read", err)
+		}
+	}
+}
+
+// TestValidateRootForwardZoneNeedsNoAnchor pins the exemption. A forward zone
+// at the root covers every name — ForwardZoneFor matches on IsSubDomain, and
+// the handler hands the query on by the same early return a global forwarder
+// takes — so nothing validates locally and no anchor is needed.
+func TestValidateRootForwardZoneNeedsNoAnchor(t *testing.T) {
+	root := &Config{
+		DNSSEC:       "on",
+		ForwardZones: []ForwardZoneConfig{{Name: ".", Servers: []string{"1.1.1.1:53"}}},
+	}
+	if err := root.Validate(); err != nil {
+		t.Fatalf("Validate() asked a root forward zone for an anchor: %v", err)
+	}
+
+	// A zone below the root leaves the rest to recursion, which does need one.
+	partial := &Config{
+		DNSSEC:       "on",
+		ForwardZones: []ForwardZoneConfig{{Name: "corp.example.", Servers: []string{"1.1.1.1:53"}}},
+	}
+	if err := partial.Validate(); err == nil ||
+		!strings.Contains(err.Error(), "no usable root trust anchor") {
+		t.Fatalf("Validate() = %v, want a subtree zone still to need an anchor", err)
+	}
+
+	// And a zone with no servers is skipped by ForwardZoneFor, so it forwards
+	// nothing and cannot stand in for one.
+	empty := &Config{
+		DNSSEC:       "on",
+		ForwardZones: []ForwardZoneConfig{{Name: ".", Servers: nil}},
+	}
+	if err := empty.Validate(); err == nil ||
+		!strings.Contains(err.Error(), "no usable root trust anchor") {
+		t.Fatalf("Validate() = %v, want a serverless root zone not to exempt", err)
+	}
+}
+
+func TestValidateOutboundIPv6ListSkippedWhole(t *testing.T) {
+	// The runtime does not read this list at all without v6, so nothing in
+	// it — not even a value that is not an address — can matter.
+	stale := &Config{OutboundIP6s: []string{"stale-value", "192.0.2.1"}}
+	if err := stale.Validate(); err != nil {
+		t.Fatalf("Validate() read outboundip6s with ipv6access off: %v", err)
+	}
+
+	on := *stale
+	on.IPv6Access = true
+	if err := on.Validate(); err == nil ||
+		!strings.Contains(err.Error(), "outboundip6s") {
+		t.Fatalf("Validate() = %v, want the list judged when v6 is in use", err)
+	}
+}
+
+func TestValidateDefaultBlocklistDir(t *testing.T) {
+	dir := t.TempDir()
+
+	// A fresh install: neither the working directory nor the default
+	// blocklist directory exists yet, and Load creates both in turn.
+	fresh := &Config{Directory: filepath.Join(dir, "db")}
+	if err := fresh.Validate(); err != nil {
+		t.Fatalf("Validate() refused a fresh working directory: %v", err)
+	}
+
+	// A plain file sitting where the default would go stops the middleware
+	// from creating it, and both list sources go quietly unloaded.
+	work := filepath.Join(dir, "work")
+	if err := os.Mkdir(work, 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(work, "blacklists"), []byte(""), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&Config{Directory: work}).Validate(); err == nil ||
+		!strings.Contains(err.Error(), "blocklistdir") {
+		t.Fatalf("Validate() = %v, want the occupied default reported", err)
+	}
+}
+
+// TestValidatePathsKeepTheirComponents pins that a parent is taken from the
+// path as written. filepath.Dir cleans, so "missing/../x" comes back as "."
+// and looks like it lives somewhere that exists — while the open and the
+// mkdir both resolve each component and fail on the one that is not there.
+func TestValidatePathsKeepTheirComponents(t *testing.T) {
+	dir := t.TempDir()
+
+	// Built by hand: filepath.Join cleans too, so the components would not
+	// survive to be judged.
+	sep := string(filepath.Separator)
+	logPath := dir + sep + "missing" + sep + ".." + sep + "access.log"
+	if err := (&Config{AccessLog: logPath}).Validate(); err == nil ||
+		!strings.Contains(err.Error(), "accesslog") {
+		t.Fatalf("Validate() = %v, want the missing component reported", err)
+	}
+
+	dbPath := dir + sep + "missing" + sep + ".." + sep + "db"
+	if err := (&Config{Directory: dbPath}).Validate(); err == nil ||
+		!strings.Contains(err.Error(), "directory") {
+		t.Fatalf("Validate() = %v, want the missing component reported", err)
+	}
+
+	// The same shape with the component present is fine.
+	if err := os.Mkdir(filepath.Join(dir, "there"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	okPath := dir + sep + "there" + sep + ".." + sep + "db"
+	if err := (&Config{Directory: okPath}).Validate(); err != nil {
+		t.Fatalf("Validate() rejected a path whose components all exist: %v", err)
 	}
 }

--- a/config/validate_test.go
+++ b/config/validate_test.go
@@ -14,6 +14,10 @@ import (
 	"time"
 )
 
+// testP256 is a generated ECDSAP256SHA256 public key, used wherever a test
+// needs an anchor that is actually usable rather than merely well-formed.
+const testP256 = "FS/jjwld5fQ2hD31w4Odohy65Je3eGSYDvJgKO0qBBEFRC5fa6GvcWdLyn0sj49unyBRv3nAHAH0UtAyYLZi7w=="
+
 func TestValidateRejectsUnusableValues(t *testing.T) {
 	for _, tc := range []struct {
 		name string
@@ -430,6 +434,8 @@ func TestValidateMirrorsRuntimeTrimming(t *testing.T) {
 		},
 		HyperlocalRoot:        true,
 		HyperlocalRootSources: []string{" 192.0.2.1:53 ", ""},
+		// Hyperlocal verifies every transfer against these, so it needs one.
+		RootKeys: []string{". 172800 IN DNSKEY 257 3 13 " + testP256},
 	}
 	if err := trimmed.Validate(); err != nil {
 		t.Fatalf("Validate() rejected values the runtime trims and uses: %v", err)
@@ -1623,5 +1629,73 @@ func TestValidateAcceptsPathsWhoseComponentsExist(t *testing.T) {
 	okPath := dir + sep + "there" + sep + ".." + sep + "db"
 	if err := (&Config{Directory: okPath}).Validate(); err != nil {
 		t.Fatalf("Validate() rejected a path whose components all exist: %v", err)
+	}
+}
+
+// TestValidateHyperlocalNeedsAnAnchor pins that hyperlocal is not covered by
+// the DNSSEC rule. The manager verifies every transfer against these keys and
+// gives up on each refresh while there are none, so with an empty set the
+// feature never loads the zone at all — whatever dnssec says.
+func TestValidateHyperlocalNeedsAnAnchor(t *testing.T) {
+	bare := &Config{DNSSEC: "off", HyperlocalRoot: true}
+	if err := bare.Validate(); err == nil ||
+		!strings.Contains(err.Error(), "hyperlocal_root") {
+		t.Fatalf("Validate() = %v, want hyperlocal without an anchor reported", err)
+	}
+
+	// Forwarding does not excuse it: the manager runs whatever the query
+	// path does.
+	forwarded := *bare
+	forwarded.ForwarderServers = []string{"1.1.1.1:53"}
+	if err := forwarded.Validate(); err == nil {
+		t.Fatal("Validate() excused hyperlocal because a forwarder is configured")
+	}
+
+	withAnchor := *bare
+	withAnchor.RootKeys = []string{". 172800 IN DNSKEY 257 3 13 " + testP256}
+	if err := withAnchor.Validate(); err != nil {
+		t.Fatalf("Validate() rejected hyperlocal with a usable anchor: %v", err)
+	}
+
+	// And with hyperlocal off the same empty set is fine.
+	off := &Config{DNSSEC: "off"}
+	if err := off.Validate(); err != nil {
+		t.Fatalf("Validate() asked for an anchor nothing reads: %v", err)
+	}
+}
+
+func TestValidateAccessLogLongChain(t *testing.T) {
+	dir := t.TempDir()
+
+	// Twenty hops is well inside what a system follows, so Stat resolves the
+	// whole chain and reports the final target as absent — which means the
+	// chase here has to walk all twenty to find where the file would go. A
+	// shorter bound would stop partway and hand back a path that is itself
+	// another link, whose parent is this directory and exists.
+	prev := "gone/real.log"
+	for i := range 20 {
+		name := fmt.Sprintf("h%d.log", i)
+		if err := os.Symlink(prev, filepath.Join(dir, name)); err != nil {
+			t.Skipf("symlink: %v", err)
+		}
+		prev = name
+	}
+	if err := (&Config{AccessLog: filepath.Join(dir, prev)}).Validate(); err == nil ||
+		!strings.Contains(err.Error(), "accesslog") {
+		t.Fatalf("Validate() = %v, want the missing directory at the end of the chain reported", err)
+	}
+
+	// A chain longer than any system follows is refused by the stat itself.
+	deep := t.TempDir()
+	prev = "end.log"
+	for i := range 80 {
+		name := fmt.Sprintf("h%d.log", i)
+		if err := os.Symlink(prev, filepath.Join(deep, name)); err != nil {
+			t.Skipf("symlink: %v", err)
+		}
+		prev = name
+	}
+	if err := (&Config{AccessLog: filepath.Join(deep, prev)}).Validate(); err == nil {
+		t.Fatal("Validate() accepted a chain no system will follow")
 	}
 }

--- a/config/validate_unix_test.go
+++ b/config/validate_unix_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 )
 
 // TestValidateRejectsSpecialFiles lives here because syscall.Mkfifo does not
@@ -345,8 +346,28 @@ func TestValidateAccessLogDeviceTargets(t *testing.T) {
 	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
 		t.Skipf("mkfifo: %v", err)
 	}
-	if err := (&Config{AccessLog: fifo}).Validate(); err == nil ||
-		!strings.Contains(err.Error(), "named pipe") {
-		t.Fatalf("Validate() = %v, want the named pipe refused", err)
+	// Refused, and without waiting: the open asks in non-blocking mode, so a
+	// FIFO nobody is reading answers straight away.
+	done := make(chan error, 1)
+	go func() { done <- (&Config{AccessLog: fifo}).Validate() }()
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("Validate() accepted a FIFO with no reader")
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("Validate() waited on a FIFO instead of reporting it")
+	}
+
+	// The same FIFO with a reader is usable, which is what /dev/stdout is
+	// in a container whose output is piped.
+	reader, err := os.OpenFile(fifo, os.O_RDONLY|syscall.O_NONBLOCK, 0) //nolint:gosec // G304 - this test made the path
+	if err != nil {
+		t.Skipf("open fifo for reading: %v", err)
+	}
+	defer reader.Close() //nolint:errcheck // nothing was written
+
+	if err := (&Config{AccessLog: fifo}).Validate(); err != nil {
+		t.Fatalf("Validate() refused a pipe somebody is reading: %v", err)
 	}
 }

--- a/config/validate_unix_test.go
+++ b/config/validate_unix_test.go
@@ -81,3 +81,25 @@ func TestValidateUnwritableExistingDirectory(t *testing.T) {
 		t.Fatal("Validate() accepted a working directory it cannot write in")
 	}
 }
+
+func TestValidateSymlinkToUnwritableDirectory(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root writes regardless of mode")
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "db")
+	if err := os.Mkdir(target, 0o500); err != nil { //nolint:gosec // G301 - the point is a directory that cannot be written
+		t.Fatal(err)
+	}
+	defer os.Chmod(target, 0o700) //nolint:errcheck,gosec // test cleanup
+
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlink: %v", err)
+	}
+	// Named directly it is refused; through a link it has to be refused too,
+	// since that is the path the server writes to.
+	if err := (&Config{Directory: link}).Validate(); err == nil {
+		t.Fatal("Validate() accepted a symlink to a directory it cannot write in")
+	}
+}

--- a/config/validate_unix_test.go
+++ b/config/validate_unix_test.go
@@ -327,3 +327,26 @@ func TestValidateEquivalentDotDotPaths(t *testing.T) {
 		t.Fatal("Validate() accepted a log path through a component that is not there")
 	}
 }
+
+// TestValidateAccessLogDeviceTargets pins the container spelling. A character
+// device is not a regular file and os.OpenFile takes it anyway, so refusing
+// everything irregular stopped a setup that works. A named pipe stays refused:
+// opening it write-only waits for a reader.
+func TestValidateAccessLogDeviceTargets(t *testing.T) {
+	if _, err := os.Stat("/dev/null"); err != nil {
+		t.Skipf("no /dev/null: %v", err)
+	}
+	if err := (&Config{AccessLog: "/dev/null"}).Validate(); err != nil {
+		t.Fatalf("Validate() refused /dev/null as an access log: %v", err)
+	}
+
+	dir := t.TempDir()
+	fifo := filepath.Join(dir, "fifo")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("mkfifo: %v", err)
+	}
+	if err := (&Config{AccessLog: fifo}).Validate(); err == nil ||
+		!strings.Contains(err.Error(), "named pipe") {
+		t.Fatalf("Validate() = %v, want the named pipe refused", err)
+	}
+}

--- a/config/validate_unix_test.go
+++ b/config/validate_unix_test.go
@@ -152,3 +152,34 @@ func TestValidateSymlinkTargetKeepsComponents(t *testing.T) {
 		t.Fatalf("Validate() rejected a target whose components all exist: %v", err)
 	}
 }
+
+// TestValidateReadOnlyBlocklistDir pins that a blocklist directory is read,
+// not necessarily written. The middleware loads local lists from it and only
+// logs when it cannot download into it, so a read-only mount carrying nothing
+// but local lists is a working setup. The working directory is different: the
+// trust-anchor store lives there, so that one has to take an entry.
+func TestValidateReadOnlyBlocklistDir(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root writes regardless of mode")
+	}
+	dir := t.TempDir()
+	lists := filepath.Join(dir, "lists")
+	if err := os.Mkdir(lists, 0o500); err != nil { //nolint:gosec // G301 - the point is a directory that cannot be written
+		t.Fatal(err)
+	}
+	defer os.Chmod(lists, 0o700) //nolint:errcheck,gosec // test cleanup
+
+	if err := (&Config{BlockListDir: lists}).Validate(); err != nil {
+		t.Fatalf("Validate() rejected a read-only blocklist directory: %v", err)
+	}
+
+	work := filepath.Join(dir, "work")
+	if err := os.Mkdir(work, 0o500); err != nil { //nolint:gosec // G301 - the point is a directory that cannot be written
+		t.Fatal(err)
+	}
+	defer os.Chmod(work, 0o700) //nolint:errcheck,gosec // test cleanup
+
+	if err := (&Config{Directory: work}).Validate(); err == nil {
+		t.Fatal("Validate() accepted a working directory it cannot write in")
+	}
+}

--- a/config/validate_unix_test.go
+++ b/config/validate_unix_test.go
@@ -1,0 +1,26 @@
+//go:build unix
+
+package config
+
+import (
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// TestValidateRejectsSpecialFiles lives here because syscall.Mkfifo does not
+// exist on Windows — a runtime skip would still fail to build there.
+func TestValidateRejectsSpecialFiles(t *testing.T) {
+	dir := t.TempDir()
+	fifo := filepath.Join(dir, "fifo")
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("mkfifo: %v", err)
+	}
+	// Not a directory, and still not something to read a hosts file from —
+	// opening it would block startup rather than fail.
+	if err := (&Config{HostsFile: fifo}).Validate(); err == nil ||
+		!strings.Contains(err.Error(), "named pipe") {
+		t.Fatalf("Validate() = %v, want the FIFO rejected", err)
+	}
+}

--- a/config/validate_unix_test.go
+++ b/config/validate_unix_test.go
@@ -61,3 +61,23 @@ func TestValidateUnwritableAccessLog(t *testing.T) {
 		t.Fatal("Validate() accepted an access log it cannot write")
 	}
 }
+
+func TestValidateUnwritableExistingDirectory(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root writes regardless of mode")
+	}
+	dir := t.TempDir()
+	target := filepath.Join(dir, "db")
+	if err := os.Mkdir(target, 0o500); err != nil { //nolint:gosec // G301 - the point is a directory that cannot be written
+		t.Fatal(err)
+	}
+	// Put write back so t.TempDir can clean up.
+	defer os.Chmod(target, 0o700) //nolint:errcheck,gosec // test cleanup
+
+	// The directory is there and is a directory; mode bits alone do not say
+	// whether this process can write in it, so the check creates an entry and
+	// takes it back out.
+	if err := (&Config{Directory: target}).Validate(); err == nil {
+		t.Fatal("Validate() accepted a working directory it cannot write in")
+	}
+}

--- a/config/validate_unix_test.go
+++ b/config/validate_unix_test.go
@@ -103,3 +103,24 @@ func TestValidateSymlinkToUnwritableDirectory(t *testing.T) {
 		t.Fatal("Validate() accepted a symlink to a directory it cannot write in")
 	}
 }
+
+// TestValidatePathsKeepTheirComponents pins the unix rule. A path is resolved
+// one component at a time here, so "missing/../x" fails on the "missing" that
+// is not there — while filepath.Dir cleans it away and would call the path
+// perfectly fine. Windows collapses ".." itself, so this is not its rule and
+// the test does not run there.
+func TestValidatePathsKeepTheirComponents(t *testing.T) {
+	dir := t.TempDir()
+	// Built by hand: filepath.Join cleans too.
+	logPath := dir + "/missing/../access.log"
+	if err := (&Config{AccessLog: logPath}).Validate(); err == nil ||
+		!strings.Contains(err.Error(), "accesslog") {
+		t.Fatalf("Validate() = %v, want the missing component reported", err)
+	}
+
+	dbPath := dir + "/missing/../db"
+	if err := (&Config{Directory: dbPath}).Validate(); err == nil ||
+		!strings.Contains(err.Error(), "directory") {
+		t.Fatalf("Validate() = %v, want the missing component reported", err)
+	}
+}

--- a/config/validate_unix_test.go
+++ b/config/validate_unix_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"syscall"
 	"testing"
-	"time"
 )
 
 // TestValidateRejectsSpecialFiles lives here because syscall.Mkfifo does not
@@ -331,8 +330,7 @@ func TestValidateEquivalentDotDotPaths(t *testing.T) {
 
 // TestValidateAccessLogDeviceTargets pins the container spelling. A character
 // device is not a regular file and os.OpenFile takes it anyway, so refusing
-// everything irregular stopped a setup that works. A named pipe stays refused:
-// opening it write-only waits for a reader.
+// everything irregular stopped a setup that works.
 func TestValidateAccessLogDeviceTargets(t *testing.T) {
 	if _, err := os.Stat("/dev/null"); err != nil {
 		t.Skipf("no /dev/null: %v", err)
@@ -340,34 +338,36 @@ func TestValidateAccessLogDeviceTargets(t *testing.T) {
 	if err := (&Config{AccessLog: "/dev/null"}).Validate(); err != nil {
 		t.Fatalf("Validate() refused /dev/null as an access log: %v", err)
 	}
+}
 
+// TestValidateLeavesAPipeAlone pins that validating does not disturb the thing
+// it is validating. A reader waiting on the pipe sees EOF the moment the last
+// writer closes, so a probe that opens and closes would end it — and the open
+// the middleware makes a moment later would then wait forever for a reader
+// that this check just sent away. The property is that the pipe is never
+// opened at all, so the test records the calls rather than timing a process.
+func TestValidateLeavesAPipeAlone(t *testing.T) {
 	dir := t.TempDir()
 	fifo := filepath.Join(dir, "fifo")
 	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
 		t.Skipf("mkfifo: %v", err)
 	}
-	// Refused, and without waiting: the open asks in non-blocking mode, so a
-	// FIFO nobody is reading answers straight away.
-	done := make(chan error, 1)
-	go func() { done <- (&Config{AccessLog: fifo}).Validate() }()
-	select {
-	case err := <-done:
-		if err == nil {
-			t.Fatal("Validate() accepted a FIFO with no reader")
-		}
-	case <-time.After(10 * time.Second):
-		t.Fatal("Validate() waited on a FIFO instead of reporting it")
-	}
 
-	// The same FIFO with a reader is usable, which is what /dev/stdout is
-	// in a container whose output is piped.
-	reader, err := os.OpenFile(fifo, os.O_RDONLY|syscall.O_NONBLOCK, 0) //nolint:gosec // G304 - this test made the path
-	if err != nil {
-		t.Skipf("open fifo for reading: %v", err)
+	original := openFile
+	defer func() { openFile = original }()
+
+	var opened []string
+	openFile = func(name string, flag int, perm os.FileMode) (*os.File, error) {
+		opened = append(opened, name)
+		return original(name, flag, perm)
 	}
-	defer reader.Close() //nolint:errcheck // nothing was written
 
 	if err := (&Config{AccessLog: fifo}).Validate(); err != nil {
-		t.Fatalf("Validate() refused a pipe somebody is reading: %v", err)
+		t.Fatalf("Validate() refused a pipe: %v", err)
+	}
+	for _, name := range opened {
+		if name == fifo {
+			t.Fatal("Validate() opened the pipe, which would send its reader away")
+		}
 	}
 }

--- a/config/validate_unix_test.go
+++ b/config/validate_unix_test.go
@@ -183,3 +183,42 @@ func TestValidateReadOnlyBlocklistDir(t *testing.T) {
 		t.Fatal("Validate() accepted a working directory it cannot write in")
 	}
 }
+
+// TestValidateUnreadableBlocklistDir pins that a blocklist directory has to be
+// listable. Stat says nothing about that — a directory with no permission bits
+// satisfies it — while the middleware walks it and, when it cannot, logs once
+// and loads no local list at all.
+func TestValidateUnreadableBlocklistDir(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root reads regardless of mode")
+	}
+	dir := t.TempDir()
+	lists := filepath.Join(dir, "lists")
+	if err := os.Mkdir(lists, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chmod(lists, 0o700) //nolint:errcheck,gosec // test cleanup
+
+	if err := (&Config{BlockListDir: lists}).Validate(); err == nil {
+		t.Fatal("Validate() accepted a blocklist directory it cannot list")
+	}
+
+	// Through a symlink too, since that is the path the middleware walks.
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(lists, link); err != nil {
+		t.Skipf("symlink: %v", err)
+	}
+	if err := (&Config{BlockListDir: link}).Validate(); err == nil {
+		t.Fatal("Validate() accepted a symlink to a directory it cannot list")
+	}
+
+	// Read-only is still fine: only writing is optional there.
+	ro := filepath.Join(dir, "ro")
+	if err := os.Mkdir(ro, 0o500); err != nil { //nolint:gosec // G301 - read-only is the point
+		t.Fatal(err)
+	}
+	defer os.Chmod(ro, 0o700) //nolint:errcheck,gosec // test cleanup
+	if err := (&Config{BlockListDir: ro}).Validate(); err != nil {
+		t.Fatalf("Validate() rejected a read-only blocklist directory: %v", err)
+	}
+}

--- a/config/validate_unix_test.go
+++ b/config/validate_unix_test.go
@@ -124,3 +124,31 @@ func TestValidatePathsKeepTheirComponents(t *testing.T) {
 		t.Fatalf("Validate() = %v, want the missing component reported", err)
 	}
 }
+
+// TestValidateSymlinkTargetKeepsComponents pins the unix rule for a relative
+// target. filepath.Join would clean "missing/../real.log" down to
+// "real.log" — which looks like it lives somewhere that exists, while the
+// open follows the target as written and fails on the missing component.
+func TestValidateSymlinkTargetKeepsComponents(t *testing.T) {
+	dir := t.TempDir()
+	link := filepath.Join(dir, "access.log")
+	if err := os.Symlink("missing/../real.log", link); err != nil {
+		t.Skipf("symlink: %v", err)
+	}
+	if err := (&Config{AccessLog: link}).Validate(); err == nil ||
+		!strings.Contains(err.Error(), "accesslog") {
+		t.Fatalf("Validate() = %v, want the missing component in the target reported", err)
+	}
+
+	// The same shape with the component present is usable.
+	if err := os.Mkdir(filepath.Join(dir, "there"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	good := filepath.Join(dir, "ok.log")
+	if err := os.Symlink("there/../real.log", good); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&Config{AccessLog: good}).Validate(); err != nil {
+		t.Fatalf("Validate() rejected a target whose components all exist: %v", err)
+	}
+}

--- a/config/validate_unix_test.go
+++ b/config/validate_unix_test.go
@@ -222,3 +222,40 @@ func TestValidateUnreadableBlocklistDir(t *testing.T) {
 		t.Fatalf("Validate() rejected a read-only blocklist directory: %v", err)
 	}
 }
+
+// TestValidateBlocklistDirMustBeTraversable pins the difference between
+// listing a directory and walking into it. A directory carrying read but not
+// execute hands back its entry names and then refuses to stat any of them,
+// which is where the middleware's walk stops — loading no list while every
+// name is visible.
+func TestValidateBlocklistDirMustBeTraversable(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root traverses regardless of mode")
+	}
+	dir := t.TempDir()
+	lists := filepath.Join(dir, "lists")
+	if err := os.Mkdir(lists, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(lists, "a.txt"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(lists, 0o400); err != nil { //nolint:gosec // G302 - read without execute is the point
+		t.Fatal(err)
+	}
+	defer os.Chmod(lists, 0o700) //nolint:errcheck,gosec // test cleanup
+
+	if err := (&Config{BlockListDir: lists}).Validate(); err == nil {
+		t.Fatal("Validate() accepted a directory it can list but not walk into")
+	}
+
+	// An empty directory has nothing to walk into and is fine.
+	empty := filepath.Join(dir, "empty")
+	if err := os.Mkdir(empty, 0o500); err != nil { //nolint:gosec // G301 - read-only is the point
+		t.Fatal(err)
+	}
+	defer os.Chmod(empty, 0o700) //nolint:errcheck,gosec // test cleanup
+	if err := (&Config{BlockListDir: empty}).Validate(); err != nil {
+		t.Fatalf("Validate() rejected an empty read-only blocklist directory: %v", err)
+	}
+}

--- a/config/validate_unix_test.go
+++ b/config/validate_unix_test.go
@@ -259,3 +259,30 @@ func TestValidateBlocklistDirMustBeTraversable(t *testing.T) {
 		t.Fatalf("Validate() rejected an empty read-only blocklist directory: %v", err)
 	}
 }
+
+// TestValidateRemoteBlocklistNeedsAWritableDir pins the split. Local lists are
+// only read, so a read-only directory serves them; a remote list is downloaded
+// into that directory with os.Create, and on a read-only mount none of them
+// load while the config test says the file is fine.
+func TestValidateRemoteBlocklistNeedsAWritableDir(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root writes regardless of mode")
+	}
+	dir := t.TempDir()
+	lists := filepath.Join(dir, "lists")
+	if err := os.Mkdir(lists, 0o500); err != nil { //nolint:gosec // G301 - read-only is the point
+		t.Fatal(err)
+	}
+	defer os.Chmod(lists, 0o700) //nolint:errcheck,gosec // test cleanup
+
+	// Local lists only: reading is enough.
+	if err := (&Config{BlockListDir: lists}).Validate(); err != nil {
+		t.Fatalf("Validate() rejected a read-only directory serving local lists: %v", err)
+	}
+
+	// With something to download, it has to take the file.
+	remote := &Config{BlockListDir: lists, BlockLists: []string{"https://example.com/list"}}
+	if err := remote.Validate(); err == nil {
+		t.Fatal("Validate() accepted a read-only directory for a remote blocklist")
+	}
+}

--- a/config/validate_unix_test.go
+++ b/config/validate_unix_test.go
@@ -3,6 +3,7 @@
 package config
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -22,5 +23,41 @@ func TestValidateRejectsSpecialFiles(t *testing.T) {
 	if err := (&Config{HostsFile: fifo}).Validate(); err == nil ||
 		!strings.Contains(err.Error(), "named pipe") {
 		t.Fatalf("Validate() = %v, want the FIFO rejected", err)
+	}
+}
+
+// These two turn on POSIX file modes. Windows does not enforce them the same
+// way, and os.Getuid there returns -1, so a runtime root check would not skip
+// either — hence the build tag rather than a skip.
+
+func TestValidateUnreadableFile(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root reads regardless of mode")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "hosts")
+	if err := os.WriteFile(path, []byte("x"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	// A regular file, and still not one this process can read — every
+	// consumer here opens it, so the type test alone was not enough.
+	if err := (&Config{HostsFile: path}).Validate(); err == nil {
+		t.Fatal("Validate() accepted a file it cannot read")
+	}
+}
+
+func TestValidateUnwritableAccessLog(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root writes regardless of mode")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ro.log")
+	if err := os.WriteFile(path, []byte(""), 0o400); err != nil {
+		t.Fatal(err)
+	}
+	// Opened write-only; the middleware logs the failure and carries on with
+	// access logging quietly switched off.
+	if err := (&Config{AccessLog: path}).Validate(); err == nil {
+		t.Fatal("Validate() accepted an access log it cannot write")
 	}
 }

--- a/config/validate_unix_test.go
+++ b/config/validate_unix_test.go
@@ -286,3 +286,44 @@ func TestValidateRemoteBlocklistNeedsAWritableDir(t *testing.T) {
 		t.Fatal("Validate() accepted a read-only directory for a remote blocklist")
 	}
 }
+
+// TestValidateEquivalentDotDotPaths pins the P3 case. With "there" present,
+// mkdir resolves "/tmp/there/../db" to "/tmp/db" and the log opens inside it —
+// so the two spellings name one place and the pending-directory shortcut has
+// to see that. Unix only: Windows collapses ".." lexically and never reaches
+// this comparison.
+func TestValidateEquivalentDotDotPaths(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "there"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &Config{
+		Directory: dir + "/there/../db",
+		AccessLog: filepath.Join(dir, "db", "access.log"),
+	}
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() missed that the two spellings are one place: %v", err)
+	}
+
+	// And the runtime agrees, in the order it does it.
+	if err := os.Mkdir(cfg.Directory, 0o750); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	f, err := os.OpenFile(cfg.AccessLog, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0o600)
+	if err != nil {
+		t.Fatalf("the runtime could not open the log this config names: %v", err)
+	}
+	f.Close() //nolint:errcheck,gosec // nothing was written
+
+	// A component that is not there is still refused — and the working
+	// directory here is one the server could make, so the shortcut is the
+	// only thing that decides.
+	missing := &Config{
+		Directory: filepath.Join(dir, "db2"),
+		AccessLog: dir + "/gone/../db2/access.log",
+	}
+	if err := missing.Validate(); err == nil {
+		t.Fatal("Validate() accepted a log path through a component that is not there")
+	}
+}

--- a/contrib/linux/sdns.conf
+++ b/contrib/linux/sdns.conf
@@ -216,7 +216,7 @@ api = "127.0.0.1:8080"
 # bearertoken = ""
 
 # Log verbosity level
-# Options: crit, error, warn, info, debug
+# Options: error, warn, info, debug
 loglevel = "info"
 
 # Query access log file path

--- a/internal/emptyzones/zones.go
+++ b/internal/emptyzones/zones.go
@@ -1,0 +1,129 @@
+// Package emptyzones holds the locally-served zones of RFC 6303, the list the
+// AS112 middleware answers for by default.
+//
+// It lives apart from that middleware so the config package can check an
+// operator's list against it. The middleware imports config, so config cannot
+// import the middleware — and a second copy of the list written by hand would
+// drift from this one, which is the mistake worth avoiding.
+package emptyzones
+
+import "github.com/miekg/dns"
+
+// Default is every zone served locally unless the operator names their own.
+// Keys are canonical: lowercase and rooted.
+var Default = map[string]bool{
+	"10.in-addr.arpa.":              true,
+	"16.172.in-addr.arpa.":          true,
+	"17.172.in-addr.arpa.":          true,
+	"18.172.in-addr.arpa.":          true,
+	"19.172.in-addr.arpa.":          true,
+	"20.172.in-addr.arpa.":          true,
+	"21.172.in-addr.arpa.":          true,
+	"22.172.in-addr.arpa.":          true,
+	"23.172.in-addr.arpa.":          true,
+	"24.172.in-addr.arpa.":          true,
+	"25.172.in-addr.arpa.":          true,
+	"26.172.in-addr.arpa.":          true,
+	"27.172.in-addr.arpa.":          true,
+	"28.172.in-addr.arpa.":          true,
+	"29.172.in-addr.arpa.":          true,
+	"30.172.in-addr.arpa.":          true,
+	"31.172.in-addr.arpa.":          true,
+	"168.192.in-addr.arpa.":         true,
+	"64.100.in-addr.arpa.":          true,
+	"65.100.in-addr.arpa.":          true,
+	"66.100.in-addr.arpa.":          true,
+	"67.100.in-addr.arpa.":          true,
+	"68.100.in-addr.arpa.":          true,
+	"69.100.in-addr.arpa.":          true,
+	"70.100.in-addr.arpa.":          true,
+	"71.100.in-addr.arpa.":          true,
+	"72.100.in-addr.arpa.":          true,
+	"73.100.in-addr.arpa.":          true,
+	"74.100.in-addr.arpa.":          true,
+	"75.100.in-addr.arpa.":          true,
+	"76.100.in-addr.arpa.":          true,
+	"77.100.in-addr.arpa.":          true,
+	"78.100.in-addr.arpa.":          true,
+	"79.100.in-addr.arpa.":          true,
+	"80.100.in-addr.arpa.":          true,
+	"81.100.in-addr.arpa.":          true,
+	"82.100.in-addr.arpa.":          true,
+	"83.100.in-addr.arpa.":          true,
+	"84.100.in-addr.arpa.":          true,
+	"85.100.in-addr.arpa.":          true,
+	"86.100.in-addr.arpa.":          true,
+	"87.100.in-addr.arpa.":          true,
+	"88.100.in-addr.arpa.":          true,
+	"89.100.in-addr.arpa.":          true,
+	"90.100.in-addr.arpa.":          true,
+	"91.100.in-addr.arpa.":          true,
+	"92.100.in-addr.arpa.":          true,
+	"93.100.in-addr.arpa.":          true,
+	"94.100.in-addr.arpa.":          true,
+	"95.100.in-addr.arpa.":          true,
+	"96.100.in-addr.arpa.":          true,
+	"97.100.in-addr.arpa.":          true,
+	"98.100.in-addr.arpa.":          true,
+	"99.100.in-addr.arpa.":          true,
+	"100.100.in-addr.arpa.":         true,
+	"101.100.in-addr.arpa.":         true,
+	"102.100.in-addr.arpa.":         true,
+	"103.100.in-addr.arpa.":         true,
+	"104.100.in-addr.arpa.":         true,
+	"105.100.in-addr.arpa.":         true,
+	"106.100.in-addr.arpa.":         true,
+	"107.100.in-addr.arpa.":         true,
+	"108.100.in-addr.arpa.":         true,
+	"109.100.in-addr.arpa.":         true,
+	"110.100.in-addr.arpa.":         true,
+	"111.100.in-addr.arpa.":         true,
+	"112.100.in-addr.arpa.":         true,
+	"113.100.in-addr.arpa.":         true,
+	"114.100.in-addr.arpa.":         true,
+	"115.100.in-addr.arpa.":         true,
+	"116.100.in-addr.arpa.":         true,
+	"117.100.in-addr.arpa.":         true,
+	"118.100.in-addr.arpa.":         true,
+	"119.100.in-addr.arpa.":         true,
+	"120.100.in-addr.arpa.":         true,
+	"121.100.in-addr.arpa.":         true,
+	"122.100.in-addr.arpa.":         true,
+	"123.100.in-addr.arpa.":         true,
+	"124.100.in-addr.arpa.":         true,
+	"125.100.in-addr.arpa.":         true,
+	"126.100.in-addr.arpa.":         true,
+	"127.100.in-addr.arpa.":         true,
+	"0.in-addr.arpa.":               true,
+	"127.in-addr.arpa.":             true,
+	"254.169.in-addr.arpa.":         true,
+	"2.0.192.in-addr.arpa.":         true,
+	"100.51.198.in-addr.arpa.":      true,
+	"113.0.203.in-addr.arpa.":       true,
+	"255.255.255.255.in-addr.arpa.": true,
+	"0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa.": true,
+	"1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa.": true,
+	"d.f.ip6.arpa.":             true,
+	"8.e.f.ip6.arpa.":           true,
+	"9.e.f.ip6.arpa.":           true,
+	"a.e.f.ip6.arpa.":           true,
+	"b.e.f.ip6.arpa.":           true,
+	"8.b.d.0.1.0.0.2.ip6.arpa.": true,
+	"empty.as112.arpa.":         true,
+	"home.arpa.":                true,
+}
+
+// Covers reports whether name, or any zone above it, is one of the zones
+// above. The middleware walks the same suffixes when it decides which
+// configured zones to keep: an entry it does not cover is dropped with a log
+// line, and a list where every entry is dropped falls back to the whole set —
+// so an operator who names a zone outside the tree quietly gets all of them.
+func Covers(name string) bool {
+	name = dns.CanonicalName(name)
+	for off, end := 0, false; !end; off, end = dns.NextLabel(name, off) {
+		if Default[name[off:]] {
+			return true
+		}
+	}
+	return false
+}

--- a/middleware/as112/as112.go
+++ b/middleware/as112/as112.go
@@ -7,6 +7,7 @@ import (
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/config"
 	"github.com/semihalev/sdns/internal/dnsname"
+	"github.com/semihalev/sdns/internal/emptyzones"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/zlog/v2"
 )
@@ -24,7 +25,7 @@ func New(cfg *config.Config) *AS112 {
 		zones := make(map[string]bool)
 
 		for _, zone := range cfg.EmptyZones {
-			if a.Match(zone, dns.TypeSOA) == rootzone {
+			if !emptyzones.Covers(zone) {
 				zlog.Error("Empty zone doesn't match in default empty zones, check your config!", "zone", zone)
 				continue
 			}
@@ -288,107 +289,7 @@ func (a *AS112) Match(name string, qtype uint16) string {
 	return rootzone
 }
 
-var defaultZones = map[string]bool{
-	"10.in-addr.arpa.":              true,
-	"16.172.in-addr.arpa.":          true,
-	"17.172.in-addr.arpa.":          true,
-	"18.172.in-addr.arpa.":          true,
-	"19.172.in-addr.arpa.":          true,
-	"20.172.in-addr.arpa.":          true,
-	"21.172.in-addr.arpa.":          true,
-	"22.172.in-addr.arpa.":          true,
-	"23.172.in-addr.arpa.":          true,
-	"24.172.in-addr.arpa.":          true,
-	"25.172.in-addr.arpa.":          true,
-	"26.172.in-addr.arpa.":          true,
-	"27.172.in-addr.arpa.":          true,
-	"28.172.in-addr.arpa.":          true,
-	"29.172.in-addr.arpa.":          true,
-	"30.172.in-addr.arpa.":          true,
-	"31.172.in-addr.arpa.":          true,
-	"168.192.in-addr.arpa.":         true,
-	"64.100.in-addr.arpa.":          true,
-	"65.100.in-addr.arpa.":          true,
-	"66.100.in-addr.arpa.":          true,
-	"67.100.in-addr.arpa.":          true,
-	"68.100.in-addr.arpa.":          true,
-	"69.100.in-addr.arpa.":          true,
-	"70.100.in-addr.arpa.":          true,
-	"71.100.in-addr.arpa.":          true,
-	"72.100.in-addr.arpa.":          true,
-	"73.100.in-addr.arpa.":          true,
-	"74.100.in-addr.arpa.":          true,
-	"75.100.in-addr.arpa.":          true,
-	"76.100.in-addr.arpa.":          true,
-	"77.100.in-addr.arpa.":          true,
-	"78.100.in-addr.arpa.":          true,
-	"79.100.in-addr.arpa.":          true,
-	"80.100.in-addr.arpa.":          true,
-	"81.100.in-addr.arpa.":          true,
-	"82.100.in-addr.arpa.":          true,
-	"83.100.in-addr.arpa.":          true,
-	"84.100.in-addr.arpa.":          true,
-	"85.100.in-addr.arpa.":          true,
-	"86.100.in-addr.arpa.":          true,
-	"87.100.in-addr.arpa.":          true,
-	"88.100.in-addr.arpa.":          true,
-	"89.100.in-addr.arpa.":          true,
-	"90.100.in-addr.arpa.":          true,
-	"91.100.in-addr.arpa.":          true,
-	"92.100.in-addr.arpa.":          true,
-	"93.100.in-addr.arpa.":          true,
-	"94.100.in-addr.arpa.":          true,
-	"95.100.in-addr.arpa.":          true,
-	"96.100.in-addr.arpa.":          true,
-	"97.100.in-addr.arpa.":          true,
-	"98.100.in-addr.arpa.":          true,
-	"99.100.in-addr.arpa.":          true,
-	"100.100.in-addr.arpa.":         true,
-	"101.100.in-addr.arpa.":         true,
-	"102.100.in-addr.arpa.":         true,
-	"103.100.in-addr.arpa.":         true,
-	"104.100.in-addr.arpa.":         true,
-	"105.100.in-addr.arpa.":         true,
-	"106.100.in-addr.arpa.":         true,
-	"107.100.in-addr.arpa.":         true,
-	"108.100.in-addr.arpa.":         true,
-	"109.100.in-addr.arpa.":         true,
-	"110.100.in-addr.arpa.":         true,
-	"111.100.in-addr.arpa.":         true,
-	"112.100.in-addr.arpa.":         true,
-	"113.100.in-addr.arpa.":         true,
-	"114.100.in-addr.arpa.":         true,
-	"115.100.in-addr.arpa.":         true,
-	"116.100.in-addr.arpa.":         true,
-	"117.100.in-addr.arpa.":         true,
-	"118.100.in-addr.arpa.":         true,
-	"119.100.in-addr.arpa.":         true,
-	"120.100.in-addr.arpa.":         true,
-	"121.100.in-addr.arpa.":         true,
-	"122.100.in-addr.arpa.":         true,
-	"123.100.in-addr.arpa.":         true,
-	"124.100.in-addr.arpa.":         true,
-	"125.100.in-addr.arpa.":         true,
-	"126.100.in-addr.arpa.":         true,
-	"127.100.in-addr.arpa.":         true,
-	"0.in-addr.arpa.":               true,
-	"127.in-addr.arpa.":             true,
-	"254.169.in-addr.arpa.":         true,
-	"2.0.192.in-addr.arpa.":         true,
-	"100.51.198.in-addr.arpa.":      true,
-	"113.0.203.in-addr.arpa.":       true,
-	"255.255.255.255.in-addr.arpa.": true,
-	"0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa.": true,
-	"1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa.": true,
-	"d.f.ip6.arpa.":             true,
-	"8.e.f.ip6.arpa.":           true,
-	"9.e.f.ip6.arpa.":           true,
-	"a.e.f.ip6.arpa.":           true,
-	"b.e.f.ip6.arpa.":           true,
-	"8.b.d.0.1.0.0.2.ip6.arpa.": true,
-	"empty.as112.arpa.":         true,
-	"home.arpa.":                true,
-}
+var defaultZones = emptyzones.Default
 
 const rootzone = "."
 

--- a/sdns.go
+++ b/sdns.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/signal"
 	"runtime/debug"
+	"strings"
 	"syscall"
 	"time"
 
@@ -174,12 +175,14 @@ func validateConfiguration() error {
 		return err
 	}
 
-	// Validate log level
-	switch cfg.LogLevel {
-	case "", "debug", "info", "warn", "error":
-		// Valid log levels
-	default:
-		err := fmt.Errorf("log verbosity level unknown: %s", cfg.LogLevel)
+	// Load only warns about keys nothing claims, so a stale key cannot turn
+	// an upgrade into an outage. This command exists to answer whether the
+	// file is right, so here they are the answer.
+	if unknown := cfg.UndecodedKeys(); len(unknown) > 0 {
+		err := fmt.Errorf(
+			"unknown config keys (typo, or settings this version no longer has): %s",
+			strings.Join(unknown, ", "),
+		)
 		fmt.Fprintf(os.Stderr, "Configuration test failed: %v\n", err)
 		return err
 	}

--- a/sdns.go
+++ b/sdns.go
@@ -35,6 +35,9 @@ var (
 		Long: `SDNS is a high-performance, recursive DNS resolver server with DNSSEC support,
 focused on preserving privacy. For more information, visit https://sdns.dev`,
 		RunE: runServer,
+		// main prints what Execute returns, so cobra printing it too would
+		// say the same thing twice.
+		SilenceErrors: true,
 	}
 
 	versionCmd = &cobra.Command{
@@ -93,6 +96,12 @@ func setup() error {
 }
 
 func runServer(cmd *cobra.Command, args []string) error {
+	// The flags parsed, so anything that fails from here is a problem with
+	// the configuration or the server, not with how the command was called —
+	// and the flag list is no help. Set here rather than on the command, so
+	// a genuine usage error still prints it.
+	cmd.SilenceUsage = true
+
 	// Handle config test mode
 	if testConfig {
 		return validateConfiguration()
@@ -171,7 +180,6 @@ func validateConfiguration() error {
 	var err error
 
 	if cfg, err = config.Load(cfgPath, version); err != nil {
-		fmt.Fprintf(os.Stderr, "Configuration test failed: %v\n", err)
 		return err
 	}
 
@@ -183,7 +191,6 @@ func validateConfiguration() error {
 			"unknown config keys (typo, or settings this version no longer has): %s",
 			strings.Join(unknown, ", "),
 		)
-		fmt.Fprintf(os.Stderr, "Configuration test failed: %v\n", err)
 		return err
 	}
 

--- a/sdns_test.go
+++ b/sdns_test.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestConfigTestReportsOnceWithoutUsage pins what `sdns -t` prints when a
+// config is wrong. It used to say the same thing three times — once from the
+// test path, once from cobra, once from main — and follow it with the flag
+// list, which answers a question nobody asked about a file that is simply
+// wrong.
+func TestConfigTestReportsOnceWithoutUsage(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sdns.conf")
+	body := fmt.Sprintf("version = %q\ndirectory = %q\ndnssec = \"off\"\n"+
+		"rootservers = [\"192.5.5.241:53\"]\nnullroute = \"not-an-ip\"\n",
+		currentConfigVersion(t), filepath.Join(dir, "db"))
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	oldPath, oldTest, oldCfg := cfgPath, testConfig, cfg
+	// runServer silences usage on the shared command; the binary exits right
+	// after, but a test leaves it set for whatever runs next.
+	oldSilence := rootCmd.SilenceUsage
+	defer func() {
+		cfgPath, testConfig, cfg = oldPath, oldTest, oldCfg
+		rootCmd.SilenceUsage = oldSilence
+	}()
+
+	var out bytes.Buffer
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"-c", path, "-t"})
+	defer func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	}()
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() accepted a config with an unusable value")
+	}
+	if !strings.Contains(err.Error(), "nullroute") {
+		t.Fatalf("Execute() = %v, want the problem named", err)
+	}
+
+	got := out.String()
+	if strings.Contains(got, "Usage:") {
+		t.Fatalf("a wrong config printed the flag list:\n%s", got)
+	}
+	if n := strings.Count(got, "nullroute"); n != 0 {
+		// main is the only printer; cobra must stay quiet.
+		t.Fatalf("cobra printed the error itself %d time(s):\n%s", n, got)
+	}
+}
+
+// TestUsageErrorStillPrintsUsage pins the other half: usage is silenced for a
+// bad configuration, not for a bad command line.
+func TestUsageErrorStillPrintsUsage(t *testing.T) {
+	var out bytes.Buffer
+	oldSilence := rootCmd.SilenceUsage
+	rootCmd.SilenceUsage = false
+	rootCmd.SetOut(&out)
+	rootCmd.SetErr(&out)
+	rootCmd.SetArgs([]string{"--nosuchflag"})
+	defer func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+		rootCmd.SilenceUsage = oldSilence
+	}()
+
+	if err := rootCmd.Execute(); err == nil {
+		t.Fatal("Execute() accepted an unknown flag")
+	}
+	if !strings.Contains(out.String(), "Usage:") {
+		t.Fatalf("an unknown flag did not print the flag list:\n%s", out.String())
+	}
+}
+
+// currentConfigVersion reads the version the generator writes, so this test
+// does not carry a copy that goes stale on the next bump.
+func currentConfigVersion(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "gen.conf")
+	oldPath, oldTest := cfgPath, testConfig
+	defer func() { cfgPath, testConfig = oldPath, oldTest }()
+
+	cfgPath, testConfig = path, true
+	_ = validateConfiguration() // generates the file when it is missing
+
+	body, err := os.ReadFile(path) //nolint:gosec // G304 - path is this test's own temp dir
+	if err != nil {
+		t.Fatalf("generate config: %v", err)
+	}
+	for line := range strings.SplitSeq(string(body), "\n") {
+		if after, ok := strings.CutPrefix(line, "version = "); ok {
+			return strings.Trim(strings.TrimSpace(after), "\"")
+		}
+	}
+	t.Fatal("generated config has no version")
+	return ""
+}


### PR DESCRIPTION
`sdns -t` called a config valid when almost nothing in it was. This file passed with exit 0:

```toml
forwardservers = ["1.1.1.1:53"]   # real key is "forwarderservers"
maxdepth_old = 30                  # from an older SDNS
bind = "this is not an address"
nullroute = "not-an-ip"
dnssec = "maybe"
rootservers = ["hello world"]
accesslist = ["999.999.999.999/99"]
```

So did one with a malformed trust anchor, an out-of-range reflex threshold, an IPv6 address in `outboundips`, and a hosts file that does not exist. Loading validated the recursion firewall, the forward zones and one duration. Nothing else.

## Keys nothing claims

The decoder already reports them and `Load` already reads that metadata for another purpose — it was simply never consulted. A typo took no effect and said nothing, and a config carried across an upgrade kept keys this version no longer has with no sign they had stopped working.

They are now recorded and logged. **Startup only warns** — refusing to run over a stale key would turn an upgrade into an outage — while **`sdns -t` fails on them**, since answering "is this file right" is that command's whole job.

Settings retained on purpose for old configs (`qname_min_level`, `killer_mode`) decode into real fields, so they are not reported.

## Values

Ranked by how badly they failed:

- **`rootkeys`** — a malformed anchor is fatal at resolver construction, so `-t` passed and the server then refused to start. The exact opposite of what a config test is for.
- **Silently ignored** — an out-of-range `reflexthreshold` is replaced by the default, so an operator who wrote `42` believed they had set a threshold. `prefetch` is a percentage of the original TTL whose low end alone is clamped, so a value above 100 puts the refresh trigger past the whole lifetime and every hit prefetches. An IPv6 address in `outboundips` is a mistake nothing downstream reports.
- **Failed later and loudly** — bind addresses, TLS material.

Now covered: enumerated values (`dnssec`, `loglevel`), listen addresses, TLS certificate and key when a TLS listener is configured, null routes, access-list entries, authority and forwarder upstreams in each accepted form, the API address, hosts file, hyperlocal transfer sources, plugin paths, blocklist source URLs, blocked and empty zone names, the numbers that cannot be negative, and the settings under their own headings — `views` (zone, networks, answers), `dns64` (prefixes and networks), `ecs` (client networks and scope lengths).

Every problem is reported together:

```
Error: invalid configuration:
  - rootkeys "this is not a DNSKEY record": dns: not a TTL: "is" at line: 1:8
  - outboundips "not-an-ip": must be an IP address
  - api = "not an address": must be host:port
  - hostsfile = "/definitely/not/here/hosts": no such file or directory
  - hyperlocal_root_sources "no-port-here": must be host:port
  - reflexthreshold = 42: must be between 0 and 1
```

## Deliberately not checked

**Domain names are validated for structure, not character set.** RFC 2181 §11 makes a label any binary string, so a name containing a space is unusual but not invalid — rejecting it would be this package inventing a rule. A blocklist entry also keeps its leading `*.`, which is the blocklist's own syntax rather than part of the name.

Judgements this package cannot make — whether an upstream answers, whether a key matches its certificate — stay with whoever uses them.

## Verification

`make test`, `go test -race ./config`, `go vet`, `golangci-lint`, `gofmt` all clean; the stricter load broke no existing test.

**The generated default config passes clean (exit 0)** — the regression that mattered most. Checked end to end with a built binary: both broken configs above now exit 1 naming every problem, and a config whose values are fine but which carries `forwardservers` and `maxdepth_old` warns on load and fails `-t` naming both.

Mutation-tested, each confirmed to turn a named test red: dropping the `Validate` call from `Load`, not recording undecoded keys, accepting `"maybe"` as a `dnssec` value, skipping the outbound address family check, and skipping view answer parsing. One mutation on the rootkeys error branch was examined and found equivalent — with the error ignored, `dns.NewRR` returns nil and the type check that follows rejects it anyway.

## After review

Review found the validator drifting from the runtime in both directions — inventing rules the code does not have, and missing ones it does. Corrections:

**Rules removed.** `views.zone` is a free-form label the middleware only carries into log lines; requiring a domain name there would have refused configs that work today. README already calls it "`zone` (label)".

**Rules corrected.** DNS64 exclude lists are kept by mask length, so an IPv6 prefix in `exclude_a_networks` is dropped with a log line and the exclusion quietly does not apply — each list now takes its own family. Testing the family with `To4() != nil` would have been the same bug the runtime documents against, since `::ffff:0:0/96` is a legal Pref64 with a non-nil `To4()`.

**Rules added.** Blocklist sources are fetched with an HTTP client, so any other scheme parses as a URL and then never loads. The remaining settings that treat zero as "use the default" reject negatives, where a negative is neither the default nor what was asked for.

**Root key algorithms.** Nothing downstream rejects an anchor whose algorithm cannot be verified with: `NewResolver` only fails on a record that will not parse, so such an anchor loads and then fails every signature it is asked to verify — validation is off while the file still says it is on. The question is put to the DNSSEC library rather than answered from a list here, because the set belongs to that library and moves with it. This is not hypothetical: a hand-written list would have claimed ED448 works, and it does not. That case is pinned by a test, and the hand-written-list version of the check was run against it to confirm the test catches it.

**One gate.** Recursion firewall, forward zones and serve-stale reported separately from `Load`, so a file with a firewall typo and a bad address took two runs to fix. They now report through the same collector. The firewall's empty mode is left to `Normalize`, which fills it in before the load path reaches the check.

All eight new or changed rules were mutation-tested individually — each check disabled in turn, the named test confirmed red, then restored.


### Found by running the binary

Two things the tests were green on. Worth recording, because both were caught only by running `sdns -t` against a hand-written file rather than by the suite:

**The one-pass promise was half-kept.** `Load` records unknown keys before the gate, but returns no `Config` when validation fails — so a file with both a bad value and an unknown key reported the value and left the key to a log line. Fixing the value and running again was how you learned about the key: exactly the second run the single gate exists to remove. The keys now join the report. They still never cause a failure on their own.

```
Error: invalid configuration:
  - nullroute = "not-an-ip": must be an IP address
  - unknown keys (a typo, or settings this version no longer has): maxdepth_old
```

**Windows.** Two tests built their TOML by concatenating a `t.TempDir()` path, so on Windows `C:\Users\...` put `\U` inside a basic string and the decoder rejected it as a bad escape. Switched to `%q`, which is what the rest of the package already does.

### Not changed

`sdns -t` prints a config error twice and follows it with a usage dump — `validateConfiguration` writes to stderr and also returns the error, which cobra prints again along with the flag list. Pre-existing and outside this PR, but more visible now that the errors are longer.


### Second review round

Four more, all confirmed against the runtime before being acted on — and one of them found the tests pinning the bug rather than catching it.

**Key material, not just algorithm.** The probe treated only `ErrAlg` as fatal, so a key of a supported algorithm carrying material of the wrong shape passed: P-256 wants 64 bytes and 42 went through. `ErrKey` is fatal now. What makes that safe is measurable rather than assumed — generated keys of RSASHA256, RSASHA512, P-256, P-384 and Ed25519 all fail with a crypto error or a bad signature, never `ErrKey`, while broken material of each of those algorithms produces exactly `ErrKey`. The accepted cases in the test used truncated material, so the test had been asserting the bug; they now carry the live root KSK and a real P-256 key.

**`dnssec = "on"` with no anchor.** Accepted before, and it does not heal: AutoTA needs a seed and refuses to take one from disk when the live set is empty (`auto_trust_anchor.go` — a non-empty live set means "the initial config seed or a previous successful AutoTA"), so every validated answer fails closed from the first query while the file says validation is on. Required now — except behind a global forwarder, which returns from `handler.go` before the resolver materializes anything and so needs no anchor of its own. A forward *zone* only hands over its own subtree, so it still needs one.

**Port range.** `SplitHostPort` separates the halves without reading them, so `bind = ":65536"` reached the listener and failed at bind time, and an upstream with such a port failed on every dial instead. Ports now go to `net.LookupPort` — the same call the net package makes when it listens or dials — rather than a numeric range test, because `:domain` really does listen on 53 and a number test would refuse a config that works. Port 0 stays legal for a listener (ask the kernel for a free one) and not for an upstream (nothing answers there).

**Trimming, per list.** `dns64` reads all five of its lists through `TrimSpace`, and the hyperlocal manager trims and drops blanks — so this branch was refusing values the server runs today. Each list is now read the way its own reader reads it, which also means the `ecs` list stays judged raw, because `internal/ecs` hands the string straight to `netip.ParsePrefix`. Mirroring is per-list; a blanket trim would have been the same class of mistake in the other direction.

`TestConfigVersionMismatch` carried `dnssec = "on"` with `rootkeys = []` as scaffolding. That combination is now refused, so the scaffold sets `dnssec = "off"`; the version warning it tests does not depend on it.

All seven new or changed rules mutation-tested individually, including the two that guard against over-correction: reverting `ecs` to trimmed, and dropping the upstream port-0 rejection.


### Third review round

Twelve findings came back; four were the ones already fixed in `8951c3f` (the review cites `verifiableAlgorithm`, a symbol that no longer exists), so eight were new. All eight were checked against the runtime before being acted on.

**Settings under disabled features were being enforced.** This was the serious one, and it is a regression this branch introduced. `dns64`'s `compileConfig`, `internal/ecs`'s `Build`, and the hyperlocal manager all return before reading another field when the feature is off — so a stale value under a disabled section has no effect on anything, and refusing to start over it turns an upgrade into an outage. Each block is now gated on its own `enabled` flag. Worth recording how this got through: the tests covering those checks were passing **without enabling anything**, so nothing in the suite distinguished "checked when on" from "checked always".

**Paths were checked for existence, not for kind.** A directory satisfies `Stat` and then fails at the read, so a certificate and key pointing at one passed here and stopped the TLS listener at startup — the exact failure mode `-t` exists to prevent. Paths the server *creates* are judged the other way round: `directory`, `blocklistdir` and `accesslog` may be absent (they are created), but a plain file already sitting at the path is refused, because the `Mkdir`/`OpenFile` that follows fails on it. `kubeconfig` is read when the integration is on.

**Null route families.** Blocked names answer A from `nullroute` and AAAA from `nullroutev6`. A swap passed validation, and then the A record packed the IPv6 address's nil `To4()` as `0.0.0.0` — a wrong answer rather than a failure, so nothing downstream complained.

**Numbers the cache silently moves.** A size under 1024 and a prefetch percentage of 1–9 are raised to the cache's own floor without a word, so the file described a server that never ran. Both must now be written as they will run; zero keeps its meaning in each (default, and off).

**Ordering.** `normalizeQnameMinimize` folds a negative minimization count to zero — which turns minimization off — and it ran *before* the gate, so the raw value never reached it. It now runs after.

**Forward zones**, and this was also mine: a zone with no name and no servers reported only the name. The two name problems are alternatives; the missing server list is independent of both.

**URLs.** `url.Parse` leaves `Host` set for `https://:443/dns-query`, which has nothing to connect to. The forwarder bootstraps `Hostname()`, so that is what is checked now, along with an explicit port. Blocklist URLs had the same hole.

Thirteen mutations, each confirmed to turn a named test red — including the three feature gates, both path-kind directions, and the ordering change.

`Test (macos-latest)` failed once on the previous commit in `internal/metric/TestLazyAutoStart`, which sets a 10 ms flush interval and sleeps 40 ms. It is not in this diff's blast radius (this branch touches `config/` only), passes 20/20 locally, and passed on ubuntu and windows in the same run.


### Fourth review round

Ten findings, nine implemented and one deliberately not. Each was checked against the runtime first, and one of the ten did not survive that check.

**Omitted `dnssec` means validation is on.** `Load` turned `""` into `"on"` a few lines *after* the gate, so a file naming neither `dnssec` nor a trust anchor passed the anchor check as though validation were off, then ran with it on and nothing to anchor to. There is no code-level default for `rootkeys` — the anchors come from the file or nowhere. The defaulting now runs before the gate, and the coercion that followed it is gone (unreachable once an invalid value is refused). This is the same mistake as before in the opposite direction: last round I read the consumer (`resolver.go`'s `cfg.DNSSEC == "on"`) and not the producer.

**The signature probe cannot see an invalid curve point.** A throwaway signature decodes to r = s = 0, and `ecdsa.Verify` rejects that before it looks at the public key — so 64 zero bytes came back as `ErrSig` and passed as a usable P-256 anchor. `crypto/ecdh` parses the point, which is exactly the part the probe cannot reach; measured, it rejects all-zeros ("point not on curve") and short encodings while accepting generated P-256 and P-384 keys. Ed25519 has no equivalent parse-time test in the standard library, and the comment says so rather than implying coverage that isn't there.

**`exclude_a_networks` is only read under the well-known prefix** (RFC 6147 §5.1.4 — `if out.hasWellKnown()` in `dns64/config.go`). A deployment on a custom prefix has the list ignored entirely, so judging it there refused a config the server runs. `exclude_aaaa_networks` is *not* gated that way and stays unconditional.

**Reflex**, both directions: `reflex.New` returns before reading the threshold when the feature is off, so that check is gated like the others; and NaN passed the range test, since every comparison against it is false — including the middleware's own `> 0 && <= 1.0` — landing on the same silent 0.7 default an out-of-range value gets.

**Ports** are now compared as the number they resolve to. Measured: `"00"` and `"+0"` both resolve to zero and slipped past a comparison against the literal `"0"`. Blocklist URLs get the port check the forwarder's already had.

**Paths** must be regular files, not merely not-directories — a FIFO passed and would block the reader. Directories the server creates use `Mkdir`, not `MkdirAll`, so their parent must exist; the access log is opened inside an existing directory or logging silently switches off. Permissions are deliberately not probed by opening: a config test run by a different user than the service would read permissions that are not the ones that matter.

**One finding not reproduced.** The review also expected TCP-only service names to be wrongly rejected because the helper passes `"udp"`. Measured on this system, `https`, `ssh` and `smtp` all resolve identically under both protocols, so the false positive does not occur. Rather than switch protocol — which could introduce the very rejection the finding warns about — the helper now accepts a name that *either* protocol resolves, which can only reduce false positives.

**One finding deliberately declined.** An empty `directory` is still not reported here. `os.Mkdir("")` fails loudly a few lines later, so this is not the silent-misconfiguration class the PR targets, and `Validate` also serves configurations built in code, which have no working directory at all. Requiring one made 47 subtests fail on legitimate bare-`Config` construction — refusing every such caller in order to co-report a failure nobody can miss is the wrong trade. Said out loud rather than dropped quietly.

Ten mutations, each confirmed to turn a named test red.


### Fifth review round

Twelve findings: eleven implemented, one declined with reason. Each checked against the runtime first.

**The probe listed failures instead of naming success.** Go refuses an RSA key under 1024 bits with a key-size policy error that is neither `ErrKey` nor `ErrAlg` nor `rsa.ErrVerification` — measured on a config-parsed 512-bit anchor — so it passed as usable while failing every real verification the same way. Enumerating what to reject can never keep up with what the crypto packages add; the probe now names the single outcome a *usable* key may produce (`rsa.ErrVerification` for RSA, a miekg signature failure for the curves) and rejects everything else.

**Rules only a file has to satisfy** moved to a Load-only pass that reports into the same list. This is the answer to the empty-`directory` finding I declined last round: a `Config` built in code supplies what it needs and legitimately leaves the rest empty, so the requirement cannot live in `Validate` — but it can live beside it and still reach one report. Two rules qualify: an empty working directory (`os.Mkdir("")` a few lines on) and a config with no root server, no forwarder and no root forward zone, where `resolver.go` hits `zlog.Fatal` on the first recursive query.

**Outbound addresses must be ones this machine holds** — `parseOutBoundAddrs` makes exactly that test and stops the process when it fails. The IPv6 list is judged only when `ipv6access` is on, since that is when it is read.

**Three more settings judged only where they are read:** the deprecated `qname_min_level` when the new key has not shadowed it (`QnameMinimizeParams` never consults it otherwise), the TCP pool settings behind `tcpkeepalive`, and the Kubernetes settings under `demo` as well as `enabled` — `kubernetes.go` returns only when *both* are false. An invalid `cluster_domain` becomes a suffix no query matches, so the feature answers nothing.

**Ports** are checked against the protocols the endpoint opens: `bind` serves UDP and TCP both, DoQ is UDP, the TLS/DoH/API listeners are TCP. Worth saying plainly: this platform's service tables are not partitioned by protocol, so no config-level test can distinguish `"udp"` from `"tcp"` here. The test proves the plumbing instead — a service name looked up on a network that cannot exist fails, which a numeric port does not, since numbers short-circuit before the network is consulted.

**Files are opened, not just stat'ed.** Type alone does not make a certificate readable, and every consumer here opens it. A dangling symlink is caught with `Lstat` — `Stat` calls it absent and the `Mkdir` that follows fails on the entry already there. The access log must be a regular writable file, since a FIFO would hold the open until a reader arrives.

**One declined.** The listener host stays unjudged. A literal may name an address this machine does not hold yet — that is how a floating address is served, and rejecting it would refuse a working HA config. Whether a *name* resolves is a runtime question of the same class as whether an upstream answers, and answering it would mean `sdns -t` doing DNS lookups through the resolver it is testing. `dns.IsDomainName("bad host")` is true by RFC 2181 §11, which this package has a standing decision not to override, so there is no structural test to fall back on. Pinned as a deliberate absence.

Eleven mutations, each confirmed to turn a named test red. Four of them did **not** fail on the first attempt — the tests were not covering the behaviour, including one where the assertion matched `os.Mkdir("")`'s own error text by accident. Those tests were rewritten until the mutations failed.


### Sixth review round

Nine findings, all nine implemented. One of them corrects a fix from the previous round.

**Forwarding was never an exemption from needing a root, and my last-round change said it was.** `NewResolver` starts `go r.run()` unconditionally, and `run()` calls `checkPriming()` as soon as the middleware is ready — which `zlog.Fatal`s on an empty root list. Keeping the resolver out of the *query path* is not keeping it out of the *process*. The exemption and the `forwardsRoot` helper behind it are gone; a loaded file needs a root server, forwarder or not.

**The IPv6 probe ran after the gate.** It decides whether the v6 lists are read at all, so `outboundip6s` went unjudged on a host that then used it, and a file whose only roots are v6 passed on a host that then had none. Moved before the gate, beside the DNSSEC default — the same ordering bug, found in a second place.

**The access log is opened through a symlink.** Judging the link itself with `Lstat` refused a link to a writable file: a setup that runs today, now behind a gate every load has to pass. `Stat` follows, which is what `OpenFile` does. (`writableDir` keeps `Lstat` deliberately — `Mkdir` does *not* follow, which is the dangling-symlink case.)

**Ed25519, partially.** The probe genuinely cannot separate an invalid Edwards point from a good key with a bad signature — `ed25519.Verify` answers false for both. But the reported vector turns out to be a *non-canonical encoding*, not an off-curve point: its y is 2^255-1, above the field prime. RFC 8032 §5.1.3 recovers y by clearing the sign bit and fails unless what remains is below 2^255-19, so rejecting it is the decoder's own rule. That needs no curve arithmetic and no new dependency. A canonical y that is not on the curve still passes, and the comment says so rather than implying cover that isn't there. The test generates 200 real keys and requires every one to pass, so a check that were too strict would show immediately.

**Ports, per endpoint and now pinned.** DoH brings an HTTP/3 listener with it on UDP at the same address; DoT is dialled over TCP alone; plain DNS asks over UDP and retries over TCP when an answer does not fit. Since a developer machine answers identically for either protocol, `net.LookupPort` is now a seam and a test records which networks each setting is judged over — the caller mappings are asserted directly, which is what the previous round could not do.

**A directory has to be one this process can write in.** Mode bits do not answer that alone — ownership, group and mount flags all decide — so the question is put the only portable way: an entry created and taken straight back out. A read-only parent used to surface one run later for the working directory and not at all for the access log. `TestLoad`'s permission case now reports at the gate with everything else, which is the point of the gate.

**Two settings judged as the pair the runtime settles**, not one field at a time: a one-label count above the maximum is quietly lowered to it, and with minimization off it is not read at all — so the old per-field check reported a value with no effect and missed one that is silently changed. The Kubernetes cluster domain is judged before the trailing dot is stripped, because the runtime strips one and puts one back: `cluster.local..` becomes a suffix with a doubled dot that no query matches.

Twelve mutations, each confirmed to turn a named test red. Two needed the tests rebuilt first — the DoH3 protocol list and the writable-directory probe were not covered by anything until the lookup seam and an unwritable-directory case were added.


### Seventh review round

Four findings, all four implemented. The first corrects a claim made in this PR's own notes.

**Ed25519 point validation is possible with the standard library, and the previous round said it was not.** `ed25519.Verify` returns a bool and answers false for a bad key and a bad signature alike — that is what was checked. `ed25519.VerifyWithOptions` returns an *error* and separates them: `bad public key` for a point off the curve or an encoding above the field prime, `invalid signature` for a key that works. Accepting nothing but the latter is fail-closed, needs no dependency and no curve arithmetic, and catches the canonical-but-off-curve keys the encoding check let through — `y = 2` decodes fine and is not on the curve.

The expected wording is measured from a key generated on the spot rather than written into the source, so a future Go release that rewords it moves both sides together. A hardcoded string would fail in the direction that matters: refusing valid anchors.

The review also corrected the arithmetic in the previous round's test comment. The reported vector's y is `p + 2`, not `2^255 - 1`; the test now derives both vectors from `p` instead of asserting a number, and covers the off-curve case that the encoding check could not reach.

**Three around the writability probe**, all introduced by that probe last round:

- A symlink to a directory returned before the probe ran, so a link to a read-only directory passed while the same directory named directly was refused. The probe runs through the link now — that is the path the server writes to.
- A dangling access-log symlink looked like an ordinary missing file to `Stat`, so the link's own directory was checked instead of the target's. `OpenFile` follows the link before creating, so the target's directory is what has to exist.
- The probe file was left behind whenever `Close` or `Remove` failed. Cleanup is set up the moment the file exists, so every path out undoes it. Pinned by a test that runs the check repeatedly and then requires the directory to hold nothing of ours.

Four mutations, each confirmed to turn a named test red.


### Eighth review round

Four findings, all four implemented. Three of them are rules *this branch added* that judge more than the server does — the same over-strictness the branch has been correcting elsewhere.

**`root6servers` is only read behind `ipv6access`** (`resolver.go`: `if cfg.IPv6Access { for _, s := range cfg.Root6Servers`). Judging it regardless meant a stale IPv6 entry on an IPv4-only host — with no effect before — stopped the server after an upgrade. Note the root-set-emptiness rule was already gated on `IPv6Access`; the per-entry rule was not, which is how it slipped past.

**The leading `*.` belongs to the blocklist alone.** `setLocked` strips it and files the rest in the wildcard map. The whitelist is stored verbatim (`b.w[dns.CanonicalName(entry)] = true`) and matched with `matchHierarchy`, which walks real labels — so `*.example.com` there is a key no query ever produces. The operator who wrote it, meaning to exempt the subdomains, got nothing while `-t` said the file was fine. Whitelisting `example.com` already covers them, and the message says so rather than only refusing.

**`filepath.Dir("/parent/db/")` is `/parent/db`** — the path itself, not its parent — so a working directory written with a trailing slash looked like one whose parent was missing, while `os.Mkdir` takes the slash without complaint. Cleaned before taking the parent, here and for the access log.

**Empty zones needed the data to move.** An entry outside the locally-served tree is dropped by the middleware, and a list where *every* entry is dropped falls back to all ninety-nine — so an operator asking for a narrower set gets the opposite. The tree lived in `middleware/as112`, which imports `config`, so `config` could not ask it, and a second copy written by hand is exactly the drift this PR keeps running into. The list moved to `internal/emptyzones` with the suffix walk that decides membership beside it; the middleware's own check now calls that function too, so there is one rule rather than two. Membership is a suffix walk, not exact equality — `sub.10.in-addr.arpa.` is covered by its parent, and the test pins that.

Five mutations, each confirmed to turn a named test red — including one on the shared suffix walk, to prove the parent-coverage behaviour is really exercised.
