### PR TITLE
Extract the secondary-zone transfer primitives from localroot

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,48 @@ answers = [
 
 Views are evaluated in declaration order; the first whose `networks` contains the client IP wins. `zone` is a free-form label used in error logs — it doesn't have to be a DNS zone name.
 
+#### Response Policy Zones (RPZ)
+
+The RPZ middleware subscribes the resolver to policy zones — locally maintained files or vendor AXFR feeds in the standard RPZ encoding — that rewrite, deny, or drop answers for the names and client networks they list. Existing commercial feeds work unmodified.
+
+**Configuration:**
+```toml
+[rpz]
+enabled = true
+mode = "shadow"    # "shadow" counts and logs every match without rewriting; "enforce" acts
+
+# A file-fed zone: reloaded automatically when the file is replaced.
+[[rpz.zone]]
+name = "badlist"                       # label for metrics, logs and the EDE text
+file = "/var/lib/sdns/badlist.zone"
+policy = "given"                       # per-zone override, see below
+
+# An AXFR-fed zone: follows the feed's own SOA schedule.
+[[rpz.zone]]
+name = "vendorfeed"
+source = "203.0.113.5:53"              # the feed's primary (host:port)
+origin = "rpz.vendor.example."         # the policy zone's apex
+# tsig_key = "feedkey.:hmac-sha256.:BASE64SECRET"   # when the provider signs transfers
+```
+
+Zones are evaluated in the order written; the first zone with a match wins. Within a zone, a client-address (`rpz-client-ip`) match outranks a name match, and the longest prefix or most specific name wins.
+
+**Triggers:** QNAME rules (exact and `*.wildcard`) and CLIENT-IP rules (IPv4 and IPv6 prefixes, in the standard reversed-owner encoding). Triggers of other types in a feed (`rpz-ip`, `rpz-nsdname`, `rpz-nsip`) load without error and are counted as skipped.
+
+**Actions** (standard RPZ RDATA encodings): NXDOMAIN (`CNAME .`), NODATA (`CNAME *.`), PASSTHRU, DROP (no answer at all), TCP-Only (truncates UDP; encrypted transports pass), and Local Data — served as if authoritative for the query name, including CNAME chasing through the resolver.
+
+**Per-zone `policy` override:** `given` uses what each rule says; `passthru`, `nxdomain`, `nodata`, `drop`, `tcp-only` replace every action in the zone; `cname` rewrites every match to the `cname = "target."` walled garden; `disabled` only observes — a later zone still acts.
+
+**Operational behavior:**
+- Policy applies to client queries only (RD=1); the resolver's own internal lookups are never policy-checked.
+- Rewritten answers carry the policy zone's SOA in the additional section and Extended DNS Error 17 (Filtered), and never claim DNSSEC authenticity.
+- A file push that fails to parse — or parses but contains no rules — keeps the previous rules serving and is counted, never silently unprotected.
+- An AXFR feed probes the SOA on its refresh interval, transfers on serial change, refuses serial rollbacks (RFC 1982), and **withdraws its rules past SOA expire** — a feed that cannot be refreshed fails open rather than enforcing stale policy.
+- `sdns -t` validates the whole `[rpz]` block, parsing file-fed zones with the same loader the server uses.
+- A non-matching query costs zero heap allocations; a 2M-rule feed measured no serving-path regression.
+
+**Metrics:** `rpz_action_total{zone,trigger,action,outcome}` (`outcome="enforced"` for the acting match, `"observed"` for shadow mode and disabled zones), `rpz_zone_rules{zone,trigger}`, `rpz_zone_rules_skipped{zone,reason}`, `rpz_reload_errors_total{zone}`, `rpz_zone_serial{zone}` (-1 for file-fed or withdrawn zones).
+
 #### DNS64 (RFC 6147)
 
 The DNS64 middleware lets IPv6-only clients reach IPv4-only services. When a client AAAA query has no usable answer, the middleware issues a secondary A-record lookup and synthesises AAAA records by embedding each IPv4 address into a configured Pref64::/n IPv6 prefix (RFC 6052). The client receives addresses in a NAT64-routable subnet and can connect to the IPv4-only target through a paired NAT64 gateway.

--- a/config/config.go
+++ b/config/config.go
@@ -247,12 +247,24 @@ type RPZ struct {
 	Zones []RPZZone `toml:"zone"`
 }
 
-// RPZZone is one [[rpz.zone]] entry.
+// RPZZone is one [[rpz.zone]] entry. A zone is fed exactly one way:
+// File for a local file, or Source+Origin for an AXFR secondary.
 type RPZZone struct {
 	// Name labels the zone in metrics, logs, and the EDE text.
 	Name string `toml:"name"`
 	// File is the policy zone in standard zone-file format.
 	File string `toml:"file"`
+	// Source is the AXFR primary (host:port). The zone then follows its
+	// own SOA schedule — probe on refresh, transfer on serial change,
+	// withdraw past expire — and File must be empty.
+	Source string `toml:"source"`
+	// Origin is the policy zone's apex, the name the AXFR asks for.
+	// Required with Source.
+	Origin string `toml:"origin"`
+	// TsigKey authenticates the transfer when the provider requires it:
+	// "name:algorithm:base64-secret", e.g.
+	// "feedkey.:hmac-sha256.:c2VjcmV0". Empty for an unsigned transfer.
+	TsigKey string `toml:"tsig_key"`
 	// Policy overrides every action the zone's rules carry:
 	// given|passthru|nxdomain|nodata|drop|tcp-only|cname|disabled.
 	// "given" (or empty) uses what each rule says; "disabled" logs what
@@ -1048,6 +1060,15 @@ emptyzones = [
 # name = "badfeed"
 # file = "/var/lib/sdns/badfeed.zone"
 # policy = "given"
+# An AXFR-fed zone instead names its primary and apex (and never a file);
+# it follows the feed's own SOA schedule and withdraws its rules past SOA
+# expire. tsig_key ("name:algorithm:base64-secret") signs the transfer
+# when the provider requires it.
+# [[rpz.zone]]
+# name = "vendorfeed"
+# source = "203.0.113.5:53"
+# origin = "rpz.vendor.example."
+# tsig_key = "feedkey.:hmac-sha256.:c2VjcmV0"
 
 # ============================
 # TCP Connection Pooling

--- a/config/validate.go
+++ b/config/validate.go
@@ -1742,9 +1742,48 @@ func (c *Config) validateRPZ(add func(string, ...any)) {
 			add("%s: cname is set but policy is %q; the target is only read with policy = \"cname\"", where, zc.Policy)
 		}
 
-		if zc.File == "" {
-			add("%s: file is required", where)
+		// A zone is fed exactly one way. The AXFR side is judged only on
+		// what is knowable offline — whether a source answers is a
+		// runtime question, and the feed loop owns it.
+		switch {
+		case zc.File != "" && zc.Source != "":
+			add("%s: file and source are both set; a zone is fed one way", where)
 			continue
+		case zc.Source != "":
+			// The feed dials this with net.Dialer over TCP, so a hostname
+			// is fine — but the halves must both be there and the port
+			// reachable, exactly as the hyperlocal sources are judged.
+			// SplitHostPort alone waves ":53", "host:" and "host:0"
+			// through, and each builds a feed that fails every cycle.
+			host, port, err := net.SplitHostPort(zc.Source)
+			switch {
+			case err != nil || host == "" || port == "":
+				add("%s: source = %q: must be host:port", where, zc.Source)
+			default:
+				if n, err := usablePort(port, "tcp"); err != nil || n == 0 {
+					add("%s: source = %q: must have a port to reach", where, zc.Source)
+				}
+			}
+			if zc.Origin == "" {
+				add("%s: source needs an origin — the apex name the transfer asks for", where)
+			} else if _, valid := dns.IsDomainName(zc.Origin); !valid || !dns.IsFqdn(zc.Origin) {
+				add("%s: origin = %q: must be a fully qualified domain name", where, zc.Origin)
+			}
+			if zc.TsigKey != "" {
+				if _, err := rpz.ParseTSIGKey(zc.TsigKey); err != nil {
+					add("%s: %v", where, err)
+				}
+			}
+			continue
+		case zc.File == "":
+			add("%s: either file or source is required", where)
+			continue
+		}
+		if zc.Origin != "" {
+			add("%s: origin is set but the zone is file-fed; the file's own SOA names the apex", where)
+		}
+		if zc.TsigKey != "" {
+			add("%s: tsig_key is set but the zone is file-fed; only transfers are signed", where)
 		}
 		z, err := rpz.LoadZoneFile(zc.Name, zc.File, policy, dns.CanonicalName(zc.Cname))
 		if err != nil {

--- a/config/validate_rpz_test.go
+++ b/config/validate_rpz_test.go
@@ -100,7 +100,7 @@ func TestValidateRPZ(t *testing.T) {
 	})
 
 	t.Run("file judged with the runtime's parser", func(t *testing.T) {
-		wantRPZProblem(t, rpzConfig(RPZZone{Name: "feed"}), "file is required")
+		wantRPZProblem(t, rpzConfig(RPZZone{Name: "feed"}), "either file or source is required")
 		// The OS names the missing file differently per platform ("no
 		// such file" vs "cannot find the file"), so the assertion holds
 		// onto the one part we control: the path in the error.
@@ -113,5 +113,61 @@ func TestValidateRPZ(t *testing.T) {
 		// which is never what an operator enabling RPZ meant.
 		empty := rpzZoneFile(t, "rpz.test. IN SOA ns. admin. 1 3600 900 604800 300\n")
 		wantRPZProblem(t, rpzConfig(RPZZone{Name: "feed", File: empty}), "compiled no rules")
+	})
+}
+
+func TestValidateRPZSourceZones(t *testing.T) {
+	good := rpzZoneFile(t, validRPZZone)
+
+	t.Run("valid source zone passes", func(t *testing.T) {
+		c := rpzConfig(RPZZone{Name: "feed", Source: "203.0.113.5:53", Origin: "rpz.vendor.example."})
+		if err := c.Validate(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("file and source are exclusive", func(t *testing.T) {
+		wantRPZProblem(t, rpzConfig(RPZZone{Name: "feed", File: good, Source: "203.0.113.5:53", Origin: "z."}), "fed one way")
+	})
+
+	t.Run("source needs a well-formed address and origin", func(t *testing.T) {
+		wantRPZProblem(t, rpzConfig(RPZZone{Name: "feed", Source: "203.0.113.5", Origin: "z."}), "host:port")
+		wantRPZProblem(t, rpzConfig(RPZZone{Name: "feed", Source: "203.0.113.5:53"}), "needs an origin")
+		wantRPZProblem(t, rpzConfig(RPZZone{Name: "feed", Source: "203.0.113.5:53", Origin: "no-dot.example"}), "fully qualified")
+		// SplitHostPort alone waves these through; each builds a feed
+		// that fails every cycle.
+		wantRPZProblem(t, rpzConfig(RPZZone{Name: "feed", Source: ":53", Origin: "z."}), "host:port")
+		wantRPZProblem(t, rpzConfig(RPZZone{Name: "feed", Source: "203.0.113.5:", Origin: "z."}), "host:port")
+		wantRPZProblem(t, rpzConfig(RPZZone{Name: "feed", Source: "203.0.113.5:0", Origin: "z."}), "port to reach")
+	})
+
+	t.Run("tsig shape judged with the runtime's parser", func(t *testing.T) {
+		base := RPZZone{Name: "feed", Source: "203.0.113.5:53", Origin: "z."}
+		bad := base
+		bad.TsigKey = "just-a-name"
+		wantRPZProblem(t, rpzConfig(bad), "tsig_key")
+		notB64 := base
+		notB64.TsigKey = "k.:hmac-sha256.:not!!base64"
+		wantRPZProblem(t, rpzConfig(notB64), "base64")
+		// An algorithm the dns library cannot sign with must be refused
+		// here, not discovered at runtime as a feed that never transfers.
+		badAlgo := base
+		badAlgo.TsigKey = "k.:hmac-sha999.:c2VjcmV0"
+		wantRPZProblem(t, rpzConfig(badAlgo), "algorithm")
+		// A key name that cannot be packed would fail the first signed
+		// request at runtime; the gate refuses it here.
+		badName := base
+		badName.TsigKey = strings.Repeat("a", 64) + ".:hmac-sha256.:c2VjcmV0"
+		wantRPZProblem(t, rpzConfig(badName), "not a valid domain name")
+		ok := base
+		ok.TsigKey = "k.:hmac-sha256.:c2VjcmV0"
+		if err := rpzConfig(ok).Validate(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("origin and tsig are refused on file zones", func(t *testing.T) {
+		wantRPZProblem(t, rpzConfig(RPZZone{Name: "feed", File: good, Origin: "z."}), "file-fed")
+		wantRPZProblem(t, rpzConfig(RPZZone{Name: "feed", File: good, TsigKey: "k.:a.:YQ=="}), "only transfers are signed")
 	})
 }

--- a/contrib/linux/sdns.conf
+++ b/contrib/linux/sdns.conf
@@ -424,6 +424,15 @@ emptyzones = [
 # name = "badfeed"
 # file = "/var/lib/sdns/badfeed.zone"
 # policy = "given"
+# An AXFR-fed zone instead names its primary and apex (and never a file);
+# it follows the feed's own SOA schedule and withdraws its rules past SOA
+# expire. tsig_key ("name:algorithm:base64-secret") signs the transfer
+# when the provider requires it.
+# [[rpz.zone]]
+# name = "vendorfeed"
+# source = "203.0.113.5:53"
+# origin = "rpz.vendor.example."
+# tsig_key = "feedkey.:hmac-sha256.:c2VjcmV0"
 
 # ============================
 # TCP Connection Pooling

--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kr/text v0.2.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/internal/rpz/parse.go
+++ b/internal/rpz/parse.go
@@ -134,6 +134,37 @@ func LoadZone(name string, r io.Reader, file string, policy Override, cnameTarge
 	return z, nil
 }
 
+// CompileRecords compiles an already-received record stream — an AXFR —
+// into a Zone, through exactly the classifier the file loader uses, so a
+// feed behaves identically whichever way it arrived. The stream must lead
+// with its apex SOA, which a strict transfer guarantees; the caller
+// normalizes duplicates first (zonetransfer.NormalizeZone), because the
+// Local Data merge accumulates records and a doubled record must not read
+// as two.
+func CompileRecords(name string, rrs []dns.RR, policy Override, cnameTarget string) (*Zone, error) {
+	if len(rrs) == 0 {
+		return nil, fmt.Errorf("rpz zone %q: empty transfer", name)
+	}
+	soa, ok := rrs[0].(*dns.SOA)
+	if !ok {
+		return nil, fmt.Errorf("rpz zone %q: transfer does not lead with its SOA", name)
+	}
+	z := &Zone{
+		Name:        name,
+		Origin:      dns.CanonicalName(soa.Hdr.Name),
+		SOA:         soa,
+		Policy:      policy,
+		CNAMETarget: cnameTarget,
+		exact:       make(map[string]*Rule),
+		wild:        make(map[string]*Rule),
+		Skipped:     make(map[string]int),
+	}
+	for _, rr := range rrs[1:] {
+		z.classify(rr)
+	}
+	return z, nil
+}
+
 // classify turns one record into a rule, or a counted skip.
 func (z *Zone) classify(rr dns.RR) {
 	hdr := rr.Header()

--- a/internal/rpz/tsig.go
+++ b/internal/rpz/tsig.go
@@ -1,0 +1,54 @@
+package rpz
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/miekg/dns"
+)
+
+// TSIGKey is a transfer-signing key as the config spells it:
+// "name:algorithm:base64-secret". It lives in the engine so the config
+// gate judges the spelling with exactly the parser the feed loop uses.
+type TSIGKey struct {
+	Name      string
+	Algorithm string
+	Secret    string
+}
+
+// ParseTSIGKey reads the config spelling. Name and algorithm come back
+// canonical (rooted), as every dns-level TSIG API expects them.
+func ParseTSIGKey(s string) (*TSIGKey, error) {
+	if s == "" {
+		return nil, nil
+	}
+	parts := strings.SplitN(s, ":", 3)
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return nil, errors.New(`tsig_key must be "name:algorithm:base64-secret"`)
+	}
+	if _, err := base64.StdEncoding.DecodeString(parts[2]); err != nil {
+		return nil, fmt.Errorf("tsig_key secret is not base64: %w", err)
+	}
+	// The name travels in every signed request; one that cannot be
+	// packed would pass here and then fail the first transfer.
+	if _, ok := dns.IsDomainName(parts[0]); !ok {
+		return nil, fmt.Errorf("tsig_key name %q is not a valid domain name", parts[0])
+	}
+	algo := dns.CanonicalName(parts[1])
+	// Only the HMACs the dns library can actually sign with: anything
+	// else would pass `sdns -t` and then fail every transfer at runtime,
+	// leaving a permanently empty, fail-open zone behind a config the
+	// gate called healthy.
+	switch algo {
+	case dns.HmacSHA1, dns.HmacSHA224, dns.HmacSHA256, dns.HmacSHA384, dns.HmacSHA512:
+	default:
+		return nil, fmt.Errorf("tsig_key algorithm %q is not supported; use one of hmac-sha1, hmac-sha224, hmac-sha256, hmac-sha384, hmac-sha512", algo)
+	}
+	return &TSIGKey{
+		Name:      dns.CanonicalName(parts[0]),
+		Algorithm: algo,
+		Secret:    parts[2],
+	}, nil
+}

--- a/internal/zonetransfer/zonetransfer.go
+++ b/internal/zonetransfer/zonetransfer.go
@@ -1,0 +1,240 @@
+// Package zonetransfer holds the secondary-zone transfer primitives:
+// strict AXFR over TCP, the SOA serial probe, RFC 1982 serial comparison,
+// schedule jitter, and RFC 5936 duplicate normalization.
+//
+// It exists because two consumers need exactly these and nothing forces
+// them to share a lifecycle: the hyperlocal root (which verifies with
+// ZONEMD against the trust anchors and schedules around a signature
+// horizon) and RPZ policy feeds (which verify nothing cryptographic and
+// withdraw on SOA expire). The refresh loops stay with their owners —
+// each is welded to its own verification and withdrawal semantics — and
+// what is shared is the part with one right answer: how a zone is pulled,
+// probed, compared, and deduplicated.
+package zonetransfer
+
+import (
+	"context"
+	"errors"
+	"math/rand/v2"
+	"net"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/dnsclient"
+)
+
+var (
+	// ErrShape is a transfer or probe whose stream is not a zone: wrong
+	// ID, wrong rcode, a stream not bracketed by the apex SOA, or a
+	// terminator that differs from the opener.
+	ErrShape = errors.New("zonetransfer: transfer did not carry a zone")
+	// ErrLimit is a stream that exceeded the caller's sanity bounds.
+	ErrLimit = errors.New("zonetransfer: transfer exceeded sanity bounds")
+)
+
+// Limits bounds one transfer, so a hostile or broken source cannot feed
+// an unbounded stream. The caller sizes them for its zone: the root is a
+// couple of megabytes; a commercial policy feed can run to millions of
+// records.
+type Limits struct {
+	MaxRecords int
+	MaxBytes   int
+}
+
+// AXFR transfers zone from addr over TCP and returns its records, the
+// closing duplicate apex SOA dropped. The transfer is bounded by ctx and
+// lim; any structural surprise refuses the whole transfer — there is no
+// partial acceptance of a zone copy.
+func AXFR(ctx context.Context, addr, zone string, timeout time.Duration, lim Limits) ([]dns.RR, error) {
+	zone = dns.CanonicalName(zone)
+
+	d := net.Dialer{Timeout: timeout}
+	raw, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	co := &dnsclient.Conn{Conn: raw}
+	defer func() { _ = co.Close() }()
+
+	deadline := time.Now().Add(timeout)
+	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
+		deadline = d
+	}
+	_ = raw.SetDeadline(deadline)
+
+	req := new(dns.Msg)
+	req.SetAxfr(zone)
+
+	if err := co.WriteMsg(req); err != nil {
+		return nil, err
+	}
+
+	var (
+		rrs      []dns.RR
+		sawFirst bool
+		total    int
+	)
+	for {
+		resp, err := co.ReadMsg()
+		if err != nil {
+			return nil, err
+		}
+		if resp.Id != req.Id || resp.Rcode != dns.RcodeSuccess {
+			return nil, ErrShape
+		}
+		for _, rr := range resp.Answer {
+			isApexSOA := rr.Header().Rrtype == dns.TypeSOA &&
+				dns.CanonicalName(rr.Header().Name) == zone
+			if !sawFirst {
+				if !isApexSOA {
+					return nil, ErrShape
+				}
+				sawFirst = true
+				rrs = append(rrs, rr)
+				continue
+			}
+			if isApexSOA {
+				// RFC 5936 §2.2: the stream begins and ends with the same
+				// SOA record. A terminator that differs from the opener is a
+				// source whose zone moved under the transfer, so the records
+				// in between belong to no single version of it. Refusing
+				// here fails over to the next source and names the fault at
+				// the transfer; without the check the stream is accepted and
+				// the inconsistency surfaces later as a verification
+				// mismatch, blamed on verification.
+				if !dns.IsDuplicate(rrs[0], rr) {
+					return nil, ErrShape
+				}
+				// The closing duplicate: the zone is complete. Anything the
+				// source appends after it is not part of the zone and is
+				// left unread.
+				return rrs, nil
+			}
+			total += dns.Len(rr)
+			if len(rrs) >= lim.MaxRecords || total > lim.MaxBytes {
+				return nil, ErrLimit
+			}
+			rrs = append(rrs, rr)
+		}
+	}
+}
+
+// ProbeSerial asks addr for zone's SOA over TCP and returns its serial.
+// TCP deliberately: the probe talks to the same transfer hosts the AXFR
+// will, so a host that cannot serve TCP is discovered at the probe.
+func ProbeSerial(ctx context.Context, addr, zone string, timeout time.Duration) (uint32, error) {
+	zone = dns.CanonicalName(zone)
+
+	d := net.Dialer{Timeout: timeout}
+	raw, err := d.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return 0, err
+	}
+	co := &dnsclient.Conn{Conn: raw}
+	defer func() { _ = co.Close() }()
+
+	deadline := time.Now().Add(timeout)
+	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
+		deadline = d
+	}
+	_ = raw.SetDeadline(deadline)
+
+	req := new(dns.Msg)
+	req.SetQuestion(zone, dns.TypeSOA)
+	req.RecursionDesired = false
+
+	if err := co.WriteMsg(req); err != nil {
+		return 0, err
+	}
+	resp, err := co.ReadMsg()
+	if err != nil {
+		return 0, err
+	}
+	if resp.Id != req.Id || resp.Rcode != dns.RcodeSuccess {
+		return 0, ErrShape
+	}
+	for _, rr := range resp.Answer {
+		if soa, ok := rr.(*dns.SOA); ok &&
+			dns.CanonicalName(soa.Header().Name) == zone {
+			return soa.Serial, nil
+		}
+	}
+	return 0, ErrShape
+}
+
+// SerialNewer reports whether b is newer than a in RFC 1982 serial
+// arithmetic (the SOA serial's number space).
+func SerialNewer(a, b uint32) bool {
+	return (b > a && b-a < 1<<31) || (b < a && a-b > 1<<31)
+}
+
+// Jitter spreads d by ±10% so a fleet restarted together does not probe
+// the same source in the same second forever.
+func Jitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return 0
+	}
+	spread := int64(d / 10)
+	return d - time.Duration(spread) + time.Duration(rand.Int64N(2*spread+1)) //nolint:gosec // schedule jitter, not key material.
+}
+
+// rrKey identifies an RRset member for duplicate detection: everything RFC
+// 8976 §3.3.1.1 counts as identity except the RDATA, which dns.IsDuplicate
+// compares directly.
+type rrKey struct {
+	owner  string
+	rtype  uint16
+	rclass uint16
+}
+
+// NormalizeZone drops duplicate RRs from a received zone, keeping the first
+// of each. RFC 5936 §2.2 requires an AXFR client to ignore duplicates, and
+// RFC 8976 §3.3.1.1 fixes the identity as owner, class, type and RDATA — the
+// TTL is not part of it.
+//
+// This runs once, before anything else reads the records, because every stage
+// downstream counts them: a doubled record must not look to any consumer like
+// a zone with two — whether the consumer is a digest, an index, or a policy
+// rule that accumulates local data.
+func NormalizeZone(rrs []dns.RR) []dns.RR {
+	seen := make(map[rrKey][]dns.RR, len(rrs))
+	out := make([]dns.RR, 0, len(rrs))
+	for _, rr := range rrs {
+		hdr := rr.Header()
+		key := rrKey{
+			owner:  dns.CanonicalName(hdr.Name),
+			rtype:  hdr.Rrtype,
+			rclass: hdr.Class,
+		}
+		if kept := firstDuplicate(seen[key], rr); kept != nil {
+			// RFC 2181 §5.2: a receiver holding records of one RRset with
+			// differing TTLs treats them as if all carried the lowest. The
+			// duplicate is dropped, but its TTL still has a say — otherwise
+			// the surviving record's lifetime depends on which copy the
+			// source happened to send first.
+			if rr.Header().Ttl < kept.Header().Ttl {
+				kept.Header().Ttl = rr.Header().Ttl
+			}
+			continue
+		}
+		// Copied, because the TTL above is rewritten in place and the caller
+		// still owns the records it handed us.
+		rr = dns.Copy(rr)
+		seen[key] = append(seen[key], rr)
+		out = append(out, rr)
+	}
+	return out
+}
+
+// firstDuplicate returns the record in rrs that rr duplicates, or nil when
+// it is new. Identity is owner, class, type and RDATA — dns.IsDuplicate
+// excludes the TTL. The sets it searches are one owner's records of one
+// type, small enough that a linear scan is the whole of it.
+func firstDuplicate(rrs []dns.RR, rr dns.RR) dns.RR {
+	for _, have := range rrs {
+		if dns.IsDuplicate(have, rr) {
+			return have
+		}
+	}
+	return nil
+}

--- a/internal/zonetransfer/zonetransfer_test.go
+++ b/internal/zonetransfer/zonetransfer_test.go
@@ -1,0 +1,158 @@
+package zonetransfer
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/dnsclient"
+)
+
+// serveZone answers one SOA probe or AXFR per connection for the given
+// zone, streaming the body between the opening and closing apex SOA.
+func serveZone(t *testing.T, zone string, body []dns.RR) string {
+	t.Helper()
+	soa := &dns.SOA{
+		Hdr:    dns.RR_Header{Name: zone, Rrtype: dns.TypeSOA, Class: dns.ClassINET, Ttl: 300},
+		Ns:     "ns." + zone,
+		Mbox:   "admin." + zone,
+		Serial: 7, Refresh: 3600, Retry: 900, Expire: 604800, Minttl: 300,
+	}
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+
+	go func() {
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer func() { _ = c.Close() }()
+				co := &dnsclient.Conn{Conn: c}
+				req, err := co.ReadMsg()
+				if err != nil || len(req.Question) != 1 {
+					return
+				}
+				resp := new(dns.Msg)
+				resp.SetReply(req)
+				switch req.Question[0].Qtype {
+				case dns.TypeSOA:
+					resp.Answer = []dns.RR{soa}
+				case dns.TypeAXFR:
+					resp.Answer = append([]dns.RR{soa}, body...)
+					resp.Answer = append(resp.Answer, soa)
+				}
+				_ = co.WriteMsg(resp)
+			}(c)
+		}
+	}()
+	return l.Addr().String()
+}
+
+// TestAXFRCarriesTheZoneParameter is the point of the extraction: the
+// primitives serve any apex, not the root the first consumer was welded
+// to. The whole shape discipline — opener, terminator, dropped closer —
+// holds for a policy-feed-shaped zone.
+func TestAXFRCarriesTheZoneParameter(t *testing.T) {
+	const zone = "feed.example."
+	body := []dns.RR{
+		&dns.CNAME{Hdr: dns.RR_Header{Name: "bad.example.com." + zone, Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300}, Target: "."},
+		&dns.A{Hdr: dns.RR_Header{Name: "walled.example.com." + zone, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300}, A: []byte{192, 0, 2, 1}},
+	}
+	addr := serveZone(t, zone, body)
+
+	rrs, err := AXFR(context.Background(), addr, zone, 3*time.Second, Limits{MaxRecords: 100, MaxBytes: 1 << 20})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Opening SOA + the body; the closing duplicate dropped.
+	if len(rrs) != 3 || rrs[0].Header().Rrtype != dns.TypeSOA {
+		t.Fatalf("rrs = %v", rrs)
+	}
+
+	serial, err := ProbeSerial(context.Background(), addr, zone, 3*time.Second)
+	if err != nil || serial != 7 {
+		t.Fatalf("probe = %d, %v", serial, err)
+	}
+
+	// The same server refuses to be treated as a different apex: the
+	// probe for another zone finds no matching SOA.
+	if _, err := ProbeSerial(context.Background(), addr, "other.example.", 3*time.Second); err == nil {
+		t.Fatal("a probe for the wrong zone answered")
+	}
+}
+
+// TestAXFRLimitsAreTheCallers pins why Limits is a parameter at all: the
+// first consumer's root-sized cap would refuse a legitimate
+// multi-million-record policy feed, so the bound belongs to the caller.
+func TestAXFRLimitsAreTheCallers(t *testing.T) {
+	const zone = "feed.example."
+	body := make([]dns.RR, 8)
+	for i := range body {
+		body[i] = &dns.A{
+			Hdr: dns.RR_Header{Name: "r.example." + zone, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+			A:   []byte{192, 0, 2, byte(i + 1)},
+		}
+	}
+	addr := serveZone(t, zone, body)
+
+	if _, err := AXFR(context.Background(), addr, zone, 3*time.Second, Limits{MaxRecords: 4, MaxBytes: 1 << 20}); err != ErrLimit {
+		t.Fatalf("tight record cap: err = %v, want ErrLimit", err)
+	}
+	if _, err := AXFR(context.Background(), addr, zone, 3*time.Second, Limits{MaxRecords: 100, MaxBytes: 16}); err != ErrLimit {
+		t.Fatalf("tight byte cap: err = %v, want ErrLimit", err)
+	}
+	if rrs, err := AXFR(context.Background(), addr, zone, 3*time.Second, Limits{MaxRecords: 100, MaxBytes: 1 << 20}); err != nil || len(rrs) != 9 {
+		t.Fatalf("roomy caps: %d rrs, %v", len(rrs), err)
+	}
+}
+
+func TestSerialNewerWraps(t *testing.T) {
+	for _, tc := range []struct {
+		a, b uint32
+		want bool
+	}{
+		{1, 2, true},
+		{2, 1, false},
+		{0xFFFFFFFF, 0, true}, // RFC 1982: the space wraps
+		{0, 0xFFFFFFFF, false},
+		{5, 5, false},
+	} {
+		if got := SerialNewer(tc.a, tc.b); got != tc.want {
+			t.Errorf("SerialNewer(%d, %d) = %v, want %v", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+func TestJitterStaysInBand(t *testing.T) {
+	const d = 10 * time.Second
+	for range 200 {
+		j := Jitter(d)
+		if j < 9*time.Second || j > 11*time.Second {
+			t.Fatalf("jitter %v outside ±10%% of %v", j, d)
+		}
+	}
+	if Jitter(0) != 0 {
+		t.Fatal("zero interval must stay zero")
+	}
+}
+
+func TestNormalizeZoneDedupsToLowestTTL(t *testing.T) {
+	mk := func(ttl uint32) dns.RR {
+		return &dns.A{
+			Hdr: dns.RR_Header{Name: "a.example.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: ttl},
+			A:   []byte{192, 0, 2, 1},
+		}
+	}
+	out := NormalizeZone([]dns.RR{mk(300), mk(60), mk(300)})
+	if len(out) != 1 || out[0].Header().Ttl != 60 {
+		t.Fatalf("out = %v", out)
+	}
+}

--- a/middleware/resolver/localroot/manager.go
+++ b/middleware/resolver/localroot/manager.go
@@ -452,19 +452,3 @@ func (m *Manager) load(rrs []dns.RR, expect uint32, expected bool) error {
 	zlog.Info("Local root zone updated", "serial", snap.serial, "records", len(rrs))
 	return nil
 }
-
-// serialNewer reports whether b is newer than a in RFC 1982 serial
-// arithmetic (the SOA serial's number space).
-func serialNewer(a, b uint32) bool {
-	return (b > a && b-a < 1<<31) || (b < a && a-b > 1<<31)
-}
-
-// jitter spreads d by ±10% so a fleet restarted together does not probe the
-// same source in the same second forever.
-func jitter(d time.Duration) time.Duration {
-	if d <= 0 {
-		return 0
-	}
-	spread := int64(d / 10)
-	return d - time.Duration(spread) + time.Duration(rand.Int64N(2*spread+1)) //nolint:gosec // schedule jitter, not key material.
-}

--- a/middleware/resolver/localroot/snapshot.go
+++ b/middleware/resolver/localroot/snapshot.go
@@ -386,20 +386,6 @@ func minRRSetTTL(rrs []dns.RR) uint32 {
 	return minTTL
 }
 
-// firstDuplicate returns the record in rrs that rr duplicates, or nil when it
-// is new. Identity is owner, class, type and RDATA — dns.IsDuplicate excludes
-// the TTL, which is what RFC 8976 §3.3.1.1 asks for. The sets it searches are
-// one owner's records of one type — a delegation's NS set, an apex RRSIG set —
-// so they are small enough that a linear scan is the whole of it.
-func firstDuplicate(rrs []dns.RR, rr dns.RR) dns.RR {
-	for _, have := range rrs {
-		if dns.IsDuplicate(have, rr) {
-			return have
-		}
-	}
-	return nil
-}
-
 // sigsCovering filters an owner's RRSIGs to those covering one type.
 func sigsCovering(sigs []dns.RR, covered uint16) []dns.RR {
 	var out []dns.RR

--- a/middleware/resolver/localroot/transfer.go
+++ b/middleware/resolver/localroot/transfer.go
@@ -2,190 +2,41 @@ package localroot
 
 import (
 	"context"
-	"errors"
-	"net"
 	"time"
 
 	"github.com/miekg/dns"
-	"github.com/semihalev/sdns/internal/dnsclient"
+	"github.com/semihalev/sdns/internal/zonetransfer"
 )
 
-var (
-	errTransferShape = errors.New("localroot: transfer did not carry a zone")
-	errTransferLimit = errors.New("localroot: transfer exceeded sanity bounds")
-)
+// The transfer primitives live in internal/zonetransfer since the RPZ
+// feeds needed the same ones; what stays here is the root's own sizing
+// and the names the rest of this package (and its tests) call.
+var errTransferShape = zonetransfer.ErrShape
 
-// Transfer sanity bounds: the root zone is a couple of megabytes and a few
-// tens of thousands of records. These caps exist so a hostile or broken
-// source cannot feed an unbounded stream; they are far above any real root.
-const (
-	maxTransferRecords = 1 << 20
-	maxTransferBytes   = 64 << 20
-)
+// rootTransferLimits bounds a root transfer: the zone is a couple of
+// megabytes and a few tens of thousands of records, and these caps are
+// far above any real root.
+var rootTransferLimits = zonetransfer.Limits{
+	MaxRecords: 1 << 20,
+	MaxBytes:   64 << 20,
+}
 
-// axfr transfers the root zone from addr over TCP and returns its records,
-// the closing duplicate apex SOA dropped. The transfer is bounded by ctx and
-// the sanity caps; any structural surprise refuses the whole transfer —
-// there is no partial acceptance of a zone copy.
+// axfr transfers the root zone from addr; see zonetransfer.AXFR.
 func axfr(ctx context.Context, addr string, timeout time.Duration) ([]dns.RR, error) {
-	d := net.Dialer{Timeout: timeout}
-	raw, err := d.DialContext(ctx, "tcp", addr)
-	if err != nil {
-		return nil, err
-	}
-	co := &dnsclient.Conn{Conn: raw}
-	defer func() { _ = co.Close() }()
-
-	deadline := time.Now().Add(timeout)
-	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
-		deadline = d
-	}
-	_ = raw.SetDeadline(deadline)
-
-	req := new(dns.Msg)
-	req.SetAxfr(".")
-
-	if err := co.WriteMsg(req); err != nil {
-		return nil, err
-	}
-
-	var (
-		rrs      []dns.RR
-		sawFirst bool
-		total    int
-	)
-	for {
-		resp, err := co.ReadMsg()
-		if err != nil {
-			return nil, err
-		}
-		if resp.Id != req.Id || resp.Rcode != dns.RcodeSuccess {
-			return nil, errTransferShape
-		}
-		for _, rr := range resp.Answer {
-			isApexSOA := rr.Header().Rrtype == dns.TypeSOA &&
-				dns.CanonicalName(rr.Header().Name) == "."
-			if !sawFirst {
-				if !isApexSOA {
-					return nil, errTransferShape
-				}
-				sawFirst = true
-				rrs = append(rrs, rr)
-				continue
-			}
-			if isApexSOA {
-				// RFC 5936 §2.2: the stream begins and ends with the same
-				// SOA record. A terminator that differs from the opener is a
-				// source whose zone moved under the transfer, so the records
-				// in between belong to no single version of it. Refusing
-				// here fails over to the next source and names the fault at
-				// the transfer; without the check the stream is accepted and
-				// the inconsistency surfaces later as a digest mismatch,
-				// blamed on verification.
-				if !dns.IsDuplicate(rrs[0], rr) {
-					return nil, errTransferShape
-				}
-				// The closing duplicate: the zone is complete. Anything the
-				// source appends after it is not part of the zone and is
-				// left unread.
-				return rrs, nil
-			}
-			total += dns.Len(rr)
-			if len(rrs) >= maxTransferRecords || total > maxTransferBytes {
-				return nil, errTransferLimit
-			}
-			rrs = append(rrs, rr)
-		}
-	}
+	return zonetransfer.AXFR(ctx, addr, ".", timeout, rootTransferLimits)
 }
 
-// rrKey identifies an RRset member for duplicate detection: everything RFC
-// 8976 §3.3.1.1 counts as identity except the RDATA, which dns.IsDuplicate
-// compares directly.
-type rrKey struct {
-	owner  string
-	rtype  uint16
-	rclass uint16
-}
-
-// normalizeZone drops duplicate RRs from a received zone, keeping the first
-// of each. RFC 5936 §2.2 requires an AXFR client to ignore duplicates, and
-// RFC 8976 §3.3.1.1 fixes the identity as owner, class, type and RDATA — the
-// TTL is not part of it.
-//
-// This runs once, before anything else reads the records, because every stage
-// downstream counts them: the apex cardinality bound, the ZONEMD scheme/hash
-// tuple check, the digest, and the index. A source that sends one record
-// twice must not look to any of them like a zone with two. Left to the tuple
-// check in particular, a doubled ZONEMD RR reads as a repeated tuple and
-// refuses a zone RFC 5936 says should simply have been deduplicated.
-func normalizeZone(rrs []dns.RR) []dns.RR {
-	seen := make(map[rrKey][]dns.RR, len(rrs))
-	out := make([]dns.RR, 0, len(rrs))
-	for _, rr := range rrs {
-		hdr := rr.Header()
-		key := rrKey{
-			owner:  dns.CanonicalName(hdr.Name),
-			rtype:  hdr.Rrtype,
-			rclass: hdr.Class,
-		}
-		if kept := firstDuplicate(seen[key], rr); kept != nil {
-			// RFC 2181 §5.2: a receiver holding records of one RRset with
-			// differing TTLs treats them as if all carried the lowest. The
-			// duplicate is dropped, but its TTL still has a say — otherwise
-			// the surviving record's lifetime depends on which copy the
-			// source happened to send first.
-			if rr.Header().Ttl < kept.Header().Ttl {
-				kept.Header().Ttl = rr.Header().Ttl
-			}
-			continue
-		}
-		// Copied, because the TTL above is rewritten in place and the caller
-		// still owns the records it handed us.
-		rr = dns.Copy(rr)
-		seen[key] = append(seen[key], rr)
-		out = append(out, rr)
-	}
-	return out
-}
-
-// probeSerial asks addr for the root SOA over TCP and returns its serial.
-// TCP deliberately: the probe talks to the same transfer hosts the AXFR
-// will, so a host that cannot serve TCP is discovered at the probe.
+// probeSerial asks addr for the root SOA; see zonetransfer.ProbeSerial.
 func probeSerial(ctx context.Context, addr string, timeout time.Duration) (uint32, error) {
-	d := net.Dialer{Timeout: timeout}
-	raw, err := d.DialContext(ctx, "tcp", addr)
-	if err != nil {
-		return 0, err
-	}
-	co := &dnsclient.Conn{Conn: raw}
-	defer func() { _ = co.Close() }()
-
-	deadline := time.Now().Add(timeout)
-	if d, ok := ctx.Deadline(); ok && d.Before(deadline) {
-		deadline = d
-	}
-	_ = raw.SetDeadline(deadline)
-
-	req := new(dns.Msg)
-	req.SetQuestion(".", dns.TypeSOA)
-	req.RecursionDesired = false
-
-	if err := co.WriteMsg(req); err != nil {
-		return 0, err
-	}
-	resp, err := co.ReadMsg()
-	if err != nil {
-		return 0, err
-	}
-	if resp.Id != req.Id || resp.Rcode != dns.RcodeSuccess {
-		return 0, errTransferShape
-	}
-	for _, rr := range resp.Answer {
-		if soa, ok := rr.(*dns.SOA); ok &&
-			dns.CanonicalName(soa.Header().Name) == "." {
-			return soa.Serial, nil
-		}
-	}
-	return 0, errTransferShape
+	return zonetransfer.ProbeSerial(ctx, addr, ".", timeout)
 }
+
+// normalizeZone deduplicates a received zone; see
+// zonetransfer.NormalizeZone.
+func normalizeZone(rrs []dns.RR) []dns.RR { return zonetransfer.NormalizeZone(rrs) }
+
+// serialNewer is RFC 1982 serial comparison; see zonetransfer.SerialNewer.
+func serialNewer(a, b uint32) bool { return zonetransfer.SerialNewer(a, b) }
+
+// jitter spreads a schedule interval; see zonetransfer.Jitter.
+func jitter(d time.Duration) time.Duration { return zonetransfer.Jitter(d) }

--- a/middleware/rpz/axfr.go
+++ b/middleware/rpz/axfr.go
@@ -1,0 +1,382 @@
+package rpz
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/rpz"
+	"github.com/semihalev/sdns/internal/zonetransfer"
+	"github.com/semihalev/zlog/v2"
+)
+
+// A policy feed can legitimately run to millions of records; these bounds
+// exist for the stream that is not a feed at all.
+var feedTransferLimits = zonetransfer.Limits{
+	MaxRecords: 16 << 20,
+	MaxBytes:   1 << 30,
+}
+
+const (
+	// axfrTimeout bounds one probe or transfer attempt.
+	axfrTimeout = 2 * time.Minute
+	// axfrInitialRetry paces attempts until the first copy lands — before
+	// that there is no SOA to take a retry interval from.
+	axfrInitialRetry = time.Minute
+)
+
+// axfrFeed keeps one AXFR-sourced zone current: probe on the SOA refresh
+// interval, transfer on serial change, retry on the SOA retry interval,
+// and withdraw the rules past SOA expire — a feed that cannot be
+// refreshed must not keep enforcing what it said long ago. The loop's
+// schedule is deliberately its own (see internal/zonetransfer's package
+// note): it is welded to exactly this withdrawal semantic.
+type axfrFeed struct {
+	r    *RPZ
+	idx  int
+	name string
+	// origin is the configured apex; source the primary.
+	origin string
+	source string
+	policy rpz.Override
+	cname  string
+	tsig   *rpz.TSIGKey
+
+	// now is the test seam for the expire clock; timeout bounds one
+	// probe or transfer attempt (a test shrinks it).
+	now     func() time.Time
+	timeout time.Duration
+
+	// serial/loaded describe the installed copy; zero serial means none.
+	serial    uint32
+	haveCopy  bool
+	loaded    time.Time
+	refresh   time.Duration
+	retry     time.Duration
+	expire    time.Duration
+	withdrawn bool
+}
+
+func newAXFRFeed(r *RPZ, idx int, zc config.RPZZone) *axfrFeed {
+	key, _ := rpz.ParseTSIGKey(zc.TsigKey) // the config gate refused a bad one
+	policy, _ := rpz.ParseOverride(zc.Policy)
+	target := ""
+	if zc.Cname != "" {
+		target = dns.CanonicalName(zc.Cname)
+	}
+	return &axfrFeed{
+		r:       r,
+		idx:     idx,
+		name:    zc.Name,
+		origin:  dns.CanonicalName(zc.Origin),
+		source:  zc.Source,
+		policy:  policy,
+		cname:   target,
+		tsig:    key,
+		now:     time.Now,
+		timeout: axfrTimeout,
+	}
+}
+
+// run is the feed's lifecycle; it holds the schedule and never returns.
+func (f *axfrFeed) run(ctx context.Context) {
+	var next time.Duration
+	// The first attempt goes out immediately: an empty zone filters
+	// nothing, and every second before the first copy is policy the
+	// operator configured and is not getting.
+	timer := time.NewTimer(0)
+	defer timer.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+		}
+		next = f.cycle(ctx)
+		timer.Reset(next)
+	}
+}
+
+// cycle is one wake of the feed: withdrawal first, then the refresh.
+// The order is the expire contract — a copy past its horizon stops
+// serving before the refresh attempt starts, not up to a transfer
+// timeout later; the next successful transfer rebuilds it.
+func (f *axfrFeed) cycle(ctx context.Context) time.Duration {
+	f.maybeWithdraw()
+	afterFailure := false
+	if err := f.refreshOnce(ctx); err != nil {
+		afterFailure = true
+		f.maybeWithdraw() // the attempt itself may have crossed the horizon
+		zlog.Warn("RPZ feed refresh failed", "zone", f.name, "source", f.source, "error", err.Error())
+	}
+	return f.sleepFor(afterFailure)
+}
+
+// Bounds on the schedule the feed's SOA dictates: a zero or tiny refresh
+// must not become a hot probe loop, and a wake must land at the expire
+// boundary so a copy is withdrawn when its time comes rather than a full
+// retry interval later.
+const minFeedInterval = 30 * time.Second
+
+// nextWake is the interval to the next cycle: SOA retry after a failure,
+// SOA refresh after success, floored so a degenerate SOA cannot spin.
+func (f *axfrFeed) nextWake(afterFailure bool) time.Duration {
+	next := f.refresh
+	if afterFailure {
+		next = f.retry
+	}
+	if !f.haveCopy || next <= 0 {
+		next = axfrInitialRetry
+	}
+	if next < minFeedInterval {
+		next = minFeedInterval
+	}
+	return next
+}
+
+// expireCap is the exact time left before the installed copy must be
+// withdrawn — no grace, no floor: the refresh clamp built on it has to
+// die at the horizon itself, or a probe succeeding just past it would
+// renew a copy that had already outlived its trust. ok is false when
+// nothing is aging toward a horizon.
+func (f *axfrFeed) expireCap() (time.Duration, bool) {
+	if !f.haveCopy || f.withdrawn {
+		return 0, false
+	}
+	return f.loaded.Add(f.expire).Sub(f.now()), true
+}
+
+// sleepFor is the actual sleep: the SOA-paced interval jittered so a
+// fleet does not probe in lockstep, then capped at the copy's remaining
+// expire. The cap is applied after the jitter and never jittered itself —
+// the expire boundary is a deadline, and a wake that must withdraw cannot
+// be allowed to drift past it. Nor is there anything to add to it: a Go
+// timer never fires early, and the withdrawal check treats the exact
+// horizon as expired, so the wake lands at the boundary and withdraws.
+func (f *axfrFeed) sleepFor(afterFailure bool) time.Duration {
+	sleep := zonetransfer.Jitter(f.nextWake(afterFailure))
+	if remaining, ok := f.expireCap(); ok && remaining < sleep {
+		sleep = remaining
+	}
+	return sleep
+}
+
+// refreshOnce probes for a serial change and transfers when one is seen
+// (or when no copy exists yet). A source advertising an older serial is
+// refused whole: nothing it transfers can be accepted (RFC 1982).
+func (f *axfrFeed) refreshOnce(ctx context.Context) error {
+	timeout := f.timeout
+	// While a live copy is aging, the attempt itself is bounded by the
+	// copy's horizon: an attempt still running at expire is cancelled so
+	// its failure path withdraws at the boundary — otherwise a cycle
+	// starting just inside the horizon would keep stale rules serving
+	// for a full transfer timeout past it, and a probe succeeding late
+	// would renew a copy that had already outlived its trust. Withdrawn
+	// (or first-copy) attempts get the full budget: there is nothing
+	// left to protect, only a zone to rebuild.
+	if remaining, ok := f.expireCap(); ok && remaining < timeout {
+		timeout = remaining
+	}
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	if f.haveCopy {
+		serial, err := zonetransfer.ProbeSerial(ctx, f.source, f.origin, f.timeout)
+		switch {
+		case err != nil && f.tsig == nil:
+			return err
+		case err != nil:
+			// The probe travels unsigned; a TSIG provider may gate even
+			// the SOA question. The signed transfer below then serves as
+			// the probe — dearer, but the alternative is a feed that can
+			// never refresh.
+		case serial == f.serial && !f.withdrawn:
+			f.loaded = f.now() // a healthy probe restarts the expire clock
+			return nil
+		case serial == f.serial:
+			// Withdrawn: the store holds an empty zone, so an equal
+			// serial is not "nothing to do" — the copy must be rebuilt.
+			// Fall through to the transfer.
+		case !zonetransfer.SerialNewer(f.serial, serial):
+			// A source advertising an older zone is refused whole:
+			// nothing it transfers can be accepted (RFC 1982).
+			return fmt.Errorf("source advertises serial %d behind installed %d", serial, f.serial)
+		}
+	}
+
+	rrs, err := f.transfer(ctx)
+	if err != nil {
+		return err
+	}
+	rrs = zonetransfer.NormalizeZone(rrs)
+	z, err := rpz.CompileRecords(f.name, rrs, f.policy, f.cname)
+	if err != nil {
+		return err
+	}
+	// The gate's zero-rule semantic, exactly as the file reload applies
+	// it: a transfer that compiles nothing is a broken push, and the
+	// previous rules keep serving.
+	if z.Rules == 0 {
+		return fmt.Errorf("transfer compiled no rules (skipped: %v)", z.Skipped)
+	}
+	// An expire of zero would disable the withdrawal horizon outright:
+	// the source is declaring its copy trustworthy for no time at all,
+	// and a feed built on that would enforce stale rules forever the day
+	// the source disappears. That is a broken SOA, not a schedule.
+	if z.SOA.Expire == 0 {
+		return fmt.Errorf("transfer SOA declares expire 0; a copy that can never be trusted cannot be installed")
+	}
+	if f.haveCopy && z.SOA.Serial != f.serial && !zonetransfer.SerialNewer(f.serial, z.SOA.Serial) {
+		return fmt.Errorf("transfer delivered serial %d behind installed %d", z.SOA.Serial, f.serial)
+	}
+
+	f.install(z)
+	return nil
+}
+
+// install swaps the compiled zone into the store and adopts its schedule.
+func (f *axfrFeed) install(z *rpz.Zone) {
+	f.r.swapZone(f.idx, z)
+
+	f.serial = z.SOA.Serial
+	f.haveCopy = true
+	f.withdrawn = false
+	f.loaded = f.now()
+	f.refresh = time.Duration(z.SOA.Refresh) * time.Second
+	f.retry = time.Duration(z.SOA.Retry) * time.Second
+	f.expire = time.Duration(z.SOA.Expire) * time.Second
+
+	publishZoneMetrics(z)
+	zoneSerial.WithLabelValues(f.name).Set(float64(z.SOA.Serial))
+	zlog.Info("RPZ feed transferred", "zone", f.name, "serial", z.SOA.Serial, "rules", z.Rules, "skipped", len(z.Skipped))
+}
+
+// maybeWithdraw retires the rules of a copy past its SOA expire: the feed
+// said how long it may be trusted without contact, and past that the
+// policy fails open on this zone rather than enforcing stale rules.
+func (f *axfrFeed) maybeWithdraw() {
+	if !f.haveCopy || f.withdrawn {
+		return
+	}
+	if f.now().Before(f.loaded.Add(f.expire)) {
+		return
+	}
+	f.withdrawn = true
+	f.r.swapZone(f.idx, &rpz.Zone{Name: f.name, Policy: f.policy, CNAMETarget: f.cname})
+	zoneSerial.WithLabelValues(f.name).Set(-1)
+	reloadErrors.WithLabelValues(f.name).Inc()
+	zlog.Warn("RPZ feed expired and its rules are withdrawn; resolution continues unfiltered by this zone",
+		"zone", f.name, "serial", f.serial, "expire", f.expire.String())
+}
+
+func (f *axfrFeed) transfer(ctx context.Context) ([]dns.RR, error) {
+	if f.tsig == nil {
+		return zonetransfer.AXFR(ctx, f.source, f.origin, f.timeout, feedTransferLimits)
+	}
+	return f.transferTSIG(ctx)
+}
+
+// transferTSIG pulls the zone through miekg's dns.Transfer, which owns
+// the RFC 8945 envelope-MAC chain — the one part of a signed transfer
+// that must not be re-implemented here — and then applies the same shape
+// and bound discipline the strict core applies: SOA-bracketed, terminator
+// duplicating the opener, caller-owned limits, closing SOA dropped.
+func (f *axfrFeed) transferTSIG(ctx context.Context) ([]dns.RR, error) {
+	req := new(dns.Msg)
+	req.SetAxfr(f.origin)
+	req.SetTsig(f.tsig.Name, f.tsig.Algorithm, 300, time.Now().Unix())
+
+	// The connection is dialed here, not left to dns.Transfer: its read
+	// deadline restarts on every envelope, so a source dripping one
+	// envelope per interval could hold an attempt open indefinitely —
+	// past the attempt budget, past the caller's cancellation, and past
+	// the expire boundary the feed loop must be awake for. A deadline
+	// cannot bound the whole attempt (the per-envelope reset overwrites
+	// whatever is set on the socket); closing the socket can — a closed
+	// connection wakes the blocked read and refuses every one after it.
+	// The watchdog fires at the attempt budget, the AfterFunc on the
+	// caller's cancellation.
+	d := net.Dialer{Timeout: f.timeout}
+	conn, err := d.DialContext(ctx, "tcp", f.source)
+	if err != nil {
+		return nil, err
+	}
+	// Deferred in this order so the drain runs after the close: closing
+	// the socket fails the producer's next read, but a producer already
+	// parked on the unbuffered envelope send needs a reader to get there.
+	// Without the drain, every early return below — shape, limit, even
+	// the terminator — can strand the transfer goroutine for good.
+	var env chan *dns.Envelope
+	defer func() {
+		if env == nil {
+			return
+		}
+		for range env { //nolint:revive // drained for the side effect
+		}
+	}()
+	defer func() { _ = conn.Close() }()
+	budget := f.timeout
+	if ctxDeadline, ok := ctx.Deadline(); ok {
+		if until := time.Until(ctxDeadline); until < budget {
+			budget = until
+		}
+	}
+	watchdog := time.AfterFunc(budget, func() { _ = conn.Close() })
+	defer watchdog.Stop()
+	stop := context.AfterFunc(ctx, func() { _ = conn.Close() })
+	defer stop()
+
+	secrets := map[string]string{f.tsig.Name: f.tsig.Secret}
+	tr := &dns.Transfer{
+		Conn:       &dns.Conn{Conn: conn, TsigSecret: secrets},
+		TsigSecret: secrets,
+	}
+
+	env, err = tr.In(req, f.source)
+	if err != nil {
+		return nil, err // In fails before spawning a producer; env stays nil
+	}
+
+	var (
+		rrs      []dns.RR
+		sawFirst bool
+		total    int
+	)
+	for e := range env {
+		if e.Error != nil {
+			return nil, e.Error
+		}
+		for _, rr := range e.RR {
+			isApexSOA := rr.Header().Rrtype == dns.TypeSOA &&
+				dns.CanonicalName(rr.Header().Name) == f.origin
+			if !sawFirst {
+				if !isApexSOA {
+					return nil, zonetransfer.ErrShape
+				}
+				sawFirst = true
+				rrs = append(rrs, rr)
+				continue
+			}
+			if isApexSOA {
+				if !dns.IsDuplicate(rrs[0], rr) {
+					return nil, zonetransfer.ErrShape
+				}
+				return rrs, nil
+			}
+			total += dns.Len(rr)
+			if len(rrs) >= feedTransferLimits.MaxRecords || total > feedTransferLimits.MaxBytes {
+				return nil, zonetransfer.ErrLimit
+			}
+			rrs = append(rrs, rr)
+		}
+	}
+	if !sawFirst {
+		return nil, zonetransfer.ErrShape
+	}
+	// The envelope stream ended without the closing SOA.
+	return nil, zonetransfer.ErrShape
+}

--- a/middleware/rpz/axfr_test.go
+++ b/middleware/rpz/axfr_test.go
@@ -1,0 +1,823 @@
+package rpz
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/dnsclient"
+	"github.com/semihalev/sdns/internal/mock"
+	rpzengine "github.com/semihalev/sdns/internal/rpz"
+	"github.com/semihalev/sdns/middleware"
+)
+
+// feedServer is a loopback AXFR primary whose zone content and serial the
+// test rewrites between cycles.
+type feedServer struct {
+	t      *testing.T
+	addr   string
+	serial atomic.Uint32
+	// rules is the body served; swapped whole.
+	rules atomic.Pointer[[]dns.RR]
+	// transfers counts AXFR requests served, so a test can assert a
+	// cycle never got that far.
+	transfers atomic.Int32
+	// tsigSecret, when set, verifies the transfer request's TSIG and
+	// signs the response envelope.
+	tsigName, tsigSecret string
+	// expire is the SOA expire the server advertises.
+	expire atomic.Uint32
+}
+
+func (s *feedServer) soa() *dns.SOA {
+	return &dns.SOA{
+		Hdr:     dns.RR_Header{Name: "feed.test.", Rrtype: dns.TypeSOA, Class: dns.ClassINET, Ttl: 300},
+		Ns:      "ns.feed.test.",
+		Mbox:    "admin.feed.test.",
+		Serial:  s.serial.Load(),
+		Refresh: 3600, Retry: 900, Expire: s.expire.Load(), Minttl: 300,
+	}
+}
+
+func startFeedServer(t *testing.T, tsigName, tsigSecret string) *feedServer {
+	t.Helper()
+	s := &feedServer{t: t, tsigName: tsigName, tsigSecret: tsigSecret}
+	s.serial.Store(1)
+	s.expire.Store(86400)
+	s.setRules("blocked.example.com.feed.test. 300 IN CNAME .")
+
+	if tsigSecret != "" {
+		startTSIGFeedServer(t, s)
+		return s
+	}
+
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+	s.addr = l.Addr().String()
+
+	go func() {
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				return
+			}
+			go s.serveConn(c)
+		}
+	}()
+	return s
+}
+
+// setRules replaces the served body with records parsed from zone-file
+// lines.
+func (s *feedServer) setRules(lines ...string) {
+	var rrs []dns.RR
+	for _, line := range lines {
+		rr, err := dns.NewRR(line)
+		if err != nil {
+			s.t.Fatalf("bad fixture rule %q: %v", line, err)
+		}
+		rrs = append(rrs, rr)
+	}
+	s.rules.Store(&rrs)
+}
+
+func (s *feedServer) serveConn(c net.Conn) {
+	defer func() { _ = c.Close() }()
+
+	co := &dnsclient.Conn{Conn: c}
+	req, err := co.ReadMsg()
+	if err != nil {
+		return
+	}
+	resp := new(dns.Msg)
+	resp.SetReply(req)
+	switch req.Question[0].Qtype {
+	case dns.TypeSOA:
+		resp.Answer = []dns.RR{s.soa()}
+	case dns.TypeAXFR:
+		s.transfers.Add(1)
+		body := *s.rules.Load()
+		resp.Answer = append([]dns.RR{s.soa()}, body...)
+		resp.Answer = append(resp.Answer, s.soa())
+	}
+	_ = co.WriteMsg(resp)
+}
+
+// startTSIGFeedServer runs the signed primary through the library's own
+// server and Transfer.Out — the pairing that owns the response-side
+// envelope-MAC chain — so our client is verified against what a real
+// provider effectively runs, not against a hand-rolled signer. A raw
+// dns.Conn cannot stand in here: it never records the request MAC, so
+// its response MACs verify against nothing.
+func startTSIGFeedServer(t *testing.T, srv *feedServer) {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	srv.addr = l.Addr().String()
+
+	mux := dns.NewServeMux()
+	mux.HandleFunc("feed.test.", func(w dns.ResponseWriter, req *dns.Msg) {
+		switch req.Question[0].Qtype {
+		case dns.TypeSOA:
+			resp := new(dns.Msg)
+			resp.SetReply(req)
+			resp.Answer = []dns.RR{srv.soa()}
+			_ = w.WriteMsg(resp)
+		case dns.TypeAXFR:
+			// The signature is what admits a transfer: absent or bad
+			// TSIG is refused — the property the unsigned-client test
+			// relies on.
+			if req.IsTsig() == nil || w.TsigStatus() != nil {
+				resp := new(dns.Msg)
+				resp.SetRcode(req, dns.RcodeRefused)
+				_ = w.WriteMsg(resp)
+				return
+			}
+			tr := new(dns.Transfer)
+			ch := make(chan *dns.Envelope, 1)
+			body := *srv.rules.Load()
+			rrs := append([]dns.RR{srv.soa()}, body...)
+			rrs = append(rrs, srv.soa())
+			ch <- &dns.Envelope{RR: rrs}
+			close(ch)
+			_ = tr.Out(w, req, ch)
+		}
+	})
+	server := &dns.Server{
+		Listener:   l,
+		Handler:    mux,
+		TsigSecret: map[string]string{srv.tsigName: srv.tsigSecret},
+	}
+	go func() { _ = server.ActivateAndServe() }()
+	t.Cleanup(func() { _ = server.Shutdown() })
+}
+
+// feedUnderTest builds an RPZ with one AXFR zone and a hand-driven feed —
+// the schedule goroutine stays parked so the test drives cycles itself.
+func feedUnderTest(t *testing.T, srv *feedServer, tsig string) (*RPZ, *axfrFeed) {
+	t.Helper()
+	zc := config.RPZZone{Name: "feed", Source: srv.addr, Origin: "feed.test.", TsigKey: tsig}
+	cfg := new(config.Config)
+	cfg.RPZ = config.RPZ{Enabled: true, Mode: "enforce", Zones: []config.RPZZone{zc}}
+
+	// New would start the live goroutine; build the placeholder store by
+	// hand instead, exactly as New lays it out.
+	r := &RPZ{enforce: true}
+	r.zones = cfg.RPZ.Zones
+	r.store.Store(&rpzengine.Store{Zones: []*rpzengine.Zone{{Name: "feed"}}})
+	return r, newAXFRFeed(r, 0, zc)
+}
+
+func TestAXFRFeedEndToEnd(t *testing.T) {
+	srv := startFeedServer(t, "", "")
+	r, feed := feedUnderTest(t, srv, "")
+
+	// Before the first transfer the zone filters nothing.
+	if _, passed := serve(t, r, "blocked.example.com.", dns.TypeA, "udp", true); !passed {
+		t.Fatal("an empty feed filtered")
+	}
+
+	if err := feed.refreshOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	// The transferred rule enforces through the full middleware.
+	if w, passed := serve(t, r, "blocked.example.com.", dns.TypeA, "udp", true); passed || w.Rcode() != dns.RcodeNameError {
+		t.Fatalf("transferred rule did not act: passed=%v rcode=%d", passed, w.Rcode())
+	}
+
+	// A pushed update travels on the next cycle.
+	srv.serial.Store(2)
+	srv.setRules("fresh.example.com.feed.test. 300 IN CNAME rpz-drop.")
+	if err := feed.refreshOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if w, passed := serve(t, r, "fresh.example.com.", dns.TypeA, "udp", true); passed || w.Written() {
+		t.Fatal("updated rule did not act")
+	}
+	if _, passed := serve(t, r, "blocked.example.com.", dns.TypeA, "udp", true); !passed {
+		t.Fatal("a rule removed by the update kept acting")
+	}
+}
+
+func TestAXFRFeedRefusesSerialRollback(t *testing.T) {
+	srv := startFeedServer(t, "", "")
+	_, feed := feedUnderTest(t, srv, "")
+
+	srv.serial.Store(10)
+	if err := feed.refreshOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if feed.serial != 10 {
+		t.Fatalf("installed serial = %d", feed.serial)
+	}
+
+	// The source rolls backwards; the probe refuses the cycle whole and
+	// the installed copy stands. "Whole" is load-bearing: the transfer
+	// must not even be attempted — a rejected source gets no second look
+	// through a dearer channel (RFC 1982's refusal, layered once, at the
+	// probe).
+	before := srv.transfers.Load()
+	srv.serial.Store(3)
+	srv.setRules("evil.example.com.feed.test. 300 IN CNAME .")
+	if err := feed.refreshOnce(context.Background()); err == nil {
+		t.Fatal("a rollback cycle reported success")
+	}
+	if feed.serial != 10 {
+		t.Fatalf("rollback moved the installed serial to %d", feed.serial)
+	}
+	if got := srv.transfers.Load() - before; got != 0 {
+		t.Fatalf("the rollback cycle transferred %d times; the probe must refuse it whole", got)
+	}
+}
+
+func TestAXFRFeedWithdrawsPastExpire(t *testing.T) {
+	srv := startFeedServer(t, "", "")
+	r, feed := feedUnderTest(t, srv, "")
+
+	clock := time.Now()
+	feed.now = func() time.Time { return clock }
+
+	if err := feed.refreshOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if w, _ := serve(t, r, "blocked.example.com.", dns.TypeA, "udp", true); !w.Written() {
+		t.Fatal("rule not serving before expire")
+	}
+
+	// The source goes dark past the SOA expire (86400s): the next failed
+	// cycle withdraws the rules, and resolution continues unfiltered.
+	srv.serial.Store(0) // the serve loop still answers; force a failure via a dead source instead
+	feed.source = "127.0.0.1:1"
+	clock = clock.Add(87000 * time.Second)
+	if err := feed.refreshOnce(context.Background()); err == nil {
+		t.Fatal("a dead source reported success")
+	}
+	feed.maybeWithdraw()
+
+	if _, passed := serve(t, r, "blocked.example.com.", dns.TypeA, "udp", true); !passed {
+		t.Fatal("expired feed kept enforcing")
+	}
+
+	// Inside the expire window the same failure keeps the rules serving.
+	srv2 := startFeedServer(t, "", "")
+	r2, feed2 := feedUnderTest(t, srv2, "")
+	clock2 := time.Now()
+	feed2.now = func() time.Time { return clock2 }
+	if err := feed2.refreshOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	feed2.source = "127.0.0.1:1"
+	clock2 = clock2.Add(3600 * time.Second)
+	_ = feed2.refreshOnce(context.Background())
+	feed2.maybeWithdraw()
+	if w, _ := serve(t, r2, "blocked.example.com.", dns.TypeA, "udp", true); !w.Written() {
+		t.Fatal("a failure inside the expire window dropped the rules")
+	}
+}
+
+func TestAXFRFeedTSIG(t *testing.T) {
+	const keyName, secret = "feedkey.", "c2VjcmV0c2VjcmV0c2VjcmV0c2VjcmV0" //nolint:gosec // G101 - loopback test fixture, not a credential
+	srv := startFeedServer(t, keyName, secret)
+	r, feed := feedUnderTest(t, srv, keyName+":hmac-sha256.:"+secret)
+
+	if err := feed.refreshOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if w, passed := serve(t, r, "blocked.example.com.", dns.TypeA, "udp", true); passed || w.Rcode() != dns.RcodeNameError {
+		t.Fatal("TSIG-fed rule did not act")
+	}
+
+	// The same primary refuses an unsigned transfer — proof the signature
+	// was doing the admitting.
+	_, unsigned := feedUnderTest(t, srv, "")
+	if err := unsigned.refreshOnce(context.Background()); err == nil {
+		t.Fatal("the TSIG primary accepted an unsigned transfer")
+	}
+}
+
+// TestWithdrawnFeedRestoresOnEqualSerial pins the review's first P1: a
+// source that comes back with the SAME serial after a withdrawal must be
+// re-transferred — the equal-serial short-circuit is "nothing to do" only
+// while the copy is actually serving.
+func TestWithdrawnFeedRestoresOnEqualSerial(t *testing.T) {
+	srv := startFeedServer(t, "", "")
+	r, feed := feedUnderTest(t, srv, "")
+	clock := time.Now()
+	feed.now = func() time.Time { return clock }
+
+	if err := feed.refreshOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// The source goes dark past expire; the rules are withdrawn.
+	goodSource := feed.source
+	feed.source = "127.0.0.1:1"
+	clock = clock.Add(87000 * time.Second)
+	_ = feed.refreshOnce(context.Background())
+	feed.maybeWithdraw()
+	if _, passed := serve(t, r, "blocked.example.com.", dns.TypeA, "udp", true); !passed {
+		t.Fatal("withdrawal did not happen")
+	}
+
+	// The provider recovers — same serial, nothing changed on its side.
+	// The copy must be rebuilt anyway.
+	feed.source = goodSource
+	if err := feed.refreshOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if w, passed := serve(t, r, "blocked.example.com.", dns.TypeA, "udp", true); passed || w.Rcode() != dns.RcodeNameError {
+		t.Fatal("a recovered equal-serial source left the zone empty forever")
+	}
+}
+
+// TestNextWakeBounds pins the schedule floor: a degenerate SOA cannot
+// spin the loop.
+func TestNextWakeBounds(t *testing.T) {
+	f := &axfrFeed{}
+
+	// No copy yet: the initial retry pace, whatever the SOA said.
+	if got := f.nextWake(true); got != axfrInitialRetry {
+		t.Fatalf("no copy: %v", got)
+	}
+
+	// A zero refresh must not become a hot loop.
+	f.haveCopy = true
+	f.refresh, f.retry = 0, 0
+	if got := f.nextWake(false); got < minFeedInterval {
+		t.Fatalf("zero refresh spun: %v", got)
+	}
+	// A tiny retry is floored; a sane one rules.
+	f.retry = time.Second
+	if got := f.nextWake(true); got != minFeedInterval {
+		t.Fatalf("tiny retry not floored: %v", got)
+	}
+	f.retry = 900 * time.Second
+	if got := f.nextWake(true); got != f.retry {
+		t.Fatalf("sane retry overridden: %v", got)
+	}
+}
+
+// TestSleepNeverDriftsPastExpire pins the review's deadline finding: the
+// jitter applies to the SOA pace, never to the expire boundary — whatever
+// the draw, the wake that must withdraw lands at the horizon.
+func TestSleepNeverDriftsPastExpire(t *testing.T) {
+	base := time.Now()
+	f := &axfrFeed{
+		now: func() time.Time { return base }, haveCopy: true,
+		refresh: 3600 * time.Second, retry: 900 * time.Second, expire: 86400 * time.Second,
+	}
+	// 10s of life left against a 900s retry pace: the cap is the exact
+	// remaining, whatever the jitter draws — not a second more.
+	f.loaded = base.Add(-f.expire + 10*time.Second)
+	for range 200 {
+		if got := f.sleepFor(true); got != 10*time.Second {
+			t.Fatalf("sleep %v is not the exact expire boundary", got)
+		}
+	}
+	// Withdrawn there is nothing left to withdraw: the SOA pace rules,
+	// jitter included (±10% of 900s).
+	f.withdrawn = true
+	if got := f.sleepFor(true); got < 800*time.Second || got > 1000*time.Second {
+		t.Fatalf("withdrawn sleep: %v", got)
+	}
+}
+
+// startDripTSIGServer is a correctly signed primary that delivers one
+// envelope every interval, indefinitely. Each envelope arrives well inside
+// dns.Transfer's per-envelope read timeout, so only an absolute bound on
+// the whole attempt can stop the stream — the review's exact scenario.
+func startDripTSIGServer(t *testing.T, name, secret string, interval time.Duration) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	soa, err := dns.NewRR("feed.test. 300 IN SOA ns.feed.test. admin.feed.test. 1 3600 900 86400 300")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	mux := dns.NewServeMux()
+	mux.HandleFunc("feed.test.", func(w dns.ResponseWriter, req *dns.Msg) {
+		if req.Question[0].Qtype != dns.TypeAXFR || req.IsTsig() == nil || w.TsigStatus() != nil {
+			return
+		}
+		tr := new(dns.Transfer)
+		ch := make(chan *dns.Envelope)
+		done := make(chan struct{})
+		go func() { defer close(done); _ = tr.Out(w, req, ch) }()
+		ch <- &dns.Envelope{RR: []dns.RR{soa}}
+		for i := 0; ; i++ {
+			rr, _ := dns.NewRR(fmt.Sprintf("drip%d.example.com.feed.test. 300 IN CNAME .", i))
+			select {
+			case ch <- &dns.Envelope{RR: []dns.RR{rr}}:
+				time.Sleep(interval)
+			case <-done:
+				return
+			}
+		}
+	})
+	server := &dns.Server{Listener: l, Handler: mux, TsigSecret: map[string]string{name: secret}}
+	go func() { _ = server.ActivateAndServe() }()
+	t.Cleanup(func() { _ = server.Shutdown() })
+	return l.Addr().String()
+}
+
+// TestTSIGTransferHonorsItsDeadline pins the review's context finding: a
+// signed source dripping envelopes just inside the per-envelope read
+// timeout must not hold the attempt past its budget, and a cancelled
+// context must cut it short.
+func TestTSIGTransferHonorsItsDeadline(t *testing.T) {
+	addr := startDripTSIGServer(t, "k.", "c2VjcmV0", 100*time.Millisecond)
+	zc := config.RPZZone{Name: "drip", Source: addr, Origin: "feed.test.", TsigKey: "k.:hmac-sha256.:c2VjcmV0"}
+
+	t.Run("attempt budget", func(t *testing.T) {
+		f := newAXFRFeed(&RPZ{}, 0, zc)
+		f.timeout = 500 * time.Millisecond
+		start := time.Now()
+		_, err := f.transferTSIG(context.Background())
+		if elapsed := time.Since(start); err == nil || elapsed > 3*time.Second {
+			t.Fatalf("drip ran %v past a 500ms budget (err=%v)", elapsed, err)
+		}
+	})
+
+	t.Run("context cancellation", func(t *testing.T) {
+		f := newAXFRFeed(&RPZ{}, 0, zc)
+		f.timeout = time.Minute
+		ctx, cancel := context.WithCancel(context.Background())
+		time.AfterFunc(200*time.Millisecond, cancel)
+		start := time.Now()
+		_, err := f.transferTSIG(ctx)
+		if elapsed := time.Since(start); err == nil || elapsed > 3*time.Second {
+			t.Fatalf("cancelled drip ran %v (err=%v)", elapsed, err)
+		}
+	})
+}
+
+// TestStaleReloadCannotOverwriteANewerOne pins the review's parse-race
+// finding: a reload claim that has been superseded while its parse ran
+// must not commit — the sequence check and the swap share the lock.
+func TestStaleReloadCannotOverwriteANewerOne(t *testing.T) {
+	path := writeZone(t, testZone)
+	r := newRPZ(t, "enforce", config.RPZZone{Name: "test", File: path})
+
+	// An old reload claims its sequence, and while "parsing", a newer
+	// push arrives and completes.
+	staleSeq := r.reloadSeq[0].Add(1)
+	if err := os.WriteFile(path, []byte(`
+rpz.test. IN SOA ns.rpz.test. admin.rpz.test. 99 3600 900 604800 300
+newrule.example.com.rpz.test. IN CNAME .
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	r.reload(0)
+	if w, _ := serve(t, r, "newrule.example.com.", dns.TypeA, "udp", true); !w.Written() {
+		t.Fatal("the newer push did not install")
+	}
+
+	// The old parse finally finishes and tries to commit the old content.
+	oldZone, err := rpzengine.LoadZone("test", strings.NewReader(testZone), "old", rpzengine.OverrideGiven, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if r.commitReload(0, staleSeq, oldZone) {
+		t.Fatal("a superseded parse committed")
+	}
+	// The newer generation still serves, and its gauges stand: a refused
+	// commit publishes nothing — metrics travel with the store swap,
+	// inside the same critical section.
+	if w, _ := serve(t, r, "newrule.example.com.", dns.TypeA, "udp", true); !w.Written() {
+		t.Fatal("the stale parse rolled the newer policy back")
+	}
+	if got := testutil.ToFloat64(zoneRules.WithLabelValues("test", rpzengine.TriggerQNAME)); got != 1 {
+		t.Fatalf("zone_rules gauge = %v after a refused commit; the newer generation's count was 1", got)
+	}
+}
+
+// serveQuiet is serve without the testing plumbing, safe for concurrent
+// readers: it reports a torn outcome instead of failing the test itself.
+func serveQuiet(r *RPZ, qname string) (rcode int, written, passed bool, err error) {
+	q := new(dns.Msg)
+	q.SetQuestion(qname, dns.TypeA)
+	q.RecursionDesired = true
+	q.SetEdns0(1232, false)
+	raw, perr := q.Pack()
+	if perr != nil {
+		return 0, false, false, perr
+	}
+	req := new(middleware.Request)
+	if !req.ParseWire(raw, time.Now(), nil) {
+		return 0, false, false, errors.New("ParseWire refused an eligible query")
+	}
+	next := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		passed = true
+		ch.Cancel()
+	})
+	w := mock.NewWriter("udp", "192.0.2.1:40000")
+	ch := middleware.NewChain([]middleware.Handler{r, next})
+	ch.ResetWire(w, req)
+	ch.Next(context.Background())
+	return w.Rcode(), w.Written(), passed, nil
+}
+
+// TestExpiredCopyWithdrawsBeforeTheRefresh pins the cycle order: past the
+// horizon the rules stop serving when the wake fires, not up to a
+// transfer timeout later. The refresh here hangs against a silent
+// source, and the withdrawal must be observable while it still hangs.
+func TestExpiredCopyWithdrawsBeforeTheRefresh(t *testing.T) {
+	srv := startFeedServer(t, "", "")
+	r, feed := feedUnderTest(t, srv, "")
+	clock := time.Now()
+	feed.now = func() time.Time { return clock }
+	if err := feed.refreshOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// A source that accepts the connection and never answers.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+	go func() {
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				return
+			}
+			defer c.Close() //nolint:revive // freed at listener close; the test is the scope
+		}
+	}()
+	feed.source = l.Addr().String()
+	// The refresh hangs for this long; the poll window below must end
+	// well before it so a late (wrongly ordered) withdrawal can never be
+	// mistaken for the early one.
+	feed.timeout = 1500 * time.Millisecond
+	clock = clock.Add(87000 * time.Second) // past the 86400s expire
+
+	done := make(chan struct{})
+	go func() { defer close(done); feed.cycle(context.Background()) }()
+
+	withdrawn := false
+	for deadline := time.Now().Add(750 * time.Millisecond); time.Now().Before(deadline); {
+		_, _, passed, err := serveQuiet(r, "blocked.example.com.")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if passed {
+			withdrawn = true
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	if !withdrawn {
+		t.Fatal("stale rules kept enforcing while the refresh attempt was in flight")
+	}
+	select {
+	case <-done:
+		t.Fatal("the refresh attempt finished before the withdrawal was observed; the order is unproven")
+	default:
+	}
+	<-done
+}
+
+// TestZeroExpireTransferIsRefused pins the review's horizon finding: a
+// source declaring expire 0 would disable withdrawal outright, so the
+// transfer is refused and the zone stays empty rather than gaining rules
+// that could never be retired.
+func TestZeroExpireTransferIsRefused(t *testing.T) {
+	srv := startFeedServer(t, "", "")
+	srv.expire.Store(0)
+	r, feed := feedUnderTest(t, srv, "")
+
+	err := feed.refreshOnce(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "expire 0") {
+		t.Fatalf("zero-expire transfer not refused: %v", err)
+	}
+	if _, passed := serve(t, r, "blocked.example.com.", dns.TypeA, "udp", true); !passed {
+		t.Fatal("a refused transfer installed rules")
+	}
+}
+
+// TestTSIGTransferDoesNotLeakTheProducer pins the drain: a stream whose
+// terminator SOA is not the last record of its envelope makes the
+// consumer return while the producer still has a send ahead of it —
+// without the drain, every such transfer strands the goroutine parked on
+// the unbuffered envelope channel.
+func TestTSIGTransferDoesNotLeakTheProducer(t *testing.T) {
+	const keyName, secret = "leakkey.", "c2VjcmV0c2VjcmV0c2VjcmV0c2VjcmV0" //nolint:gosec // G101 - loopback test fixture, not a credential
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	soa, _ := dns.NewRR("feed.test. 300 IN SOA ns.feed.test. admin.feed.test. 1 3600 900 86400 300")
+	rule, _ := dns.NewRR("blocked.example.com.feed.test. 300 IN CNAME .")
+	junk, _ := dns.NewRR("trailing.example.com.feed.test. 300 IN CNAME .")
+
+	mux := dns.NewServeMux()
+	mux.HandleFunc("feed.test.", func(w dns.ResponseWriter, req *dns.Msg) {
+		if req.Question[0].Qtype != dns.TypeAXFR || req.IsTsig() == nil || w.TsigStatus() != nil {
+			return
+		}
+		tr := new(dns.Transfer)
+		ch := make(chan *dns.Envelope, 2)
+		// The closing SOA arrives mid-envelope: the consumer returns at
+		// it, the producer reads on and parks on its next send.
+		ch <- &dns.Envelope{RR: []dns.RR{soa, rule}}
+		ch <- &dns.Envelope{RR: []dns.RR{soa, junk}}
+		close(ch)
+		_ = tr.Out(w, req, ch)
+	})
+	server := &dns.Server{Listener: l, Handler: mux, TsigSecret: map[string]string{keyName: secret}}
+	go func() { _ = server.ActivateAndServe() }()
+	t.Cleanup(func() { _ = server.Shutdown() })
+
+	zc := config.RPZZone{Name: "leak", Source: l.Addr().String(), Origin: "feed.test.", TsigKey: keyName + ":hmac-sha256.:" + secret}
+	f := newAXFRFeed(&RPZ{}, 0, zc)
+
+	before := runtime.NumGoroutine()
+	const rounds = 8
+	for range rounds {
+		rrs, err := f.transferTSIG(context.Background())
+		if err != nil || len(rrs) == 0 {
+			t.Fatalf("transfer failed: %v", err)
+		}
+	}
+	// Give stranded producers nothing to wait for; only a leak keeps the
+	// count elevated by the full round count.
+	for deadline := time.Now().Add(2 * time.Second); time.Now().Before(deadline); {
+		if runtime.NumGoroutine()-before < rounds {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("goroutines grew by %d over %d transfers; the producer is leaking", runtime.NumGoroutine()-before, rounds)
+}
+
+// TestConcurrentSwapAndServe is the phase's exit criterion in code: one
+// zone slot rewritten through both writer paths — the feed's swap and
+// the watcher's sequenced commit — while readers serve through the
+// middleware. Every response must be a whole generation (blocked by the
+// installed rule or passed clean); -race owns the memory-order proof.
+func TestConcurrentSwapAndServe(t *testing.T) {
+	r := newRPZ(t, "enforce", config.RPZZone{Name: "test", File: writeZone(t, testZone)})
+	// The same name carries a different action in each generation, so a
+	// single response tells exactly which one answered: NXDOMAIN is X,
+	// a Local Data answer is Y, and anything else — a pass, a blend — is
+	// a torn store. Distinct per-generation names could not see that: a
+	// store wrongly carrying both rules would still produce individually
+	// valid outcomes.
+	const zoneX = `
+rpz.test. IN SOA ns.rpz.test. admin.rpz.test. 10 3600 900 604800 300
+probe.example.com.rpz.test. IN CNAME .
+`
+	const zoneY = `
+rpz.test. IN SOA ns.rpz.test. admin.rpz.test. 11 3600 900 604800 300
+probe.example.com.rpz.test. IN A 203.0.113.99
+`
+	zx, err := rpzengine.LoadZone("test", strings.NewReader(zoneX), "x", rpzengine.OverrideGiven, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	zy, err := rpzengine.LoadZone("test", strings.NewReader(zoneY), "y", rpzengine.OverrideGiven, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The probe name must resolve to a generation from the first query,
+	// so X is installed before any reader starts.
+	r.swapZone(0, zx)
+
+	stop := make(chan struct{})
+	torn := make(chan string, 8)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(stop)
+		for start := time.Now(); time.Since(start) < 300*time.Millisecond; {
+			r.swapZone(0, zx) // the feed's path
+			seq := r.reloadSeq[0].Add(1)
+			r.commitReload(0, seq, zy) // the watcher's path
+		}
+	}()
+	for range 3 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for served := 0; ; served++ {
+				select {
+				case <-stop:
+					if served == 0 {
+						torn <- "reader finished without serving a single query"
+					}
+					return
+				default:
+				}
+				rcode, _, passed, err := serveQuiet(r, "probe.example.com.")
+				if err != nil {
+					torn <- err.Error()
+					return
+				}
+				if passed || (rcode != dns.RcodeNameError && rcode != dns.RcodeSuccess) {
+					torn <- fmt.Sprintf("neither generation answered: passed=%v rcode=%d", passed, rcode)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	select {
+	case msg := <-torn:
+		t.Fatal(msg)
+	default:
+	}
+}
+
+// TestRefreshAttemptCannotOutliveTheHorizon pins the review's P1: a
+// cycle starting just inside the horizon must not let its refresh
+// attempt keep stale rules serving past expire. The attempt is bounded
+// by the copy's remaining trust — cancelled at the boundary, its failure
+// path withdraws there, not a full transfer timeout later.
+func TestRefreshAttemptCannotOutliveTheHorizon(t *testing.T) {
+	srv := startFeedServer(t, "", "")
+	r, feed := feedUnderTest(t, srv, "")
+	if err := feed.refreshOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// A source that accepts the connection and never answers.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = l.Close() })
+	go func() {
+		for {
+			c, err := l.Accept()
+			if err != nil {
+				return
+			}
+			defer c.Close() //nolint:revive // freed at listener close; the test is the scope
+		}
+	}()
+	feed.source = l.Addr().String()
+	feed.timeout = 30 * time.Second // the budget the horizon must beat
+
+	// ~500ms of trust left, and the clock keeps running from there so
+	// the horizon actually passes while the attempt is in flight.
+	offset := 86400*time.Second - 500*time.Millisecond
+	feed.now = func() time.Time { return time.Now().Add(offset) }
+
+	began := time.Now()
+	feed.cycle(context.Background())
+	elapsed := time.Since(began)
+	// The cut lands at the horizon itself: ~500ms, not 500ms plus the
+	// wake grace — the grace belongs to the timer, never to the attempt.
+	if elapsed > 1200*time.Millisecond {
+		t.Fatalf("the attempt ran %v with the horizon 500ms away", elapsed)
+	}
+	if _, _, passed, err := serveQuiet(r, "blocked.example.com."); err != nil || !passed {
+		t.Fatalf("rules still serving past the horizon (err=%v)", err)
+	}
+}
+
+// TestLateProbeCannotRenewAnExpiredCopy pins the grace hole the review
+// found: a probe that would succeed just past the horizon must not
+// refresh loaded and revalidate a copy that had already outlived its
+// trust — the attempt's clamp is dead by then, healthy source or not.
+func TestLateProbeCannotRenewAnExpiredCopy(t *testing.T) {
+	srv := startFeedServer(t, "", "")
+	r, feed := feedUnderTest(t, srv, "")
+	if err := feed.refreshOnce(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	// 200ms past the horizon, source alive and answering.
+	past := feed.loaded.Add(feed.expire).Add(200 * time.Millisecond)
+	feed.now = func() time.Time { return past }
+
+	if err := feed.refreshOnce(context.Background()); err == nil {
+		t.Fatal("a probe past the horizon renewed the expired copy")
+	}
+	feed.maybeWithdraw()
+	if _, _, passed, err := serveQuiet(r, "blocked.example.com."); err != nil || !passed {
+		t.Fatalf("expired copy kept serving after a late probe (err=%v)", err)
+	}
+}

--- a/middleware/rpz/metrics.go
+++ b/middleware/rpz/metrics.go
@@ -36,6 +36,11 @@ var (
 		Name: "rpz_reload_errors_total",
 		Help: "Zone loads or reloads that failed; the previous store keeps serving",
 	}, []string{"zone"})
+
+	zoneSerial = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "rpz_zone_serial",
+		Help: "SOA serial of an AXFR-fed zone's installed copy; -1 for file-sourced zones and for a feed whose rules are withdrawn",
+	}, []string{"zone"})
 )
 
 // countMatch runs on the match path only — the non-matching query touches

--- a/middleware/rpz/reload.go
+++ b/middleware/rpz/reload.go
@@ -27,6 +27,11 @@ func (r *RPZ) watch() {
 
 	dirs := make(map[string]bool)
 	for _, zc := range r.zones {
+		if zc.File == "" {
+			// AXFR-fed zones have no file to watch; their feed loop owns
+			// their freshness.
+			continue
+		}
 		dir := filepath.Dir(zc.File)
 		if dirs[dir] {
 			continue
@@ -52,7 +57,9 @@ func (r *RPZ) watchLoop(watcher *fsnotify.Watcher) {
 				continue
 			}
 			for i := range r.zones {
-				if filepath.Clean(event.Name) != filepath.Clean(r.zones[i].File) {
+				// Empty File is an AXFR feed; Clean("") is "." and must
+				// never match an event.
+				if r.zones[i].File == "" || filepath.Clean(event.Name) != filepath.Clean(r.zones[i].File) {
 					continue
 				}
 				idx := i
@@ -72,11 +79,15 @@ func (r *RPZ) watchLoop(watcher *fsnotify.Watcher) {
 
 // reload re-reads one zone and swaps a store carrying it. A failed parse
 // keeps the old zone serving and says so — a bad push never leaves the
-// resolver unprotected or half-loaded.
+// resolver unprotected or half-loaded. The parse runs outside the lock,
+// so a slow file never stalls an AXFR feed's install — which opens a
+// race the sequence below closes: a slow parse of the *previous* push
+// finishing after a fast parse of the next one must not write the old
+// generation back over the new. Each reload claims the zone's sequence
+// before parsing, and the commit refuses a claim that is no longer the
+// latest.
 func (r *RPZ) reload(idx int) {
-	r.reloadMu.Lock()
-	defer r.reloadMu.Unlock()
-
+	seq := r.reloadSeq[idx].Add(1)
 	zc := r.zones[idx]
 	policy, _ := rpz.ParseOverride(zc.Policy)
 	target := ""
@@ -100,12 +111,44 @@ func (r *RPZ) reload(idx int) {
 		return
 	}
 
+	if !r.commitReload(idx, seq, z) {
+		zlog.Debug("RPZ reload superseded by a newer push", "zone", zc.Name)
+		return
+	}
+
+	zlog.Info("RPZ zone reloaded", "zone", zc.Name, "rules", z.Rules, "skipped", len(z.Skipped))
+}
+
+// commitReload installs a parsed zone only if seq is still the latest
+// claim for idx — the check and the swap share the lock, so a superseded
+// parse cannot slip between them. The gauges are published inside the
+// same critical section: published after it, a commit that finished
+// first could write its counts over a newer generation's.
+func (r *RPZ) commitReload(idx int, seq uint64, z *rpz.Zone) bool {
+	r.reloadMu.Lock()
+	defer r.reloadMu.Unlock()
+	if r.reloadSeq[idx].Load() != seq {
+		return false
+	}
+	r.swapZoneLocked(idx, z)
+	publishZoneMetrics(z)
+	return true
+}
+
+// swapZone publishes a new compiled zone at idx: a copied slice, a fresh
+// immutable store, one atomic swap. reloadMu serializes writers — the
+// file watcher and the AXFR feeds share it — so two swaps cannot build
+// from the same old slice and lose one another.
+func (r *RPZ) swapZone(idx int, z *rpz.Zone) {
+	r.reloadMu.Lock()
+	defer r.reloadMu.Unlock()
+	r.swapZoneLocked(idx, z)
+}
+
+func (r *RPZ) swapZoneLocked(idx int, z *rpz.Zone) {
 	old := r.store.Load()
 	zones := make([]*rpz.Zone, len(old.Zones))
 	copy(zones, old.Zones)
 	zones[idx] = z
 	r.store.Store(&rpz.Store{Zones: zones})
-
-	publishZoneMetrics(z)
-	zlog.Info("RPZ zone reloaded", "zone", zc.Name, "rules", z.Rules, "skipped", len(z.Skipped))
 }

--- a/middleware/rpz/rpz.go
+++ b/middleware/rpz/rpz.go
@@ -41,10 +41,14 @@ type RPZ struct {
 	// client follows it.
 	queryer middleware.Queryer
 
-	// reloadMu serializes reloads; zones is the config list the watcher
-	// re-reads files from, index-aligned with the store's zones.
-	reloadMu sync.Mutex
-	zones    []config.RPZZone
+	// reloadMu serializes store swaps; zones is the config list the
+	// watcher re-reads files from, index-aligned with the store's zones.
+	// reloadSeq carries each zone's reload generation, claimed before a
+	// parse and checked at the commit, so a slow parse of an old push
+	// cannot write over a newer one.
+	reloadMu  sync.Mutex
+	reloadSeq []atomic.Uint64
+	zones     []config.RPZZone
 }
 
 // New builds the middleware from the config. A zone file that fails to
@@ -59,12 +63,32 @@ func New(cfg *config.Config) *RPZ {
 	}
 
 	r.zones = cfg.RPZ.Zones
+	r.reloadSeq = make([]atomic.Uint64, len(cfg.RPZ.Zones))
 	zones := make([]*rpz.Zone, 0, len(cfg.RPZ.Zones))
 	for _, zc := range cfg.RPZ.Zones {
+		if zc.Source != "" {
+			// An AXFR feed starts empty — it filters nothing until its
+			// first transfer lands — and its lifecycle goroutine owns it
+			// from here.
+			policy, _ := rpz.ParseOverride(zc.Policy)
+			target := ""
+			if zc.Cname != "" {
+				target = dns.CanonicalName(zc.Cname)
+			}
+			zones = append(zones, &rpz.Zone{Name: zc.Name, Policy: policy, CNAMETarget: target})
+			zoneSerial.WithLabelValues(zc.Name).Set(-1)
+			continue
+		}
 		zones = append(zones, loadZone(zc))
+		zoneSerial.WithLabelValues(zc.Name).Set(-1)
 	}
 	r.store.Store(&rpz.Store{Zones: zones})
 	r.watch()
+	for idx, zc := range cfg.RPZ.Zones {
+		if zc.Source != "" {
+			go newAXFRFeed(r, idx, zc).run(context.Background())
+		}
+	}
 
 	return r
 }


### PR DESCRIPTION
Phase 3 of `docs/rpz-design.md` starts here, per its §5.8: *"Phase 3's first work item is extracting a generic secondary-zone transfer core ... that localroot then also consumes."* This PR is that extraction alone — pure refactor, zero behavior change — so the RPZ AXFR PR that follows stays small and reviewable.

## What moved

`internal/zonetransfer`, zone-parameterized:

- **`AXFR`** — the strict transfer loop with the RFC 5936 shape discipline intact: SOA-bracketed stream, a terminator that must duplicate the opener (a zone that moved mid-transfer belongs to no single version), no partial acceptance, closing SOA dropped.
- **`ProbeSerial`** — TCP deliberately, so a host that cannot serve the transfer is discovered at the probe.
- **`SerialNewer`** (RFC 1982), **`Jitter`** (±10%), **`NormalizeZone`** (RFC 5936 §2.2 dedup + RFC 2181 §5.2 lowest-TTL merge).
- **`Limits` became a caller parameter** — the root's couple-of-megabytes caps would refuse a legitimate multi-million-record policy feed, so the bound belongs to the consumer.

## What deliberately did not move

The refresh loops. localroot's schedule is welded to its ZONEMD signature horizon and trust-anchor lifecycle; RPZ's will be welded to SOA-expire withdrawal. A shared scheduler would be a hook forest serving two callers badly. The design's "transfer + SOA-schedule core" is delivered as **shared primitives + per-consumer schedules** — a conscious, stated deviation.

## Behavior-identical proof

localroot consumes the package through thin wrappers that fix the zone at `"."` and the root's own limits, so its call sites and tests are untouched. The full localroot suite — the adversarial tests included — passes unchanged, and it now exercises the shared core through the aliases. The two definitions my change orphaned (`firstDuplicate`, the unused limit alias) are removed.

The core's own tests cover only what is new: a non-root apex through the same shape discipline (probe for the wrong zone refused), caller-owned limits (tight caps refuse, roomy caps pass), RFC 1982 wrap, jitter band, lowest-TTL dedup.

Full suite green · `-race` clean on both packages · lint 0.

Net: localroot −204 lines, core +240.