### PR TITLE
Let three flaky tests fail for their own reasons

### DIFF
--- a/internal/cache/eviction_storm_test.go
+++ b/internal/cache/eviction_storm_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"runtime"
 	"sort"
 	"sync"
 	"sync/atomic"
@@ -178,17 +179,39 @@ func TestAddLatencyUnderEvictionStorm(t *testing.T) {
 			"reads are queueing behind bulk eviction work",
 			getP99, maxStall)
 	}
-	if !isCI() {
-		if addMax > maxStall {
-			t.Errorf("Add stalled %v under eviction storm, want < %v; "+
-				"an insert must never wait on bulk eviction work",
-				addMax, maxStall)
-		}
-		if getMax > maxStall {
-			t.Errorf("Get stalled %v under eviction storm, want < %v; "+
-				"reads must never wait on bulk eviction work",
-				getMax, maxStall)
-		}
+	if isCI() {
+		return
+	}
+
+	// The absolute bound is a single worst sample, so one descheduling event
+	// spends the whole budget. isCI() was the proxy for "dedicated hardware",
+	// but a developer machine is not dedicated either while it is running the
+	// rest of the suite, and that is where this bound went red without a
+	// regression behind it. Ask the machine instead of guessing from the
+	// environment: measure what it costs to deschedule a loop that touches no
+	// cache at all, at the same concurrency, right after the storm. When that
+	// alone reaches the bound, the storm's maximum cannot be attributed to
+	// eviction and the bound is not evidence of anything.
+	//
+	// The p99 assertions above stay unconditional: they held at ~30µs on a
+	// host oversubscribed nearly threefold, which is the whole reason they
+	// are the portable signal.
+	if floor := schedulerStallMax(writers+readers, 300*time.Millisecond); floor >= maxStall {
+		t.Logf("absolute-stall bound not asserted: this host descheduled a "+
+			"no-op loop for %v against a %v bound (add max %v, get max %v)",
+			floor, maxStall, addMax, getMax)
+		return
+	}
+
+	if addMax > maxStall {
+		t.Errorf("Add stalled %v under eviction storm, want < %v; "+
+			"an insert must never wait on bulk eviction work",
+			addMax, maxStall)
+	}
+	if getMax > maxStall {
+		t.Errorf("Get stalled %v under eviction storm, want < %v; "+
+			"reads must never wait on bulk eviction work",
+			getMax, maxStall)
 	}
 }
 
@@ -228,4 +251,45 @@ func BenchmarkAddUnderCapacity(b *testing.B) {
 			c.Add(k, int(k)) //nolint:gosec // G115 - bench key
 		}
 	})
+}
+
+// schedulerStallMax reports the longest a goroutine waited on this machine
+// when nothing was asked of it but the scheduler, at the concurrency the
+// storm runs at. It is the floor under any single stall the storm test can
+// attribute to the cache: whatever eviction does, it cannot be seen beneath
+// the delay the host imposes on a loop that touches nothing.
+//
+// The maximum is what this compares against, because the bound it guards is
+// itself a maximum — one sample against one sample.
+func schedulerStallMax(goroutines int, d time.Duration) time.Duration {
+	var (
+		mu   sync.Mutex
+		lat  []time.Duration
+		stop atomic.Bool
+		wg   sync.WaitGroup
+	)
+	for range goroutines {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			local := make([]time.Duration, 0, 1<<14)
+			for !stop.Load() {
+				start := time.Now()
+				runtime.Gosched()
+				local = append(local, time.Since(start))
+			}
+			mu.Lock()
+			lat = append(lat, local...)
+			mu.Unlock()
+		}()
+	}
+	time.Sleep(d)
+	stop.Store(true)
+	wg.Wait()
+
+	if len(lat) == 0 {
+		return 0
+	}
+	sort.Slice(lat, func(i, j int) bool { return lat[i] < lat[j] })
+	return lat[len(lat)-1]
 }

--- a/middleware/resolver/query_copy_test.go
+++ b/middleware/resolver/query_copy_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"math"
 	"testing"
 
 	"github.com/miekg/dns"
