### PR TITLE
cache: the Store admission/serve sidecar seam (RPZ phase 4 prerequisite)

### DIFF
--- a/middleware/autowire_test.go
+++ b/middleware/autowire_test.go
@@ -193,3 +193,43 @@ func TestPutChain_NilSafe(t *testing.T) {
 	Setup(&config.Config{})
 	GlobalPipeline().PutChain(nil) // nil chain must not panic either
 }
+
+// sidecarPolicyHandler implements SidecarPolicyProvider.
+type sidecarPolicyHandler struct{ n string }
+
+func (h *sidecarPolicyHandler) Name() string                            { return h.n }
+func (h *sidecarPolicyHandler) ServeDNS(ctx context.Context, ch *Chain) { ch.Next(ctx) }
+func (h *sidecarPolicyHandler) SidecarEvaluator() SidecarEvaluator {
+	return func(*dns.Msg) *Sidecar { return nil }
+}
+func (h *sidecarPolicyHandler) WireHitGate() WireHitGate { return nil }
+
+// sidecarSetterHandler implements SidecarPolicySetter.
+type sidecarSetterHandler struct {
+	n   string
+	got SidecarPolicyProvider
+}
+
+func (h *sidecarSetterHandler) Name() string                             { return h.n }
+func (h *sidecarSetterHandler) ServeDNS(ctx context.Context, ch *Chain)  { ch.Next(ctx) }
+func (h *sidecarSetterHandler) SetSidecarPolicy(p SidecarPolicyProvider) { h.got = p }
+
+// TestAutoWire_SidecarPolicy pins the seam's wiring: the provider is
+// discovered and injected into the setter before the pipeline publishes,
+// and with no provider registered the setter is never called.
+func TestAutoWire_SidecarPolicy(t *testing.T) {
+	provider := &sidecarPolicyHandler{n: "policy"}
+	setter := &sidecarSetterHandler{n: "cache"}
+	p := &Pipeline{handlers: []Handler{provider, setter}}
+	p.autoWire()
+	if setter.got != SidecarPolicyProvider(provider) {
+		t.Fatal("the sidecar policy provider was not wired into the setter")
+	}
+
+	lone := &sidecarSetterHandler{n: "cache"}
+	p2 := &Pipeline{handlers: []Handler{lone}}
+	p2.autoWire()
+	if lone.got != nil {
+		t.Fatal("a setter was called with no provider registered")
+	}
+}

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -1330,7 +1330,9 @@ func (c *Cache) serveHitFromWire(
 		// lives inside, past the chase's own decline gates.
 		return c.serveChaseHit(ctx, ch, entry, capability, leaser, spent)
 	}
