### PR TITLE
Skip a record that only claims to be a DNSKEY, rather than asserting on it

### DIFF
--- a/middleware/resolver/auto_trust_anchor.go
+++ b/middleware/resolver/auto_trust_anchor.go
@@ -268,15 +268,22 @@ func (r *Resolver) AutoTA() {
 	}
 
 	for _, k := range candidate {
-		validTag := dnssec.KeyTag(k.(*dns.DNSKEY))
-		ok := false
+		key, ok := k.(*dns.DNSKEY)
+		if !ok {
+			continue
+		}
+		validTag := dnssec.KeyTag(key)
+		configured := false
 		for _, kv := range r.configuredRootKeys {
-			currTag := dnssec.KeyTag(kv.(*dns.DNSKEY))
-			if currTag == validTag {
-				ok = true
+			current, ok := kv.(*dns.DNSKEY)
+			if !ok {
+				continue
+			}
+			if dnssec.KeyTag(current) == validTag {
+				configured = true
 			}
 		}
-		if !ok {
+		if !configured {
 			zlog.Warn("Please update missing rootkeys in config", "keytag", validTag)
 		}
 	}
@@ -728,11 +735,12 @@ func verifyFetchedKeysWithWork(
 
 	currentKeys := make(map[uint16][]*dns.DNSKEY)
 	for _, r := range rootKeys {
-		dnskey := r.(*dns.DNSKEY)
-		if dnskey.Flags&DNSKEYFlagKSK != 0 {
-			tag := dnssec.KeyTag(dnskey)
-			currentKeys[tag] = append(currentKeys[tag], dnskey)
+		dnskey, ok := r.(*dns.DNSKEY)
+		if !ok || dnskey.Flags&DNSKEYFlagKSK == 0 {
+			continue
 		}
+		tag := dnssec.KeyTag(dnskey)
+		currentKeys[tag] = append(currentKeys[tag], dnskey)
 	}
 
 	if len(currentKeys) == 0 {
@@ -748,8 +756,8 @@ func verifyFetchedKeysWithWork(
 	// collides on tag.
 	revokedBootstrap := make(map[uint16][]*dns.DNSKEY)
 	for _, r := range fetchedkeys {
-		dnskey := r.(*dns.DNSKEY)
-		if dnskey.Flags&DNSKEYFlagRevoke == 0 {
+		dnskey, ok := r.(*dns.DNSKEY)
+		if !ok || dnskey.Flags&DNSKEYFlagRevoke == 0 {
 			continue
 		}
 		for _, candidate := range currentKeys[dnssec.KeyTag(dnskey)-DNSKEYFlagRevoke] {

--- a/middleware/resolver/auto_trust_anchor_types_test.go
+++ b/middleware/resolver/auto_trust_anchor_types_test.go
@@ -1,0 +1,90 @@
+package resolver
+
+import (
+	"bytes"
+	"encoding/base64"
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// unlimitedSignatureWork lets every verification attempt through: these tests
+// are about the type of the records, not about the work budget.
+type unlimitedSignatureWork struct{}
+
+func (unlimitedSignatureWork) CheckDNSKEYCandidate(uint32) error { return nil }
+func (unlimitedSignatureWork) CheckRRsetSignature(uint32) error  { return nil }
+func (unlimitedSignatureWork) BeginSignature() (func(), error)   { return func() {}, nil }
+
+// dnskeyImpostor answers TypeDNSKEY from its header without being a
+// *dns.DNSKEY. dnsutil.ExtractRRSet selects on the header, so an impostor
+// reaches every loop a real key reaches — and an unchecked type assertion
+// there is a panic in the trust-anchor refresh, which takes the resolver with
+// it. The records these loops walk come from a network response and from
+// configuration, so neither source is ours to trust.
+func dnskeyImpostor() dns.RR {
+	return &dns.RFC3597{
+		Hdr: dns.RR_Header{
+			Name: ".", Rrtype: dns.TypeDNSKEY,
+			Class: dns.ClassINET, Ttl: 172800,
+		},
+		Rdata: "00",
+	}
+}
+
+func testRootKSK() *dns.DNSKEY {
+	return &dns.DNSKEY{
+		Hdr: dns.RR_Header{
+			Name: ".", Rrtype: dns.TypeDNSKEY,
+			Class: dns.ClassINET, Ttl: 172800,
+		},
+		Flags: 257, Protocol: 3, Algorithm: dns.RSASHA256,
+		PublicKey: base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0x5a}, 260)),
+	}
+}
+
+// TestVerifyFetchedKeysSkipsRecordsThatAreNotDNSKEYs pins both loops that walk
+// records claiming to be DNSKEYs: the configured trust anchors, and the keys
+// fetched from the root. Each must skip a record it cannot use rather than
+// assert on its type.
+func TestVerifyFetchedKeysSkipsRecordsThatAreNotDNSKEYs(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		rootKeys []dns.RR
+		rrs      []dns.RR
+	}{
+		{
+			// Reaches the trust-anchor loop: with nothing usable in it,
+			// the answer is "no KSK", not a crash.
+			name:     "impostor among the trust anchors",
+			rootKeys: []dns.RR{dnskeyImpostor()},
+			rrs:      []dns.RR{dnskeyImpostor()},
+		},
+		{
+			// A usable anchor gets past the first loop, so the fetched-key
+			// loop is the one that meets the impostor.
+			name:     "impostor among the fetched keys",
+			rootKeys: []dns.RR{testRootKSK()},
+			rrs:      []dns.RR{dnskeyImpostor()},
+		},
+		{
+			// Both loops see one of each: the impostor must be stepped over
+			// without taking the real key with it.
+			name:     "impostor beside a real key",
+			rootKeys: []dns.RR{dnskeyImpostor(), testRootKSK()},
+			rrs:      []dns.RR{dnskeyImpostor(), testRootKSK()},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ok, _, err := verifyFetchedKeysWithWork(
+				tc.rootKeys, tc.rrs, unlimitedSignatureWork{})
+			if ok {
+				t.Fatal("nothing here is signed, so nothing may verify")
+			}
+			if err == nil {
+				t.Fatal("want an error naming what was missing")
+			}
+			t.Logf("err = %v", err)
+		})
+	}
+}


### PR DESCRIPTION
## The defect

Four loops in `auto_trust_anchor.go` took `rr.(*dns.DNSKEY)` without checking, while three others in the same file already did — so the file was inconsistent as well as unsafe.

A record can carry `Rrtype` DNSKEY in its header without being a `*dns.DNSKEY`; `dns.RFC3597` is exactly that shape. `dnsutil.ExtractRRSet` selects on the header, so such a record reaches every loop a real key reaches.

The two sources feeding these loops are a root DNSKEY response and the operator's configuration. Neither is ours to trust, and a panic in `AutoTA` is not a failed refresh — it takes the resolver down.

## The fix

Each site now skips what it cannot use, matching the guarded sites beside it:

```go
dnskey, ok := r.(*dns.DNSKEY)
if !ok || dnskey.Flags&DNSKEYFlagKSK == 0 {
    continue
}
```

## Verification

`TestVerifyFetchedKeysSkipsRecordsThatAreNotDNSKEYs` drives `verifyFetchedKeysWithWork` with an impostor among the trust anchors, among the fetched keys, and beside a real key. Removing either guard makes it panic:

```
panic: interface conversion: dns.RR is *dns.RFC3597, not *dns.DNSKEY
```

Restoring it returns a named error instead — `No KSK DNSKEY matches DS records from parent` for the anchor case, `Response is missing required RRSIG records` for the others.

Stated plainly: the two sites inside `AutoTA` (lines 271/278) only feed a "please update your config" warning, and `AutoTA` drives a network refresh, so they are covered by the shape of the fix rather than by the test.

Full suite green · `golangci-lint` 0 issues.