### PR TITLE
Read the debug switches as booleans, and build with the Go we ship

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           # Pinned deliberately: allocation counts are toolchain-sensitive,
           # and the hard-zero gate's verdict must not drift with "stable".
           # Keep in lockstep with go.mod's toolchain directive.
-          go-version: '1.26.5'
+          go-version: '1.27.0'
 
       # The main test job runs with -race on every OS, which skips every
       # !race-tagged allocation pin. This job is where they actually run.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.5-alpine AS builder
+FROM golang:1.27.0-alpine AS builder
 
 COPY . /go/src/github.com/semihalev/sdns/
 

--- a/api/README.md
+++ b/api/README.md
@@ -100,6 +100,8 @@ HTTP/1.1 400 Bad Request
 
 `SDNS_PPROF=1` in the sdns environment enables the standard `net/http/pprof` routes under `/debug/pprof/` (heap, goroutine, allocs, profile, symbol, trace). These bypass the bearer-token check; see Authentication.
 
+The value is read as a boolean, so `1` and `true` turn the routes on while an unset variable, `0`, `false`, or anything that is not a boolean leaves them off. Bind `api` to a loopback address whenever they are on.
+
 ## Server limits
 
 `ReadHeaderTimeout` is 10 s. Batch bodies are bounded by `MaxBytesReader` at 8 MiB. Graceful shutdown waits up to 10 s for in-flight requests when the parent context is cancelled.

--- a/api/api.go
+++ b/api/api.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/pprof"
-	"os"
 	"strings"
 	"time"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/debugenv"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/sdns/middleware/blocklist"
 	"github.com/semihalev/zlog/v2"
@@ -45,11 +45,7 @@ type API struct {
 	metricsHandler http.Handler
 }
 
-var debugpprof bool
-
-func init() {
-	_, debugpprof = os.LookupEnv("SDNS_PPROF")
-}
+var debugpprof = debugenv.PProf()
 
 // New return new api.
 func New(cfg *config.Config) *API {

--- a/go.mod
+++ b/go.mod
@@ -75,4 +75,4 @@ require (
 
 go 1.26.0
 
-toolchain go1.26.5
+toolchain go1.27.0

--- a/internal/debugenv/debugenv.go
+++ b/internal/debugenv/debugenv.go
@@ -1,0 +1,30 @@
+// Package debugenv reads the environment switches that expose sdns's
+// diagnostic surfaces. Each switch is named in exactly one place here, so the
+// two readers of a switch cannot drift apart on either its spelling or its
+// meaning.
+package debugenv
+
+import (
+	"os"
+	"strconv"
+)
+
+// on reports whether a switch is set to a value that asks for the surface.
+//
+// The documented spelling is a boolean — the README uses SDNS_DEBUGNS=true and
+// the API guide uses SDNS_PPROF=1 — so a boolean is what is read, and anything
+// else leaves the surface off: unset, empty, "false", "0", or a word Go does
+// not recognize. Presence alone used to be enough, which read an operator's
+// explicit SDNS_PPROF=false as a request to publish pprof; the routes bypass
+// the API's bearer token, so the failure was silent and in the wrong
+// direction. Off is the safe answer to a value nobody can interpret.
+func on(name string) bool {
+	enabled, err := strconv.ParseBool(os.Getenv(name))
+	return err == nil && enabled
+}
+
+// PProf reports whether the API should serve the net/http/pprof routes.
+func PProf() bool { return on("SDNS_PPROF") }
+
+// DebugNS reports whether the CHAOS-class nameserver debug view is served.
+func DebugNS() bool { return on("SDNS_DEBUGNS") }

--- a/internal/debugenv/debugenv_test.go
+++ b/internal/debugenv/debugenv_test.go
@@ -1,0 +1,62 @@
+package debugenv
+
+import "testing"
+
+func TestUnsetSwitchIsOff(t *testing.T) {
+	if on("SDNS_SWITCH_NOBODY_SET") {
+		t.Fatal("an unset switch reported on")
+	}
+}
+
+// The switch reads a boolean, not mere presence. "false" is the case that
+// matters: it used to turn the surface on, which is the opposite of what the
+// operator who typed it asked for.
+func TestSwitchNeedsABooleanNotMerePresence(t *testing.T) {
+	for name, want := range map[string]bool{
+		"empty": false,
+		"false": false,
+		"FALSE": false,
+		"0":     false,
+		"yes":   false,
+		"on":    false,
+		"true":  true,
+		"TRUE":  true,
+		"1":     true,
+		"t":     true,
+	} {
+		value := name
+		if name == "empty" {
+			value = ""
+		}
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("SDNS_PPROF", value)
+			if got := PProf(); got != want {
+				t.Fatalf("SDNS_PPROF=%q: PProf() = %v, want %v", value, got, want)
+			}
+		})
+	}
+}
+
+// Each switch answers for its own variable — the two must not collapse onto
+// one name, which is the way a shared helper would fail silently.
+func TestSwitchesReadTheirOwnVariable(t *testing.T) {
+	t.Setenv("SDNS_PPROF", "true")
+	t.Setenv("SDNS_DEBUGNS", "false")
+
+	if !PProf() {
+		t.Error("PProf() = false with SDNS_PPROF=true")
+	}
+	if DebugNS() {
+		t.Error("DebugNS() = true with SDNS_DEBUGNS=false")
+	}
+
+	t.Setenv("SDNS_PPROF", "false")
+	t.Setenv("SDNS_DEBUGNS", "true")
+
+	if PProf() {
+		t.Error("PProf() = true with SDNS_PPROF=false")
+	}
+	if !DebugNS() {
+		t.Error("DebugNS() = false with SDNS_DEBUGNS=true")
+	}
+}

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"net/netip"
-	"os"
 	"slices"
 	"strings"
 	"sync"