@@ -144,11 +145,28 @@ func TestAcquireAttemptReqAllocatesNothing(t *testing.T) {
 	// inside binary.Read, a pre-existing per-attempt cost this test does
 	// not own. The one allocation left is the private OPT shell —
 	// packing writes into the OPT header, so attempts cannot share it.
-	if n := testing.AllocsPerRun(100, func() {
+	if n := minAllocsPerRun(5, 100, func() {
 		att := acquireAttemptReq(leader)
 		att.Id = 42
 		ReleaseMsg(att)
 	}); n != 1 {
 		t.Fatalf("allocs = %v, want exactly the OPT shell", n)
 	}
+}
+
+// minAllocsPerRun is testing.AllocsPerRun repeated, keeping the lowest count.
+//
+// Allocation noise is one-sided: something else in the process allocating
+// during a measurement can only raise the average, never lower it. So the
+// minimum across repeats is the count the code under test actually pays, and
+// a pin written against it goes red for a real regression rather than for a
+// busy machine. A regression still shows, because it raises every repeat.
+func minAllocsPerRun(repeats, runs int, f func()) float64 {
+	lowest := math.Inf(1)
+	for range repeats {
+		if n := testing.AllocsPerRun(runs, f); n < lowest {
+			lowest = n
+		}
+	}
+	return lowest
 }

--- a/server/restart_test.go
+++ b/server/restart_test.go
@@ -17,20 +17,28 @@ import (
 // them assigns the ephemeral port — and on Windows a port handed out for
 // UDP can fall inside a range excluded for TCP, so the bind fails on the
 // fixture instead of on the property under test.
+// dualStackFreeAddr finds a loopback port both transports will accept.
+//
+// TCP picks the port and UDP confirms it, not the other way round: Windows
+// keeps excluded ephemeral ranges that TCP must avoid and UDP need not, so a
+// port chosen for UDP can be one TCP is never allowed to bind, and every
+// attempt draws from the same forbidden pool. Asking the constrained
+// transport first means the retries are spent only on the genuine race — the
+// port going to another process between the two binds.
 func dualStackFreeAddr(t *testing.T) string {
 	t.Helper()
 	for range 20 {
-		pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
 		if err != nil {
 			continue
 		}
-		addr := pc.LocalAddr().String()
-		ln, err := net.Listen("tcp", addr)
-		_ = pc.Close()
+		addr := ln.Addr().String()
+		pc, err := net.ListenPacket("udp", addr)
+		_ = ln.Close()
 		if err != nil {
 			continue // this port is spoken for on the other transport
 		}
-		_ = ln.Close()
+		_ = pc.Close()
 		return addr
 	}
 	t.Fatal("no loopback port both transports would accept")


### PR DESCRIPTION
Closes the three open flake tasks. Each test went red without a regression behind it, and each was measuring the host as much as the code.

## Eviction storm (`TestAddLatencyUnderEvictionStorm`)

The absolute per-operation stall bound was gated on `!isCI()`, reading "not CI" as "dedicated hardware". A developer machine running the rest of the suite is not dedicated either — and that is exactly where it went red. The bound is a *single worst sample*, so one descheduling event spends the whole 50 ms budget.

It now asks the machine rather than inferring from the environment: a no-op loop at the same concurrency, timed immediately after the storm. When the host's own scheduling reaches the bound, the storm's maximum cannot be attributed to eviction, so the bound is not asserted and the numbers are logged instead.

Verified both directions on a 10-core host:

| | before | after |
| --- | --- | --- |
| 28 spinning processes | `FAIL` — Add stalled 64 ms | `PASS` — floor 125 ms reported, bound not asserted |
| quiet | `PASS`, bound asserted | `PASS`, bound asserted (no log line) |

The p99 assertions stay unconditional. They held at ~32 µs under that same 2.8× oversubscription, which is the whole reason they are the portable signal — the failure this test exists to catch drags p99 across hundreds of thousands of samples.

## Attempt-copy pin (`TestAcquireAttemptReqAllocatesNothing`)

Compared one `AllocsPerRun` against an exact count. Allocation noise is one-sided — another goroutine allocating during the measurement can only raise the average, never lower it — so the lowest of several runs is the count the code actually pays. A regression still shows, because it raises every run.

## `dualStackFreeAddr`

Asked UDP for a port, then hoped TCP would take it. Windows keeps excluded ephemeral ranges that TCP must avoid and UDP need not, so a port chosen for UDP can be one TCP is never allowed to bind — and all twenty retries draw from the same forbidden pool. TCP picks now and UDP confirms, leaving the retries for the genuine race (the port going to another process between the two binds).

## Verification

Full suite green · `golangci-lint` 0 issues · `GOOS=windows go vet ./server/` clean · the two restart tests and the alloc pin pass under the same artificial load.