-	if g := c.wireHitGate; g != nil && !g.AllowWireHit(entry.sidecar.Load()) {
+	gate := c.wireHitGate
+	sc := entry.sidecar.Load()
+	if gate != nil && gate.JudgeWireHit(sc) != middleware.WireHitServe {
 		wireSkipPolicy.Inc()
 		return false
 	}
@@ -1359,6 +1361,9 @@ func (c *Cache) serveHitFromWire(
 	}
 	switch err := leaser.CommitWire(body, info); {
 	case err == nil:
+		if gate != nil {
+			gate.CountWireHit(sc)
+		}
 		boundRequestToEntryLifetime(ctx, entry)
 		c.metrics.Hit()
 		wireFastServed.Inc()
@@ -1370,6 +1375,9 @@ func (c *Cache) serveHitFromWire(
 	default:
 		// Transport-level failure after commit: the bytes left the
 		// process; the response counts as written (Msg-path parity).
+		if gate != nil {
+			gate.CountWireHit(sc)
+		}
 		boundRequestToEntryLifetime(ctx, entry)
 		c.metrics.Hit()
 		ch.Cancel()
@@ -1467,6 +1475,24 @@ func (c *Cache) handleCacheHit(
 		}
 	}
 
+	// The policy verdict is judged once per hit, before the byte/decoded
+	// split, because both halves read it: the byte path serves only on
+	// WireHitServe, and the decoded fallback restamps on WireHitRestamp.
+	// It is judged for internal serves too — the verdict is a pure
+	// function of the stored state, and the Msg-path chase reaches its
+	// segments through internal sub-queries, which is where a stale
+	// segment gets its restamp.
+	policyVerdict := middleware.WireHitServe
+	var policySC *middleware.Sidecar
+	if g := c.wireHitGate; g != nil {
+		policySC = entry.sidecar.Load()
+		policyVerdict = g.JudgeWireHit(policySC)
+	} else if c.store.sidecarEvaluator != nil && entry.sidecar.Load() == nil {
+		// An evaluator without a gate still owes pre-wiring entries
+		// their stamp.
+		policyVerdict = middleware.WireHitRestamp
+	}
+
 	// Byte fast path: serve the stored wire directly. The entry-local gate
 	// runs first, then the writer chain's preflight — both allocation-free
 	// and together complete, so a request bound for the Msg path never
@@ -1480,7 +1506,7 @@ func (c *Cache) handleCacheHit(
 		if !entry.wireEligibleFor(req) {
 			return wireSkipEntry
 		}
-		if g := c.wireHitGate; g != nil && !g.AllowWireHit(entry.sidecar.Load()) {
+		if policyVerdict != middleware.WireHitServe {
 			return wireSkipPolicy
 		}
 		ww, ok := w.(middleware.WireWriter)
@@ -1500,6 +1526,9 @@ func (c *Cache) handleCacheHit(
 		}
 		switch err := ww.WriteWire(body, info); {
 		case err == nil:
+			if g := c.wireHitGate; g != nil {
+				g.CountWireHit(policySC)
+			}
 			// The answer is out, so bind the request tree to this entry's
 			// lifetime. The byte path is normally reached only by external
 			// clients, whose responses nothing derives from — but Queryer is
@@ -1523,6 +1552,9 @@ func (c *Cache) handleCacheHit(
 			// still gets this entry's answer: it binds like any other
 			// terminal outcome. Only a fallback stays unbound, because
 			// there the message path binds instead.
+			if g := c.wireHitGate; g != nil {
+				g.CountWireHit(policySC)
+			}
 			boundRequestToEntryLifetime(ctx, entry)
 			ch.Cancel()
 			served = true
@@ -1542,15 +1574,19 @@ func (c *Cache) handleCacheHit(
 		return false
 	}
 
-	// The decoded serve is where an unevaluated entry gets its sidecar:
-	// the wire gate turned it away for being unknown, and this message —
-	// TTL-adjusted but record-identical to the stored truth, before the
-	// chase below appends other entries' records — is exactly what the
-	// admission evaluator would have seen. The CAS keeps a concurrent
-	// stamp from being overwritten; losing it means someone else already
-	// evaluated the same records.
-	if ev := c.store.sidecarEvaluator; ev != nil && entry.sidecar.Load() == nil {
-		entry.sidecar.CompareAndSwap(nil, ev(msg))
+	// The decoded serve is where an unusable sidecar gets replaced: the
+	// gate judged Restamp — unevaluated, or stamped under a generation it
+	// no longer accepts — and this message, TTL-adjusted but
+	// record-identical to the stored truth, before the chase below
+	// appends other entries' records, is exactly what the admission
+	// evaluator would have seen. The CAS is against the judged pointer,
+	// stale or nil alike, so the entry rejoins the byte path instead of
+	// decoding until eviction; losing the CAS means someone else already
+	// restamped the same records.
+	if policyVerdict == middleware.WireHitRestamp {
+		if ev := c.store.sidecarEvaluator; ev != nil {
+			entry.CompareAndStampSidecar(policySC, ev(msg))
+		}
 	}
 
 	// The message materialized, so the entry was live: bind the request tree

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -121,6 +121,12 @@ type Cache struct {
 	// get a slot is a cache miss, never a client-visible error.
 	dnssecCryptoLimiter middleware.DNSSECCryptoLimiter
 
+	// wireHitGate is the serve half of the sidecar seam: consulted before
+	// any record-bearing byte serve with the sidecar(s) the reply would be
+	// built from. Wired at Setup alongside the store's evaluator; nil (no
+	// policy middleware registered) costs one field check per hit.
+	wireHitGate middleware.WireHitGate
+
 	config  CacheConfig
 	metrics *CacheMetrics
 
@@ -1324,6 +1330,10 @@ func (c *Cache) serveHitFromWire(
 		// lives inside, past the chase's own decline gates.
 		return c.serveChaseHit(ctx, ch, entry, capability, leaser, spent)
 	}
+	if g := c.wireHitGate; g != nil && !g.AllowWireHit(entry.sidecar.Load()) {
+		wireSkipPolicy.Inc()
+		return false
+	}
 	if mismatch := entry.wireChainMismatch(capability); mismatch != nil {
 		mismatch.Inc()
 		return false
@@ -1470,6 +1480,9 @@ func (c *Cache) handleCacheHit(
 		if !entry.wireEligibleFor(req) {
 			return wireSkipEntry
 		}
+		if g := c.wireHitGate; g != nil && !g.AllowWireHit(entry.sidecar.Load()) {
+			return wireSkipPolicy
+		}
 		ww, ok := w.(middleware.WireWriter)
 		if !ok {
 			return wireSkipWriter
@@ -1527,6 +1540,17 @@ func (c *Cache) handleCacheHit(
 	if msg == nil {
 		// Entry expired between check and use
 		return false
+	}
+
+	// The decoded serve is where an unevaluated entry gets its sidecar:
+	// the wire gate turned it away for being unknown, and this message —
+	// TTL-adjusted but record-identical to the stored truth, before the
+	// chase below appends other entries' records — is exactly what the
+	// admission evaluator would have seen. The CAS keeps a concurrent
+	// stamp from being overwritten; losing it means someone else already
+	// evaluated the same records.
+	if ev := c.store.sidecarEvaluator; ev != nil && entry.sidecar.Load() == nil {
+		entry.sidecar.CompareAndSwap(nil, ev(msg))
 	}
 
 	// The message materialized, so the entry was live: bind the request tree
@@ -1649,8 +1673,21 @@ func (c *Cache) Set(key uint64, msg *dns.Msg) {
 	if ttl > 0 {
 		entry.origTTL = uint32(ttl.Seconds())
 	}
+	c.store.stampSidecar(entry, filtered)
 
 	c.store.SetEntryWithKey(key, entry, mt)
+}
+
+// SetSidecarPolicy wires both halves of the sidecar seam
+// (middleware.SidecarPolicySetter, injected by Setup before the pipeline
+// publishes): the evaluator stamps entries at every admission door, the
+// gate judges record-bearing byte serves.
+func (c *Cache) SetSidecarPolicy(p middleware.SidecarPolicyProvider) {
+	if p == nil {
+		return
+	}
+	c.store.SetSidecarEvaluator(p.SidecarEvaluator())
+	c.wireHitGate = p.WireHitGate()
 }
 
 // (*Cache).Stats stats returns cache statistics.

--- a/middleware/cache/entry_wire_chase.go
+++ b/middleware/cache/entry_wire_chase.go
@@ -76,14 +76,18 @@ func (c *Cache) serveChaseHit(
 	// The reply would compose every segment's records, so the gate sees
 	// every segment's sidecar, in chain order — the per-segment principle:
 	// a whole-chain verdict on the alias would go stale the moment a
-	// target entry refreshed under it.
+	// target entry refreshed under it. The slice is built only when a
+	// gate is wired: an unconditional array would escape through the
+	// interface call and cost every ungated chase an allocation the
+	// hit-class pins forbid.
 	gate := c.wireHitGate
-	var scs [maxWireChaseHops]*middleware.Sidecar
+	var scs []*middleware.Sidecar
 	if gate != nil {
+		scs = make([]*middleware.Sidecar, n)
 		for i := range n {
 			scs[i] = segs[i].entry.sidecar.Load()
 		}
-		if gate.JudgeWireChase(scs[:n]) != middleware.WireHitServe {
+		if gate.JudgeWireChase(scs) != middleware.WireHitServe {
 			wireSkipPolicy.Inc()
 			return false
 		}
@@ -123,7 +127,7 @@ func (c *Cache) serveChaseHit(
 	switch err := leaser.CommitWire(body, info); {
 	case err == nil:
 		if gate != nil {
-			gate.CountWireChase(scs[:n])
+			gate.CountWireChase(scs)
 		}
 		// The reply contains every segment's records, so the request
 		// inherits every segment's cache-lifetime bound — the wire twin of
@@ -140,7 +144,7 @@ func (c *Cache) serveChaseHit(
 		return false
 	default:
 		if gate != nil {
-			gate.CountWireChase(scs[:n])
+			gate.CountWireChase(scs)
 		}
 		for i := range n {
 			boundRequestToEntryLifetime(ctx, segs[i].entry)

--- a/middleware/cache/entry_wire_chase.go
+++ b/middleware/cache/entry_wire_chase.go
@@ -77,12 +77,13 @@ func (c *Cache) serveChaseHit(
 	// every segment's sidecar, in chain order — the per-segment principle:
 	// a whole-chain verdict on the alias would go stale the moment a
 	// target entry refreshed under it.
-	if g := c.wireHitGate; g != nil {
-		var scs [maxWireChaseHops]*middleware.Sidecar
+	gate := c.wireHitGate
+	var scs [maxWireChaseHops]*middleware.Sidecar
+	if gate != nil {
 		for i := range n {
 			scs[i] = segs[i].entry.sidecar.Load()
 		}
-		if !g.AllowWireChase(scs[:n]) {
+		if gate.JudgeWireChase(scs[:n]) != middleware.WireHitServe {
 			wireSkipPolicy.Inc()
 			return false
 		}
@@ -121,6 +122,9 @@ func (c *Cache) serveChaseHit(
 
 	switch err := leaser.CommitWire(body, info); {
 	case err == nil:
+		if gate != nil {
+			gate.CountWireChase(scs[:n])
+		}
 		// The reply contains every segment's records, so the request
 		// inherits every segment's cache-lifetime bound — the wire twin of
 		// the Msg chase's lineage inheritance.
@@ -135,6 +139,9 @@ func (c *Cache) serveChaseHit(
 		wireFastFallback.Inc()
 		return false
 	default:
+		if gate != nil {
+			gate.CountWireChase(scs[:n])
+		}
 		for i := range n {
 			boundRequestToEntryLifetime(ctx, segs[i].entry)
 		}

--- a/middleware/cache/entry_wire_chase.go
+++ b/middleware/cache/entry_wire_chase.go
@@ -31,6 +31,10 @@ import (
 // chase re-resolves and re-admits it — self-healing at the cost of one
 // decoded serve.
 
+// The chase depth must fit the sidecar chain the gate receives; a
+// negative constant here fails the build.
+const _ = uint(middleware.SidecarChainCap - maxWireChaseHops)
+
 const (
 	// maxWireChaseHops mirrors the Msg-path chase depth.
 	maxWireChaseHops = 10
@@ -76,18 +80,17 @@ func (c *Cache) serveChaseHit(
 	// The reply would compose every segment's records, so the gate sees
 	// every segment's sidecar, in chain order — the per-segment principle:
 	// a whole-chain verdict on the alias would go stale the moment a
-	// target entry refreshed under it. The slice is built only when a
-	// gate is wired: an unconditional array would escape through the
-	// interface call and cost every ungated chase an allocation the
-	// hit-class pins forbid.
+	// target entry refreshed under it. The chain travels by value: a
+	// slice here escapes through the interface call and puts a heap
+	// allocation on every gated chase hit, which the zero-allocation hit
+	// contract forbids with the gate wired no less than without it.
 	gate := c.wireHitGate
-	var scs []*middleware.Sidecar
+	var chain middleware.SidecarChain
 	if gate != nil {
-		scs = make([]*middleware.Sidecar, n)
 		for i := range n {
-			scs[i] = segs[i].entry.sidecar.Load()
+			chain.Append(segs[i].entry.sidecar.Load())
 		}
-		if gate.JudgeWireChase(scs) != middleware.WireHitServe {
+		if gate.JudgeWireChase(chain) != middleware.WireHitServe {
 			wireSkipPolicy.Inc()
 			return false
 		}
@@ -127,7 +130,7 @@ func (c *Cache) serveChaseHit(
 	switch err := leaser.CommitWire(body, info); {
 	case err == nil:
 		if gate != nil {
-			gate.CountWireChase(scs)
+			gate.CountWireChase(chain)
 		}
 		// The reply contains every segment's records, so the request
 		// inherits every segment's cache-lifetime bound — the wire twin of
@@ -144,7 +147,7 @@ func (c *Cache) serveChaseHit(
 		return false
 	default:
 		if gate != nil {
-			gate.CountWireChase(scs)
+			gate.CountWireChase(chain)
 		}
 		for i := range n {
 			boundRequestToEntryLifetime(ctx, segs[i].entry)

--- a/middleware/cache/entry_wire_chase.go
+++ b/middleware/cache/entry_wire_chase.go
@@ -73,6 +73,21 @@ func (c *Cache) serveChaseHit(
 		return false
 	}
 
+	// The reply would compose every segment's records, so the gate sees
+	// every segment's sidecar, in chain order — the per-segment principle:
+	// a whole-chain verdict on the alias would go stale the moment a
+	// target entry refreshed under it.
+	if g := c.wireHitGate; g != nil {
+		var scs [maxWireChaseHops]*middleware.Sidecar
+		for i := range n {
+			scs[i] = segs[i].entry.sidecar.Load()
+		}
+		if !g.AllowWireChase(scs[:n]) {
+			wireSkipPolicy.Inc()
+			return false
+		}
+	}
+
 	size := wire.HeaderLen + (ch.Request.WireQuestionEnd() - wire.HeaderLen)
 	for i := range n {
 		size += len(segs[i].body) + segs[i].anCount*wireChaseHeadroom

--- a/middleware/cache/prometheus.go
+++ b/middleware/cache/prometheus.go
@@ -61,6 +61,7 @@ var (
 	wireSkipEntry     = wireFastPath.Register("skip_entry")
 	wireSkipWriter    = wireFastPath.Register("skip_writer")
 	wireSkipDNSSEC    = wireFastPath.Register("skip_dnssec")
+	wireSkipPolicy    = wireFastPath.Register("skip_policy")
 	wireSkipSize      = wireFastPath.Register("skip_size")
 	wireSkipBuild     = wireFastPath.Register("skip_build")
 	wireSkipChase     = wireFastPath.Register("skip_chase")

--- a/middleware/cache/sidecar_seam_test.go
+++ b/middleware/cache/sidecar_seam_test.go
@@ -1,0 +1,317 @@
+package cache
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/middleware"
+)
+
+// recordingPolicy is a SidecarPolicyProvider that remembers what the seam
+// showed it: every message the evaluator saw and every sidecar set the
+// gate judged.
+type recordingPolicy struct {
+	mu        sync.Mutex
+	evaluated []string
+	hits      []*middleware.Sidecar
+	chases    [][]*middleware.Sidecar
+	allow     bool
+}
+
+func (p *recordingPolicy) SidecarEvaluator() middleware.SidecarEvaluator {
+	return func(msg *dns.Msg) *middleware.Sidecar {
+		p.mu.Lock()
+		defer p.mu.Unlock()
+		p.evaluated = append(p.evaluated, msg.Question[0].Name)
+		return &middleware.Sidecar{Value: msg.Question[0].Name}
+	}
+}
+
+func (p *recordingPolicy) WireHitGate() middleware.WireHitGate { return p }
+
+func (p *recordingPolicy) AllowWireHit(sc *middleware.Sidecar) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.hits = append(p.hits, sc)
+	return p.allow
+}
+
+func (p *recordingPolicy) AllowWireChase(scs []*middleware.Sidecar) bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.chases = append(p.chases, append([]*middleware.Sidecar(nil), scs...))
+	return p.allow
+}
+
+func seamResponse(name string, answers ...dns.RR) *dns.Msg {
+	resp := new(dns.Msg)
+	resp.SetQuestion(name, dns.TypeA)
+	resp.Response = true
+	resp.RecursionAvailable = true
+	resp.Answer = answers
+	return resp
+}
+
+func seamA(name string) *dns.A {
+	return &dns.A{
+		Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+		A:   []byte{192, 0, 2, 1},
+	}
+}
+
+// TestEveryAdmissionDoorStampsTheSidecar pins the seam's admission
+// contract: no door admits an entry unevaluated while an evaluator is
+// wired — the writer/resolver funnel, the prefetch CAS replacement, and
+// the compatibility Set alike.
+func TestEveryAdmissionDoorStampsTheSidecar(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, Expire: 600})
+	defer c.Stop()
+	p := &recordingPolicy{allow: true}
+	c.SetSidecarPolicy(p)
+
+	// Door 1: the SetFromResponse funnel (writer and resolver paths).
+	resp := seamResponse("door1.test.", seamA("door1.test."))
+	c.store.SetFromResponseWithCut(resp, false, time.Time{}, 0)
+	key := CacheKey{Question: resp.Question[0], CD: false}.Hash()
+	entry, ok := c.store.LookupByKey(key)
+	if !ok || entry.Sidecar() == nil {
+		t.Fatal("the SetFromResponse funnel admitted an unevaluated entry")
+	}
+	if entry.Sidecar().Value != "door1.test." {
+		t.Fatalf("evaluator saw the wrong message: %v", entry.Sidecar().Value)
+	}
+
+	// Door 2: the prefetch replacement.
+	if !c.store.ReplaceIfCurrent(key, entry, seamResponse("door1.test.", seamA("door1.test.")), time.Time{}, 0) {
+		t.Fatal("replacement declined")
+	}
+	replaced, ok := c.store.LookupByKey(key)
+	if !ok || replaced == entry {
+		t.Fatal("replacement did not install a new entry")
+	}
+	if replaced.Sidecar() == nil {
+		t.Fatal("the replacement door admitted an unevaluated entry")
+	}
+
+	// Door 3: the compatibility Set.
+	resp3 := seamResponse("door3.test.", seamA("door3.test."))
+	key3 := CacheKey{Question: resp3.Question[0], CD: false}.Hash()
+	c.Set(key3, resp3)
+	entry3, ok := c.store.LookupByKey(key3)
+	if !ok || entry3.Sidecar() == nil {
+		t.Fatal("the compatibility Set admitted an unevaluated entry")
+	}
+}
+
+// TestUnwiredSeamLeavesEntriesUnstamped pins the nil half of the
+// contract: with no policy registered, entries carry a nil sidecar and
+// nothing is consulted — today's behavior, byte for byte.
+func TestUnwiredSeamLeavesEntriesUnstamped(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, Expire: 600})
+	defer c.Stop()
+
+	resp := seamResponse("plain.test.", seamA("plain.test."))
+	c.store.SetFromResponseWithCut(resp, false, time.Time{}, 0)
+	entry, ok := c.store.LookupByKey(CacheKey{Question: resp.Question[0], CD: false}.Hash())
+	if !ok {
+		t.Fatal("entry missing")
+	}
+	if entry.Sidecar() != nil {
+		t.Fatal("an unwired seam stamped a sidecar")
+	}
+}
+
+// seamServe drives one query through cache + terminal on the Msg-born
+// path. AllowDirectPack declares the mock an owned byte sink, so hits
+// the gate approves genuinely serve bytes (the mock unpacks them for the
+// same asserts either way).
+func seamServe(t *testing.T, c *Cache, name string) *mock.Writer {
+	t.Helper()
+	q := new(dns.Msg)
+	q.SetQuestion(name, dns.TypeA)
+	q.RecursionDesired = true
+
+	terminal := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		resp := seamResponse(name, seamA(name))
+		resp.SetReply(ch.Request.Msg())
+		resp.Answer = []dns.RR{seamA(name)}
+		_ = ch.Writer.WriteMsg(resp)
+		ch.Cancel()
+	})
+	w := mock.NewWriter("udp", "192.0.2.9:53000")
+	ch := middleware.NewChain([]middleware.Handler{c, terminal})
+	ch.Reset(w, q)
+	ch.AllowDirectPack()
+	ch.Next(context.Background())
+	return w
+}
+
+// TestWireGateDeclineFallsToTheDecodedPath pins the serve half: a gate
+// that turns a byte serve away is consulted with the entry's own sidecar,
+// and the same query is answered — correctly — by the decoded path.
+func TestWireGateDeclineFallsToTheDecodedPath(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, Expire: 600})
+	defer c.Stop()
+	p := &recordingPolicy{allow: false}
+	c.SetSidecarPolicy(p)
+
+	seamServe(t, c, "gated.test.") // miss primes the entry
+	before := len(p.hits)
+	w := seamServe(t, c, "gated.test.") // hit
+	if !w.Written() || w.Rcode() != dns.RcodeSuccess || len(w.Msg().Answer) != 1 {
+		t.Fatalf("declined byte serve did not answer from the decoded path: written=%v rcode=%d", w.Written(), w.Rcode())
+	}
+	if len(p.hits) == before {
+		t.Fatal("the gate was never consulted on a hit")
+	}
+	sc := p.hits[len(p.hits)-1]
+	if sc == nil || sc.Value != "gated.test." {
+		t.Fatalf("the gate saw the wrong sidecar: %v", sc)
+	}
+}
+
+// TestWireGateApprovalServesBytes is the other verdict: an allowing gate
+// is consulted and the hit still serves.
+func TestWireGateApprovalServesBytes(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, Expire: 600})
+	defer c.Stop()
+	p := &recordingPolicy{allow: true}
+	c.SetSidecarPolicy(p)
+
+	seamServe(t, c, "open.test.")
+	served := wireFastServed.Value()
+	w := seamServe(t, c, "open.test.")
+	if !w.Written() || len(w.Msg().Answer) != 1 {
+		t.Fatal("approved hit did not answer")
+	}
+	if len(p.hits) == 0 {
+		t.Fatal("the gate was never consulted")
+	}
+	if wireFastServed.Value() == served {
+		t.Fatal("an approving gate kept the hit off the byte path")
+	}
+}
+
+// TestDecodedServeStampsAnUnevaluatedEntry pins the unknown-never-clean
+// recovery: an entry admitted before the seam was wired carries no
+// sidecar, the gate turns its byte serve away, and the decoded serve that
+// answers instead evaluates and stamps it — the next hit has a sidecar.
+func TestDecodedServeStampsAnUnevaluatedEntry(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, Expire: 600})
+	defer c.Stop()
+
+	seamServe(t, c, "late.test.") // admitted with no evaluator wired
+
+	p := &recordingPolicy{allow: false}
+	c.SetSidecarPolicy(p)
+	w := seamServe(t, c, "late.test.")
+	if !w.Written() {
+		t.Fatal("hit did not answer")
+	}
+
+	key := CacheKey{Question: dns.Question{Name: "late.test.", Qtype: dns.TypeA, Qclass: dns.ClassINET}, CD: false}.Hash()
+	entry, ok := c.store.LookupByKey(key)
+	if !ok {
+		t.Fatal("entry missing")
+	}
+	if entry.Sidecar() == nil {
+		t.Fatal("the decoded serve left the entry unevaluated; every later hit stays off the byte path forever")
+	}
+}
+
+// TestChaseGateSeesEverySegmentInOrder pins the per-segment principle on
+// the composed chase: the gate is shown one sidecar per segment, alias
+// first — a whole-chain verdict on the alias entry alone would go stale
+// when the target refreshed under it.
+func TestChaseGateSeesEverySegmentInOrder(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, Expire: 600})
+	defer c.Stop()
+	p := &recordingPolicy{allow: true}
+	c.SetSidecarPolicy(p)
+
+	alias := seamResponse("alias.seam.test.", &dns.CNAME{
+		Hdr:    dns.RR_Header{Name: "alias.seam.test.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+		Target: "target.seam.test.",
+	})
+	c.store.SetFromResponseWithCut(alias, false, time.Time{}, 0)
+	target := seamResponse("target.seam.test.", seamA("target.seam.test."))
+	c.store.SetFromResponseWithCut(target, false, time.Time{}, 0)
+
+	req, _ := wireTestRequest(t, "alias.seam.test.", dns.TypeA, false)
+	w := mock.NewWriter("udp", "192.0.2.9:53000")
+	ch := middleware.NewChain([]middleware.Handler{c, middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		ch.Cancel()
+	})})
+	ch.ResetWire(w, req)
+	ch.AllowDirectPack()
+	ch.Next(context.Background())
+
+	if len(p.chases) == 0 {
+		t.Fatal("the chase gate was never consulted")
+	}
+	seen := p.chases[len(p.chases)-1]
+	if len(seen) != 2 || seen[0] == nil || seen[1] == nil ||
+		seen[0].Value != "alias.seam.test." || seen[1].Value != "target.seam.test." {
+		t.Fatalf("chase gate did not see every segment in order: %v", seen)
+	}
+}
+
+// TestCompareAndStampSidecar pins the restamp primitive: a stale pointer
+// loses to a concurrent stamp instead of overwriting it.
+func TestCompareAndStampSidecar(t *testing.T) {
+	e := &CacheEntry{}
+	first := &middleware.Sidecar{Value: 1}
+	if !e.CompareAndStampSidecar(nil, first) {
+		t.Fatal("first stamp refused")
+	}
+	stale := &middleware.Sidecar{Value: 2}
+	if e.CompareAndStampSidecar(nil, stale) {
+		t.Fatal("a stale claim overwrote a live stamp")
+	}
+	if e.Sidecar() != first {
+		t.Fatal("stamp lost")
+	}
+	next := &middleware.Sidecar{Value: 3}
+	if !e.CompareAndStampSidecar(first, next) || e.Sidecar() != next {
+		t.Fatal("restamp from the live value refused")
+	}
+}
+
+// TestRawPathGateKeepsADeclinedHitOffBytes pins the wire-born exact-hit
+// gate specifically: with the gate declining, the byte fast path must not
+// serve — the Msg body answers instead — and the fast-served counter
+// proves which one did.
+func TestRawPathGateKeepsADeclinedHitOffBytes(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, Expire: 600})
+	defer c.Stop()
+	p := &recordingPolicy{allow: false}
+	c.SetSidecarPolicy(p)
+
+	resp := seamResponse("raw.seam.test.", seamA("raw.seam.test."))
+	c.store.SetFromResponseWithCut(resp, false, time.Time{}, 0)
+
+	served := wireFastServed.Value()
+	req, _ := wireTestRequest(t, "raw.seam.test.", dns.TypeA, false)
+	w := mock.NewWriter("udp", "192.0.2.9:53000")
+	ch := middleware.NewChain([]middleware.Handler{c, middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		ch.Cancel()
+	})})
+	ch.ResetWire(w, req)
+	ch.AllowDirectPack()
+	ch.Next(context.Background())
+
+	if !w.Written() || len(w.Msg().Answer) != 1 {
+		t.Fatal("declined hit did not answer from the decoded path")
+	}
+	if wireFastServed.Value() != served {
+		t.Fatal("a declining gate let the raw byte path serve")
+	}
+	if len(p.hits) == 0 {
+		t.Fatal("the gate was never consulted")
+	}
+}

--- a/middleware/cache/sidecar_seam_test.go
+++ b/middleware/cache/sidecar_seam_test.go
@@ -13,14 +13,18 @@ import (
 )
 
 // recordingPolicy is a SidecarPolicyProvider that remembers what the seam
-// showed it: every message the evaluator saw and every sidecar set the
-// gate judged.
+// showed it: every message the evaluator saw, every sidecar set the gate
+// judged, and every committed serve it was asked to count.
 type recordingPolicy struct {
-	mu        sync.Mutex
-	evaluated []string
-	hits      []*middleware.Sidecar
-	chases    [][]*middleware.Sidecar
-	allow     bool
+	mu           sync.Mutex
+	evaluated    []string
+	hits         []*middleware.Sidecar
+	chases       [][]*middleware.Sidecar
+	counted      []*middleware.Sidecar
+	countedChase [][]*middleware.Sidecar
+	verdict      middleware.WireHitVerdict
+	// stamp overrides the evaluator's result value when set.
+	stamp string
 }
 
 func (p *recordingPolicy) SidecarEvaluator() middleware.SidecarEvaluator {
@@ -28,24 +32,39 @@ func (p *recordingPolicy) SidecarEvaluator() middleware.SidecarEvaluator {
 		p.mu.Lock()
 		defer p.mu.Unlock()
 		p.evaluated = append(p.evaluated, msg.Question[0].Name)
+		if p.stamp != "" {
+			return &middleware.Sidecar{Value: p.stamp}
+		}
 		return &middleware.Sidecar{Value: msg.Question[0].Name}
 	}
 }
 
 func (p *recordingPolicy) WireHitGate() middleware.WireHitGate { return p }
 
-func (p *recordingPolicy) AllowWireHit(sc *middleware.Sidecar) bool {
+func (p *recordingPolicy) JudgeWireHit(sc *middleware.Sidecar) middleware.WireHitVerdict {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.hits = append(p.hits, sc)
-	return p.allow
+	return p.verdict
 }
 
-func (p *recordingPolicy) AllowWireChase(scs []*middleware.Sidecar) bool {
+func (p *recordingPolicy) JudgeWireChase(scs []*middleware.Sidecar) middleware.WireHitVerdict {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.chases = append(p.chases, append([]*middleware.Sidecar(nil), scs...))
-	return p.allow
+	return p.verdict
+}
+
+func (p *recordingPolicy) CountWireHit(sc *middleware.Sidecar) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.counted = append(p.counted, sc)
+}
+
+func (p *recordingPolicy) CountWireChase(scs []*middleware.Sidecar) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.countedChase = append(p.countedChase, append([]*middleware.Sidecar(nil), scs...))
 }
 
 func seamResponse(name string, answers ...dns.RR) *dns.Msg {
@@ -71,7 +90,7 @@ func seamA(name string) *dns.A {
 func TestEveryAdmissionDoorStampsTheSidecar(t *testing.T) {
 	c := New(&config.Config{CacheSize: 1024, Expire: 600})
 	defer c.Stop()
-	p := &recordingPolicy{allow: true}
+	p := &recordingPolicy{verdict: middleware.WireHitServe}
 	c.SetSidecarPolicy(p)
 
 	// Door 1: the SetFromResponse funnel (writer and resolver paths).
@@ -157,7 +176,7 @@ func seamServe(t *testing.T, c *Cache, name string) *mock.Writer {
 func TestWireGateDeclineFallsToTheDecodedPath(t *testing.T) {
 	c := New(&config.Config{CacheSize: 1024, Expire: 600})
 	defer c.Stop()
-	p := &recordingPolicy{allow: false}
+	p := &recordingPolicy{verdict: middleware.WireHitDecode}
 	c.SetSidecarPolicy(p)
 
 	seamServe(t, c, "gated.test.") // miss primes the entry
@@ -180,7 +199,7 @@ func TestWireGateDeclineFallsToTheDecodedPath(t *testing.T) {
 func TestWireGateApprovalServesBytes(t *testing.T) {
 	c := New(&config.Config{CacheSize: 1024, Expire: 600})
 	defer c.Stop()
-	p := &recordingPolicy{allow: true}
+	p := &recordingPolicy{verdict: middleware.WireHitServe}
 	c.SetSidecarPolicy(p)
 
 	seamServe(t, c, "open.test.")
@@ -199,7 +218,7 @@ func TestWireGateApprovalServesBytes(t *testing.T) {
 
 // TestDecodedServeStampsAnUnevaluatedEntry pins the unknown-never-clean
 // recovery: an entry admitted before the seam was wired carries no
-// sidecar, the gate turns its byte serve away, and the decoded serve that
+// sidecar, the gate judges it Restamp, and the decoded serve that
 // answers instead evaluates and stamps it — the next hit has a sidecar.
 func TestDecodedServeStampsAnUnevaluatedEntry(t *testing.T) {
 	c := New(&config.Config{CacheSize: 1024, Expire: 600})
@@ -207,7 +226,7 @@ func TestDecodedServeStampsAnUnevaluatedEntry(t *testing.T) {
 
 	seamServe(t, c, "late.test.") // admitted with no evaluator wired
 
-	p := &recordingPolicy{allow: false}
+	p := &recordingPolicy{verdict: middleware.WireHitRestamp}
 	c.SetSidecarPolicy(p)
 	w := seamServe(t, c, "late.test.")
 	if !w.Written() {
@@ -231,7 +250,7 @@ func TestDecodedServeStampsAnUnevaluatedEntry(t *testing.T) {
 func TestChaseGateSeesEverySegmentInOrder(t *testing.T) {
 	c := New(&config.Config{CacheSize: 1024, Expire: 600})
 	defer c.Stop()
-	p := &recordingPolicy{allow: true}
+	p := &recordingPolicy{verdict: middleware.WireHitServe}
 	c.SetSidecarPolicy(p)
 
 	alias := seamResponse("alias.seam.test.", &dns.CNAME{
@@ -258,6 +277,10 @@ func TestChaseGateSeesEverySegmentInOrder(t *testing.T) {
 	if len(seen) != 2 || seen[0] == nil || seen[1] == nil ||
 		seen[0].Value != "alias.seam.test." || seen[1].Value != "target.seam.test." {
 		t.Fatalf("chase gate did not see every segment in order: %v", seen)
+	}
+	// The committed composition counts once, with the same segments.
+	if len(p.countedChase) != 1 || len(p.countedChase[0]) != 2 {
+		t.Fatalf("committed chase counted %d times", len(p.countedChase))
 	}
 }
 
@@ -289,7 +312,7 @@ func TestCompareAndStampSidecar(t *testing.T) {
 func TestRawPathGateKeepsADeclinedHitOffBytes(t *testing.T) {
 	c := New(&config.Config{CacheSize: 1024, Expire: 600})
 	defer c.Stop()
-	p := &recordingPolicy{allow: false}
+	p := &recordingPolicy{verdict: middleware.WireHitDecode}
 	c.SetSidecarPolicy(p)
 
 	resp := seamResponse("raw.seam.test.", seamA("raw.seam.test."))
@@ -313,5 +336,172 @@ func TestRawPathGateKeepsADeclinedHitOffBytes(t *testing.T) {
 	}
 	if len(p.hits) == 0 {
 		t.Fatal("the gate was never consulted")
+	}
+}
+
+// TestStaleSidecarIsRestampedNotStranded pins the review's first P1: a
+// non-nil sidecar the gate judges stale must be replaced by the decoded
+// serve — CAS over the judged pointer, not only over nil — or the entry
+// decodes on every hit until eviction after a policy reload.
+func TestStaleSidecarIsRestampedNotStranded(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, Expire: 600})
+	defer c.Stop()
+	p := &recordingPolicy{verdict: middleware.WireHitServe, stamp: "gen1"}
+	c.SetSidecarPolicy(p)
+
+	seamServe(t, c, "reload.test.") // admitted and stamped under gen1
+
+	// The policy reloads: gen1 stamps are now stale, fresh evaluations
+	// say gen2.
+	p.mu.Lock()
+	p.verdict = middleware.WireHitRestamp
+	p.stamp = "gen2"
+	p.mu.Unlock()
+
+	w := seamServe(t, c, "reload.test.")
+	if !w.Written() || len(w.Msg().Answer) != 1 {
+		t.Fatal("hit did not answer")
+	}
+	key := CacheKey{Question: dns.Question{Name: "reload.test.", Qtype: dns.TypeA, Qclass: dns.ClassINET}, CD: false}.Hash()
+	entry, ok := c.store.LookupByKey(key)
+	if !ok {
+		t.Fatal("entry missing")
+	}
+	sc := entry.Sidecar()
+	if sc == nil || sc.Value != "gen2" {
+		t.Fatalf("stale sidecar not restamped: %v — the entry decodes until eviction", sc)
+	}
+}
+
+// TestFallbackAfterApprovalCountsNothing pins the review's second P1: a
+// Serve verdict is a pure decision, and a byte serve that still falls
+// back past it — writer fallback here — must count nothing; the decoded
+// path's own writer owns that outcome.
+func TestFallbackAfterApprovalCountsNothing(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, Expire: 600})
+	defer c.Stop()
+	p := &recordingPolicy{verdict: middleware.WireHitServe}
+	c.SetSidecarPolicy(p)
+
+	seamServe(t, c, "fallback.test.") // prime
+
+	q := new(dns.Msg)
+	q.SetQuestion("fallback.test.", dns.TypeA)
+	q.RecursionDesired = true
+	w := mock.NewWriter("udp", "192.0.2.9:53000")
+	ch := middleware.NewChain([]middleware.Handler{c, middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		ch.Cancel()
+	})})
+	ch.Reset(w, q)
+	ch.AllowDirectPack()
+	ch.Writer = &fallbackWireWriter{ResponseWriter: ch.Writer}
+	before := len(p.counted)
+	ch.Next(context.Background())
+
+	if !w.Written() || len(w.Msg().Answer) != 1 {
+		t.Fatal("fallback hit did not answer from the decoded path")
+	}
+	if len(p.counted) != before {
+		t.Fatal("a serve that fell back to the decoded path was counted as a byte hit")
+	}
+	if len(p.hits) == 0 {
+		t.Fatal("the gate was never consulted")
+	}
+}
+
+// TestCommittedByteServeCountsExactlyOnce is the positive half: bytes
+// out means one Count call carrying the judged sidecar — on the Msg-born
+// inline byte path and the wire-born exact hit alike.
+func TestCommittedByteServeCountsExactlyOnce(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, Expire: 600})
+	defer c.Stop()
+	p := &recordingPolicy{verdict: middleware.WireHitServe}
+	c.SetSidecarPolicy(p)
+
+	seamServe(t, c, "counted.test.")
+	before := len(p.counted)
+	seamServe(t, c, "counted.test.")
+	if got := len(p.counted) - before; got != 1 {
+		t.Fatalf("a committed byte serve counted %d times", got)
+	}
+	if sc := p.counted[len(p.counted)-1]; sc == nil || sc.Value != "counted.test." {
+		t.Fatalf("the count carried the wrong sidecar: %v", sc)
+	}
+
+	// The wire-born twin commits through the lease instead of WriteWire.
+	req, _ := wireTestRequest(t, "counted.test.", dns.TypeA, false)
+	w := mock.NewWriter("udp", "192.0.2.9:53000")
+	ch := middleware.NewChain([]middleware.Handler{c, middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		ch.Cancel()
+	})})
+	ch.ResetWire(w, req)
+	ch.AllowDirectPack()
+	before = len(p.counted)
+	ch.Next(context.Background())
+	if !w.Written() || len(w.Msg().Answer) != 1 {
+		t.Fatal("wire-born hit did not answer")
+	}
+	if got := len(p.counted) - before; got != 1 {
+		t.Fatalf("a committed wire-born serve counted %d times", got)
+	}
+}
+
+// fallbackWireWriter approves the wire preflight and then refuses the
+// bytes with the fallback sentinel, sending the serve to the decoded
+// path after the gate already said Serve.
+type fallbackWireWriter struct {
+	middleware.ResponseWriter
+}
+
+func (w *fallbackWireWriter) WireReady() (middleware.WireCapability, bool) {
+	next, ok := w.ResponseWriter.(middleware.WireWriter)
+	if !ok {
+		return middleware.WireCapability{}, false
+	}
+	return next.WireReady()
+}
+
+func (w *fallbackWireWriter) WriteWire([]byte, middleware.WireInfo) error {
+	return middleware.ErrWireFallback
+}
+
+func (w *fallbackWireWriter) BeginWire(size, reserve int) []byte {
+	return make([]byte, 0, size+reserve)
+}
+
+func (w *fallbackWireWriter) CommitWire([]byte, middleware.WireInfo) error {
+	return middleware.ErrWireFallback
+}
+
+func (w *fallbackWireWriter) AbortWire() {}
+
+// TestRawFallbackAfterApprovalCountsNothing is the wire-born twin of the
+// fallback pin: the raw exact hit's lease commits through CommitWire, and
+// a fallback there must leave the count untouched too.
+func TestRawFallbackAfterApprovalCountsNothing(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, Expire: 600})
+	defer c.Stop()
+	p := &recordingPolicy{verdict: middleware.WireHitServe}
+	c.SetSidecarPolicy(p)
+
+	resp := seamResponse("rawfall.test.", seamA("rawfall.test."))
+	c.store.SetFromResponseWithCut(resp, false, time.Time{}, 0)
+
+	req, _ := wireTestRequest(t, "rawfall.test.", dns.TypeA, false)
+	w := mock.NewWriter("udp", "192.0.2.9:53000")
+	ch := middleware.NewChain([]middleware.Handler{c, middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		ch.Cancel()
+	})})
+	ch.ResetWire(w, req)
+	ch.AllowDirectPack()
+	ch.Writer = &fallbackWireWriter{ResponseWriter: ch.Writer}
+	before := len(p.counted)
+	ch.Next(context.Background())
+
+	if !w.Written() || len(w.Msg().Answer) != 1 {
+		t.Fatal("fallback hit did not answer from the decoded path")
+	}
+	if len(p.counted) != before {
+		t.Fatal("a raw serve that fell back was counted as a byte hit")
 	}
 }

--- a/middleware/cache/sidecar_seam_test.go
+++ b/middleware/cache/sidecar_seam_test.go
@@ -48,11 +48,19 @@ func (p *recordingPolicy) JudgeWireHit(sc *middleware.Sidecar) middleware.WireHi
 	return p.verdict
 }
 
-func (p *recordingPolicy) JudgeWireChase(scs []*middleware.Sidecar) middleware.WireHitVerdict {
+func (p *recordingPolicy) JudgeWireChase(chain middleware.SidecarChain) middleware.WireHitVerdict {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.chases = append(p.chases, append([]*middleware.Sidecar(nil), scs...))
+	p.chases = append(p.chases, chainSidecars(chain))
 	return p.verdict
+}
+
+func chainSidecars(chain middleware.SidecarChain) []*middleware.Sidecar {
+	out := make([]*middleware.Sidecar, chain.Len())
+	for i := range out {
+		out[i] = chain.At(i)
+	}
+	return out
 }
 
 func (p *recordingPolicy) CountWireHit(sc *middleware.Sidecar) {
@@ -61,10 +69,10 @@ func (p *recordingPolicy) CountWireHit(sc *middleware.Sidecar) {
 	p.counted = append(p.counted, sc)
 }
 
-func (p *recordingPolicy) CountWireChase(scs []*middleware.Sidecar) {
+func (p *recordingPolicy) CountWireChase(chain middleware.SidecarChain) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	p.countedChase = append(p.countedChase, append([]*middleware.Sidecar(nil), scs...))
+	p.countedChase = append(p.countedChase, chainSidecars(chain))
 }
 
 func seamResponse(name string, answers ...dns.RR) *dns.Msg {
@@ -503,5 +511,86 @@ func TestRawFallbackAfterApprovalCountsNothing(t *testing.T) {
 	}
 	if len(p.counted) != before {
 		t.Fatal("a raw serve that fell back was counted as a byte hit")
+	}
+}
+
+// staticGate is an allocation-free Serve gate for the alloc pins: it
+// must not record anything, or the pin would measure the recorder.
+type staticGate struct{}
+
+func (staticGate) JudgeWireHit(*middleware.Sidecar) middleware.WireHitVerdict { //nolint:revive // interface
+	return middleware.WireHitServe
+}
+
+func (staticGate) JudgeWireChase(middleware.SidecarChain) middleware.WireHitVerdict {
+	return middleware.WireHitServe
+}
+
+func (staticGate) CountWireHit(*middleware.Sidecar)              {}
+func (staticGate) CountWireChase(middleware.SidecarChain)        {}
+func (staticGate) SidecarEvaluator() middleware.SidecarEvaluator { return nil }
+func (staticGate) WireHitGate() middleware.WireHitGate           { return staticGate{} }
+
+// sinkWriter is a mock transport whose Write discards without decoding,
+// so a serve loop under AllocsPerRun measures the serve, not the sink.
+type sinkWriter struct {
+	*mock.Writer
+	wrote int
+}
+
+func (s *sinkWriter) Write(b []byte) (int, error) {
+	s.wrote++
+	return len(b), nil
+}
+
+// gatedHitAllocs measures allocations per raw wire hit for qname against
+// a primed cache.
+func gatedHitAllocs(t *testing.T, c *Cache, qname string) float64 {
+	t.Helper()
+	req, _ := wireTestRequest(t, qname, dns.TypeA, false)
+	w := &sinkWriter{Writer: mock.NewWriter("udp", "192.0.2.9:53000")}
+	ch := middleware.NewChain([]middleware.Handler{c, middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		ch.Cancel()
+	})})
+	allocs := testing.AllocsPerRun(200, func() {
+		ch.ResetWire(w, req)
+		ch.AllowDirectPack()
+		ch.Next(context.Background())
+	})
+	if w.wrote == 0 {
+		t.Fatalf("%s never served bytes; the pin measured nothing", qname)
+	}
+	return allocs
+}
+
+// TestGatedByteHitsAllocateNoMoreThanUngated pins the §5.11 half the CI
+// gates cannot see: with a Serve gate wired, the steady-state byte hit —
+// exact and chase alike — costs exactly what it costs without one. The
+// pin is baseline-relative so it measures the gate's addition, not the
+// harness.
+func TestGatedByteHitsAllocateNoMoreThanUngated(t *testing.T) {
+	prime := func(c *Cache) {
+		c.store.SetFromResponseWithCut(seamResponse("exact.pin.test.", seamA("exact.pin.test.")), false, time.Time{}, 0)
+		c.store.SetFromResponseWithCut(seamResponse("alias.pin.test.", &dns.CNAME{
+			Hdr:    dns.RR_Header{Name: "alias.pin.test.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+			Target: "exact.pin.test.",
+		}), false, time.Time{}, 0)
+	}
+
+	base := New(&config.Config{CacheSize: 1024, Expire: 600})
+	defer base.Stop()
+	prime(base)
+
+	gated := New(&config.Config{CacheSize: 1024, Expire: 600})
+	defer gated.Stop()
+	gated.SetSidecarPolicy(staticGate{})
+	prime(gated)
+
+	for _, qname := range []string{"exact.pin.test.", "alias.pin.test."} {
+		ungated := gatedHitAllocs(t, base, qname)
+		withGate := gatedHitAllocs(t, gated, qname)
+		if withGate > ungated {
+			t.Fatalf("%s: gated hit allocates %.1f vs %.1f ungated; the gate must be free on the byte path", qname, withGate, ungated)
+		}
 	}
 }

--- a/middleware/cache/store.go
+++ b/middleware/cache/store.go
@@ -49,6 +49,30 @@ type Store struct {
 	// keep one stable shape, but no shared failure state is read or written.
 	failureCacheDisabled bool
 	cfg                  CacheConfig
+
+	// sidecarEvaluator, when wired, is called once per admitted entry with
+	// that entry's own stored message; its result is stamped as the
+	// entry's sidecar before publication. Every admission door funnels
+	// through a stamp — the seam's contract is that no entry reaches the
+	// positive cache unevaluated while an evaluator is wired. Written once
+	// at Setup, before the pipeline publishes; nil costs one field check.
+	sidecarEvaluator middleware.SidecarEvaluator
+}
+
+// SetSidecarEvaluator wires the admission half of the sidecar seam. Call
+// before the store serves traffic; the field is not synchronized.
+func (s *Store) SetSidecarEvaluator(ev middleware.SidecarEvaluator) {
+	s.sidecarEvaluator = ev
+}
+
+// stampSidecar evaluates msg — the entry's own stored records — and
+// stamps the result. Pre-publication entries are stamped with a plain
+// store; nothing else can hold them yet.
+func (s *Store) stampSidecar(e *CacheEntry, msg *dns.Msg) {
+	if e == nil || s.sidecarEvaluator == nil {
+		return
+	}
+	e.sidecar.Store(s.sidecarEvaluator(msg))
 }
 
 // NewStore returns a Store backed by the supplied sub-caches. The
@@ -627,6 +651,7 @@ func (s *Store) setFromResponseWithKey(key uint64, resp *dns.Msg, scope netip.Pr
 		e.cd = keyCD
 		e.cutUntil = cutUntil
 		e.cutKey = cutKey
+		s.stampSidecar(e, msg)
 		return e
 	}
 
@@ -692,6 +717,7 @@ func (s *Store) ReplaceIfCurrent(key uint64, expected *CacheEntry, resp *dns.Msg
 		entry.scope = expected.scope
 		entry.cutUntil = cutUntil
 		entry.cutKey = cutKey
+		s.stampSidecar(entry, filtered)
 		return entry
 	}
 

--- a/middleware/cache/types.go
+++ b/middleware/cache/types.go
@@ -9,6 +9,7 @@ import (
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/internal/cache"
 	"github.com/semihalev/sdns/internal/dnsutil"
+	"github.com/semihalev/sdns/middleware"
 	// Aliased: this file's local "wire" is the packed body itself.
 	wirepack "github.com/semihalev/sdns/internal/wire"
 	"golang.org/x/time/rate"
@@ -92,6 +93,28 @@ type CacheEntry struct {
 	// It is retained for the optional Phase-3 generation design; Phase 1b
 	// enforcement depends only on cutUntil.
 	cutKey uint64
+
+	// sidecar is policy state stamped beside the immutable entry — the
+	// same shape as the prefetch claim above: a mutable atomic the entry
+	// carries without ever being copied. The cache never reads its Value;
+	// it is stamped at admission by the wired evaluator and handed to the
+	// wire-hit gate at serve time. nil means unevaluated — unknown, never
+	// clean (middleware.Sidecar's contract).
+	sidecar atomic.Pointer[middleware.Sidecar]
+}
+
+// Sidecar returns the entry's stamped policy state; nil means the entry
+// was never evaluated.
+func (e *CacheEntry) Sidecar() *middleware.Sidecar {
+	return e.sidecar.Load()
+}
+
+// CompareAndStampSidecar installs next if the entry still carries prev —
+// the restamp a serve performs when it finds a stale generation. The
+// generation lives inside the opaque value; the CAS only guarantees no
+// concurrent restamp is silently overwritten.
+func (e *CacheEntry) CompareAndStampSidecar(prev, next *middleware.Sidecar) bool {
+	return e.sidecar.CompareAndSwap(prev, next)
 }
 
 // remaining returns the entry's effective remaining lifetime at now:

--- a/middleware/pipeline.go
+++ b/middleware/pipeline.go
@@ -245,12 +245,20 @@ func (p *Pipeline) autoWire() {
 		cryptoProvider    string
 		cryptoProviders   []string
 		hasCryptoConsumer bool
+		sidecarPolicy     SidecarPolicyProvider
+		sidecarProviders  []string
 	)
 	for _, h := range p.handlers {
 		if sp, ok := h.(StoreProvider); ok {
 			providers = append(providers, h.Name())
 			if store == nil {
 				store = sp.Store()
+			}
+		}
+		if sp, ok := h.(SidecarPolicyProvider); ok {
+			sidecarProviders = append(sidecarProviders, h.Name())
+			if sidecarPolicy == nil {
+				sidecarPolicy = sp
 			}
 		}
 		if _, ok := h.(StoreSetter); ok {
@@ -282,6 +290,10 @@ func (p *Pipeline) autoWire() {
 	if isNilInterface(cryptoLimiter) && hasCryptoConsumer {
 		zlog.Warn("DNSSEC crypto limiter consumer present but no provider registered; optional cache-side DNSSEC work will fail open")
 	}
+	if len(sidecarProviders) > 1 {
+		zlog.Warn("Multiple SidecarPolicyProviders registered; first wins",
+			"first", sidecarProviders[0], "others", sidecarProviders[1:])
+	}
 
 	for _, h := range p.handlers {
 		if s, ok := h.(QueryerSetter); ok {
@@ -298,6 +310,11 @@ func (p *Pipeline) autoWire() {
 		if !isNilInterface(cryptoLimiter) {
 			if s, ok := h.(DNSSECCryptoLimiterSetter); ok {
 				s.SetDNSSECCryptoLimiter(cryptoLimiter)
+			}
+		}
+		if sidecarPolicy != nil {
+			if s, ok := h.(SidecarPolicySetter); ok {
+				s.SetSidecarPolicy(sidecarPolicy)
 			}
 		}
 	}

--- a/middleware/sidecar.go
+++ b/middleware/sidecar.go
@@ -1,0 +1,63 @@
+package middleware
+
+import "github.com/miekg/dns"
+
+// Sidecar is policy state stamped beside a cache entry: an opaque value a
+// policy middleware computed from the entry's own stored records. The
+// cache carries and hands it back without reading Value.
+//
+// The nil pointer is load-bearing: an absent sidecar means the entry was
+// never evaluated — unknown, never clean. A policy layer that evaluated an
+// entry and matched nothing must say so with a non-nil Sidecar, or every
+// hit on that entry re-takes the decoded path forever.
+type Sidecar struct {
+	Value any
+}
+
+// SidecarEvaluator computes a Sidecar from one entry's stored message —
+// the truth being admitted, after cacheability filtering, never the
+// client's copy. It is called once per admitted entry through every
+// admission door the store has. A nil result declines to evaluate and
+// leaves the entry unknown.
+//
+// The evaluator runs on admission paths (resolver completions, prefetch
+// refreshes, the cache writer) and must be safe for concurrent use.
+type SidecarEvaluator func(msg *dns.Msg) *Sidecar
+
+// WireHitGate judges record-bearing byte serves. When a gate is wired,
+// the cache consults it before serving stored bytes for an exact hit or
+// a composed CNAME chase; a false verdict declines the byte serve and the
+// same query is answered by the decoded path instead — where the policy
+// layer's own response writer sees a full message. Composite denial
+// classes (subtree cuts, failure state) carry no stored records and are
+// never gated.
+//
+// The gate owns any per-hit accounting: a true verdict is the only place
+// a byte-served hit's policy outcome can be counted, because no later
+// layer decodes it. Verdicts must be computed from the sidecars alone —
+// per-query policy state belongs to the policy middleware's own
+// query-time hold, which steers queries off the byte path entirely by
+// withholding its writer's wire capability.
+type WireHitGate interface {
+	// AllowWireHit judges a single-entry byte serve. sc is the entry's
+	// sidecar; nil means unevaluated.
+	AllowWireHit(sc *Sidecar) bool
+	// AllowWireChase judges a composed chase, one sidecar per segment in
+	// chain order. Any nil element is an unevaluated segment.
+	AllowWireChase(sidecars []*Sidecar) bool
+}
+
+// SidecarPolicyProvider is implemented by the handler that owns response
+// policy over stored answers (tomorrow: rpz). Either method may return
+// nil to leave that half of the seam unwired.
+type SidecarPolicyProvider interface {
+	SidecarEvaluator() SidecarEvaluator
+	WireHitGate() WireHitGate
+}
+
+// SidecarPolicySetter is implemented by the handler that owns the entry
+// store (today: the cache middleware). Setup wires the first provider in
+// pipeline order into every setter.
+type SidecarPolicySetter interface {
+	SetSidecarPolicy(p SidecarPolicyProvider)
+}

--- a/middleware/sidecar.go
+++ b/middleware/sidecar.go
@@ -45,6 +45,38 @@ const (
 	WireHitRestamp
 )
 
+// SidecarChainCap bounds a chase composition's segments; it mirrors the
+// wire chase depth (the cache asserts its own bound fits at compile
+// time).
+const SidecarChainCap = 10
+
+// SidecarChain carries one sidecar per chase segment, in chain order, as
+// a bounded value — never a slice. The gate methods receive it by value,
+// so a gated chase hit stays allocation-free: a slice here escapes
+// through the interface call and puts a heap allocation on every
+// cache-contained chase, which the zero-allocation hit contract forbids.
+type SidecarChain struct {
+	n   int
+	scs [SidecarChainCap]*Sidecar
+}
+
+// Append adds the next segment's sidecar; it reports false when the
+// chain is full (the caller's depth bound should make that impossible).
+func (c *SidecarChain) Append(sc *Sidecar) bool {
+	if c.n >= len(c.scs) {
+		return false
+	}
+	c.scs[c.n] = sc
+	c.n++
+	return true
+}
+
+// Len returns the number of segments carried.
+func (c *SidecarChain) Len() int { return c.n }
+
+// At returns segment i's sidecar; nil means that segment is unevaluated.
+func (c *SidecarChain) At(i int) *Sidecar { return c.scs[i] }
+
 // WireHitGate judges record-bearing byte serves. When a gate is wired,
 // the cache consults it before serving stored bytes for an exact hit or
 // a composed CNAME chase; any verdict but WireHitServe declines the byte
@@ -66,13 +98,13 @@ type WireHitGate interface {
 	JudgeWireHit(sc *Sidecar) WireHitVerdict
 	// JudgeWireChase judges a composed chase, one sidecar per segment in
 	// chain order. Any nil element is an unevaluated segment.
-	JudgeWireChase(sidecars []*Sidecar) WireHitVerdict
+	JudgeWireChase(sidecars SidecarChain) WireHitVerdict
 	// CountWireHit records the policy outcome of a byte-served exact
 	// hit. Called once, after the transport accepted the bytes; no later
 	// layer decodes them, so this is the only place the outcome exists.
 	CountWireHit(sc *Sidecar)
 	// CountWireChase is CountWireHit for a committed chase composition.
-	CountWireChase(sidecars []*Sidecar)
+	CountWireChase(sidecars SidecarChain)
 }
 
 // SidecarPolicyProvider is implemented by the handler that owns response

--- a/middleware/sidecar.go
+++ b/middleware/sidecar.go
@@ -24,27 +24,55 @@ type Sidecar struct {
 // refreshes, the cache writer) and must be safe for concurrent use.
 type SidecarEvaluator func(msg *dns.Msg) *Sidecar
 
+// WireHitVerdict is a gate's judgment of one byte serve.
+type WireHitVerdict uint8
+
+const (
+	// WireHitServe permits the byte serve. Nothing is counted here — a
+	// serve can still decline past the gate (writer readiness, build,
+	// transport fallback) and land on the decoded path, so accounting
+	// waits for the committed-bytes callback below.
+	WireHitServe WireHitVerdict = iota
+	// WireHitDecode sends the query to the decoded path because policy
+	// wants the full message there. The sidecar itself was usable; the
+	// cache changes nothing about it.
+	WireHitDecode
+	// WireHitRestamp sends the query to the decoded path because the
+	// sidecar is unusable — unevaluated, or stamped under a generation
+	// the gate no longer accepts. The decoded serve re-evaluates the
+	// entry's records and restamps over the judged pointer, so the entry
+	// rejoins the byte path instead of decoding until eviction.
+	WireHitRestamp
+)
+
 // WireHitGate judges record-bearing byte serves. When a gate is wired,
 // the cache consults it before serving stored bytes for an exact hit or
-// a composed CNAME chase; a false verdict declines the byte serve and the
-// same query is answered by the decoded path instead — where the policy
-// layer's own response writer sees a full message. Composite denial
-// classes (subtree cuts, failure state) carry no stored records and are
-// never gated.
+// a composed CNAME chase; any verdict but WireHitServe declines the byte
+// serve and the same query is answered by the decoded path instead —
+// where the policy layer's own response writer sees a full message.
+// Composite denial classes (subtree cuts, failure state) carry no stored
+// records and are never gated.
 //
-// The gate owns any per-hit accounting: a true verdict is the only place
-// a byte-served hit's policy outcome can be counted, because no later
-// layer decodes it. Verdicts must be computed from the sidecars alone —
+// The Judge methods are pure decisions computed from the sidecars alone —
 // per-query policy state belongs to the policy middleware's own
 // query-time hold, which steers queries off the byte path entirely by
-// withholding its writer's wire capability.
+// withholding its writer's wire capability. Accounting is separate: the
+// Count methods fire exactly once per byte-served hit, after the bytes
+// were committed to the transport — the only point where a byte serve
+// can no longer fall back to the decoded path and be counted twice.
 type WireHitGate interface {
-	// AllowWireHit judges a single-entry byte serve. sc is the entry's
+	// JudgeWireHit judges a single-entry byte serve. sc is the entry's
 	// sidecar; nil means unevaluated.
-	AllowWireHit(sc *Sidecar) bool
-	// AllowWireChase judges a composed chase, one sidecar per segment in
+	JudgeWireHit(sc *Sidecar) WireHitVerdict
+	// JudgeWireChase judges a composed chase, one sidecar per segment in
 	// chain order. Any nil element is an unevaluated segment.
-	AllowWireChase(sidecars []*Sidecar) bool
+	JudgeWireChase(sidecars []*Sidecar) WireHitVerdict
+	// CountWireHit records the policy outcome of a byte-served exact
+	// hit. Called once, after the transport accepted the bytes; no later
+	// layer decodes them, so this is the only place the outcome exists.
+	CountWireHit(sc *Sidecar)
+	// CountWireChase is CountWireHit for a committed chase composition.
+	CountWireChase(sidecars []*Sidecar)
 }
 
 // SidecarPolicyProvider is implemented by the handler that owns response


### PR DESCRIPTION
The seam docs/rpz-design.md §5.6 requires before the response-IP phase: policy state carried beside cache entries, stamped at admission, judged at the byte serve. This PR is deliberately policy-free — no RPZ logic, no behavior change while unwired — so the seam's design can be reviewed on its own, as the design doc prescribes.

## Design

**The sidecar.** `CacheEntry` gains one atomic pointer beside its immutable payload (the same shape as the existing prefetch claim — a mutable atomic the entry carries without being copied). The cache never reads the value. `nil` is load-bearing: an absent sidecar means *unknown, never clean* — because a fourth admission door may exist someday, and the audit indeed found one the design's callsite list didn't (below).

**Admission.** One evaluator, wired into the `Store`, stamps every entry with the result of evaluating that entry's own stored records — the truth, post-filter, never the client's copy. The design named three doors (writer, resolver's direct store, prefetch replacement); reading the code found they funnel through **three construction sites**, and all three stamp:
- `setFromResponseWithKey` — the writer's `SetFromResponseWithKey/Scoped` and the resolver's `SetFromResponseWithCut` funnel here;
- `ReplaceIfCurrent` — the prefetch CAS replacement;
- `Cache.Set` → `SetEntryWithKey` — the compatibility door for prefetch write-backs and plugin callers, which the design's list did not carry.

An entry admitted before the seam was wired carries `nil`; the first decoded serve evaluates the message it already built and CAS-stamps it, so such an entry pays the Msg path once, not forever.

**Serve.** A `WireHitGate` is consulted before every record-bearing byte serve, with the sidecar(s) the reply would be built from:
- the wire-born exact hit (`serveHitFromWire`),
- the Msg-born inline byte path (`handleCacheHit`),
- the composed chase (`serveChaseHit`) — one sidecar **per segment, in chain order**: a whole-chain verdict on the alias entry would go stale the moment the target refreshed under it (§5.6 item 4).

A false verdict declines to the decoded path, where the policy middleware's own response writer sees a full message. Composite denial classes (subtree cuts, failure state) carry no stored records and are never gated. The gate signature is entry-only by design: per-query policy state stays in the policy middleware, which steers a query off the byte path entirely by withholding its writer's wire capability — so the gate never needs the request, and a verdict is a pure function of the stored state.

**Wiring.** Setup's marker pattern: `SidecarPolicyProvider` (rpz, in the next PR) → `SidecarPolicySetter` (cache), first provider wins with a warning, injected before the pipeline publishes so the atomic store is the happens-before barrier — same discipline as the existing Store/Queryer wiring.

## Cost while unwired

One nil field check per hit and 8 bytes per entry. The existing zero-alloc hit-class pins (`TestServeRawWireHitAllocatesNothing`, the acquire pins) run unchanged and green.

## Verification

- Seam tests: every door stamps (each pinned separately); unwired leaves entries unstamped; a declining gate is consulted with the entry's own sidecar and the decoded path answers correctly; an approving gate genuinely serves bytes (fast-served counter); the chase gate sees every segment in order; the decoded serve stamps an unevaluated entry; CAS restamp semantics; autoWire injects the provider (and never calls a setter without one).
- 8/8 guard mutations killed, one per stamp/gate/wiring point.
- Full suite, `-race` on middleware + cache, lint clean.

Phase 4 proper (rpz-ip triggers, the match-list sidecar values, serve-time merge, winner-bounded counting) follows in its own PR on top of this seam.