@@ -14,6 +13,7 @@ import (
 	"github.com/semihalev/sdns/config"
 	internalcache "github.com/semihalev/sdns/internal/cache"
 	"github.com/semihalev/sdns/internal/contextutil"
+	"github.com/semihalev/sdns/internal/debugenv"
 	"github.com/semihalev/sdns/internal/dnsutil"
 	"github.com/semihalev/sdns/internal/ecs"
 	"github.com/semihalev/sdns/internal/metric"
@@ -24,11 +24,7 @@ import (
 	"golang.org/x/time/rate"
 )
 
-var debugns bool
-
-func init() {
-	_, debugns = os.LookupEnv("SDNS_DEBUGNS")
-}
+var debugns = debugenv.DebugNS()
 
 const (
 	name   = "cache"

--- a/middleware/resolver/handler.go
+++ b/middleware/resolver/handler.go
@@ -2,7 +2,6 @@ package resolver
 
 import (
 	"context"
-	"os"
 	"time"
 
 	"github.com/miekg/dns"
@@ -10,6 +9,7 @@ import (
 	"github.com/semihalev/sdns/internal/authority"
 	"github.com/semihalev/sdns/internal/cache"
 	"github.com/semihalev/sdns/internal/contextutil"
+	"github.com/semihalev/sdns/internal/debugenv"
 	"github.com/semihalev/sdns/internal/dnsutil"
 	"github.com/semihalev/sdns/middleware"
 	"github.com/semihalev/zlog/v2"
@@ -50,10 +50,7 @@ const contextKeyNSList contextKey = 1 << 16
 const maxDnameDepth = 10
 
 // debugns is initialized once at startup.
-var debugns = func() bool {
-	_, ok := os.LookupEnv("SDNS_DEBUGNS")
-	return ok
-}()
+var debugns = debugenv.DebugNS()
 
 // New returns a new Handler.
 func New(cfg *config.Config) *DNSHandler {


### PR DESCRIPTION
Two small defects found while profiling, both pre-tag hygiene.

## The switches meant the opposite of what they said

`SDNS_PPROF` and `SDNS_DEBUGNS` were read with `os.LookupEnv` and the value discarded:

```go
_, debugpprof = os.LookupEnv("SDNS_PPROF")
```

Presence alone enabled the surface. `SDNS_PPROF=false` — which is what an operator writes to turn profiling *off* — turned it **on**. The pprof routes bypass the API's bearer-token check, so the failure was silent and in the unsafe direction.

Both variables are documented as booleans (`SDNS_DEBUGNS=true` in the README, `SDNS_PPROF=1` in the API guide), so a boolean is now what gets read. Unset, empty, `0`, `false`, or a word Go does not recognize all leave the surface off — off being the safe answer to a value nobody can interpret.

The two readers of `SDNS_DEBUGNS` had each grown their own copy of the lookup in separate packages. `internal/debugenv` names each switch exactly once so its spelling and its meaning cannot drift apart again; a test pins that the two functions answer for their own variable.

## The gate verified a toolchain nobody released

`go.mod` pinned `toolchain go1.26.5`, and the allocation gate was pinned to match it deliberately — allocation counts are toolchain-sensitive and its verdict must not drift with `stable`. But `release.yml` builds with `stable` and the Dockerfile built with `golang:1.26.5-alpine`, so the published binary and the gate had come apart.

`go.mod`, the `Dockerfile` and the gate now all say `1.27.0`, and the gate passes there. Two things deliberately unchanged:

- the `go` directive stays at `1.26.0`, so the language floor — and the `stdversion` vet check that enforces it — is untouched, and downstream builders are not forced to a newer toolchain;
- `BENCHMARKS.md` keeps saying 1.26.5, because it records the toolchain a published measurement actually used.

## Verification

Full suite green · `-race` clean on the touched packages · `golangci-lint` 0 issues · `go vet` clean on linux/darwin/windows/freebsd · allocation gate clean under 1.27.