### PR TITLE
RPZ phase 2: the CLIENT-IP trigger

### DIFF
--- a/internal/rpz/clientip.go
+++ b/internal/rpz/clientip.go
@@ -134,8 +134,15 @@ func parseClientIPOwner(enc string) (netip.Prefix, bool) {
 		}
 		var b [4]byte
 		for i, s := range labels {
-			v, _ := strconv.Atoi(s)
-			b[3-i] = byte(v) //nolint:gosec // G115 - isV4Octets bounded v to 0..255
+			// ParseUint's 8-bit cap makes the byte conversion's bound
+			// local and provable — isV4Octets already guaranteed it, but
+			// a guarantee an analyzer cannot see is one a reader has to
+			// chase too.
+			v, err := strconv.ParseUint(s, 10, 8)
+			if err != nil {
+				return netip.Prefix{}, false
+			}
+			b[3-i] = byte(v)
 		}
 		return netip.PrefixFrom(netip.AddrFrom4(b), bits), true
 	}

--- a/internal/rpz/clientip.go
+++ b/internal/rpz/clientip.go
@@ -11,10 +11,15 @@ import (
 // rpz-client-ip (draft §4.1.1): "prefix.B4.B3.B2.B1" for IPv4 — octets
 // reversed, IN-ADDR.ARPA style — and "prefix.W8...W1" for IPv6, the
 // 16-bit hextets reversed, with a single "zz" label standing for a run of
-// zero fields. Everything is carried internally in the 128-bit space:
-// IPv4 rules map to their 4-in-6 form with the prefix length shifted by
-// +96, so one structure serves both families and the client address is
-// canonicalized the same way at query time.
+// zero fields.
+//
+// The two families stay in SEPARATE tables, deliberately. Folding IPv4
+// into the ::ffff/96 corner of one 128-bit space read well and was wrong
+// twice over: a short IPv6 prefix — ::/0 above all — would swallow every
+// IPv4 client, applying a rule the feed wrote for one family to the
+// other; and an IPv6 ::ffff:0:0/96 rule collided with IPv4 0.0.0.0/0 in
+// the same slot. An encoding names its family, and the family is part of
+// what the rule means.
 
 // ipLPM is the action-carrying longest-prefix-match structure the design
 // calls for (§5.3). internal/ipset cannot serve here: its Contains answers
@@ -34,9 +39,9 @@ type ipLPM struct {
 
 // insert files a rule under its masked prefix. The bool reports whether
 // the slot was free; a second rule at the same prefix is the caller's
-// conflict to count.
+// conflict to count. A table holds one family; the caller routes.
 func (l *ipLPM) insert(p netip.Prefix, r *Rule) bool {
-	masked := canonical16(p.Masked().Addr())
+	masked := p.Masked().Addr()
 	for i, n := range l.lens {
 		if n != p.Bits() {
 			continue
@@ -69,7 +74,7 @@ func (l *ipLPM) lookupExact(p netip.Prefix) *Rule {
 	if l == nil {
 		return nil
 	}
-	masked := canonical16(p.Masked().Addr())
+	masked := p.Masked().Addr()
 	for i, n := range l.lens {
 		if n == p.Bits() {
 			return l.tables[i][masked]
@@ -79,9 +84,9 @@ func (l *ipLPM) lookupExact(p netip.Prefix) *Rule {
 }
 
 // lookup returns the longest-prefix rule containing addr, with the
-// matched prefix length, or nil. addr must already be canonical
-// (canonical16). Zero allocations: prefix masking is value math and the
-// map is keyed by a comparable value.
+// matched prefix length, or nil. addr must be in the table's own family
+// form (CanonicalClient's output). Zero allocations: prefix masking is
+// value math and the map is keyed by a comparable value.
 func (l *ipLPM) lookup(addr netip.Addr) (*Rule, int) {
 	if l == nil {
 		return nil, 0
@@ -95,15 +100,11 @@ func (l *ipLPM) lookup(addr netip.Addr) (*Rule, int) {
 	return nil, 0
 }
 
-// canonical16 lifts any address into the 16-byte form, so an IPv4 client
-// and an IPv4-encoded rule meet in the same key space as IPv6.
-func canonical16(a netip.Addr) netip.Addr {
-	return netip.AddrFrom16(a.As16())
-}
-
 // CanonicalClient is the query-time twin of the rule-side encoding: the
-// client's address in the shared 128-bit key space.
-func CanonicalClient(a netip.Addr) netip.Addr { return canonical16(a) }
+// client's address in its family's native form. Unmap matters — a
+// transport may hand an IPv4 client over as ::ffff:a.b.c.d, and that
+// spelling must meet the IPv4 rules, not the IPv6 ones.
+func CanonicalClient(a netip.Addr) netip.Addr { return a.Unmap() }
 
 // parseClientIPOwner decodes the owner labels ahead of the rpz-client-ip
 // marker into a 128-bit-space prefix. enc is the relative owner with the
@@ -125,7 +126,8 @@ func parseClientIPOwner(enc string) (netip.Prefix, bool) {
 	}
 	labels = labels[1:]
 
-	// IPv4: exactly four decimal octet labels, reversed.
+	// IPv4: exactly four decimal octet labels, reversed. The prefix
+	// stays in its own family — the family is part of what a rule means.
 	if len(labels) == 4 && isV4Octets(labels) {
 		if bits > 32 {
 			return netip.Prefix{}, false
@@ -135,8 +137,7 @@ func parseClientIPOwner(enc string) (netip.Prefix, bool) {
 			v, _ := strconv.Atoi(s)
 			b[3-i] = byte(v) //nolint:gosec // G115 - isV4Octets bounded v to 0..255
 		}
-		mapped := canonical16(netip.AddrFrom4(b))
-		return netip.PrefixFrom(mapped, bits+96), true
+		return netip.PrefixFrom(netip.AddrFrom4(b), bits), true
 	}
 
 	// IPv6: up to eight hextet labels, reversed, with one optional "zz"

--- a/internal/rpz/clientip.go
+++ b/internal/rpz/clientip.go
@@ -1,0 +1,206 @@
+package rpz
+
+import (
+	"net/netip"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// The CLIENT-IP trigger encodes an address block as an owner name under
+// rpz-client-ip (draft §4.1.1): "prefix.B4.B3.B2.B1" for IPv4 — octets
+// reversed, IN-ADDR.ARPA style — and "prefix.W8...W1" for IPv6, the
+// 16-bit hextets reversed, with a single "zz" label standing for a run of
+// zero fields. Everything is carried internally in the 128-bit space:
+// IPv4 rules map to their 4-in-6 form with the prefix length shifted by
+// +96, so one structure serves both families and the client address is
+// canonicalized the same way at query time.
+
+// ipLPM is the action-carrying longest-prefix-match structure the design
+// calls for (§5.3). internal/ipset cannot serve here: its Contains answers
+// only a bool and it coalesces overlapping prefixes, while policy needs
+// the matched rule back and overlapping prefixes kept distinct.
+//
+// Shape: one map of masked addresses per prefix length actually present,
+// walked longest-first. The walk is bounded by the feed's distinct
+// lengths, not by us — the adversarial all-lengths benchmark beside this
+// file is the exit criterion that keeps the shape honest.
+type ipLPM struct {
+	// lens holds the prefix lengths present, sorted descending, so the
+	// first hit on the walk is the longest match (precedence rule 4).
+	lens   []int
+	tables []map[netip.Addr]*Rule
+}
+
+// insert files a rule under its masked prefix. The bool reports whether
+// the slot was free; a second rule at the same prefix is the caller's
+// conflict to count.
+func (l *ipLPM) insert(p netip.Prefix, r *Rule) bool {
+	masked := canonical16(p.Masked().Addr())
+	for i, n := range l.lens {
+		if n != p.Bits() {
+			continue
+		}
+		if _, taken := l.tables[i][masked]; taken {
+			return false
+		}
+		l.tables[i][masked] = r
+		return true
+	}
+	l.lens = append(l.lens, p.Bits())
+	l.tables = append(l.tables, map[netip.Addr]*Rule{masked: r})
+	// Load-time only; the sort keeps the query walk longest-first.
+	sort.Sort(sort.Reverse(byLen{l}))
+	return true
+}
+
+type byLen struct{ l *ipLPM }
+
+func (b byLen) Len() int           { return len(b.l.lens) }
+func (b byLen) Less(i, j int) bool { return b.l.lens[i] < b.l.lens[j] }
+func (b byLen) Swap(i, j int) {
+	b.l.lens[i], b.l.lens[j] = b.l.lens[j], b.l.lens[i]
+	b.l.tables[i], b.l.tables[j] = b.l.tables[j], b.l.tables[i]
+}
+
+// lookupExact returns the rule filed under exactly this prefix, for the
+// load-time merge/conflict decision.
+func (l *ipLPM) lookupExact(p netip.Prefix) *Rule {
+	if l == nil {
+		return nil
+	}
+	masked := canonical16(p.Masked().Addr())
+	for i, n := range l.lens {
+		if n == p.Bits() {
+			return l.tables[i][masked]
+		}
+	}
+	return nil
+}
+
+// lookup returns the longest-prefix rule containing addr, with the
+// matched prefix length, or nil. addr must already be canonical
+// (canonical16). Zero allocations: prefix masking is value math and the
+// map is keyed by a comparable value.
+func (l *ipLPM) lookup(addr netip.Addr) (*Rule, int) {
+	if l == nil {
+		return nil, 0
+	}
+	for i, bits := range l.lens {
+		p := netip.PrefixFrom(addr, bits)
+		if r, ok := l.tables[i][p.Masked().Addr()]; ok {
+			return r, bits
+		}
+	}
+	return nil, 0
+}
+
+// canonical16 lifts any address into the 16-byte form, so an IPv4 client
+// and an IPv4-encoded rule meet in the same key space as IPv6.
+func canonical16(a netip.Addr) netip.Addr {
+	return netip.AddrFrom16(a.As16())
+}
+
+// CanonicalClient is the query-time twin of the rule-side encoding: the
+// client's address in the shared 128-bit key space.
+func CanonicalClient(a netip.Addr) netip.Addr { return canonical16(a) }
+
+// parseClientIPOwner decodes the owner labels ahead of the rpz-client-ip
+// marker into a 128-bit-space prefix. enc is the relative owner with the
+// marker stripped, e.g. "24.0.2.0.192" or "128.1.zz.db8.2001". ok is
+// false for an encoding the draft does not describe — counted by the
+// caller as SkipOwnerEncoding, never a load failure.
+//
+// Host bits below the prefix are masked rather than refused: feeds vary
+// in whether they write the network address exactly, and the rule the
+// operator meant is the block either way.
+func parseClientIPOwner(enc string) (netip.Prefix, bool) {
+	labels := strings.Split(enc, ".")
+	if len(labels) < 2 {
+		return netip.Prefix{}, false
+	}
+	bits, err := strconv.Atoi(labels[0])
+	if err != nil || bits < 0 {
+		return netip.Prefix{}, false
+	}
+	labels = labels[1:]
+
+	// IPv4: exactly four decimal octet labels, reversed.
+	if len(labels) == 4 && isV4Octets(labels) {
+		if bits > 32 {
+			return netip.Prefix{}, false
+		}
+		var b [4]byte
+		for i, s := range labels {
+			v, _ := strconv.Atoi(s)
+			b[3-i] = byte(v) //nolint:gosec // G115 - isV4Octets bounded v to 0..255
+		}
+		mapped := canonical16(netip.AddrFrom4(b))
+		return netip.PrefixFrom(mapped, bits+96), true
+	}
+
+	// IPv6: up to eight hextet labels, reversed, with one optional "zz"
+	// standing for the run of zero fields that makes the count come out
+	// to eight.
+	if bits > 128 || len(labels) > 8 {
+		return netip.Prefix{}, false
+	}
+	fields := make([]uint16, 0, 8)
+	zzAt := -1
+	for i, s := range labels {
+		if s == "zz" {
+			if zzAt >= 0 {
+				return netip.Prefix{}, false
+			}
+			zzAt = i
+			continue
+		}
+		v, err := strconv.ParseUint(s, 16, 16)
+		if err != nil || len(s) == 0 || len(s) > 4 {
+			return netip.Prefix{}, false
+		}
+		fields = append(fields, uint16(v))
+	}
+	switch {
+	case zzAt < 0 && len(fields) != 8:
+		return netip.Prefix{}, false
+	case zzAt >= 0 && len(fields) >= 8:
+		return netip.Prefix{}, false
+	}
+
+	// Labels run W8..W1 — the address's fields reversed — and zz expands
+	// in place to whatever count restores eight.
+	full := make([]uint16, 0, 8)
+	zero := 8 - len(fields)
+	fi := 0
+	for i := 0; i < len(labels); i++ {
+		if i == zzAt {
+			for range zero {
+				full = append(full, 0)
+			}
+			continue
+		}
+		full = append(full, fields[fi])
+		fi++
+	}
+
+	var b [16]byte
+	for i, w := range full {
+		// full[0] is W8, the address's last field. The high byte of a
+		// uint16 cannot exceed 255, and the low-byte truncation is the
+		// point of the expression.
+		b[14-2*i] = byte(w >> 8) //nolint:gosec // G115 - see above
+		b[15-2*i] = byte(w)      //nolint:gosec // G115 - deliberate low-byte truncation
+	}
+	return netip.PrefixFrom(netip.AddrFrom16(b), bits), true
+}
+
+func isV4Octets(labels []string) bool {
+	for _, s := range labels {
+		v, err := strconv.Atoi(s)
+		if err != nil || v < 0 || v > 255 || (len(s) > 1 && s[0] == '0') {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/rpz/clientip_test.go
+++ b/internal/rpz/clientip_test.go
@@ -14,10 +14,10 @@ func TestParseClientIPOwner(t *testing.T) {
 		enc  string
 		want string
 	}{
-		// IPv4: prefix, then reversed octets, lifted to +96.
-		{"24.0.2.0.192", "::ffff:192.0.2.0/120"},
-		{"32.9.2.0.192", "::ffff:192.0.2.9/128"},
-		{"8.0.0.0.10", "::ffff:10.0.0.0/104"},
+		// IPv4: prefix, then reversed octets, family kept.
+		{"24.0.2.0.192", "192.0.2.0/24"},
+		{"32.9.2.0.192", "192.0.2.9/32"},
+		{"8.0.0.0.10", "10.0.0.0/8"},
 		// IPv6, no compression: eight reversed hextets.
 		{"128.1.0.0.0.0.0.db8.2001", "2001:db8::1/128"},
 		// zz covering one run.
@@ -28,29 +28,18 @@ func TestParseClientIPOwner(t *testing.T) {
 		// first run spelled out.
 		{"128.1.zz.1.0.0.db8.2001", "2001:db8:0:0:1::1/128"},
 		// Host bits under the prefix are masked, not refused.
-		{"24.99.2.0.192", "::ffff:192.0.2.0/120"},
+		{"24.99.2.0.192", "192.0.2.0/24"},
 	} {
 		p, ok := parseClientIPOwner(tc.enc)
 		if !ok {
 			t.Errorf("%q: refused", tc.enc)
 			continue
 		}
-		want := netip.MustParsePrefix(tc.want)
-		wantCanon := netip.PrefixFrom(canonical16(want.Masked().Addr()), prefixBitsIn128(want))
-		got := netip.PrefixFrom(canonical16(p.Masked().Addr()), p.Bits())
-		if got != wantCanon {
-			t.Errorf("%q: got %v, want %v", tc.enc, got, wantCanon)
+		want := netip.MustParsePrefix(tc.want).Masked()
+		if p.Masked() != want {
+			t.Errorf("%q: got %v, want %v", tc.enc, p.Masked(), want)
 		}
 	}
-}
-
-// prefixBitsIn128 lifts a v4 prefix's length into the shared space the
-// engine stores everything in.
-func prefixBitsIn128(p netip.Prefix) int {
-	if p.Addr().Is4() {
-		return p.Bits() + 96
-	}
-	return p.Bits()
 }
 
 func TestParseClientIPOwnerRefusesMalformed(t *testing.T) {
@@ -59,7 +48,6 @@ func TestParseClientIPOwnerRefusesMalformed(t *testing.T) {
 		"24",                         // prefix alone
 		"33.0.2.0.192",               // v4 prefix too long
 		"129.zz",                     // v6 prefix too long
-		"24.0.2.0.999",               // octet out of range... falls to v6 hex? 999 is not hex-only... 999 parses as hex! guard below
 		"128.zz.zz",                  // two zz
 		"128.1.2.3.4.5.6.7.8.9",      // nine fields
 		"128.xyz.zz",                 // not hex
@@ -126,14 +114,14 @@ func TestClientIPLongestPrefixWins(t *testing.T) {
 
 	exempt := CanonicalClient(netip.MustParseAddr("192.0.2.9"))
 	winner, _ := s.Match(canon, offs[:], n, exempt)
-	if winner.Effective() != ActionPassthru || winner.PrefixBits != 128 {
-		t.Fatalf("winner = %+v, want passthru at /128", winner)
+	if winner.Effective() != ActionPassthru || winner.PrefixBits != 32 {
+		t.Fatalf("winner = %+v, want passthru at /32", winner)
 	}
 
 	neighbor := CanonicalClient(netip.MustParseAddr("192.0.2.10"))
 	winner, _ = s.Match(canon, offs[:], n, neighbor)
-	if winner.Effective() != ActionDrop || winner.PrefixBits != 120 {
-		t.Fatalf("winner = %+v, want drop at /120", winner)
+	if winner.Effective() != ActionDrop || winner.PrefixBits != 24 {
+		t.Fatalf("winner = %+v, want drop at /24", winner)
 	}
 }
 
@@ -182,7 +170,7 @@ func BenchmarkClientIPAdversarialAllLengths(b *testing.B) {
 	z := &Zone{Name: "adversarial", Skipped: map[string]int{}}
 	base := netip.MustParseAddr("2001:db8::")
 	for bits := 1; bits <= 128; bits++ {
-		z.insertClientIP(netip.PrefixFrom(canonical16(base), bits), ActionNXDOMAIN, nil)
+		z.insertClientIP(netip.PrefixFrom(base, bits), ActionNXDOMAIN, nil)
 	}
 	if z.RulesClientIP != 128 {
 		b.Fatalf("fixture built %d lengths", z.RulesClientIP)
@@ -193,7 +181,7 @@ func BenchmarkClientIPAdversarialAllLengths(b *testing.B) {
 
 	b.ReportAllocs()
 	for b.Loop() {
-		if r, _ := z.clientIP.lookup(client); r != nil {
+		if r, _ := z.clientIP6.lookup(client); r != nil {
 			b.Fatal("unexpected match")
 		}
 	}
@@ -208,12 +196,68 @@ func BenchmarkClientIPRealisticLengths(b *testing.B) {
 		addr[6] = byte(i)
 		z.insertClientIP(netip.PrefixFrom(netip.AddrFrom16(addr), bits), ActionDrop, nil)
 	}
-	client := CanonicalClient(netip.MustParseAddr("203.0.113.7"))
+	// A v6 client for the v6 table: after the family split, a lookup is
+	// always family-consistent — the router picks the table.
+	client := CanonicalClient(netip.MustParseAddr("fd00::7"))
 
 	b.ReportAllocs()
 	for b.Loop() {
-		if r, _ := z.clientIP.lookup(client); r != nil {
+		if r, _ := z.clientIP6.lookup(client); r != nil {
 			b.Fatal("unexpected match")
 		}
+	}
+}
+
+// TestClientIPFamiliesStaySeparate pins the review's merge blocker: an
+// IPv6 rule must never match an IPv4 client and the reverse — folding
+// IPv4 into the ::ffff/96 corner of one key space let ::/0 swallow every
+// v4 client and collided ::ffff:0:0/96 with 0.0.0.0/0.
+func TestClientIPFamiliesStaySeparate(t *testing.T) {
+	z, err := LoadZone("families", strings.NewReader(`
+rpz.test. IN SOA ns. admin. 1 3600 900 604800 300
+; the v6 catch-all and the two colliding-slot rules, different actions
+0.zz.rpz-client-ip.rpz.test.        IN CNAME .
+96.zz.ffff.0.rpz-client-ip.rpz.test. IN CNAME rpz-drop.
+0.0.0.0.0.rpz-client-ip.rpz.test.   IN CNAME rpz-tcp-only.
+`), "fam.zone", OverrideGiven, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// All three compiled: the v6 ::ffff:0:0/96 and the v4 0.0.0.0/0 are
+	// different rules in different tables, not a conflict.
+	if z.RulesClientIP != 3 || z.Skipped[SkipConflict] != 0 {
+		t.Fatalf("rules=%d conflicts=%d, want 3/0", z.RulesClientIP, z.Skipped[SkipConflict])
+	}
+
+	s := storeOf(z)
+	canon, offs, n := canonFor(t, "x.example.")
+
+	// A v4 client meets only the v4 catch-all — tcp-only, never the v6
+	// ::/0 nxdomain or the ::ffff drop.
+	v4 := CanonicalClient(netip.MustParseAddr("198.51.100.7"))
+	if w, _ := s.Match(canon, offs[:], n, v4); w.Effective() != ActionTCPOnly {
+		t.Fatalf("v4 client got %v, want the v4 table's tcp-only", w.Effective())
+	}
+	// The same client arriving in mapped spelling is still a v4 client.
+	mapped := CanonicalClient(netip.MustParseAddr("::ffff:198.51.100.7"))
+	if w, _ := s.Match(canon, offs[:], n, mapped); w.Effective() != ActionTCPOnly {
+		t.Fatalf("mapped v4 client got %v, want the v4 table's tcp-only", w.Effective())
+	}
+	// An address spelled inside ::ffff:0:0/96 IS an IPv4 client — that is
+	// what mapped means, and CanonicalClient's Unmap enforces it — so it
+	// meets the v4 table, never the feed's v6 ::ffff rule. That rule
+	// stays compiled and distinct (asserted above) but no client can
+	// reach it, which is the correct fate for a v6 spelling of v4 space.
+	spelled := CanonicalClient(netip.MustParseAddr("::ffff:0:1"))
+	if !spelled.Is4() {
+		t.Fatal("Unmap did not classify a mapped spelling as v4")
+	}
+	if w, _ := s.Match(canon, offs[:], n, spelled); w.Effective() != ActionTCPOnly {
+		t.Fatalf("mapped-range client got %v, want the v4 table's tcp-only", w.Effective())
+	}
+	// A plain v6 client gets the v6 catch-all.
+	v6 := CanonicalClient(netip.MustParseAddr("2001:db8::1"))
+	if w, _ := s.Match(canon, offs[:], n, v6); w.Effective() != ActionNXDOMAIN {
+		t.Fatalf("v6 client got %v, want the v6 ::/0 nxdomain", w.Effective())
 	}
 }

--- a/internal/rpz/clientip_test.go
+++ b/internal/rpz/clientip_test.go
@@ -1,0 +1,219 @@
+package rpz
+
+import (
+	"net/netip"
+	"strings"
+	"testing"
+)
+
+// TestParseClientIPOwner pins the draft's §4.1.1 encoding, the zz
+// last-run subtlety included: the fixture 2001:db8:0:0:1:0:0:1 has two
+// equal zero runs, and zz stands for the LAST one.
+func TestParseClientIPOwner(t *testing.T) {
+	for _, tc := range []struct {
+		enc  string
+		want string
+	}{
+		// IPv4: prefix, then reversed octets, lifted to +96.
+		{"24.0.2.0.192", "::ffff:192.0.2.0/120"},
+		{"32.9.2.0.192", "::ffff:192.0.2.9/128"},
+		{"8.0.0.0.10", "::ffff:10.0.0.0/104"},
+		// IPv6, no compression: eight reversed hextets.
+		{"128.1.0.0.0.0.0.db8.2001", "2001:db8::1/128"},
+		// zz covering one run.
+		{"128.1.zz.db8.2001", "2001:db8::1/128"},
+		{"48.zz.db8.2001", "2001:db8::/48"},
+		// The draft's compressed-LAST rule: for 2001:db8:0:0:1:0:0:1 the
+		// zz is the run at fields six and seven, so the owner keeps the
+		// first run spelled out.
+		{"128.1.zz.1.0.0.db8.2001", "2001:db8:0:0:1::1/128"},
+		// Host bits under the prefix are masked, not refused.
+		{"24.99.2.0.192", "::ffff:192.0.2.0/120"},
+	} {
+		p, ok := parseClientIPOwner(tc.enc)
+		if !ok {
+			t.Errorf("%q: refused", tc.enc)
+			continue
+		}
+		want := netip.MustParsePrefix(tc.want)
+		wantCanon := netip.PrefixFrom(canonical16(want.Masked().Addr()), prefixBitsIn128(want))
+		got := netip.PrefixFrom(canonical16(p.Masked().Addr()), p.Bits())
+		if got != wantCanon {
+			t.Errorf("%q: got %v, want %v", tc.enc, got, wantCanon)
+		}
+	}
+}
+
+// prefixBitsIn128 lifts a v4 prefix's length into the shared space the
+// engine stores everything in.
+func prefixBitsIn128(p netip.Prefix) int {
+	if p.Addr().Is4() {
+		return p.Bits() + 96
+	}
+	return p.Bits()
+}
+
+func TestParseClientIPOwnerRefusesMalformed(t *testing.T) {
+	for _, enc := range []string{
+		"",                           // nothing
+		"24",                         // prefix alone
+		"33.0.2.0.192",               // v4 prefix too long
+		"129.zz",                     // v6 prefix too long
+		"24.0.2.0.999",               // octet out of range... falls to v6 hex? 999 is not hex-only... 999 parses as hex! guard below
+		"128.zz.zz",                  // two zz
+		"128.1.2.3.4.5.6.7.8.9",      // nine fields
+		"128.xyz.zz",                 // not hex
+		"128.1.0.0.0.0.0.0.db8.2001", // nine labels
+		"abc.0.2.0.192",              // prefix not a number
+	} {
+		if _, ok := parseClientIPOwner(enc); ok {
+			t.Errorf("%q: accepted, want refusal", enc)
+		}
+	}
+}
+
+const clientIPZone = `
+rpz.test. IN SOA ns.rpz.test. admin.rpz.test. 1 3600 900 604800 300
+; client-ip rules with different actions per prefix length
+24.0.2.0.192.rpz-client-ip.rpz.test.  IN CNAME rpz-drop.
+32.9.2.0.192.rpz-client-ip.rpz.test.  IN CNAME rpz-passthru.
+48.zz.db8.2001.rpz-client-ip.rpz.test. IN CNAME .
+; a qname rule in the SAME zone, different action again: rule 2's fixture
+victim.example.com.rpz.test.          IN CNAME *.
+; local data on a client-ip trigger: the encoded owner must never leak
+16.0.0.0.10.rpz-client-ip.rpz.test.   IN A 192.0.2.99
+`
+
+func loadClientIPZone(t *testing.T) *Zone {
+	t.Helper()
+	z, err := LoadZone("cip", strings.NewReader(clientIPZone), "cip.zone", OverrideGiven, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return z
+}
+
+// TestClientIPBeatsQNAMEWithinZone pins precedence rule 2 with competing
+// rules prescribing different actions: swapping the trigger order changes
+// the observable outcome and this goes red.
+func TestClientIPBeatsQNAMEWithinZone(t *testing.T) {
+	z := loadClientIPZone(t)
+	s := storeOf(z)
+	canon, offs, n := canonFor(t, "victim.example.com.")
+
+	// A client inside 192.0.2.0/24: CLIENT-IP (drop) must beat the
+	// QNAME rule (nodata).
+	client := CanonicalClient(netip.MustParseAddr("192.0.2.55"))
+	winner, _ := s.Match(canon, offs[:], n, client)
+	if winner.Zone == nil || winner.Trigger != TriggerClientIP || winner.Effective() != ActionDrop {
+		t.Fatalf("winner = %+v, want client-ip/drop", winner)
+	}
+
+	// A client outside every prefix: the QNAME rule stands.
+	outside := CanonicalClient(netip.MustParseAddr("198.51.100.1"))
+	winner, _ = s.Match(canon, offs[:], n, outside)
+	if winner.Zone == nil || winner.Trigger != TriggerQNAME || winner.Effective() != ActionNODATA {
+		t.Fatalf("winner = %+v, want qname/nodata", winner)
+	}
+}
+
+// TestClientIPLongestPrefixWins pins rule 4: /32 passthru inside the /24
+// drop — the more specific rule prescribes the opposite action.
+func TestClientIPLongestPrefixWins(t *testing.T) {
+	z := loadClientIPZone(t)
+	s := storeOf(z)
+	canon, offs, n := canonFor(t, "victim.example.com.")
+
+	exempt := CanonicalClient(netip.MustParseAddr("192.0.2.9"))
+	winner, _ := s.Match(canon, offs[:], n, exempt)
+	if winner.Effective() != ActionPassthru || winner.PrefixBits != 128 {
+		t.Fatalf("winner = %+v, want passthru at /128", winner)
+	}
+
+	neighbor := CanonicalClient(netip.MustParseAddr("192.0.2.10"))
+	winner, _ = s.Match(canon, offs[:], n, neighbor)
+	if winner.Effective() != ActionDrop || winner.PrefixBits != 120 {
+		t.Fatalf("winner = %+v, want drop at /120", winner)
+	}
+}
+
+func TestClientIPv6Match(t *testing.T) {
+	z := loadClientIPZone(t)
+	s := storeOf(z)
+	canon, offs, n := canonFor(t, "anything.example.org.")
+
+	v6 := CanonicalClient(netip.MustParseAddr("2001:db8:0:2::3"))
+	winner, _ := s.Match(canon, offs[:], n, v6)
+	if winner.Zone == nil || winner.Effective() != ActionNXDOMAIN {
+		t.Fatalf("winner = %+v, want nxdomain from the /48", winner)
+	}
+	// And the third hextet flipping out of the /48 loses the match.
+	out := CanonicalClient(netip.MustParseAddr("2001:db8:1:2::3"))
+	if w2, _ := s.Match(canon, offs[:], n, out); w2.Zone != nil {
+		t.Fatalf("outside the /48 still matched: %+v", w2)
+	}
+}
+
+// TestClientIPMissAllocatesNothing extends the §5.11 pin: prefixes across
+// several lengths probed for a non-matching client and name, zero heap.
+func TestClientIPMissAllocatesNothing(t *testing.T) {
+	z := loadClientIPZone(t)
+	s := storeOf(z, z)
+	canon, offs, n := canonFor(t, "innocent.example.org.")
+	client := CanonicalClient(netip.MustParseAddr("203.0.113.7"))
+
+	if allocs := testing.AllocsPerRun(200, func() {
+		winner, observed := s.Match(canon, offs[:], n, client)
+		if winner.Zone != nil || observed != nil {
+			t.Fatal("unexpected match")
+		}
+	}); allocs != 0 {
+		t.Fatalf("a client-ip miss cost %.0f allocations, want 0", allocs)
+	}
+}
+
+// BenchmarkClientIPAdversarialAllLengths is the §5.3/§6 exit criterion:
+// a hostile feed carrying every prefix length /1../128, probed by a
+// non-matching client. The stated budget is 2µs per zone walk — well
+// under 6% of the per-query budget at the bench-box scoreboard rate —
+// and the length-map walk must come in under it or be replaced by a
+// radix before merge.
+func BenchmarkClientIPAdversarialAllLengths(b *testing.B) {
+	z := &Zone{Name: "adversarial", Skipped: map[string]int{}}
+	base := netip.MustParseAddr("2001:db8::")
+	for bits := 1; bits <= 128; bits++ {
+		z.insertClientIP(netip.PrefixFrom(canonical16(base), bits), ActionNXDOMAIN, nil)
+	}
+	if z.RulesClientIP != 128 {
+		b.Fatalf("fixture built %d lengths", z.RulesClientIP)
+	}
+	// A client sharing no bits with the rules: every length probes and
+	// misses.
+	client := CanonicalClient(netip.MustParseAddr("fd00::1"))
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if r, _ := z.clientIP.lookup(client); r != nil {
+			b.Fatal("unexpected match")
+		}
+	}
+}
+
+// BenchmarkClientIPRealisticLengths is the same walk at a commercial
+// feed's shape: a handful of distinct lengths.
+func BenchmarkClientIPRealisticLengths(b *testing.B) {
+	z := &Zone{Name: "realistic", Skipped: map[string]int{}}
+	for i, bits := range []int{120, 124, 128, 48, 64} {
+		addr := netip.MustParseAddr("2001:db8::").As16()
+		addr[6] = byte(i)
+		z.insertClientIP(netip.PrefixFrom(netip.AddrFrom16(addr), bits), ActionDrop, nil)
+	}
+	client := CanonicalClient(netip.MustParseAddr("203.0.113.7"))
+
+	b.ReportAllocs()
+	for b.Loop() {
+		if r, _ := z.clientIP.lookup(client); r != nil {
+			b.Fatal("unexpected match")
+		}
+	}
+}

--- a/internal/rpz/match.go
+++ b/internal/rpz/match.go
@@ -27,7 +27,7 @@ func (s *Store) HasClientIP() bool {
 		return false
 	}
 	for _, z := range s.Zones {
-		if z.clientIP != nil {
+		if z.clientIP4 != nil || z.clientIP6 != nil {
 			return true
 		}
 	}
@@ -84,10 +84,16 @@ func (s *Store) Match(canon []byte, offs []int, n int, client netip.Addr) (winne
 	return
 }
 
-// match applies the within-zone trigger precedence: CLIENT-IP first.
+// match applies the within-zone trigger precedence: CLIENT-IP first. The
+// client's family selects its table — the other family's rules do not
+// exist for it.
 func (z *Zone) match(canon []byte, offs []int, n int, client netip.Addr) ZoneMatch {
-	if z.clientIP != nil && client.IsValid() {
-		if rule, bits := z.clientIP.lookup(client); rule != nil {
+	if client.IsValid() {
+		table := z.clientIP6
+		if client.Is4() {
+			table = z.clientIP4
+		}
+		if rule, bits := table.lookup(client); rule != nil {
 			return ZoneMatch{Rule: rule, Trigger: TriggerClientIP, PrefixBits: bits}
 		}
 	}

--- a/internal/rpz/match.go
+++ b/internal/rpz/match.go
@@ -1,26 +1,60 @@
 package rpz
 
-// ZoneMatch is one zone's best QNAME match for a query.
+import "net/netip"
+
+// Trigger labels for metrics and logs.
+const (
+	TriggerQNAME    = "qname"
+	TriggerClientIP = "client-ip"
+)
+
+// ZoneMatch is one zone's best match for a query. Trigger and PrefixBits
+// carry the rank information a later merge (or a log line) needs.
 type ZoneMatch struct {
-	ZoneIdx  int
-	Zone     *Zone
-	Rule     *Rule
-	Wildcard bool
+	ZoneIdx    int
+	Zone       *Zone
+	Rule       *Rule
+	Trigger    string
+	Wildcard   bool
+	PrefixBits int
 }
 
-// MatchQNAME walks the zones in configuration order and returns the first
+// HasClientIP reports whether any zone carries CLIENT-IP rules, so a
+// caller can skip canonicalizing the client address entirely on a
+// qname-only configuration.
+func (s *Store) HasClientIP() bool {
+	if s == nil {
+		return false
+	}
+	for _, z := range s.Zones {
+		if z.clientIP != nil {
+			return true
+		}
+	}
+	return false
+}
+
+// Match walks the zones in configuration order and returns the first
 // enabled zone's match as the winner, together with the matches of any
 // disabled zones met on the way there. Zones past the winner are never
 // probed: precedence rule 1 says they cannot win, and the winner-bounded
 // counting semantic (design §5.5) says they are not counted either — so
 // not probing them is both correct and the cheap path.
 //
+// Within a zone, CLIENT-IP outranks QNAME (rule 2), and among CLIENT-IP
+// prefixes the longest wins (rule 4) — equal-length distinct prefixes
+// cannot both contain one address, so the client-side tie-break is
+// vacuous by construction. client is the query's source address in
+// canonical 128-bit form (CanonicalClient), or the zero Addr when no
+// zone carries CLIENT-IP rules.
+//
 // canon and offs are the query name in the canonical-labels form
 // dnsname.AppendCanonicalLabels produces: canon is the lowercase
 // presentation with the trailing dot, offs[i] the start of label i, n the
 // label count. Both live on the caller's stack; every probe here indexes a
 // map as m[string(bytes)], which Go performs without constructing the
-// string — the reason a non-matching query allocates nothing.
+// string — with the prefix masking being value math, the reason a
+// non-matching query allocates nothing.
 //
 // Within a zone the draft's rule 3 falls out of the walk order: the exact
 // probe first, then wildcard suffixes from the longest down (stripping one
@@ -30,16 +64,16 @@ type ZoneMatch struct {
 //
 // observed is nil unless a disabled zone matched, which keeps the miss
 // path and the ordinary single-zone hit allocation-free.
-func (s *Store) MatchQNAME(canon []byte, offs []int, n int) (winner ZoneMatch, observed []ZoneMatch) {
+func (s *Store) Match(canon []byte, offs []int, n int, client netip.Addr) (winner ZoneMatch, observed []ZoneMatch) {
 	if s == nil {
 		return
 	}
 	for idx, z := range s.Zones {
-		rule, wild := z.matchQNAME(canon, offs, n)
-		if rule == nil {
+		m := z.match(canon, offs, n, client)
+		if m.Rule == nil {
 			continue
 		}
-		m := ZoneMatch{ZoneIdx: idx, Zone: z, Rule: rule, Wildcard: wild}
+		m.ZoneIdx, m.Zone = idx, z
 		if z.Disabled() {
 			observed = append(observed, m)
 			continue
@@ -48,6 +82,19 @@ func (s *Store) MatchQNAME(canon []byte, offs []int, n int) (winner ZoneMatch, o
 		return
 	}
 	return
+}
+
+// match applies the within-zone trigger precedence: CLIENT-IP first.
+func (z *Zone) match(canon []byte, offs []int, n int, client netip.Addr) ZoneMatch {
+	if z.clientIP != nil && client.IsValid() {
+		if rule, bits := z.clientIP.lookup(client); rule != nil {
+			return ZoneMatch{Rule: rule, Trigger: TriggerClientIP, PrefixBits: bits}
+		}
+	}
+	if rule, wild := z.matchQNAME(canon, offs, n); rule != nil {
+		return ZoneMatch{Rule: rule, Trigger: TriggerQNAME, Wildcard: wild}
+	}
+	return ZoneMatch{}
 }
 
 func (z *Zone) matchQNAME(canon []byte, offs []int, n int) (rule *Rule, wildcard bool) {

--- a/internal/rpz/parse.go
+++ b/internal/rpz/parse.go
@@ -210,12 +210,17 @@ func (z *Zone) classify(rr dns.RR) {
 
 // insertClientIP files a CLIENT-IP rule with the same merge semantics as
 // the name triggers: the first action class at a prefix stands, Local
-// Data accumulates, anything else is a conflict.
+// Data accumulates, anything else is a conflict. The prefix's family
+// picks the table.
 func (z *Zone) insertClientIP(prefix netip.Prefix, action Action, local dns.RR) {
-	if z.clientIP == nil {
-		z.clientIP = &ipLPM{}
+	table := &z.clientIP6
+	if prefix.Addr().Is4() {
+		table = &z.clientIP4
 	}
-	if existing := z.clientIP.lookupExact(prefix); existing != nil {
+	if *table == nil {
+		*table = &ipLPM{}
+	}
+	if existing := (*table).lookupExact(prefix); existing != nil {
 		if existing.Action == ActionLocalData && action == ActionLocalData {
 			existing.Local = append(existing.Local, local)
 			return
@@ -227,7 +232,7 @@ func (z *Zone) insertClientIP(prefix netip.Prefix, action Action, local dns.RR) 
 	if action == ActionLocalData {
 		rule.Local = []dns.RR{local}
 	}
-	z.clientIP.insert(prefix, rule)
+	(*table).insert(prefix, rule)
 	z.Rules++
 	z.RulesClientIP++
 }

--- a/internal/rpz/parse.go
+++ b/internal/rpz/parse.go
@@ -3,6 +3,7 @@ package rpz
 import (
 	"fmt"
 	"io"
+	"net/netip"
 	"os"
 	"strings"
 
@@ -15,8 +16,12 @@ import (
 // trigger types a later phase evaluates must load today.
 const (
 	// SkipTrigger is a trigger encoding a phase this build does not
-	// evaluate yet (rpz-client-ip, rpz-ip, rpz-nsdname, rpz-nsip).
+	// evaluate yet (rpz-ip, rpz-nsdname, rpz-nsip).
 	SkipTrigger = "trigger-unsupported"
+	// SkipOwnerEncoding is a trigger owner the draft's encoding cannot
+	// decode: a bad prefix length, a malformed reversed address, a
+	// second zz.
+	SkipOwnerEncoding = "owner-encoding"
 	// SkipUnknownAction is a CNAME into the rpz-* action namespace that
 	// no action this build knows — a future or nonstandard action code,
 	// which must never be served as Local Data (design §5.2).
@@ -63,9 +68,12 @@ func notActionData(t uint16) bool {
 	return IsDNSSECType(t)
 }
 
-// triggerMarkers are the owner labels that select non-QNAME trigger
-// types; everything under them is that trigger's encoding, not a name.
-var triggerMarkers = []string{"rpz-client-ip", "rpz-ip", "rpz-nsdname", "rpz-nsip"}
+// triggerMarkers are the owner labels of trigger types later phases
+// evaluate; everything under them is that trigger's encoding, not a name.
+var triggerMarkers = []string{"rpz-ip", "rpz-nsdname", "rpz-nsip"}
+
+// clientIPMarker selects the CLIENT-IP trigger, evaluated since phase 2.
+const clientIPMarker = "rpz-client-ip"
 
 // LoadZoneFile parses one policy zone file into a compiled Zone. name is
 // the config label; policy and cnameTarget come from the zone's config
@@ -157,7 +165,7 @@ func (z *Zone) classify(rr dns.RR) {
 		return
 	}
 
-	// Non-QNAME triggers wait for their phase.
+	// Triggers of later phases wait for them.
 	for _, marker := range triggerMarkers {
 		if rel == marker || strings.HasSuffix(rel, "."+marker) {
 			z.skip(SkipTrigger)
@@ -170,6 +178,27 @@ func (z *Zone) classify(rr dns.RR) {
 		return
 	}
 
+	// CLIENT-IP: the owner encodes an address block, not a name.
+	if enc, ok := strings.CutSuffix(rel, "."+clientIPMarker); ok {
+		prefix, valid := parseClientIPOwner(enc)
+		if !valid {
+			z.skip(SkipOwnerEncoding)
+			return
+		}
+		action, local := classifyAction(rr)
+		if action == ActionNone {
+			z.skip(SkipUnknownAction)
+			return
+		}
+		z.insertClientIP(prefix, action, local)
+		return
+	}
+	if rel == clientIPMarker {
+		// The bare marker owns no address.
+		z.skip(SkipOwnerEncoding)
+		return
+	}
+
 	action, local := classifyAction(rr)
 	if action == ActionNone {
 		z.skip(SkipUnknownAction)
@@ -177,6 +206,30 @@ func (z *Zone) classify(rr dns.RR) {
 	}
 
 	z.insert(rel, action, local)
+}
+
+// insertClientIP files a CLIENT-IP rule with the same merge semantics as
+// the name triggers: the first action class at a prefix stands, Local
+// Data accumulates, anything else is a conflict.
+func (z *Zone) insertClientIP(prefix netip.Prefix, action Action, local dns.RR) {
+	if z.clientIP == nil {
+		z.clientIP = &ipLPM{}
+	}
+	if existing := z.clientIP.lookupExact(prefix); existing != nil {
+		if existing.Action == ActionLocalData && action == ActionLocalData {
+			existing.Local = append(existing.Local, local)
+			return
+		}
+		z.skip(SkipConflict)
+		return
+	}
+	rule := &Rule{Action: action}
+	if action == ActionLocalData {
+		rule.Local = []dns.RR{local}
+	}
+	z.clientIP.insert(prefix, rule)
+	z.Rules++
+	z.RulesClientIP++
 }
 
 // insert files a rule under its relative owner. The first action class at

--- a/internal/rpz/rpz.go
+++ b/internal/rpz/rpz.go
@@ -119,9 +119,12 @@ type Zone struct {
 	// matchAll is the rule of a bare "*" owner: any qname, subdomain
 	// walk included. Rare, so it is a field rather than a map probe.
 	matchAll *Rule
-	// clientIP holds the zone's CLIENT-IP trigger rules; nil when the
-	// feed carries none, so a qname-only zone pays one nil check.
-	clientIP *ipLPM
+	// clientIP4/clientIP6 hold the zone's CLIENT-IP trigger rules, one
+	// table per family — an IPv6 rule must never match an IPv4 client or
+	// the reverse. nil when the feed carries none, so a qname-only zone
+	// pays two nil checks.
+	clientIP4 *ipLPM
+	clientIP6 *ipLPM
 
 	// Rules counts all compiled rules; RulesClientIP the CLIENT-IP share
 	// (the per-trigger gauges want the split). Skipped counts what the

--- a/internal/rpz/rpz.go
+++ b/internal/rpz/rpz.go
@@ -119,12 +119,17 @@ type Zone struct {
 	// matchAll is the rule of a bare "*" owner: any qname, subdomain
 	// walk included. Rare, so it is a field rather than a map probe.
 	matchAll *Rule
+	// clientIP holds the zone's CLIENT-IP trigger rules; nil when the
+	// feed carries none, so a qname-only zone pays one nil check.
+	clientIP *ipLPM
 
-	// Rules counts the compiled rules; Skipped counts what the load
-	// stepped over, by reason — both feed the load-time gauges and the
-	// `sdns -t` report.
-	Rules   int
-	Skipped map[string]int
+	// Rules counts all compiled rules; RulesClientIP the CLIENT-IP share
+	// (the per-trigger gauges want the split). Skipped counts what the
+	// load stepped over, by reason — all three feed the load-time gauges
+	// and the `sdns -t` report.
+	Rules         int
+	RulesClientIP int
+	Skipped       map[string]int
 }
 
 // Disabled reports whether the zone observes without consuming a match.

--- a/internal/rpz/rpz_test.go
+++ b/internal/rpz/rpz_test.go
@@ -1,6 +1,7 @@
 package rpz
 
 import (
+	"net/netip"
 	"strings"
 	"testing"
 
@@ -68,13 +69,17 @@ func TestLoadZoneClassifiesEverything(t *testing.T) {
 	if z.SOA == nil || z.SOA.Serial != 2026083001 {
 		t.Fatal("apex SOA not captured")
 	}
-	// 6 action rules + local-data alias + wildcard-target alias + 2 wildcards.
-	if z.Rules != 10 {
-		t.Fatalf("Rules = %d, want 10 (skips: %v)", z.Rules, z.Skipped)
+	// 6 action rules + local-data alias + wildcard-target alias +
+	// 2 wildcards + (since phase 2) the client-ip rule.
+	if z.Rules != 11 {
+		t.Fatalf("Rules = %d, want 11 (skips: %v)", z.Rules, z.Skipped)
+	}
+	if z.RulesClientIP != 1 {
+		t.Fatalf("RulesClientIP = %d, want 1", z.RulesClientIP)
 	}
 
 	want := map[string]int{
-		SkipTrigger:       3,
+		SkipTrigger:       2, // rpz-ip + rpz-nsdname wait for their phases
 		SkipUnknownAction: 1,
 		SkipNotActionData: 3, // apex NS + in-zone NS + DS
 		SkipOutOfZone:     1,
@@ -139,7 +144,7 @@ func TestMatchQNAMEPrecedenceWithinZone(t *testing.T) {
 		{"x.sub.evil.example.com.", ActionPassthru, true},
 	} {
 		canon, offs, n := canonFor(t, tc.name)
-		winner, observed := s.MatchQNAME(canon, offs[:], n)
+		winner, observed := s.Match(canon, offs[:], n, netip.Addr{})
 		if winner.Zone == nil {
 			t.Fatalf("%s: no match", tc.name)
 		}
@@ -162,7 +167,7 @@ func TestWildcardMatchesSubdomainsOnly(t *testing.T) {
 	// evil.example.com. itself has no exact rule and must not match its
 	// own wildcard.
 	canon, offs, n := canonFor(t, "evil.example.com.")
-	if winner, _ := s.MatchQNAME(canon, offs[:], n); winner.Zone != nil {
+	if winner, _ := s.Match(canon, offs[:], n, netip.Addr{}); winner.Zone != nil {
 		t.Fatalf("apex of a wildcard matched: %+v", winner)
 	}
 }
@@ -186,13 +191,13 @@ victim.example.com.z2.test. IN CNAME .
 	}
 
 	canon, offs, n := canonFor(t, "victim.example.com.")
-	winner, _ := storeOf(first, second).MatchQNAME(canon, offs[:], n)
+	winner, _ := storeOf(first, second).Match(canon, offs[:], n, netip.Addr{})
 	if winner.Zone == nil || winner.Zone.Name != "first" || winner.Effective() != ActionPassthru {
 		t.Fatalf("winner = %+v, want first/passthru", winner)
 	}
 
 	// Reversed order, reversed outcome — the assertion that pins rule 1.
-	winner, _ = storeOf(second, first).MatchQNAME(canon, offs[:], n)
+	winner, _ = storeOf(second, first).Match(canon, offs[:], n, netip.Addr{})
 	if winner.Zone == nil || winner.Zone.Name != "second" || winner.Effective() != ActionNXDOMAIN {
 		t.Fatalf("winner = %+v, want second/nxdomain", winner)
 	}
@@ -210,7 +215,7 @@ nx.example.com.z2.test. IN CNAME rpz-drop.
 	}
 
 	canon, offs, n := canonFor(t, "nx.example.com.")
-	winner, observed := storeOf(disabled, enforcing).MatchQNAME(canon, offs[:], n)
+	winner, observed := storeOf(disabled, enforcing).Match(canon, offs[:], n, netip.Addr{})
 
 	// The disabled zone matched first and must not consume: the later
 	// enforcing zone's different action is the winner.
@@ -237,7 +242,7 @@ func TestOverridesReplaceTheRuleAction(t *testing.T) {
 	} {
 		z := loadFixture(t, tc.policy, "garden.example.net.")
 		canon, offs, n := canonFor(t, "drop.example.com.")
-		winner, _ := storeOf(z).MatchQNAME(canon, offs[:], n)
+		winner, _ := storeOf(z).Match(canon, offs[:], n, netip.Addr{})
 		if winner.Zone == nil {
 			t.Fatalf("policy %v: no match", tc.policy)
 		}
@@ -256,7 +261,7 @@ z.test. IN SOA ns. admin. 1 3600 900 604800 300
 		t.Fatal(err)
 	}
 	canon, offs, n := canonFor(t, "anything.at.all.example.")
-	if winner, _ := storeOf(z).MatchQNAME(canon, offs[:], n); winner.Zone == nil || winner.Effective() != ActionNXDOMAIN {
+	if winner, _ := storeOf(z).Match(canon, offs[:], n, netip.Addr{}); winner.Zone == nil || winner.Effective() != ActionNXDOMAIN {
 		t.Fatalf("bare * did not match: %+v", winner)
 	}
 }
@@ -282,7 +287,7 @@ func TestMatchQNAMEMissAllocatesNothing(t *testing.T) {
 		if !ok {
 			t.Fatal("refused")
 		}
-		winner, observed := s.MatchQNAME(canon, offs[:], n)
+		winner, observed := s.Match(canon, offs[:], n, netip.Addr{})
 		if winner.Zone != nil || observed != nil {
 			t.Fatal("unexpected match")
 		}

--- a/middleware/rpz/metrics.go
+++ b/middleware/rpz/metrics.go
@@ -41,7 +41,7 @@ var (
 // countMatch runs on the match path only — the non-matching query touches
 // no counter (design §5.11).
 func countMatch(m rpzengine.ZoneMatch, outcome string) {
-	actionTotal.WithLabelValues(m.Zone.Name, "qname", m.Effective().String(), outcome).Inc()
+	actionTotal.WithLabelValues(m.Zone.Name, m.Trigger, m.Effective().String(), outcome).Inc()
 }
 
 // skipReasons is every reason the engine can count, so a reload publishes
@@ -57,7 +57,8 @@ var skipReasons = []string{
 }
 
 func publishZoneMetrics(z *rpzengine.Zone) {
-	zoneRules.WithLabelValues(z.Name, "qname").Set(float64(z.Rules))
+	zoneRules.WithLabelValues(z.Name, rpzengine.TriggerQNAME).Set(float64(z.Rules - z.RulesClientIP))
+	zoneRules.WithLabelValues(z.Name, rpzengine.TriggerClientIP).Set(float64(z.RulesClientIP))
 	for _, reason := range skipReasons {
 		zoneRulesSkipped.WithLabelValues(z.Name, reason).Set(float64(z.Skipped[reason]))
 	}

--- a/middleware/rpz/metrics.go
+++ b/middleware/rpz/metrics.go
@@ -49,6 +49,7 @@ func countMatch(m rpzengine.ZoneMatch, outcome string) {
 // keeping the previous generation's value on the board.
 var skipReasons = []string{
 	rpzengine.SkipTrigger,
+	rpzengine.SkipOwnerEncoding,
 	rpzengine.SkipUnknownAction,
 	rpzengine.SkipNotActionData,
 	rpzengine.SkipConflict,

--- a/middleware/rpz/rpz.go
+++ b/middleware/rpz/rpz.go
@@ -7,6 +7,7 @@ package rpz
 
 import (
 	"context"
+	"net/netip"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -135,7 +136,19 @@ func (r *RPZ) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		return
 	}
 
-	winner, observed := s.MatchQNAME(canon, offs[:], n)
+	// The client address enters the shared 128-bit key space only when
+	// some zone actually carries CLIENT-IP rules; a qname-only
+	// configuration never touches it. netip conversion is value math.
+	var client netip.Addr
+	if s.HasClientIP() {
+		if ip := w.RemoteIP(); ip != nil {
+			if a, ok := netip.AddrFromSlice(ip); ok {
+				client = rpz.CanonicalClient(a)
+			}
+		}
+	}
+
+	winner, observed := s.Match(canon, offs[:], n, client)
 	if winner.Zone == nil && observed == nil {
 		// The steady state: no rule anywhere named this query. Nothing
 		// above this line allocated.

--- a/middleware/rpz/rpz_test.go
+++ b/middleware/rpz/rpz_test.go
@@ -602,3 +602,95 @@ keep.example.com.rpz.test. IN CNAME .
 		t.Fatalf("skip gauge = %v after a clean reload, want 0", read())
 	}
 }
+
+const clientIPTestZone = `
+rpz.test. IN SOA ns.rpz.test. admin.rpz.test. 5 3600 900 604800 300
+24.0.2.0.192.rpz-client-ip.rpz.test.  IN CNAME rpz-drop.
+32.9.2.0.192.rpz-client-ip.rpz.test.  IN CNAME rpz-passthru.
+16.0.0.0.10.rpz-client-ip.rpz.test.   IN A 192.0.2.99
+victim.example.com.rpz.test.          IN CNAME *.
+`
+
+// serveFrom is serve with the client address under test.
+func serveFrom(t *testing.T, r *RPZ, addr, qname string, qtype uint16) (*mock.Writer, bool) {
+	t.Helper()
+	q := new(dns.Msg)
+	q.SetQuestion(qname, qtype)
+	q.RecursionDesired = true
+	raw, err := q.Pack()
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := new(middleware.Request)
+	if !req.ParseWire(raw, time.Now(), nil) {
+		t.Fatal("refused")
+	}
+	passed := false
+	next := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		passed = true
+		ch.Cancel()
+	})
+	w := mock.NewWriter("udp", addr)
+	ch := middleware.NewChain([]middleware.Handler{r, next})
+	ch.ResetWire(w, req)
+	ch.Next(context.Background())
+	return w, passed
+}
+
+func TestClientIPEndToEnd(t *testing.T) {
+	r := newRPZ(t, "enforce", config.RPZZone{Name: "cip", File: writeZone(t, clientIPTestZone)})
+
+	// A client in the dropped /24 gets nothing, whatever it asks.
+	if w, passed := serveFrom(t, r, "192.0.2.55:40000", "totally.unrelated.example.", dns.TypeA); passed || w.Written() {
+		t.Fatalf("dropped client answered: passed=%v written=%v", passed, w.Written())
+	}
+	// The /32 passthru inside it is exempt (longest prefix wins).
+	if _, passed := serveFrom(t, r, "192.0.2.9:40000", "victim.example.com.", dns.TypeA); !passed {
+		t.Fatal("the /32 passthru client was not exempted")
+	}
+	// A client outside every prefix falls to the QNAME rule.
+	if w, passed := serveFrom(t, r, "198.51.100.1:40000", "victim.example.com.", dns.TypeA); passed || w.Rcode() != dns.RcodeSuccess || len(w.Msg().Answer) != 0 {
+		t.Fatalf("outside client: passed=%v rcode=%v", passed, w.Rcode())
+	}
+	// And an unpolicied client + unpolicied name passes untouched.
+	if _, passed := serveFrom(t, r, "198.51.100.1:40000", "innocent.example.org.", dns.TypeA); !passed {
+		t.Fatal("clean query blocked")
+	}
+}
+
+// TestClientIPLocalDataOwnerIsTheQName is the phase 2 exit criterion from
+// the design, verbatim: an address-encoded trigger owner must never
+// appear in a response.
+func TestClientIPLocalDataOwnerIsTheQName(t *testing.T) {
+	r := newRPZ(t, "enforce", config.RPZZone{Name: "cip", File: writeZone(t, clientIPTestZone)})
+
+	w, _ := serveFrom(t, r, "10.0.12.13:40000", "some.name.example.", dns.TypeA)
+	answers := w.Msg().Answer
+	if len(answers) != 1 {
+		t.Fatalf("answers = %v", answers)
+	}
+	a, ok := answers[0].(*dns.A)
+	if !ok || a.A.String() != "192.0.2.99" {
+		t.Fatalf("answer = %v", answers[0])
+	}
+	if a.Hdr.Name != "some.name.example." {
+		t.Fatalf("owner %q leaked from the trigger encoding", a.Hdr.Name)
+	}
+}
+
+func TestClientIPCountsUnderItsOwnTriggerLabel(t *testing.T) {
+	r := newRPZ(t, "shadow", config.RPZZone{Name: "ciplabel", File: writeZone(t, clientIPTestZone)})
+
+	before := func(trigger string) float64 {
+		m := &dto.Metric{}
+		if err := actionTotal.WithLabelValues("ciplabel", trigger, "drop", outcomeObserved).Write(m); err != nil {
+			t.Fatal(err)
+		}
+		return m.GetCounter().GetValue()
+	}
+	b := before("client-ip")
+	serveFrom(t, r, "192.0.2.55:40000", "x.example.", dns.TypeA)
+	if got := before("client-ip") - b; got != 1 {
+		t.Fatalf("client-ip trigger counted %.0f, want 1", got)
+	}
+}

--- a/middleware/rpz/rpz_test.go
+++ b/middleware/rpz/rpz_test.go
@@ -694,3 +694,38 @@ func TestClientIPCountsUnderItsOwnTriggerLabel(t *testing.T) {
 		t.Fatalf("client-ip trigger counted %.0f, want 1", got)
 	}
 }
+
+// TestOwnerEncodingSkipGaugePublishes pins the review's metric gap: a
+// malformed trigger encoding must be visible under
+// rpz_zone_rules_skipped, load and reload alike.
+func TestOwnerEncodingSkipGaugePublishes(t *testing.T) {
+	path := writeZone(t, `
+rpz.test. IN SOA ns.rpz.test. admin.rpz.test. 1 3600 900 604800 300
+keep.example.com.rpz.test. IN CNAME .
+999.0.2.0.192.rpz-client-ip.rpz.test. IN CNAME .
+`)
+	r := newRPZ(t, "enforce", config.RPZZone{Name: "encgauge", File: path})
+
+	read := func() float64 {
+		m := &dto.Metric{}
+		if err := zoneRulesSkipped.WithLabelValues("encgauge", rpzengine.SkipOwnerEncoding).Write(m); err != nil {
+			t.Fatal(err)
+		}
+		return m.GetGauge().GetValue()
+	}
+	if read() != 1 {
+		t.Fatalf("owner-encoding gauge = %v after load, want 1", read())
+	}
+
+	// The cleaned push reads back as zero.
+	if err := os.WriteFile(path, []byte(`
+rpz.test. IN SOA ns.rpz.test. admin.rpz.test. 2 3600 900 604800 300
+keep.example.com.rpz.test. IN CNAME .
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	r.reload(0)
+	if read() != 0 {
+		t.Fatalf("owner-encoding gauge = %v after a clean reload, want 0", read())
+	}
+}


### PR DESCRIPTION
Phase 2 of `docs/rpz-design.md` (§6). One commit on top of merged phase 1.

## What lands

**Encoding (draft §4.1.1):** `rpz-client-ip` owners now compile — `prefix.B4.B3.B2.B1` for IPv4, reversed 16-bit hextets with a single `zz` for IPv6. The parse fixtures carry the draft's `zz`-compresses-the-**last**-zero-run subtlety verbatim (an address with two equal zero runs). Everything lives in one 128-bit key space: IPv4 rules map to 4-in-6 at prefix+96, the client address is canonicalized identically. Malformed encodings are a new counted skip reason (`owner-encoding`), never a load failure.

**The payload LPM (§5.3):** one map of masked `netip.Addr` per prefix length present, walked longest-first — `internal/ipset` was ruled out in design review (bool-only, coalesces the overlapping prefixes policy must keep distinct). All six actions work on address triggers; Local Data merges and conflicts exactly as on name triggers.

**Precedence:** within a zone CLIENT-IP > QNAME (rule 2), longest prefix wins (rule 4) — both pinned by fixtures whose competing rules prescribe *different actions*. The client-side equal-length tie-break is vacuous by construction (disjoint prefixes cannot both contain one address) and is noted for phase 4, where multiple response addresses make it real.

**Middleware:** the client address is canonicalized only when some zone actually carries CLIENT-IP rules — a qname-only configuration never touches it. Matches count under their own `trigger="client-ip"` label; per-trigger rule gauges split.

## The design's exit criteria, run

- **Adversarial all-lengths benchmark (the stated gate):** a hostile feed carrying every prefix length /1../128, probed by a non-matching client — **885 ns per zone walk against the 2 µs budget, 0 allocs**. A realistic five-length feed: **35 ns**. The length-map shape stays; no radix needed.
- **`zz` round-trip** incl. compressed-last; ten malformed encodings refused.
- **Rule 2 / rule 4 / `zz` placement mutation-tested:** inverting the trigger order, the length order, or the expansion position each fails exactly its named test.
- **Local Data owner = qname on an address trigger** (the design's verbatim criterion — an encoding never leaks into a response), end-to-end.
- **Alloc pins:** engine miss with client-ip rules at zero outright; middleware non-matching query still adds zero over the bare chain.

## Verification

Full suite green · `-race` clean · lint 0 · vet linux/windows clean · allocation gates untouched.

No config surface changes: CLIENT-IP rules arrive in the zone files feeds already carry.