### PR TITLE
RPZ phase 4: the response-IP trigger over sidecar candidates

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,10 @@ example.com.		0	CH	HINFO	"Host" "IPv6:[2001:500:8d::53]:53 rtt:148ms health:[GOO
 | **serve_stale**      | Serve expired positive answers as a last resort after resolution ends in SERVFAIL (RFC 8767). A learned delegation lease remains a hard ceiling. Default: false |
 | **serve_stale_max_ttl** | Maximum time an answer may be served after its TTL expires (duration string). An explicit `0s` leaves the delegation lease as the only upper bound; because forwarder mode learns no delegation cut, `0s` there permits retention until cache eviction. Default: `24h` |
 | **[recursion_firewall]** | Request-tree work budgets (outbound/internal queries, DNSSEC operations) with off/shadow/enforce modes, plus RFC 9520 failure-cache tuning. See the Recursion Firewall section below |
+| **[rpz]**            | Response Policy Zones: subscribe to policy feeds — local files or vendor AXFR, TSIG-signed if the provider requires it — that rewrite, deny, or drop answers by query name, client address, or answer address. `enabled`, `mode` ("shadow"/"enforce"), and one `[[rpz.zone]]` entry per zone. See [Response Policy Zones](#response-policy-zones-rpz) |
+| **[ecs]**            | EDNS Client Subnet (RFC 7871): forward truncated client prefixes upstream and cache answers per scope. See [EDNS Client Subnet](#edns-client-subnet-rfc-7871) |
+| **[dns64]**          | DNS64 synthesis for IPv6-only clients (RFC 6147) with per-network gating and exclusions. See [DNS64](#dns64-rfc-6147) |
+| **[kubernetes]**     | Kubernetes DNS: serve `cluster.local` services, pods, SRV, and PTR straight from the API server. See [Kubernetes DNS Middleware](#kubernetes-dns-middleware) |
 | **rootkeys**         | DNSSEC root zone trust anchors in DNSKEY format                                                                     |
 | **fallbackservers**  | Upstream DNS servers used when all others fail. Format: "IP:port" (e.g., "8.8.8.8:53")                             |
 | **[[forward_zone]]** | Per-zone forwarding: `name` plus `servers` sends that zone's queries to its own recursive upstreams while everything else resolves normally. Most specific zone wins. Servers accept the same formats as **forwarderservers**. A forwarded zone is not validated locally — see [Per-zone forwarding](#per-zone-forwarding) |
@@ -331,6 +335,18 @@ source = "203.0.113.5:53"              # the feed's primary (host:port)
 origin = "rpz.vendor.example."         # the policy zone's apex
 # tsig_key = "feedkey.:hmac-sha256.:BASE64SECRET"   # when the provider signs transfers
 ```
+
+Each `[[rpz.zone]]` entry (a zone is fed exactly one way — `file` or `source`):
+
+| Field        | Description |
+| ------------ | ----------- |
+| **name**     | Zone label used in metrics, logs, and the EDE text. Required, unique across zones |
+| **file**     | Path to a local policy zone file. Reloaded automatically when the file is replaced — the file's directory is watched, so atomic renames are caught. Best practice: deploy the file in its own directory |
+| **source**   | AXFR primary (`host:port`) of a vendor feed. The feed keeps itself current on the zone's own SOA schedule: probe on refresh, transfer on serial change, retry on retry, and withdraw past expire |
+| **origin**   | The policy zone's apex as an FQDN. Required with `source`; refused with `file` (the file's own SOA names the apex) |
+| **tsig_key** | `name:algorithm:base64-secret` for signed transfers. Algorithms: `hmac-sha1`, `hmac-sha224`, `hmac-sha256`, `hmac-sha384`, `hmac-sha512`. Only meaningful with `source` |
+| **policy**   | Per-zone action override; default `given`. See the override list below |
+| **cname**    | Walled-garden target FQDN; required exactly when `policy = "cname"` |
 
 Zones are evaluated in the order written; the first zone with a match wins. Within a zone, a client-address (`rpz-client-ip`) match outranks a name match, which outranks an answer-address (`rpz-ip`) match; the longest prefix or most specific name wins. Answer-address policy is judged against what a query actually resolved to — the cache keeps storing the unmodified answer, only the client's response is rewritten, so per-client exemptions keep working across cached entries and a reload re-evaluates already-cached answers on their next hit.
 
@@ -588,6 +604,7 @@ This is useful when:
 *   Full DNS RFC compatibility
 *   DNS queries using both IPv4 and IPv6 authoritative servers
 *   High-performance DNS caching with prefetch support
+*   Serve-stale as a last resort on resolution failure (RFC 8767), bounded by the learned delegation lease
 *   Full DNSSEC validation support with RFC 8914 Extended DNS Errors (EDE)
 *   DNS over TLS (DoT) support
 *   DNS over HTTPS (DoH) support with HTTP/3
@@ -597,7 +614,8 @@ This is useful when:
 *   RTT-based server prioritization with adaptive timeouts
 *   Parallel DNS lookups for improved performance
 *   Failover to backup servers on failure
-*   DNS forwarding support
+*   DNS forwarding support, including per-zone conditional forwarding
+*   EDNS Client Subnet forwarding with scoped caching (RFC 7871)
 *   EDNS Cookie support (RFC 7873)
 *   EDNS NSID support (RFC 5001)
 *   Extended DNS Errors (EDE) support (RFC 8914)
@@ -605,7 +623,7 @@ This is useful when:
 *   Query-based rate limiting
 *   Client IP-based rate limiting
 *   IP-based access control lists
-*   Response Policy Zones (RPZ) with shadow mode, per-zone overrides, and automatic feed reload (see docs/rpz-design.md)
+*   Response Policy Zones (RPZ): QNAME, client-address, and answer-address triggers; shadow mode; per-zone overrides; file and TSIG-signed AXFR feeds
 *   Comprehensive access logging
 *   Prometheus metrics with optional per-domain tracking
 *   DNS sinkholing for malicious domains
@@ -616,6 +634,9 @@ This is useful when:
 *   External plugin support
 *   Binary DNS logging via dnstap protocol (RFC 6742)
 *   QNAME minimization for privacy (RFC 9156)
+*   Hyperlocal root zone (RFC 8806) with ZONEMD verification (RFC 8976)
+*   Per-client views: static answers scoped to client networks
+*   Recursion work firewall: per-request-tree budgets on outbound queries, internal work, and DNSSEC operations, with shadow and enforce modes
 *   Automatic DNSSEC trust anchor updates (RFC 5011)
 *   Zero-allocation cache operations for improved performance
 *   **Owned UDP/TCP/DoT serving engine: wire-eligible warm cache hits answered from raw bytes, allocation-free per query on UDP and TCP (DoT rides the same path; TLS record buffers are the runtime's), with batched `recvmmsg`/`sendmmsg` I/O on Linux — composite answers that need message shaping take the ordinary path**

--- a/README.md
+++ b/README.md
@@ -332,9 +332,9 @@ origin = "rpz.vendor.example."         # the policy zone's apex
 # tsig_key = "feedkey.:hmac-sha256.:BASE64SECRET"   # when the provider signs transfers
 ```
 
-Zones are evaluated in the order written; the first zone with a match wins. Within a zone, a client-address (`rpz-client-ip`) match outranks a name match, and the longest prefix or most specific name wins.
+Zones are evaluated in the order written; the first zone with a match wins. Within a zone, a client-address (`rpz-client-ip`) match outranks a name match, which outranks an answer-address (`rpz-ip`) match; the longest prefix or most specific name wins. Answer-address policy is judged against what a query actually resolved to — the cache keeps storing the unmodified answer, only the client's response is rewritten, so per-client exemptions keep working across cached entries and a reload re-evaluates already-cached answers on their next hit.
 
-**Triggers:** QNAME rules (exact and `*.wildcard`) and CLIENT-IP rules (IPv4 and IPv6 prefixes, in the standard reversed-owner encoding). Triggers of other types in a feed (`rpz-ip`, `rpz-nsdname`, `rpz-nsip`) load without error and are counted as skipped.
+**Triggers:** QNAME rules (exact and `*.wildcard`), CLIENT-IP rules, and IP (answer-address, `rpz-ip`) rules — the address triggers take IPv4 and IPv6 prefixes in the standard reversed-owner encoding. Triggers of other types in a feed (`rpz-nsdname`, `rpz-nsip`) load without error and are counted as skipped.
 
 **Actions** (standard RPZ RDATA encodings): NXDOMAIN (`CNAME .`), NODATA (`CNAME *.`), PASSTHRU, DROP (no answer at all), TCP-Only (truncates UDP; encrypted transports pass), and Local Data — served as if authoritative for the query name, including CNAME chasing through the resolver.
 

--- a/internal/rpz/match.go
+++ b/internal/rpz/match.go
@@ -4,9 +4,24 @@ import "net/netip"
 
 // Trigger labels for metrics and logs.
 const (
-	TriggerQNAME    = "qname"
-	TriggerClientIP = "client-ip"
+	TriggerQNAME      = "qname"
+	TriggerClientIP   = "client-ip"
+	TriggerResponseIP = "ip"
 )
+
+// triggerRank orders trigger types within one zone (precedence rule 2):
+// CLIENT-IP > QNAME > IP.
+func triggerRank(trigger string) int {
+	switch trigger {
+	case TriggerClientIP:
+		return 3
+	case TriggerQNAME:
+		return 2
+	case TriggerResponseIP:
+		return 1
+	}
+	return 0
+}
 
 // ZoneMatch is one zone's best match for a query. Trigger and PrefixBits
 // carry the rank information a later merge (or a log line) needs.

--- a/internal/rpz/parse.go
+++ b/internal/rpz/parse.go
@@ -70,10 +70,14 @@ func notActionData(t uint16) bool {
 
 // triggerMarkers are the owner labels of trigger types later phases
 // evaluate; everything under them is that trigger's encoding, not a name.
-var triggerMarkers = []string{"rpz-ip", "rpz-nsdname", "rpz-nsip"}
+var triggerMarkers = []string{"rpz-nsdname", "rpz-nsip"}
 
 // clientIPMarker selects the CLIENT-IP trigger, evaluated since phase 2.
 const clientIPMarker = "rpz-client-ip"
+
+// responseIPMarker selects the IP (response) trigger, evaluated since
+// phase 4. The owner encoding is CLIENT-IP's exactly.
+const responseIPMarker = "rpz-ip"
 
 // LoadZoneFile parses one policy zone file into a compiled Zone. name is
 // the config label; policy and cnameTarget come from the zone's config
@@ -209,22 +213,19 @@ func (z *Zone) classify(rr dns.RR) {
 		return
 	}
 
-	// CLIENT-IP: the owner encodes an address block, not a name.
+	// CLIENT-IP and IP: the owner encodes an address block, not a name.
+	// The two triggers share one encoding and one merge semantic; only
+	// the tables differ — one pair judges the querier, the other the
+	// answer.
 	if enc, ok := strings.CutSuffix(rel, "."+clientIPMarker); ok {
-		prefix, valid := parseClientIPOwner(enc)
-		if !valid {
-			z.skip(SkipOwnerEncoding)
-			return
-		}
-		action, local := classifyAction(rr)
-		if action == ActionNone {
-			z.skip(SkipUnknownAction)
-			return
-		}
-		z.insertClientIP(prefix, action, local)
+		z.insertIPOwner(enc, rr, z.insertClientIP)
 		return
 	}
-	if rel == clientIPMarker {
+	if enc, ok := strings.CutSuffix(rel, "."+responseIPMarker); ok {
+		z.insertIPOwner(enc, rr, z.insertResponseIP)
+		return
+	}
+	if rel == clientIPMarker || rel == responseIPMarker {
 		// The bare marker owns no address.
 		z.skip(SkipOwnerEncoding)
 		return
@@ -239,14 +240,40 @@ func (z *Zone) classify(rr dns.RR) {
 	z.insert(rel, action, local)
 }
 
-// insertClientIP files a CLIENT-IP rule with the same merge semantics as
-// the name triggers: the first action class at a prefix stands, Local
-// Data accumulates, anything else is a conflict. The prefix's family
-// picks the table.
+// insertIPOwner decodes an address-encoded owner and hands the rule to
+// the trigger's own filing function.
+func (z *Zone) insertIPOwner(enc string, rr dns.RR, file func(netip.Prefix, Action, dns.RR)) {
+	prefix, valid := parseClientIPOwner(enc)
+	if !valid {
+		z.skip(SkipOwnerEncoding)
+		return
+	}
+	action, local := classifyAction(rr)
+	if action == ActionNone {
+		z.skip(SkipUnknownAction)
+		return
+	}
+	file(prefix, action, local)
+}
+
+// insertClientIP and insertResponseIP file an address rule into their
+// trigger's family tables.
 func (z *Zone) insertClientIP(prefix netip.Prefix, action Action, local dns.RR) {
-	table := &z.clientIP6
+	z.insertIP(prefix, action, local, &z.clientIP4, &z.clientIP6, &z.RulesClientIP)
+}
+
+func (z *Zone) insertResponseIP(prefix netip.Prefix, action Action, local dns.RR) {
+	z.insertIP(prefix, action, local, &z.responseIP4, &z.responseIP6, &z.RulesResponseIP)
+}
+
+// insertIP files an address rule with the same merge semantics as the
+// name triggers: the first action class at a prefix stands, Local Data
+// accumulates, anything else is a conflict. The prefix's family picks
+// the table.
+func (z *Zone) insertIP(prefix netip.Prefix, action Action, local dns.RR, t4, t6 **ipLPM, counter *int) {
+	table := t6
 	if prefix.Addr().Is4() {
-		table = &z.clientIP4
+		table = t4
 	}
 	if *table == nil {
 		*table = &ipLPM{}
@@ -265,7 +292,7 @@ func (z *Zone) insertClientIP(prefix netip.Prefix, action Action, local dns.RR) 
 	}
 	(*table).insert(prefix, rule)
 	z.Rules++
-	z.RulesClientIP++
+	*counter++
 }
 
 // insert files a rule under its relative owner. The first action class at

--- a/internal/rpz/responseip.go
+++ b/internal/rpz/responseip.go
@@ -71,17 +71,15 @@ type ResponseMatches struct {
 	List []ResponseMatch
 }
 
-// EvaluateResponse computes the per-zone best IP-trigger matches over a
-// response's answer records. It returns nil when no zone carries
-// response triggers — the caller then stamps nothing and the sidecar
-// machinery stays off. Local Data records are deep-copied at this
-// boundary: a slice-header copy would keep the old generation's
-// allocations reachable through every stamped entry.
-func (s *Store) EvaluateResponse(answers []dns.RR) *ResponseMatches {
-	if !s.HasResponseIP() {
-		return nil
-	}
-	rm := &ResponseMatches{Gen: s.Gen}
+// EvaluateResponseList computes the per-zone best IP-trigger matches
+// over a response's answer records, ascending by zone index. nil means
+// nothing matched (or no zone carries response triggers — callers that
+// need the distinction ask HasResponseIP), and nothing was allocated to
+// say so. Local Data records are deep-copied at this boundary: a
+// slice-header copy would keep the old generation's allocations
+// reachable through every stamped entry.
+func (s *Store) EvaluateResponseList(answers []dns.RR) []ResponseMatch {
+	var list []ResponseMatch
 	for idx, z := range s.Zones {
 		if !z.hasResponseTriggers() {
 			continue
@@ -91,9 +89,19 @@ func (s *Store) EvaluateResponse(answers []dns.RR) *ResponseMatches {
 			continue
 		}
 		best.ZoneIdx = idx
-		rm.List = append(rm.List, best)
+		list = append(list, best)
 	}
-	return rm
+	return list
+}
+
+// EvaluateResponse is EvaluateResponseList boxed with the generation:
+// nil when no zone carries response triggers, an empty non-nil result
+// for the explicit none.
+func (s *Store) EvaluateResponse(answers []dns.RR) *ResponseMatches {
+	if !s.HasResponseIP() {
+		return nil
+	}
+	return &ResponseMatches{Gen: s.Gen, List: s.EvaluateResponseList(answers)}
 }
 
 // matchResponse probes every answer address against the zone's family
@@ -165,43 +173,6 @@ func copyRecords(rrs []dns.RR) []dns.RR {
 		out[i] = dns.Copy(rr)
 	}
 	return out
-}
-
-// FoldResponseLists merges the per-segment match lists of one composed
-// chase, deduplicating per zone by the rank key: two segments matching
-// the same zone collapse to that zone's single rule-4 best, so one query
-// counts a zone exactly once (§5.6 item 4). Inputs and output are
-// ascending by zone index.
-func FoldResponseLists(lists ...[]ResponseMatch) []ResponseMatch {
-	var out []ResponseMatch
-	for _, list := range lists {
-		for _, m := range list {
-			pos := -1
-			for i := range out {
-				if out[i].ZoneIdx == m.ZoneIdx {
-					pos = i
-					break
-				}
-			}
-			if pos == -1 {
-				out = append(out, m)
-				continue
-			}
-			if m.betterThan(out[pos]) {
-				out[pos] = m
-			}
-		}
-	}
-	sortResponseMatches(out)
-	return out
-}
-
-func sortResponseMatches(list []ResponseMatch) {
-	for i := 1; i < len(list); i++ {
-		for j := i; j > 0 && list[j].ZoneIdx < list[j-1].ZoneIdx; j-- {
-			list[j], list[j-1] = list[j-1], list[j]
-		}
-	}
 }
 
 // asZoneMatch lifts a response candidate into the ZoneMatch shape the

--- a/internal/rpz/responseip.go
+++ b/internal/rpz/responseip.go
@@ -1,0 +1,267 @@
+package rpz
+
+import (
+	"net/netip"
+
+	"github.com/miekg/dns"
+)
+
+// HasResponseIP reports whether any zone carries IP (response) trigger
+// rules — the switch that turns the whole sidecar machinery on.
+func (s *Store) HasResponseIP() bool {
+	if s == nil {
+		return false
+	}
+	for _, z := range s.Zones {
+		if z.hasResponseTriggers() {
+			return true
+		}
+	}
+	return false
+}
+
+// ResponseTriggerBefore reports whether any zone ahead of idx carries
+// response triggers — §5.4's hold decision: a query-time match in zone
+// idx is final immediately iff this is false. A same-zone response
+// trigger never displaces a query-time match (rule 2: CLIENT-IP > QNAME
+// > IP), which is why the scan is strictly before idx.
+func (s *Store) ResponseTriggerBefore(idx int) bool {
+	if s == nil {
+		return false
+	}
+	for i := 0; i < idx && i < len(s.Zones); i++ {
+		if s.Zones[i].hasResponseTriggers() {
+			return true
+		}
+	}
+	return false
+}
+
+// ResponseMatch is one zone's best IP-trigger match over a response's
+// answer addresses, carried value-only: zone index, action, rank key
+// (prefix length and matched address, both canonical 128-bit — IPv4
+// mapped, +96), and — for Local Data — deep copies of the rule's
+// records. Nothing here points into the policy store: a stamped
+// candidate must not pin the generation it was computed under (§5.6).
+type ResponseMatch struct {
+	ZoneIdx    int
+	Action     Action
+	PrefixBits int
+	Addr       netip.Addr
+	Local      []dns.RR
+}
+
+// betterThan is precedence rule 4: the longer prefix wins; on equal
+// length, the numerically smaller 128-bit address.
+func (m ResponseMatch) betterThan(o ResponseMatch) bool {
+	if m.PrefixBits != o.PrefixBits {
+		return m.PrefixBits > o.PrefixBits
+	}
+	return m.Addr.Compare(o.Addr) < 0
+}
+
+// ResponseMatches is the entry-local evaluation result the sidecar
+// carries: the generation it was computed under and one best match per
+// matching zone, ascending zone index, over ALL zones uniformly —
+// enabled, disabled, and shadow alike. An empty List is the explicit
+// "evaluated, nothing matched"; the winner is a property of the query
+// and is computed at the serve-time merge, never here (§5.6 item 2).
+type ResponseMatches struct {
+	Gen  uint64
+	List []ResponseMatch
+}
+
+// EvaluateResponse computes the per-zone best IP-trigger matches over a
+// response's answer records. It returns nil when no zone carries
+// response triggers — the caller then stamps nothing and the sidecar
+// machinery stays off. Local Data records are deep-copied at this
+// boundary: a slice-header copy would keep the old generation's
+// allocations reachable through every stamped entry.
+func (s *Store) EvaluateResponse(answers []dns.RR) *ResponseMatches {
+	if !s.HasResponseIP() {
+		return nil
+	}
+	rm := &ResponseMatches{Gen: s.Gen}
+	for idx, z := range s.Zones {
+		if !z.hasResponseTriggers() {
+			continue
+		}
+		best, found := z.matchResponse(answers)
+		if !found {
+			continue
+		}
+		best.ZoneIdx = idx
+		rm.List = append(rm.List, best)
+	}
+	return rm
+}
+
+// matchResponse probes every answer address against the zone's family
+// tables and keeps the rule-4 best. The record's own type picks the
+// family: an A record is judged by the v4 table only, an AAAA by the v6
+// table only.
+func (z *Zone) matchResponse(answers []dns.RR) (ResponseMatch, bool) {
+	var best ResponseMatch
+	found := false
+	for _, rr := range answers {
+		var addr netip.Addr
+		var table *ipLPM
+		switch a := rr.(type) {
+		case *dns.A:
+			ip, ok := netip.AddrFromSlice(a.A)
+			if !ok {
+				continue
+			}
+			addr, table = ip.Unmap(), z.responseIP4
+		case *dns.AAAA:
+			ip, ok := netip.AddrFromSlice(a.AAAA)
+			if !ok {
+				continue
+			}
+			addr, table = ip, z.responseIP6
+		default:
+			continue
+		}
+		rule, bits := table.lookup(addr)
+		if rule == nil {
+			continue
+		}
+		m := ResponseMatch{
+			Action:     rule.Action,
+			PrefixBits: canonicalBits(addr, bits),
+			Addr:       canonicalAddr(addr),
+		}
+		if found && !m.betterThan(best) {
+			continue
+		}
+		if rule.Action == ActionLocalData {
+			m.Local = copyRecords(rule.Local)
+		}
+		best, found = m, true
+	}
+	return best, found
+}
+
+// canonicalBits maps a v4 prefix length into the shared 128-bit space
+// (+96), so rule 4 compares v4 and v6 matches on one scale.
+func canonicalBits(addr netip.Addr, bits int) int {
+	if addr.Is4() {
+		return bits + 96
+	}
+	return bits
+}
+
+// canonicalAddr is the matched address as a 128-bit value (v4 mapped).
+func canonicalAddr(addr netip.Addr) netip.Addr {
+	return netip.AddrFrom16(addr.As16())
+}
+
+// copyRecords clones each record into fresh backing (dns.Copy): the
+// candidate owns its data outright and the old policy store stays
+// collectible after a reload (§5.6's deep-copy clause).
+func copyRecords(rrs []dns.RR) []dns.RR {
+	out := make([]dns.RR, len(rrs))
+	for i, rr := range rrs {
+		out[i] = dns.Copy(rr)
+	}
+	return out
+}
+
+// FoldResponseLists merges the per-segment match lists of one composed
+// chase, deduplicating per zone by the rank key: two segments matching
+// the same zone collapse to that zone's single rule-4 best, so one query
+// counts a zone exactly once (§5.6 item 4). Inputs and output are
+// ascending by zone index.
+func FoldResponseLists(lists ...[]ResponseMatch) []ResponseMatch {
+	var out []ResponseMatch
+	for _, list := range lists {
+		for _, m := range list {
+			pos := -1
+			for i := range out {
+				if out[i].ZoneIdx == m.ZoneIdx {
+					pos = i
+					break
+				}
+			}
+			if pos == -1 {
+				out = append(out, m)
+				continue
+			}
+			if m.betterThan(out[pos]) {
+				out[pos] = m
+			}
+		}
+	}
+	sortResponseMatches(out)
+	return out
+}
+
+func sortResponseMatches(list []ResponseMatch) {
+	for i := 1; i < len(list); i++ {
+		for j := i; j > 0 && list[j].ZoneIdx < list[j-1].ZoneIdx; j-- {
+			list[j], list[j-1] = list[j-1], list[j]
+		}
+	}
+}
+
+// asZoneMatch lifts a response candidate into the ZoneMatch shape the
+// action and counting layers already speak. The synthetic Rule carries
+// the candidate's own copied data, never a pointer into any store.
+func (m ResponseMatch) asZoneMatch(s *Store) ZoneMatch {
+	return ZoneMatch{
+		ZoneIdx:    m.ZoneIdx,
+		Zone:       s.Zones[m.ZoneIdx],
+		Rule:       &Rule{Action: m.Action, Local: m.Local},
+		Trigger:    TriggerResponseIP,
+		PrefixBits: m.PrefixBits,
+	}
+}
+
+// Merge is the serve-time selection (§5.4/§5.6 item 3): the held
+// query-time candidates meet the response-trigger candidates, and the
+// ordinary precedence rules pick one decision per zone (rule 2), then
+// the first enabled zone with a decision wins (rule 1, over enabled
+// zones only — a disabled zone observes without consuming, §5.5).
+//
+// held is the enabled-zone query match Match returned (zero when none);
+// heldObserved the disabled-zone query matches it collected; resp the
+// sidecar's (or a fresh evaluation's) uniform per-zone response list.
+// observed carries every matched zone before the winner — and every
+// matched zone at all when no enabled zone decides — each with the
+// decision it would have taken; winner-bounded counting reads it
+// directly.
+func (s *Store) Merge(held ZoneMatch, heldObserved []ZoneMatch, resp []ResponseMatch) (winner ZoneMatch, observed []ZoneMatch) {
+	// One decision per zone: index the query-time candidates, then walk
+	// zones ascending and let rule 2 pick between a zone's query match
+	// and its response match.
+	ri := 0
+	for idx, z := range s.Zones {
+		var decision ZoneMatch
+		if held.Zone != nil && held.ZoneIdx == idx {
+			decision = held
+		}
+		for _, o := range heldObserved {
+			if o.ZoneIdx == idx {
+				decision = o
+			}
+		}
+		for ri < len(resp) && resp[ri].ZoneIdx < idx {
+			ri++
+		}
+		if ri < len(resp) && resp[ri].ZoneIdx == idx {
+			if decision.Zone == nil || triggerRank(TriggerResponseIP) > triggerRank(decision.Trigger) {
+				decision = resp[ri].asZoneMatch(s)
+			}
+		}
+		if decision.Zone == nil {
+			continue
+		}
+		if z.Disabled() {
+			observed = append(observed, decision)
+			continue
+		}
+		winner = decision
+		return
+	}
+	return
+}

--- a/internal/rpz/responseip.go
+++ b/internal/rpz/responseip.go
@@ -175,6 +175,43 @@ func copyRecords(rrs []dns.RR) []dns.RR {
 	return out
 }
 
+// FoldResponseLists merges the per-segment match lists of one composed
+// chase, deduplicating per zone by the rank key: two segments matching
+// the same zone collapse to that zone's single rule-4 best, so one query
+// counts a zone exactly once (§5.6 item 4). Inputs and output are
+// ascending by zone index.
+func FoldResponseLists(lists ...[]ResponseMatch) []ResponseMatch {
+	var out []ResponseMatch
+	for _, list := range lists {
+		for _, m := range list {
+			pos := -1
+			for i := range out {
+				if out[i].ZoneIdx == m.ZoneIdx {
+					pos = i
+					break
+				}
+			}
+			if pos == -1 {
+				out = append(out, m)
+				continue
+			}
+			if m.betterThan(out[pos]) {
+				out[pos] = m
+			}
+		}
+	}
+	sortResponseMatches(out)
+	return out
+}
+
+func sortResponseMatches(list []ResponseMatch) {
+	for i := 1; i < len(list); i++ {
+		for j := i; j > 0 && list[j].ZoneIdx < list[j-1].ZoneIdx; j-- {
+			list[j], list[j-1] = list[j-1], list[j]
+		}
+	}
+}
+
 // asZoneMatch lifts a response candidate into the ZoneMatch shape the
 // action and counting layers already speak. The synthetic Rule carries
 // the candidate's own copied data, never a pointer into any store.

--- a/internal/rpz/responseip_test.go
+++ b/internal/rpz/responseip_test.go
@@ -1,0 +1,292 @@
+package rpz
+
+import (
+	"net/netip"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+const responseIPZone = `
+rpz.test. IN SOA ns.rpz.test. admin.rpz.test. 1 3600 900 604800 300
+; response-ip rules: a broad block and a narrow exception-shaped rule
+24.0.2.0.192.rpz-ip.rpz.test.   IN CNAME .
+32.9.2.0.192.rpz-ip.rpz.test.   IN CNAME *.
+48.zz.db8.2001.rpz-ip.rpz.test. IN CNAME rpz-drop.
+; local data on a response trigger
+32.7.2.0.192.rpz-ip.rpz.test.   IN A 203.0.113.53
+`
+
+func loadResponseIPZone(t *testing.T) *Zone {
+	t.Helper()
+	z, err := LoadZone("rip", strings.NewReader(responseIPZone), "rip.zone", OverrideGiven, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if z.RulesResponseIP != 4 {
+		t.Fatalf("RulesResponseIP = %d, want 4 (skips: %v)", z.RulesResponseIP, z.Skipped)
+	}
+	return z
+}
+
+func answerA(ip string) dns.RR {
+	return &dns.A{
+		Hdr: dns.RR_Header{Name: "x.example.com.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 60},
+		A:   netip.MustParseAddr(ip).AsSlice(),
+	}
+}
+
+func answerAAAA(ip string) dns.RR {
+	return &dns.AAAA{
+		Hdr:  dns.RR_Header{Name: "x.example.com.", Rrtype: dns.TypeAAAA, Class: dns.ClassINET, Ttl: 60},
+		AAAA: netip.MustParseAddr(ip).AsSlice(),
+	}
+}
+
+// TestEvaluateResponseBasics pins the evaluation shell: nil without any
+// response rules, explicit none with them, matches carried with their
+// canonical rank keys and the store's generation.
+func TestEvaluateResponseBasics(t *testing.T) {
+	empty := &Store{Zones: []*Zone{{Name: "plain"}}, Gen: 7}
+	if empty.EvaluateResponse([]dns.RR{answerA("192.0.2.9")}) != nil {
+		t.Fatal("a store without response rules evaluated something")
+	}
+
+	s := &Store{Zones: []*Zone{loadResponseIPZone(t)}, Gen: 9}
+	none := s.EvaluateResponse([]dns.RR{answerA("198.51.100.1")})
+	if none == nil || len(none.List) != 0 || none.Gen != 9 {
+		t.Fatalf("explicit none broken: %+v", none)
+	}
+
+	rm := s.EvaluateResponse([]dns.RR{answerA("192.0.2.1")})
+	if len(rm.List) != 1 || rm.Gen != 9 {
+		t.Fatalf("match list: %+v", rm)
+	}
+	m := rm.List[0]
+	if m.Action != ActionNXDOMAIN || m.PrefixBits != 24+96 {
+		t.Fatalf("match: %+v", m)
+	}
+}
+
+// TestEvaluateResponseRule4 pins precedence rule 4 across the answer's
+// addresses: the longest prefix wins whatever record order says, and on
+// equal length the numerically smaller 128-bit address does.
+func TestEvaluateResponseRule4(t *testing.T) {
+	s := &Store{Zones: []*Zone{loadResponseIPZone(t)}}
+
+	// /32 outranks /24 even listed second.
+	rm := s.EvaluateResponse([]dns.RR{answerA("192.0.2.1"), answerA("192.0.2.9")})
+	if len(rm.List) != 1 || rm.List[0].Action != ActionNODATA || rm.List[0].PrefixBits != 32+96 {
+		t.Fatalf("longest prefix lost: %+v", rm.List)
+	}
+
+	// Two /32 matches: 192.0.2.7 (local data) < 192.0.2.9 numerically.
+	rm = s.EvaluateResponse([]dns.RR{answerA("192.0.2.9"), answerA("192.0.2.7")})
+	if len(rm.List) != 1 || rm.List[0].Action != ActionLocalData {
+		t.Fatalf("smaller address lost the tie: %+v", rm.List)
+	}
+}
+
+// TestEvaluateResponseFamiliesStaySeparate pins the family split on the
+// response side: an A record is never judged by a v6 rule.
+func TestEvaluateResponseFamiliesStaySeparate(t *testing.T) {
+	z, err := LoadZone("fam", strings.NewReader(`
+rpz.test. IN SOA ns.rpz.test. admin.rpz.test. 1 3600 900 604800 300
+0.zz.rpz-ip.rpz.test. IN CNAME .
+`), "fam.zone", OverrideGiven, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &Store{Zones: []*Zone{z}}
+
+	if rm := s.EvaluateResponse([]dns.RR{answerA("192.0.2.1")}); len(rm.List) != 0 {
+		t.Fatal("a v6 ::/0 rule judged an A record")
+	}
+	if rm := s.EvaluateResponse([]dns.RR{answerAAAA("2001:db8::1")}); len(rm.List) != 1 {
+		t.Fatal("the v6 rule missed an AAAA record")
+	}
+}
+
+// TestEvaluateResponseListsEveryZoneUniformly pins §5.6 item 2: the list
+// carries every matching zone — disabled included — because the winner
+// is the query's property, not the entry's.
+func TestEvaluateResponseListsEveryZoneUniformly(t *testing.T) {
+	disabled := loadResponseIPZone(t)
+	disabled.Policy = OverrideDisabled
+	enabled := loadResponseIPZone(t)
+	s := &Store{Zones: []*Zone{disabled, enabled}}
+
+	rm := s.EvaluateResponse([]dns.RR{answerA("192.0.2.1")})
+	if len(rm.List) != 2 || rm.List[0].ZoneIdx != 0 || rm.List[1].ZoneIdx != 1 {
+		t.Fatalf("uniform list broken: %+v", rm.List)
+	}
+}
+
+// TestEvaluateResponseDeepCopiesLocalData pins the §5.6 deep-copy
+// clause: mutating a candidate's record must not reach the store's rule
+// — a header copy would satisfy the type and pin the old generation.
+func TestEvaluateResponseDeepCopiesLocalData(t *testing.T) {
+	z := loadResponseIPZone(t)
+	s := &Store{Zones: []*Zone{z}}
+
+	rm := s.EvaluateResponse([]dns.RR{answerA("192.0.2.7")})
+	if len(rm.List) != 1 || rm.List[0].Action != ActionLocalData || len(rm.List[0].Local) != 1 {
+		t.Fatalf("local-data match: %+v", rm.List)
+	}
+	rm.List[0].Local[0].(*dns.A).A[0] = 99
+
+	again := s.EvaluateResponse([]dns.RR{answerA("192.0.2.7")})
+	if got := again.List[0].Local[0].(*dns.A).A[0]; got == 99 {
+		t.Fatal("a candidate mutation reached the store: the copy is shallow")
+	}
+}
+
+// mergeFixtureStore builds two zones for the merge tests: zone 0 with
+// response rules, zone 1 qname-only.
+func mergeFixtureStore(t *testing.T) *Store {
+	t.Helper()
+	z0 := loadResponseIPZone(t)
+	z1, err := LoadZone("names", strings.NewReader(`
+rpz.test. IN SOA ns.rpz.test. admin.rpz.test. 1 3600 900 604800 300
+victim.example.com.rpz.test. IN CNAME *.
+`), "names.zone", OverrideGiven, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &Store{Zones: []*Zone{z0, z1}}
+}
+
+// TestMergeZoneOrderOutranksTriggerType is the review's P0 shape in
+// reverse: a held QNAME match in zone 1 loses to zone 0's response
+// match, because rule 1 outranks everything.
+func TestMergeZoneOrderOutranksTriggerType(t *testing.T) {
+	s := mergeFixtureStore(t)
+	held := ZoneMatch{ZoneIdx: 1, Zone: s.Zones[1], Rule: &Rule{Action: ActionNODATA}, Trigger: TriggerQNAME}
+	resp := s.EvaluateResponse([]dns.RR{answerA("192.0.2.1")})
+
+	winner, observed := s.Merge(held, nil, resp.List)
+	if winner.ZoneIdx != 0 || winner.Trigger != TriggerResponseIP || winner.Rule.Action != ActionNXDOMAIN {
+		t.Fatalf("zone order lost: %+v", winner)
+	}
+	if len(observed) != 0 {
+		t.Fatalf("nothing stood before the winner: %+v", observed)
+	}
+}
+
+// TestMergeHeldCandidateSurvivesANoneSidecar is the P0 scenario itself:
+// zone 0's response rules do NOT match, zone 1's held QNAME does — the
+// merge must answer with the held action, never the stored truth.
+func TestMergeHeldCandidateSurvivesANoneSidecar(t *testing.T) {
+	s := mergeFixtureStore(t)
+	held := ZoneMatch{ZoneIdx: 1, Zone: s.Zones[1], Rule: &Rule{Action: ActionNODATA}, Trigger: TriggerQNAME}
+
+	winner, _ := s.Merge(held, nil, nil)
+	if winner.ZoneIdx != 1 || winner.Trigger != TriggerQNAME {
+		t.Fatalf("the held candidate was dropped over a none sidecar: %+v", winner)
+	}
+}
+
+// TestMergeSameZoneTriggerPrecedence pins rule 2 inside the merge: a
+// query-time match and a response match in the same zone resolve to the
+// query trigger.
+func TestMergeSameZoneTriggerPrecedence(t *testing.T) {
+	s := mergeFixtureStore(t)
+	held := ZoneMatch{ZoneIdx: 0, Zone: s.Zones[0], Rule: &Rule{Action: ActionPassthru}, Trigger: TriggerQNAME}
+	resp := s.EvaluateResponse([]dns.RR{answerA("192.0.2.1")})
+
+	winner, _ := s.Merge(held, nil, resp.List)
+	if winner.Trigger != TriggerQNAME || winner.Rule.Action != ActionPassthru {
+		t.Fatalf("rule 2 lost inside a zone: %+v", winner)
+	}
+}
+
+// TestMergeDisabledObservesWithoutConsuming pins §5.5 in the merge: a
+// disabled zone's response match is observed and the next enabled zone
+// still wins; with no enabled zone at all, everything matched is
+// observed.
+func TestMergeDisabledObservesWithoutConsuming(t *testing.T) {
+	s := mergeFixtureStore(t)
+	s.Zones[0].Policy = OverrideDisabled
+	held := ZoneMatch{ZoneIdx: 1, Zone: s.Zones[1], Rule: &Rule{Action: ActionNODATA}, Trigger: TriggerQNAME}
+	resp := s.EvaluateResponse([]dns.RR{answerA("192.0.2.1")})
+
+	winner, observed := s.Merge(held, nil, resp.List)
+	if winner.ZoneIdx != 1 {
+		t.Fatalf("a disabled zone consumed the query: %+v", winner)
+	}
+	if len(observed) != 1 || observed[0].ZoneIdx != 0 || observed[0].Trigger != TriggerResponseIP {
+		t.Fatalf("the disabled match was not observed: %+v", observed)
+	}
+
+	s.Zones[1].Policy = OverrideDisabled
+	winner, observed = s.Merge(held, []ZoneMatch{held}, resp.List)
+	if winner.Zone != nil || len(observed) != 2 {
+		t.Fatalf("no-enabled-winner case: winner=%+v observed=%+v", winner, observed)
+	}
+}
+
+// TestMergeIsWinnerBounded pins the counting cut: a zone matching AFTER
+// the winner appears in neither the winner nor the observed list.
+func TestMergeIsWinnerBounded(t *testing.T) {
+	s := mergeFixtureStore(t)
+	// Zone 0 wins by response match; zone 1 also "matched" via a held
+	// candidate — but zone 1 is past the winner.
+	held := ZoneMatch{ZoneIdx: 1, Zone: s.Zones[1], Rule: &Rule{Action: ActionNODATA}, Trigger: TriggerQNAME}
+	resp := s.EvaluateResponse([]dns.RR{answerA("192.0.2.1")})
+
+	winner, observed := s.Merge(held, nil, resp.List)
+	if winner.ZoneIdx != 0 {
+		t.Fatalf("winner: %+v", winner)
+	}
+	if len(observed) != 0 {
+		t.Fatalf("a zone past the winner was counted: %+v", observed)
+	}
+}
+
+// TestOldGenerationIsCollectible pins §5.6's retention clause with the
+// garbage collector as the judge: after a reload drops the old store, a
+// live Local Data candidate must not keep the old rules reachable — the
+// finalizer on the store's own record only runs if the candidate's copy
+// is truly deep.
+func TestOldGenerationIsCollectible(t *testing.T) {
+	z := loadResponseIPZone(t)
+	rule := z.responseIP4.lookupExact(netip.MustParsePrefix("192.0.2.7/32"))
+	if rule == nil || len(rule.Local) != 1 {
+		t.Fatal("fixture rule missing")
+	}
+	collected := make(chan struct{})
+	runtime.SetFinalizer(rule.Local[0].(*dns.A), func(*dns.A) { close(collected) })
+
+	s := &Store{Zones: []*Zone{z}}
+	rm := s.EvaluateResponse([]dns.RR{answerA("192.0.2.7")})
+	if len(rm.List) != 1 || len(rm.List[0].Local) != 1 {
+		t.Fatal("no local-data candidate")
+	}
+
+	// The reload: every reference to the old generation is dropped while
+	// the stamped candidate lives on.
+	z, s, rule = nil, nil, nil
+	_ = z
+	_ = s
+	_ = rule
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		runtime.GC()
+		select {
+		case <-collected:
+			// The candidate still serves its own copy.
+			if rm.List[0].Local[0].(*dns.A).A == nil {
+				t.Fatal("candidate lost its record")
+			}
+			return
+		default:
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the old generation is pinned: a live candidate keeps the store's records reachable")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/internal/rpz/responseip_test.go
+++ b/internal/rpz/responseip_test.go
@@ -290,3 +290,28 @@ func TestOldGenerationIsCollectible(t *testing.T) {
 		time.Sleep(10 * time.Millisecond)
 	}
 }
+
+// TestFoldResponseLists pins the chase fold's dedupe directly: two
+// segment lists matching one zone collapse to the rule-4 best, in zone
+// order. Terminal-only chains never exercise this in composition, but a
+// segment admitted with both alias and address records can — the fold
+// must hold whatever shape an admission produced.
+func TestFoldResponseLists(t *testing.T) {
+	s := &Store{Zones: []*Zone{loadResponseIPZone(t)}}
+	seg1 := s.EvaluateResponseList([]dns.RR{answerA("192.0.2.1")}) // /24 NXDOMAIN
+	seg2 := s.EvaluateResponseList([]dns.RR{answerA("192.0.2.9")}) // /32 NODATA
+
+	folded := FoldResponseLists(seg1, seg2)
+	if len(folded) != 1 {
+		t.Fatalf("one zone folded to %d entries", len(folded))
+	}
+	if folded[0].Action != ActionNODATA || folded[0].PrefixBits != 32+96 {
+		t.Fatalf("the fold kept the wrong rank: %+v", folded[0])
+	}
+
+	// Order-independent: the better match first folds the same.
+	folded = FoldResponseLists(seg2, seg1)
+	if len(folded) != 1 || folded[0].Action != ActionNODATA {
+		t.Fatalf("fold is order-sensitive: %+v", folded)
+	}
+}

--- a/internal/rpz/rpz.go
+++ b/internal/rpz/rpz.go
@@ -125,14 +125,26 @@ type Zone struct {
 	// pays two nil checks.
 	clientIP4 *ipLPM
 	clientIP6 *ipLPM
+	// responseIP4/responseIP6 are the IP (response) trigger's tables,
+	// family-separated for the same reason: an answer's A record must
+	// never be judged by an IPv6 rule or the reverse.
+	responseIP4 *ipLPM
+	responseIP6 *ipLPM
 
-	// Rules counts all compiled rules; RulesClientIP the CLIENT-IP share
-	// (the per-trigger gauges want the split). Skipped counts what the
-	// load stepped over, by reason — all three feed the load-time gauges
-	// and the `sdns -t` report.
-	Rules         int
-	RulesClientIP int
-	Skipped       map[string]int
+	// Rules counts all compiled rules; RulesClientIP and RulesResponseIP
+	// the per-trigger shares (the per-trigger gauges want the split).
+	// Skipped counts what the load stepped over, by reason — all of them
+	// feed the load-time gauges and the `sdns -t` report.
+	Rules           int
+	RulesClientIP   int
+	RulesResponseIP int
+	Skipped         map[string]int
+}
+
+// hasResponseTriggers reports whether this zone carries any response
+// trigger — the bit §5.4's hold decision scans.
+func (z *Zone) hasResponseTriggers() bool {
+	return z.responseIP4 != nil || z.responseIP6 != nil
 }
 
 // Disabled reports whether the zone observes without consuming a match.
@@ -143,6 +155,11 @@ func (z *Zone) Disabled() bool { return z.Policy == OverrideDisabled }
 // is evaluation order (precedence rule 1).
 type Store struct {
 	Zones []*Zone
+	// Gen numbers this generation; the owner assigns it at every swap.
+	// A response-trigger candidate stamped beside a cache entry carries
+	// the Gen it was computed under, and a serve that finds another
+	// generation live re-evaluates instead of trusting it (§5.6 item 5).
+	Gen uint64
 }
 
 // Empty reports whether no zone carries any rule — the whole engine is

--- a/internal/rpz/rpz_test.go
+++ b/internal/rpz/rpz_test.go
@@ -70,16 +70,20 @@ func TestLoadZoneClassifiesEverything(t *testing.T) {
 		t.Fatal("apex SOA not captured")
 	}
 	// 6 action rules + local-data alias + wildcard-target alias +
-	// 2 wildcards + (since phase 2) the client-ip rule.
-	if z.Rules != 11 {
-		t.Fatalf("Rules = %d, want 11 (skips: %v)", z.Rules, z.Skipped)
+	// 2 wildcards + (since phase 2) the client-ip rule + (since phase 4)
+	// the response-ip rule.
+	if z.Rules != 12 {
+		t.Fatalf("Rules = %d, want 12 (skips: %v)", z.Rules, z.Skipped)
 	}
 	if z.RulesClientIP != 1 {
 		t.Fatalf("RulesClientIP = %d, want 1", z.RulesClientIP)
 	}
+	if z.RulesResponseIP != 1 {
+		t.Fatalf("RulesResponseIP = %d, want 1", z.RulesResponseIP)
+	}
 
 	want := map[string]int{
-		SkipTrigger:       2, // rpz-ip + rpz-nsdname wait for their phases
+		SkipTrigger:       1, // rpz-nsdname waits for its phase
 		SkipUnknownAction: 1,
 		SkipNotActionData: 3, // apex NS + in-zone NS + DS
 		SkipOutOfZone:     1,

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -1330,7 +1330,7 @@ func (c *Cache) serveHitFromWire(
 		// lives inside, past the chase's own decline gates.
 		return c.serveChaseHit(ctx, ch, entry, capability, leaser, spent)
 	}
-	gate := c.wireHitGate
+	gate := c.effectiveGate(w)
 	sc := entry.sidecar.Load()
 	if gate != nil && gate.JudgeWireHit(sc) != middleware.WireHitServe {
 		wireSkipPolicy.Inc()
@@ -1483,10 +1483,11 @@ func (c *Cache) handleCacheHit(
 	// segments through internal sub-queries, which is where a stale
 	// segment gets its restamp.
 	policyVerdict := middleware.WireHitServe
+	policyGate := c.effectiveGate(w)
 	var policySC *middleware.Sidecar
-	if g := c.wireHitGate; g != nil {
+	if policyGate != nil {
 		policySC = entry.sidecar.Load()
-		policyVerdict = g.JudgeWireHit(policySC)
+		policyVerdict = policyGate.JudgeWireHit(policySC)
 	} else if c.store.sidecarEvaluator != nil && entry.sidecar.Load() == nil {
 		// An evaluator without a gate still owes pre-wiring entries
 		// their stamp.
@@ -1526,8 +1527,8 @@ func (c *Cache) handleCacheHit(
 		}
 		switch err := ww.WriteWire(body, info); {
 		case err == nil:
-			if g := c.wireHitGate; g != nil {
-				g.CountWireHit(policySC)
+			if policyGate != nil {
+				policyGate.CountWireHit(policySC)
 			}
 			// The answer is out, so bind the request tree to this entry's
 			// lifetime. The byte path is normally reached only by external
@@ -1552,8 +1553,8 @@ func (c *Cache) handleCacheHit(
 			// still gets this entry's answer: it binds like any other
 			// terminal outcome. Only a fallback stays unbound, because
 			// there the message path binds instead.
-			if g := c.wireHitGate; g != nil {
-				g.CountWireHit(policySC)
+			if policyGate != nil {
+				policyGate.CountWireHit(policySC)
 			}
 			boundRequestToEntryLifetime(ctx, entry)
 			ch.Cancel()
@@ -1724,6 +1725,25 @@ func (c *Cache) SetSidecarPolicy(p middleware.SidecarPolicyProvider) {
 	}
 	c.store.SetSidecarEvaluator(p.SidecarEvaluator())
 	c.wireHitGate = p.WireHitGate()
+}
+
+// effectiveGate resolves the gate for one hit: the query's own, when the
+// policy layer's writer carries one (middleware.QueryPolicyGate — that
+// is how held candidates, an already-fallen decision, or an exemption
+// reach the byte-serve judgment), else the globally wired gate. Resolved
+// once per hit and used for the judge and the count alike, so a
+// per-query gate's memoized decision is counted by the same object that
+// judged it. Costs one type assertion, and only on the gated path.
+func (c *Cache) effectiveGate(w middleware.ResponseWriter) middleware.WireHitGate {
+	if c.wireHitGate == nil {
+		return nil
+	}
+	if p, ok := w.(middleware.QueryPolicyGate); ok {
+		if g := p.QueryWireHitGate(); g != nil {
+			return g
+		}
+	}
+	return c.wireHitGate
 }
 
 // (*Cache).Stats stats returns cache statistics.

--- a/middleware/cache/entry_wire_chase.go
+++ b/middleware/cache/entry_wire_chase.go
@@ -84,7 +84,7 @@ func (c *Cache) serveChaseHit(
 	// slice here escapes through the interface call and puts a heap
 	// allocation on every gated chase hit, which the zero-allocation hit
 	// contract forbids with the gate wired no less than without it.
-	gate := c.wireHitGate
+	gate := c.effectiveGate(ch.Writer)
 	var chain middleware.SidecarChain
 	if gate != nil {
 		for i := range n {

--- a/middleware/cache/sidecar_seam_test.go
+++ b/middleware/cache/sidecar_seam_test.go
@@ -594,3 +594,62 @@ func TestGatedByteHitsAllocateNoMoreThanUngated(t *testing.T) {
 		}
 	}
 }
+
+// queryGateWriter carries a per-query gate the way a policy writer does.
+type queryGateWriter struct {
+	middleware.ResponseWriter
+	gate middleware.WireHitGate
+}
+
+func (w *queryGateWriter) QueryWireHitGate() middleware.WireHitGate { return w.gate }
+
+func (w *queryGateWriter) WireReady() (middleware.WireCapability, bool) {
+	if ww, ok := w.ResponseWriter.(middleware.WireWriter); ok {
+		return ww.WireReady()
+	}
+	return middleware.WireCapability{}, false
+}
+
+func (w *queryGateWriter) WriteWire(body []byte, info middleware.WireInfo) error {
+	if ww, ok := w.ResponseWriter.(middleware.WireWriter); ok {
+		return ww.WriteWire(body, info)
+	}
+	return middleware.ErrWireFallback
+}
+
+// TestWriterGateOverridesTheGlobalGate pins the per-query channel: when
+// the writer carries a gate, the cache judges and counts through it and
+// never consults the globally wired one for that hit.
+func TestWriterGateOverridesTheGlobalGate(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, Expire: 600})
+	defer c.Stop()
+	global := &recordingPolicy{verdict: middleware.WireHitServe}
+	c.SetSidecarPolicy(global)
+
+	seamServe(t, c, "override.test.") // prime
+
+	perQuery := &recordingPolicy{verdict: middleware.WireHitServe}
+	q := new(dns.Msg)
+	q.SetQuestion("override.test.", dns.TypeA)
+	q.RecursionDesired = true
+	w := mock.NewWriter("udp", "192.0.2.9:53000")
+	ch := middleware.NewChain([]middleware.Handler{c, middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		resp := seamResponse("override.test.", seamA("override.test."))
+		resp.SetReply(ch.Request.Msg())
+		resp.Answer = []dns.RR{seamA("override.test.")}
+		_ = ch.Writer.WriteMsg(resp)
+		ch.Cancel()
+	})})
+	ch.Reset(w, q)
+	ch.AllowDirectPack()
+	ch.Writer = &queryGateWriter{ResponseWriter: ch.Writer, gate: perQuery}
+	globalBefore, queryBefore := len(global.hits)+len(global.counted), len(perQuery.hits)+len(perQuery.counted)
+	ch.Next(context.Background())
+
+	if len(perQuery.hits)+len(perQuery.counted) == queryBefore {
+		t.Fatal("the writer-carried gate was never consulted")
+	}
+	if len(global.hits)+len(global.counted) != globalBefore {
+		t.Fatal("the global gate was consulted although the writer carried its own")
+	}
+}

--- a/middleware/rpz/axfr_test.go
+++ b/middleware/rpz/axfr_test.go
@@ -180,7 +180,7 @@ func feedUnderTest(t *testing.T, srv *feedServer, tsig string) (*RPZ, *axfrFeed)
 	// hand instead, exactly as New lays it out.
 	r := &RPZ{enforce: true}
 	r.zones = cfg.RPZ.Zones
-	r.store.Store(&rpzengine.Store{Zones: []*rpzengine.Zone{{Name: "feed"}}})
+	r.publishStore(&rpzengine.Store{Zones: []*rpzengine.Zone{{Name: "feed"}}})
 	return r, newAXFRFeed(r, 0, zc)
 }
 

--- a/middleware/rpz/metrics.go
+++ b/middleware/rpz/metrics.go
@@ -63,8 +63,9 @@ var skipReasons = []string{
 }
 
 func publishZoneMetrics(z *rpzengine.Zone) {
-	zoneRules.WithLabelValues(z.Name, rpzengine.TriggerQNAME).Set(float64(z.Rules - z.RulesClientIP))
+	zoneRules.WithLabelValues(z.Name, rpzengine.TriggerQNAME).Set(float64(z.Rules - z.RulesClientIP - z.RulesResponseIP))
 	zoneRules.WithLabelValues(z.Name, rpzengine.TriggerClientIP).Set(float64(z.RulesClientIP))
+	zoneRules.WithLabelValues(z.Name, rpzengine.TriggerResponseIP).Set(float64(z.RulesResponseIP))
 	for _, reason := range skipReasons {
 		zoneRulesSkipped.WithLabelValues(z.Name, reason).Set(float64(z.Skipped[reason]))
 	}

--- a/middleware/rpz/reload.go
+++ b/middleware/rpz/reload.go
@@ -150,5 +150,5 @@ func (r *RPZ) swapZoneLocked(idx int, z *rpz.Zone) {
 	zones := make([]*rpz.Zone, len(old.Zones))
 	copy(zones, old.Zones)
 	zones[idx] = z
-	r.store.Store(&rpz.Store{Zones: zones})
+	r.publishStore(&rpz.Store{Zones: zones})
 }

--- a/middleware/rpz/rpz.go
+++ b/middleware/rpz/rpz.go
@@ -36,7 +36,7 @@ type RPZ struct {
 	// enabled gates the sidecar seam: a disabled middleware returns nil
 	// provider halves so the cache stays entirely unwired.
 	enabled bool
-	store   atomic.Pointer[rpz.Store]
+	store   atomic.Pointer[policyStore]
 
 	// queryer resolves a Local Data CNAME's target through the internal
 	// sub-pipeline, the same seam dns64 uses. Nil when no wiring exists
@@ -278,10 +278,15 @@ func (r *RPZ) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 // waits on the serve-time merge, and continues the chain under it. The
 // wrap is restored around Next the way every writer wrapper in the tree
 // is; it installs on both the inline and replay passes, and the pass
-// that writes is the one that counts.
+// that writes is the one that counts. The wrap itself is pooled: with
+// response rules configured every query passes through here, and the
+// clean wire hit must not pay a heap allocation for a wrapper that only
+// delegates (§5.11). After the restore nothing can reach the object —
+// writes happen within Next or on a replay pass that installs its own.
 func (r *RPZ) serveWrapped(ctx context.Context, ch *middleware.Chain, held rpz.ZoneMatch, heldObserved []rpz.ZoneMatch, holding bool) {
 	w := ch.Writer
-	ch.Writer = &responseWrap{
+	wrap := wrapPool.Get().(*responseWrap)
+	*wrap = responseWrap{
 		ResponseWriter: w,
 		r:              r,
 		ctx:            ctx,
@@ -289,7 +294,12 @@ func (r *RPZ) serveWrapped(ctx context.Context, ch *middleware.Chain, held rpz.Z
 		heldObserved:   heldObserved,
 		holding:        holding,
 	}
-	defer func() { ch.Writer = w }()
+	ch.Writer = wrap
+	defer func() {
+		ch.Writer = w
+		*wrap = responseWrap{}
+		wrapPool.Put(wrap)
+	}()
 	ch.Next(ctx)
 }
 

--- a/middleware/rpz/rpz.go
+++ b/middleware/rpz/rpz.go
@@ -33,6 +33,9 @@ const localDataTTL = 300
 // reload; everything else is set at construction and read-only after.
 type RPZ struct {
 	enforce bool
+	// enabled gates the sidecar seam: a disabled middleware returns nil
+	// provider halves so the cache stays entirely unwired.
+	enabled bool
 	store   atomic.Pointer[rpz.Store]
 
 	// queryer resolves a Local Data CNAME's target through the internal
@@ -58,9 +61,10 @@ type RPZ struct {
 func New(cfg *config.Config) *RPZ {
 	r := &RPZ{enforce: cfg.RPZ.Mode == "enforce"}
 	if !cfg.RPZ.Enabled || len(cfg.RPZ.Zones) == 0 {
-		r.store.Store(&rpz.Store{})
+		r.publishStore(&rpz.Store{})
 		return r
 	}
+	r.enabled = true
 
 	r.zones = cfg.RPZ.Zones
 	r.reloadSeq = make([]atomic.Uint64, len(cfg.RPZ.Zones))
@@ -82,7 +86,7 @@ func New(cfg *config.Config) *RPZ {
 		zones = append(zones, loadZone(zc))
 		zoneSerial.WithLabelValues(zc.Name).Set(-1)
 	}
-	r.store.Store(&rpz.Store{Zones: zones})
+	r.publishStore(&rpz.Store{Zones: zones})
 	r.watch()
 	for idx, zc := range cfg.RPZ.Zones {
 		if zc.Source != "" {
@@ -173,11 +177,39 @@ func (r *RPZ) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	}
 
 	winner, observed := s.Match(canon, offs[:], n, client)
-	if winner.Zone == nil && observed == nil {
+	hasResp := s.HasResponseIP()
+	if winner.Zone == nil && observed == nil && !hasResp {
 		// The steady state: no rule anywhere named this query. Nothing
 		// above this line allocated.
 		ch.Next(ctx)
 		return
+	}
+
+	// §5.4: a query-time match in zone k is final immediately iff no
+	// zone before k carries response triggers; otherwise it is held as a
+	// candidate through resolution, and the serve-time merge in the
+	// response wrap owns the decision — and with it, every count for
+	// this query, winner-bounded against the merged winner.
+	if hasResp {
+		switch {
+		case winner.Zone != nil && s.ResponseTriggerBefore(winner.ZoneIdx):
+			// Held: an earlier zone's response triggers may displace
+			// this match. Everything decodes so the merge sees the
+			// message.
+			r.serveWrapped(ctx, ch, winner, observed, true)
+			return
+		case winner.Zone == nil:
+			// No final query decision, but the response side may still
+			// match. Disabled query-time matches (if any) count only
+			// against the merged winner, which forces the decoded path
+			// for them too.
+			r.serveWrapped(ctx, ch, rpz.ZoneMatch{}, observed, len(observed) > 0)
+			return
+		}
+		// A final winner with no response-trigger zone ahead of it:
+		// enforcement acts here (or shadow counts here), later zones are
+		// past the winner-bounded cut either way, and the flow below is
+		// phase 1's unchanged.
 	}
 
 	// A worker replay of an inline handoff walks this handler again with
@@ -240,6 +272,25 @@ func (r *RPZ) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 		countMatch(winner, outcomeEnforced)
 	}
 	r.act(ctx, ch, winner, action)
+}
+
+// serveWrapped installs the response wrap for a query whose decision
+// waits on the serve-time merge, and continues the chain under it. The
+// wrap is restored around Next the way every writer wrapper in the tree
+// is; it installs on both the inline and replay passes, and the pass
+// that writes is the one that counts.
+func (r *RPZ) serveWrapped(ctx context.Context, ch *middleware.Chain, held rpz.ZoneMatch, heldObserved []rpz.ZoneMatch, holding bool) {
+	w := ch.Writer
+	ch.Writer = &responseWrap{
+		ResponseWriter: w,
+		r:              r,
+		ctx:            ctx,
+		held:           held,
+		heldObserved:   heldObserved,
+		holding:        holding,
+	}
+	defer func() { ch.Writer = w }()
+	ch.Next(ctx)
 }
 
 // chaseNeeded mirrors serveLocalData's fallback exactly: the rule holds no
@@ -341,11 +392,20 @@ func (r *RPZ) act(ctx context.Context, ch *middleware.Chain, winner rpz.ZoneMatc
 	}
 }
 
-// serveLocalData synthesizes the rule's records as if the policy zone were
+// serveLocalData synthesizes the rule's records and writes them.
+func (r *RPZ) serveLocalData(ctx context.Context, ch *middleware.Chain, msg *dns.Msg, winner rpz.ZoneMatch, do bool) {
+	m := r.buildLocalData(ctx, msg, winner, do)
+	_ = ch.Writer.WriteMsg(m)
+	ch.Cancel()
+}
+
+// buildLocalData synthesizes the rule's records as if the policy zone were
 // authoritative for the client's qname: every answer owner is the qname,
 // only RDATA and TTL come from the rule (design §5.2 — an address-encoded
-// or wildcard trigger owner must never leak into a response).
-func (r *RPZ) serveLocalData(ctx context.Context, ch *middleware.Chain, msg *dns.Msg, winner rpz.ZoneMatch, do bool) {
+// or wildcard trigger owner must never leak into a response). msg supplies
+// the question and ID — the client's request, or on the response path the
+// truth being replaced, which carries the same pair.
+func (r *RPZ) buildLocalData(ctx context.Context, msg *dns.Msg, winner rpz.ZoneMatch, do bool) *dns.Msg {
 	q := msg.Question[0]
 	m := dnsutil.SetRcode(msg, dns.RcodeSuccess, do)
 	m.Authoritative = true
@@ -392,8 +452,7 @@ func (r *RPZ) serveLocalData(ctx context.Context, ch *middleware.Chain, msg *dns
 	}
 
 	stamp(m, winner)
-	_ = ch.Writer.WriteMsg(m)
-	ch.Cancel()
+	return m
 }
 
 // expandCNAME copies the rule's CNAME onto the qname, expanding a
@@ -464,4 +523,9 @@ func stamp(m *dns.Msg, winner rpz.ZoneMatch) {
 // first.
 func debugLogEnabled() bool {
 	return zlog.Default().GetLevel() <= zlog.LevelDebug
+}
+
+// debugMatch is the shared shadow/observed debug line.
+func debugMatch(msg string, m rpz.ZoneMatch) {
+	zlog.Debug(msg, "zone", m.Zone.Name, "trigger", m.Trigger, "action", m.Effective().String())
 }

--- a/middleware/rpz/rpz.go
+++ b/middleware/rpz/rpz.go
@@ -196,20 +196,28 @@ func (r *RPZ) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 			// Held: an earlier zone's response triggers may displace
 			// this match. Everything decodes so the merge sees the
 			// message.
-			r.serveWrapped(ctx, ch, winner, observed, true)
+			wrap, prev := r.installWrap(ctx, ch, winner, observed, wrapHold)
+			defer r.restoreWrap(ch, prev, wrap)
+			ch.Next(ctx)
 			return
 		case winner.Zone == nil:
-			// No final query decision, but the response side may still
-			// match. Disabled query-time matches (if any) count only
-			// against the merged winner, which forces the decoded path
-			// for them too.
-			r.serveWrapped(ctx, ch, rpz.ZoneMatch{}, observed, len(observed) > 0)
+			// No final query decision: the response side may still
+			// match. The wrap's own gate judges byte serves with this
+			// query's context — the disabled query-time matches ride
+			// along and are counted winner-bounded on either path.
+			wrap, prev := r.installWrap(ctx, ch, rpz.ZoneMatch{}, observed, wrapPoliced)
+			defer r.restoreWrap(ch, prev, wrap)
+			ch.Next(ctx)
 			return
+		default:
+			// A final winner with no response-trigger zone ahead of it:
+			// the decision falls in the flow below, and however the
+			// query continues — shadow, PASSTHRU, TCP-Only over TCP —
+			// the response side is silenced for it: zones past the
+			// winner count in neither mode.
+			wrap, prev := r.installWrap(ctx, ch, rpz.ZoneMatch{}, nil, wrapBypass)
+			defer r.restoreWrap(ch, prev, wrap)
 		}
-		// A final winner with no response-trigger zone ahead of it:
-		// enforcement acts here (or shadow counts here), later zones are
-		// past the winner-bounded cut either way, and the flow below is
-		// phase 1's unchanged.
 	}
 
 	// A worker replay of an inline handoff walks this handler again with
@@ -274,33 +282,37 @@ func (r *RPZ) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	r.act(ctx, ch, winner, action)
 }
 
-// serveWrapped installs the response wrap for a query whose decision
-// waits on the serve-time merge, and continues the chain under it. The
-// wrap is restored around Next the way every writer wrapper in the tree
-// is; it installs on both the inline and replay passes, and the pass
-// that writes is the one that counts. The wrap itself is pooled: with
-// response rules configured every query passes through here, and the
-// clean wire hit must not pay a heap allocation for a wrapper that only
-// delegates (§5.11). After the restore nothing can reach the object —
-// writes happen within Next or on a replay pass that installs its own.
-func (r *RPZ) serveWrapped(ctx context.Context, ch *middleware.Chain, held rpz.ZoneMatch, heldObserved []rpz.ZoneMatch, holding bool) {
+// installWrap puts this query's response wrap — and with it the query's
+// own wire-hit gate — on the chain, returning the restore the caller
+// defers around its continuation, the way every writer wrapper in the
+// tree is scoped. The wrap installs on both the inline and replay
+// passes, and the pass that writes is the one that counts. It is
+// pooled: with response rules configured every query passes through
+// here, and the clean wire hit must not pay a heap allocation for a
+// wrapper that only delegates (§5.11). After the restore nothing can
+// reach the object — writes happen within the continuation or on a
+// replay pass that installs its own.
+func (r *RPZ) installWrap(ctx context.Context, ch *middleware.Chain, held rpz.ZoneMatch, heldObserved []rpz.ZoneMatch, mode wrapMode) (*responseWrap, middleware.ResponseWriter) {
 	w := ch.Writer
 	wrap := wrapPool.Get().(*responseWrap)
 	*wrap = responseWrap{
 		ResponseWriter: w,
 		r:              r,
 		ctx:            ctx,
+		mode:           mode,
 		held:           held,
 		heldObserved:   heldObserved,
-		holding:        holding,
 	}
 	ch.Writer = wrap
-	defer func() {
-		ch.Writer = w
-		*wrap = responseWrap{}
-		wrapPool.Put(wrap)
-	}()
-	ch.Next(ctx)
+	return wrap, w
+}
+
+// restoreWrap is installWrap's other half, deferred with plain arguments
+// so no closure escapes onto the clean path.
+func (r *RPZ) restoreWrap(ch *middleware.Chain, prev middleware.ResponseWriter, wrap *responseWrap) {
+	ch.Writer = prev
+	*wrap = responseWrap{}
+	wrapPool.Put(wrap)
 }
 
 // chaseNeeded mirrors serveLocalData's fallback exactly: the rule holds no

--- a/middleware/rpz/sidecar.go
+++ b/middleware/rpz/sidecar.go
@@ -1,0 +1,302 @@
+package rpz
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/dnsutil"
+	"github.com/semihalev/sdns/internal/rpz"
+	"github.com/semihalev/sdns/middleware"
+)
+
+// storeGen numbers policy generations process-wide. Every published
+// store carries one, and every sidecar candidate is stamped with the
+// generation it was computed under — the single-object snapshot §5.6
+// item 5 requires: a candidate can never pair old rules with a new
+// generation, because both travel in the same *rpz.Store.
+var storeGen atomic.Uint64
+
+// publishStore assigns the next generation and swaps the store in.
+// Every store swap in this package goes through here.
+func (r *RPZ) publishStore(s *rpz.Store) {
+	s.Gen = storeGen.Add(1)
+	r.store.Store(s)
+}
+
+// SidecarEvaluator implements middleware.SidecarPolicyProvider: the
+// admission half of the cache seam. It evaluates a stored answer's
+// records against the response-IP tables and returns the uniform
+// per-zone match list, stamped with the generation it read. nil when the
+// middleware is disabled, and a nil Sidecar when no zone carries
+// response rules — the seam then stays entirely off.
+func (r *RPZ) SidecarEvaluator() middleware.SidecarEvaluator {
+	if !r.enabled {
+		return nil
+	}
+	return func(msg *dns.Msg) *middleware.Sidecar {
+		rm := r.store.Load().EvaluateResponse(msg.Answer)
+		if rm == nil {
+			return nil
+		}
+		return &middleware.Sidecar{Value: rm}
+	}
+}
+
+// WireHitGate implements middleware.SidecarPolicyProvider: the serve
+// half of the seam. nil when disabled.
+func (r *RPZ) WireHitGate() middleware.WireHitGate {
+	if !r.enabled {
+		return nil
+	}
+	return r
+}
+
+// sidecarMatches unwraps a stamped sidecar; ok is false for nil or a
+// foreign value.
+func sidecarMatches(sc *middleware.Sidecar) (*rpz.ResponseMatches, bool) {
+	if sc == nil {
+		return nil, false
+	}
+	rm, ok := sc.Value.(*rpz.ResponseMatches)
+	return rm, ok
+}
+
+// JudgeWireHit is the pure byte-serve decision over one entry's sidecar.
+// Held query-time candidates never reach this path: a holding query's
+// writer withholds its wire capability, so the gate only ever judges the
+// response side (§5.6 item 6).
+func (r *RPZ) JudgeWireHit(sc *middleware.Sidecar) middleware.WireHitVerdict {
+	s := r.store.Load()
+	if !s.HasResponseIP() {
+		return middleware.WireHitServe
+	}
+	rm, ok := sidecarMatches(sc)
+	if !ok || rm.Gen != s.Gen {
+		return middleware.WireHitRestamp
+	}
+	return r.judgeList(s, rm.List)
+}
+
+// JudgeWireChase judges a composed chase: any unevaluated or stale
+// segment sends the whole hit to the decoded path, whose per-segment
+// internal serves restamp as they chase; otherwise the folded lists are
+// judged exactly like an exact hit.
+func (r *RPZ) JudgeWireChase(chain middleware.SidecarChain) middleware.WireHitVerdict {
+	s := r.store.Load()
+	if !s.HasResponseIP() {
+		return middleware.WireHitServe
+	}
+	folded, ok := r.foldChain(s, chain)
+	if !ok {
+		return middleware.WireHitRestamp
+	}
+	return r.judgeList(s, folded)
+}
+
+// judgeList maps a merge over the response candidates to a verdict:
+// no enabled winner serves the truth; in shadow everything serves (the
+// count happens at the commit); in enforce a PASSTHRU winner serves and
+// anything else needs the decoded path to synthesize.
+func (r *RPZ) judgeList(s *rpz.Store, list []rpz.ResponseMatch) middleware.WireHitVerdict {
+	if len(list) == 0 {
+		return middleware.WireHitServe
+	}
+	winner, _ := s.Merge(rpz.ZoneMatch{}, nil, list)
+	if winner.Zone == nil || !r.enforce {
+		return middleware.WireHitServe
+	}
+	if winner.Effective() == rpz.ActionPassthru {
+		return middleware.WireHitServe
+	}
+	return middleware.WireHitDecode
+}
+
+// CountWireHit records a committed byte serve's policy outcome under the
+// winner-bounded semantic — the byte path is the only place this hit's
+// outcome still exists (§5.5).
+func (r *RPZ) CountWireHit(sc *middleware.Sidecar) {
+	s := r.store.Load()
+	rm, ok := sidecarMatches(sc)
+	if !ok || rm.Gen != s.Gen {
+		return
+	}
+	r.countList(s, rm.List)
+}
+
+// CountWireChase is CountWireHit over the folded chase.
+func (r *RPZ) CountWireChase(chain middleware.SidecarChain) {
+	s := r.store.Load()
+	folded, ok := r.foldChain(s, chain)
+	if !ok {
+		return
+	}
+	r.countList(s, folded)
+}
+
+func (r *RPZ) countList(s *rpz.Store, list []rpz.ResponseMatch) {
+	if len(list) == 0 {
+		return
+	}
+	winner, observed := s.Merge(rpz.ZoneMatch{}, nil, list)
+	for _, o := range observed {
+		countMatch(o, outcomeObserved)
+	}
+	if winner.Zone == nil {
+		return
+	}
+	if r.enforce {
+		// A byte serve committed under an enforcing winner means the
+		// action was PASSTHRU — acting, by not acting.
+		countMatch(winner, outcomeEnforced)
+		return
+	}
+	countMatch(winner, outcomeObserved)
+}
+
+// foldChain gen-checks every segment and folds their lists per zone by
+// the rank key. ok is false when any segment is unevaluated or stale.
+func (r *RPZ) foldChain(s *rpz.Store, chain middleware.SidecarChain) ([]rpz.ResponseMatch, bool) {
+	lists := make([][]rpz.ResponseMatch, 0, chain.Len())
+	for i := 0; i < chain.Len(); i++ {
+		rm, ok := sidecarMatches(chain.At(i))
+		if !ok || rm.Gen != s.Gen {
+			return nil, false
+		}
+		lists = append(lists, rm.List)
+	}
+	return rpz.FoldResponseLists(lists...), true
+}
+
+// responseWrap is the response-side writer: it sees every decoded answer
+// leaving this query — cache hit or fresh resolution — evaluates its
+// records, merges them with the query-time candidates held under §5.4,
+// and applies (enforce) or counts (shadow) the winning action. Byte
+// serves pass through untouched: the gate judged and counted them.
+type responseWrap struct {
+	middleware.ResponseWriter
+	r   *RPZ
+	ctx context.Context
+
+	// held is the enabled-zone query-time match §5.4 held; heldObserved
+	// the disabled-zone matches gathered on the way. holding hides the
+	// wire capability so every serve for this query is decoded — the
+	// merge needs the message.
+	held         rpz.ZoneMatch
+	heldObserved []rpz.ZoneMatch
+	holding      bool
+}
+
+// WriteMsg runs the serve-time merge on the outgoing decoded response.
+func (w *responseWrap) WriteMsg(m *dns.Msg) error {
+	s := w.r.store.Load()
+	var list []rpz.ResponseMatch
+	if rm := s.EvaluateResponse(m.Answer); rm != nil {
+		list = rm.List
+	}
+	winner, observed := s.Merge(w.held, w.heldObserved, list)
+	for _, o := range observed {
+		countMatch(o, outcomeObserved)
+	}
+	if winner.Zone == nil {
+		return w.ResponseWriter.WriteMsg(m)
+	}
+	if !w.r.enforce {
+		countMatch(winner, outcomeObserved)
+		if debugLogEnabled() {
+			zlog_debugResponse(winner)
+		}
+		return w.ResponseWriter.WriteMsg(m)
+	}
+	countMatch(winner, outcomeEnforced)
+	return w.rewrite(m, winner)
+}
+
+// rewrite applies the winning action to the outgoing response. The
+// synthesized replies mirror act()'s exactly; the truth is discarded.
+func (w *responseWrap) rewrite(m *dns.Msg, winner rpz.ZoneMatch) error {
+	do := hasDO(m)
+	switch winner.Effective() {
+	case rpz.ActionPassthru:
+		return w.ResponseWriter.WriteMsg(m)
+	case rpz.ActionDrop:
+		// No reply at all: swallowing the write releases the query
+		// without a response, the accesslist mechanism at this layer.
+		return nil
+	case rpz.ActionTCPOnly:
+		if w.Proto() != "udp" {
+			return w.ResponseWriter.WriteMsg(m)
+		}
+		tc := new(dns.Msg)
+		tc.SetReply(m)
+		tc.Question = m.Question
+		tc.RecursionAvailable = true
+		tc.Truncated = true
+		return w.ResponseWriter.WriteMsg(tc)
+	case rpz.ActionNXDOMAIN:
+		reply := dnsutil.SetRcode(m, dns.RcodeNameError, do)
+		stamp(reply, winner)
+		return w.ResponseWriter.WriteMsg(reply)
+	case rpz.ActionNODATA:
+		reply := dnsutil.SetRcode(m, dns.RcodeSuccess, do)
+		stamp(reply, winner)
+		return w.ResponseWriter.WriteMsg(reply)
+	case rpz.ActionLocalData:
+		reply := w.r.buildLocalData(w.ctx, m, winner, do)
+		return w.ResponseWriter.WriteMsg(reply)
+	}
+	return w.ResponseWriter.WriteMsg(m)
+}
+
+// hasDO reads the DO bit off the message's own OPT; the wrap sits below
+// the edns layer, so the client's OPT is what the message carries.
+func hasDO(m *dns.Msg) bool {
+	if opt := m.IsEdns0(); opt != nil {
+		return opt.Do()
+	}
+	return false
+}
+
+// The wire capability passes through untouched unless this query holds
+// candidates: a held query must be answered from the decoded path, where
+// the merge can see the message (§5.4).
+func (w *responseWrap) WireReady() (middleware.WireCapability, bool) {
+	if w.holding {
+		return middleware.WireCapability{}, false
+	}
+	if ww, ok := w.ResponseWriter.(middleware.WireWriter); ok {
+		return ww.WireReady()
+	}
+	return middleware.WireCapability{}, false
+}
+
+func (w *responseWrap) WriteWire(body []byte, info middleware.WireInfo) error {
+	if ww, ok := w.ResponseWriter.(middleware.WireWriter); ok {
+		return ww.WriteWire(body, info)
+	}
+	return middleware.ErrWireFallback
+}
+
+func (w *responseWrap) BeginWire(size, reserve int) []byte {
+	if l, ok := w.ResponseWriter.(middleware.WireBodyLeaser); ok {
+		return l.BeginWire(size, reserve)
+	}
+	return nil
+}
+
+func (w *responseWrap) CommitWire(body []byte, info middleware.WireInfo) error {
+	if l, ok := w.ResponseWriter.(middleware.WireBodyLeaser); ok {
+		return l.CommitWire(body, info)
+	}
+	return middleware.ErrWireFallback
+}
+
+func (w *responseWrap) AbortWire() {
+	if l, ok := w.ResponseWriter.(middleware.WireBodyLeaser); ok {
+		l.AbortWire()
+	}
+}
+
+func zlog_debugResponse(winner rpz.ZoneMatch) {
+	debugMatch("RPZ response match in shadow", winner)
+}

--- a/middleware/rpz/sidecar.go
+++ b/middleware/rpz/sidecar.go
@@ -81,37 +81,18 @@ func sidecarMatches(sc *middleware.Sidecar) (*rpz.ResponseMatches, bool) {
 	return rm, ok
 }
 
-// JudgeWireHit is the pure byte-serve decision over one entry's sidecar,
-// and it is deliberately blunt: bytes serve only when the entry matched
-// nothing. Any match — enforce or shadow, winner or loser — goes to the
-// decoded path, because only this query's response wrap knows the held
-// candidates and the §5.4 finality that make the winner-bounded count
-// (and the action) correct; a decoded serve on a query whose decision
-// already fell carries no wrap and stays silent, exactly as a zone past
-// the winner must. That bluntness is also what keeps this judgment free
-// of the judge/commit generation race: nothing countable ever rides the
-// byte path, so there is nothing for a commit-time reload to miscount.
+// The globally wired gate serves the queries rpz never wrapped — the
+// exempt ones its own ServeDNS gates out (internal, RD=0, non-INET) and
+// deployments without response rules. It is neutral: it keeps entries
+// healthy (a stale sidecar still restamps) and serves everything else as
+// bytes, counting nothing, because policy does not apply to those
+// queries at all. Every policed query carries its own gate on the
+// response wrap (middleware.QueryPolicyGate), which is how held
+// candidates and §5.4 finality reach the byte-serve judgment.
 func (r *RPZ) JudgeWireHit(sc *middleware.Sidecar) middleware.WireHitVerdict {
-	s := r.store.Load()
-	if !s.HasResponseIP() {
-		return middleware.WireHitServe
-	}
-	rm, ok := sidecarMatches(sc)
-	if !ok || rm.Gen != s.Gen {
-		return middleware.WireHitRestamp
-	}
-	if len(rm.List) == 0 {
-		return middleware.WireHitServe
-	}
-	return middleware.WireHitDecode
+	return r.neutralJudge(sc)
 }
 
-// JudgeWireChase judges a composed chase: any unevaluated or stale
-// segment sends the hit to the decoded path to be restamped as it
-// re-chases; any matching segment sends it there for the merge. The
-// decoded chase composes the whole answer before the wrap evaluates it,
-// so two segments matching one zone collapse to that zone's single
-// rule-4 best by construction (§5.6 item 4).
 func (r *RPZ) JudgeWireChase(chain middleware.SidecarChain) middleware.WireHitVerdict {
 	s := r.store.Load()
 	if !s.HasResponseIP() {
@@ -122,20 +103,23 @@ func (r *RPZ) JudgeWireChase(chain middleware.SidecarChain) middleware.WireHitVe
 		if !ok || rm.Gen != s.Gen {
 			return middleware.WireHitRestamp
 		}
-		if len(rm.List) > 0 {
-			return middleware.WireHitDecode
-		}
 	}
 	return middleware.WireHitServe
 }
 
-// CountWireHit and CountWireChase are deliberately empty: the judge
-// above never lets a matching entry serve bytes, so a committed byte
-// serve is always a none — and none is counted as nothing. Every real
-// count happens in the response wrap, which alone holds the query-time
-// candidates the winner-bounded semantic is defined over.
 func (r *RPZ) CountWireHit(*middleware.Sidecar)       {}
 func (r *RPZ) CountWireChase(middleware.SidecarChain) {}
+
+func (r *RPZ) neutralJudge(sc *middleware.Sidecar) middleware.WireHitVerdict {
+	s := r.store.Load()
+	if !s.HasResponseIP() {
+		return middleware.WireHitServe
+	}
+	if rm, ok := sidecarMatches(sc); !ok || rm.Gen != s.Gen {
+		return middleware.WireHitRestamp
+	}
+	return middleware.WireHitServe
+}
 
 // wrapPool recycles response wraps: with response rules configured every
 // query installs one, and the clean wire hit must not pay a heap
@@ -144,27 +128,146 @@ func (r *RPZ) CountWireChase(middleware.SidecarChain) {}
 // so the put after the restore hands back an object nothing can reach.
 var wrapPool = sync.Pool{New: func() any { return new(responseWrap) }}
 
-// responseWrap is the response-side writer: it sees every decoded answer
-// leaving this query — cache hit or fresh resolution — evaluates its
-// records, merges them with the query-time candidates held under §5.4,
-// and applies (enforce) or counts (shadow) the winning action. Byte
-// serves pass through untouched: the gate admits only none entries.
+// wrapMode is what this query's wrap owes the response side.
+type wrapMode uint8
+
+const (
+	// wrapPoliced: no query-time winner; the byte path may serve, its
+	// gate judging and counting through this wrap, and every decoded
+	// answer runs the merge in WriteMsg.
+	wrapPoliced wrapMode = iota
+	// wrapHold: a query-time candidate is held under §5.4; the wire
+	// capability is withheld so the merge sees every answer decoded.
+	wrapHold
+	// wrapBypass: the query's decision already fell (a final winner
+	// continuing in shadow or under PASSTHRU); the response side serves
+	// bytes freely and counts nothing — zones past the winner stay
+	// silent in both modes.
+	wrapBypass
+)
+
+// responseWrap is the response-side writer and this query's own wire-hit
+// gate: it sees every decoded answer leaving the query — cache hit or
+// fresh resolution — evaluates its records, merges them with the
+// query-time candidates held under §5.4, and applies (enforce) or counts
+// (shadow) the winning action; on the byte path its gate judges the
+// entry's sidecar with the same merge and memoizes the decision, so the
+// count after the commit records exactly what was judged and served,
+// whatever a concurrent reload does in between.
 type responseWrap struct {
 	middleware.ResponseWriter
-	r   *RPZ
-	ctx context.Context
+	r    *RPZ
+	ctx  context.Context
+	mode wrapMode
 
 	// held is the enabled-zone query-time match §5.4 held; heldObserved
-	// the disabled-zone matches gathered on the way. holding hides the
-	// wire capability so every serve for this query is decoded — the
-	// merge needs the message.
+	// the disabled-zone matches gathered on the way.
 	held         rpz.ZoneMatch
 	heldObserved []rpz.ZoneMatch
-	holding      bool
+
+	// The decision token: the merge the gate judged Serve with, counted
+	// verbatim at the commit. Judge and commit run on one goroutine
+	// within one hit, and the wrap resets between queries.
+	decided         bool
+	decidedWinner   rpz.ZoneMatch
+	decidedObserved []rpz.ZoneMatch
+}
+
+// QueryWireHitGate hands the cache this query's own gate
+// (middleware.QueryPolicyGate).
+func (w *responseWrap) QueryWireHitGate() middleware.WireHitGate { return w }
+
+// JudgeWireHit is the byte-serve decision with the query's context: the
+// entry's matches merge with the held disabled observations, and any
+// outcome that leaves the stored answer intact — nothing matched, no
+// enabled winner, shadow, an enforcing PASSTHRU — serves bytes, with the
+// decision memoized for the commit-time count. Only an enforcing rewrite
+// needs the decoded path. A bypass wrap serves everything and decides
+// nothing; a holding wrap never reaches here (its wire is withheld).
+func (w *responseWrap) JudgeWireHit(sc *middleware.Sidecar) middleware.WireHitVerdict {
+	s := w.r.store.Load()
+	if !s.HasResponseIP() {
+		return middleware.WireHitServe
+	}
+	rm, ok := sidecarMatches(sc)
+	if !ok || rm.Gen != s.Gen {
+		return middleware.WireHitRestamp
+	}
+	if w.mode != wrapPoliced {
+		return middleware.WireHitServe
+	}
+	return w.judgeList(s, rm.List)
+}
+
+// JudgeWireChase is JudgeWireHit over a composed chase: every segment
+// must be evaluated and current, and the folded per-zone bests (§5.6
+// item 4's dedupe) enter the same merge.
+func (w *responseWrap) JudgeWireChase(chain middleware.SidecarChain) middleware.WireHitVerdict {
+	s := w.r.store.Load()
+	if !s.HasResponseIP() {
+		return middleware.WireHitServe
+	}
+	lists := make([][]rpz.ResponseMatch, 0, middleware.SidecarChainCap)
+	for i := 0; i < chain.Len(); i++ {
+		rm, ok := sidecarMatches(chain.At(i))
+		if !ok || rm.Gen != s.Gen {
+			return middleware.WireHitRestamp
+		}
+		lists = append(lists, rm.List)
+	}
+	if w.mode != wrapPoliced {
+		return middleware.WireHitServe
+	}
+	return w.judgeList(s, rpz.FoldResponseLists(lists...))
+}
+
+func (w *responseWrap) judgeList(s *policyStore, list []rpz.ResponseMatch) middleware.WireHitVerdict {
+	if len(list) == 0 && len(w.heldObserved) == 0 {
+		// The steady state: nothing to merge, nothing to count.
+		return middleware.WireHitServe
+	}
+	winner, observed := s.Merge(rpz.ZoneMatch{}, w.heldObserved, list)
+	if winner.Zone != nil && w.r.enforce && winner.Effective() != rpz.ActionPassthru {
+		w.decided = false
+		return middleware.WireHitDecode
+	}
+	w.decided, w.decidedWinner, w.decidedObserved = true, winner, observed
+	return middleware.WireHitServe
+}
+
+// CountWireHit and CountWireChase record the memoized decision after the
+// bytes were committed — exactly once, exactly what was judged.
+func (w *responseWrap) CountWireHit(*middleware.Sidecar)       { w.countDecided() }
+func (w *responseWrap) CountWireChase(middleware.SidecarChain) { w.countDecided() }
+
+func (w *responseWrap) countDecided() {
+	if !w.decided {
+		return
+	}
+	w.decided = false
+	for _, o := range w.decidedObserved {
+		countMatch(o, outcomeObserved)
+	}
+	if w.decidedWinner.Zone == nil {
+		return
+	}
+	if w.r.enforce {
+		// A byte serve committed under an enforcing winner means the
+		// action was PASSTHRU — acting, by not acting.
+		countMatch(w.decidedWinner, outcomeEnforced)
+		return
+	}
+	countMatch(w.decidedWinner, outcomeObserved)
+	if debugLogEnabled() {
+		debugMatch("RPZ response match in shadow", w.decidedWinner)
+	}
 }
 
 // WriteMsg runs the serve-time merge on the outgoing decoded response.
 func (w *responseWrap) WriteMsg(m *dns.Msg) error {
+	if w.mode == wrapBypass {
+		return w.ResponseWriter.WriteMsg(m)
+	}
 	s := w.r.store.Load()
 	list := s.EvaluateResponseList(m.Answer)
 	winner, observed := s.Merge(w.held, w.heldObserved, list)
@@ -234,7 +337,7 @@ func hasDO(m *dns.Msg) bool {
 // candidates: a held query must be answered from the decoded path, where
 // the merge can see the message (§5.4).
 func (w *responseWrap) WireReady() (middleware.WireCapability, bool) {
-	if w.holding {
+	if w.mode == wrapHold {
 		return middleware.WireCapability{}, false
 	}
 	if ww, ok := w.ResponseWriter.(middleware.WireWriter); ok {

--- a/middleware/rpz/sidecar.go
+++ b/middleware/rpz/sidecar.go
@@ -2,6 +2,7 @@ package rpz
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 
 	"github.com/miekg/dns"
@@ -17,29 +18,47 @@ import (
 // generation, because both travel in the same *rpz.Store.
 var storeGen atomic.Uint64
 
+// policyStore is one published generation with its shared explicit-none
+// sidecar. The none sentinel rides the same pointer as the rules, so an
+// evaluator can never stamp one generation's none beside another's rules
+// — and because it is shared, an admission that matched nothing
+// allocates nothing per entry (§5.11's explicit-none clause).
+type policyStore struct {
+	*rpz.Store
+	none *middleware.Sidecar
+}
+
 // publishStore assigns the next generation and swaps the store in.
 // Every store swap in this package goes through here.
 func (r *RPZ) publishStore(s *rpz.Store) {
 	s.Gen = storeGen.Add(1)
-	r.store.Store(s)
+	r.store.Store(&policyStore{
+		Store: s,
+		none:  &middleware.Sidecar{Value: &rpz.ResponseMatches{Gen: s.Gen}},
+	})
 }
 
 // SidecarEvaluator implements middleware.SidecarPolicyProvider: the
 // admission half of the cache seam. It evaluates a stored answer's
-// records against the response-IP tables and returns the uniform
-// per-zone match list, stamped with the generation it read. nil when the
-// middleware is disabled, and a nil Sidecar when no zone carries
-// response rules — the seam then stays entirely off.
+// records against the response-IP tables and returns the per-zone match
+// list stamped with the generation it read — or the generation's shared
+// none, so the overwhelmingly common clean admission allocates nothing.
+// nil when the middleware is disabled, and a nil Sidecar when no zone
+// carries response rules — the seam then stays entirely off.
 func (r *RPZ) SidecarEvaluator() middleware.SidecarEvaluator {
 	if !r.enabled {
 		return nil
 	}
 	return func(msg *dns.Msg) *middleware.Sidecar {
-		rm := r.store.Load().EvaluateResponse(msg.Answer)
-		if rm == nil {
+		s := r.store.Load()
+		if !s.HasResponseIP() {
 			return nil
 		}
-		return &middleware.Sidecar{Value: rm}
+		list := s.EvaluateResponseList(msg.Answer)
+		if len(list) == 0 {
+			return s.none
+		}
+		return &middleware.Sidecar{Value: &rpz.ResponseMatches{Gen: s.Gen, List: list}}
 	}
 }
 
@@ -62,10 +81,16 @@ func sidecarMatches(sc *middleware.Sidecar) (*rpz.ResponseMatches, bool) {
 	return rm, ok
 }
 
-// JudgeWireHit is the pure byte-serve decision over one entry's sidecar.
-// Held query-time candidates never reach this path: a holding query's
-// writer withholds its wire capability, so the gate only ever judges the
-// response side (§5.6 item 6).
+// JudgeWireHit is the pure byte-serve decision over one entry's sidecar,
+// and it is deliberately blunt: bytes serve only when the entry matched
+// nothing. Any match — enforce or shadow, winner or loser — goes to the
+// decoded path, because only this query's response wrap knows the held
+// candidates and the §5.4 finality that make the winner-bounded count
+// (and the action) correct; a decoded serve on a query whose decision
+// already fell carries no wrap and stays silent, exactly as a zone past
+// the winner must. That bluntness is also what keeps this judgment free
+// of the judge/commit generation race: nothing countable ever rides the
+// byte path, so there is nothing for a commit-time reload to miscount.
 func (r *RPZ) JudgeWireHit(sc *middleware.Sidecar) middleware.WireHitVerdict {
 	s := r.store.Load()
 	if !s.HasResponseIP() {
@@ -75,104 +100,55 @@ func (r *RPZ) JudgeWireHit(sc *middleware.Sidecar) middleware.WireHitVerdict {
 	if !ok || rm.Gen != s.Gen {
 		return middleware.WireHitRestamp
 	}
-	return r.judgeList(s, rm.List)
-}
-
-// JudgeWireChase judges a composed chase: any unevaluated or stale
-// segment sends the whole hit to the decoded path, whose per-segment
-// internal serves restamp as they chase; otherwise the folded lists are
-// judged exactly like an exact hit.
-func (r *RPZ) JudgeWireChase(chain middleware.SidecarChain) middleware.WireHitVerdict {
-	s := r.store.Load()
-	if !s.HasResponseIP() {
-		return middleware.WireHitServe
-	}
-	folded, ok := r.foldChain(s, chain)
-	if !ok {
-		return middleware.WireHitRestamp
-	}
-	return r.judgeList(s, folded)
-}
-
-// judgeList maps a merge over the response candidates to a verdict:
-// no enabled winner serves the truth; in shadow everything serves (the
-// count happens at the commit); in enforce a PASSTHRU winner serves and
-// anything else needs the decoded path to synthesize.
-func (r *RPZ) judgeList(s *rpz.Store, list []rpz.ResponseMatch) middleware.WireHitVerdict {
-	if len(list) == 0 {
-		return middleware.WireHitServe
-	}
-	winner, _ := s.Merge(rpz.ZoneMatch{}, nil, list)
-	if winner.Zone == nil || !r.enforce {
-		return middleware.WireHitServe
-	}
-	if winner.Effective() == rpz.ActionPassthru {
+	if len(rm.List) == 0 {
 		return middleware.WireHitServe
 	}
 	return middleware.WireHitDecode
 }
 
-// CountWireHit records a committed byte serve's policy outcome under the
-// winner-bounded semantic — the byte path is the only place this hit's
-// outcome still exists (§5.5).
-func (r *RPZ) CountWireHit(sc *middleware.Sidecar) {
+// JudgeWireChase judges a composed chase: any unevaluated or stale
+// segment sends the hit to the decoded path to be restamped as it
+// re-chases; any matching segment sends it there for the merge. The
+// decoded chase composes the whole answer before the wrap evaluates it,
+// so two segments matching one zone collapse to that zone's single
+// rule-4 best by construction (§5.6 item 4).
+func (r *RPZ) JudgeWireChase(chain middleware.SidecarChain) middleware.WireHitVerdict {
 	s := r.store.Load()
-	rm, ok := sidecarMatches(sc)
-	if !ok || rm.Gen != s.Gen {
-		return
+	if !s.HasResponseIP() {
+		return middleware.WireHitServe
 	}
-	r.countList(s, rm.List)
-}
-
-// CountWireChase is CountWireHit over the folded chase.
-func (r *RPZ) CountWireChase(chain middleware.SidecarChain) {
-	s := r.store.Load()
-	folded, ok := r.foldChain(s, chain)
-	if !ok {
-		return
-	}
-	r.countList(s, folded)
-}
-
-func (r *RPZ) countList(s *rpz.Store, list []rpz.ResponseMatch) {
-	if len(list) == 0 {
-		return
-	}
-	winner, observed := s.Merge(rpz.ZoneMatch{}, nil, list)
-	for _, o := range observed {
-		countMatch(o, outcomeObserved)
-	}
-	if winner.Zone == nil {
-		return
-	}
-	if r.enforce {
-		// A byte serve committed under an enforcing winner means the
-		// action was PASSTHRU — acting, by not acting.
-		countMatch(winner, outcomeEnforced)
-		return
-	}
-	countMatch(winner, outcomeObserved)
-}
-
-// foldChain gen-checks every segment and folds their lists per zone by
-// the rank key. ok is false when any segment is unevaluated or stale.
-func (r *RPZ) foldChain(s *rpz.Store, chain middleware.SidecarChain) ([]rpz.ResponseMatch, bool) {
-	lists := make([][]rpz.ResponseMatch, 0, chain.Len())
 	for i := 0; i < chain.Len(); i++ {
 		rm, ok := sidecarMatches(chain.At(i))
 		if !ok || rm.Gen != s.Gen {
-			return nil, false
+			return middleware.WireHitRestamp
 		}
-		lists = append(lists, rm.List)
+		if len(rm.List) > 0 {
+			return middleware.WireHitDecode
+		}
 	}
-	return rpz.FoldResponseLists(lists...), true
+	return middleware.WireHitServe
 }
+
+// CountWireHit and CountWireChase are deliberately empty: the judge
+// above never lets a matching entry serve bytes, so a committed byte
+// serve is always a none — and none is counted as nothing. Every real
+// count happens in the response wrap, which alone holds the query-time
+// candidates the winner-bounded semantic is defined over.
+func (r *RPZ) CountWireHit(*middleware.Sidecar)       {}
+func (r *RPZ) CountWireChase(middleware.SidecarChain) {}
+
+// wrapPool recycles response wraps: with response rules configured every
+// query installs one, and the clean wire hit must not pay a heap
+// allocation for it (§5.11). The wrap's lifetime is the Next call it
+// brackets — the same discipline every writer wrapper in the tree keeps —
+// so the put after the restore hands back an object nothing can reach.
+var wrapPool = sync.Pool{New: func() any { return new(responseWrap) }}
 
 // responseWrap is the response-side writer: it sees every decoded answer
 // leaving this query — cache hit or fresh resolution — evaluates its
 // records, merges them with the query-time candidates held under §5.4,
 // and applies (enforce) or counts (shadow) the winning action. Byte
-// serves pass through untouched: the gate judged and counted them.
+// serves pass through untouched: the gate admits only none entries.
 type responseWrap struct {
 	middleware.ResponseWriter
 	r   *RPZ
@@ -190,10 +166,7 @@ type responseWrap struct {
 // WriteMsg runs the serve-time merge on the outgoing decoded response.
 func (w *responseWrap) WriteMsg(m *dns.Msg) error {
 	s := w.r.store.Load()
-	var list []rpz.ResponseMatch
-	if rm := s.EvaluateResponse(m.Answer); rm != nil {
-		list = rm.List
-	}
+	list := s.EvaluateResponseList(m.Answer)
 	winner, observed := s.Merge(w.held, w.heldObserved, list)
 	for _, o := range observed {
 		countMatch(o, outcomeObserved)
@@ -204,7 +177,7 @@ func (w *responseWrap) WriteMsg(m *dns.Msg) error {
 	if !w.r.enforce {
 		countMatch(winner, outcomeObserved)
 		if debugLogEnabled() {
-			zlog_debugResponse(winner)
+			debugMatch("RPZ response match in shadow", winner)
 		}
 		return w.ResponseWriter.WriteMsg(m)
 	}
@@ -295,8 +268,4 @@ func (w *responseWrap) AbortWire() {
 	if l, ok := w.ResponseWriter.(middleware.WireBodyLeaser); ok {
 		l.AbortWire()
 	}
-}
-
-func zlog_debugResponse(winner rpz.ZoneMatch) {
-	debugMatch("RPZ response match in shadow", winner)
 }

--- a/middleware/rpz/sidecar.go
+++ b/middleware/rpz/sidecar.go
@@ -185,8 +185,20 @@ func (w *responseWrap) QueryWireHitGate() middleware.WireHitGate { return w }
 // needs the decoded path. A bypass wrap serves everything and decides
 // nothing; a holding wrap never reaches here (its wire is withheld).
 func (w *responseWrap) JudgeWireHit(sc *middleware.Sidecar) middleware.WireHitVerdict {
+	// A fresh judgment voids any earlier one: the cache may judge this
+	// gate again after a lease or transport fallback, and a commit must
+	// only ever count the decision of the judge it followed — never a
+	// memo an abandoned serve left behind.
+	w.decided = false
 	s := w.r.store.Load()
 	if !s.HasResponseIP() {
+		// A reload dropped the last response trigger under this query.
+		// The held disabled observations count under any generation, so
+		// they still enter the merge — an empty response side, not a
+		// skipped one.
+		if w.mode == wrapPoliced && len(w.heldObserved) > 0 {
+			return w.judgeList(s, nil)
+		}
 		return middleware.WireHitServe
 	}
 	rm, ok := sidecarMatches(sc)
@@ -203,8 +215,12 @@ func (w *responseWrap) JudgeWireHit(sc *middleware.Sidecar) middleware.WireHitVe
 // must be evaluated and current, and the folded per-zone bests (§5.6
 // item 4's dedupe) enter the same merge.
 func (w *responseWrap) JudgeWireChase(chain middleware.SidecarChain) middleware.WireHitVerdict {
+	w.decided = false
 	s := w.r.store.Load()
 	if !s.HasResponseIP() {
+		if w.mode == wrapPoliced && len(w.heldObserved) > 0 {
+			return w.judgeList(s, nil)
+		}
 		return middleware.WireHitServe
 	}
 	lists := make([][]rpz.ResponseMatch, 0, middleware.SidecarChainCap)

--- a/middleware/rpz/sidecar_test.go
+++ b/middleware/rpz/sidecar_test.go
@@ -1,0 +1,482 @@
+package rpz
+
+import (
+	"context"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/mock"
+	rpzengine "github.com/semihalev/sdns/internal/rpz"
+	"github.com/semihalev/sdns/middleware"
+	"github.com/semihalev/sdns/middleware/cache"
+)
+
+// The phase 4 exit criteria (design §6) as tests: truth in the cache,
+// the P0 scenarios verbatim, per-client outcomes over one entry, reload
+// re-evaluation, both counting paths.
+
+const respTestZone = `
+rpz.test. IN SOA ns.rpz.test. admin.rpz.test. 1 3600 900 604800 300
+24.0.113.0.203.rpz-ip.rpz.test.  IN CNAME .
+32.9.100.51.198.rpz-ip.rpz.test. IN CNAME rpz-passthru.
+`
+
+const qnameTestZone = `
+rpz.test. IN SOA ns.rpz.test. admin.rpz.test. 2 3600 900 604800 300
+victim.example.com.rpz.test. IN CNAME .
+`
+
+// spyPolicy wraps the RPZ provider so a test can see which path served:
+// Count* fires only on committed byte serves.
+type spyPolicy struct {
+	r *RPZ
+
+	mu          sync.Mutex
+	countHits   int
+	countChases int
+}
+
+func (p *spyPolicy) SidecarEvaluator() middleware.SidecarEvaluator { return p.r.SidecarEvaluator() }
+func (p *spyPolicy) WireHitGate() middleware.WireHitGate           { return p }
+
+func (p *spyPolicy) JudgeWireHit(sc *middleware.Sidecar) middleware.WireHitVerdict {
+	return p.r.JudgeWireHit(sc)
+}
+
+func (p *spyPolicy) JudgeWireChase(chain middleware.SidecarChain) middleware.WireHitVerdict {
+	return p.r.JudgeWireChase(chain)
+}
+
+func (p *spyPolicy) CountWireHit(sc *middleware.Sidecar) {
+	p.mu.Lock()
+	p.countHits++
+	p.mu.Unlock()
+	p.r.CountWireHit(sc)
+}
+
+func (p *spyPolicy) CountWireChase(chain middleware.SidecarChain) {
+	p.mu.Lock()
+	p.countChases++
+	p.mu.Unlock()
+	p.r.CountWireChase(chain)
+}
+
+// chainQueryer routes the cache's decoded CNAME chase back through the
+// same handlers, the shape Setup wires in production.
+type chainQueryer struct {
+	handlers []middleware.Handler
+}
+
+func (q *chainQueryer) Query(_ context.Context, req *dns.Msg) (*dns.Msg, error) {
+	w := mock.NewWriter("udp", "127.0.0.1:0")
+	ch := middleware.NewChain(q.handlers)
+	ch.Reset(w, req)
+	ch.Next(context.Background())
+	if !w.Written() {
+		return nil, middleware.ErrNoResponse
+	}
+	return w.Msg(), nil
+}
+
+// sidecarHarness is one full rpz→cache→authority pipeline with the seam
+// wired the way Setup wires it.
+type sidecarHarness struct {
+	r     *RPZ
+	c     *cache.Cache
+	spy   *spyPolicy
+	truth map[string]string // qname -> A address the authority serves
+}
+
+func newSidecarHarness(t *testing.T, mode string, zones ...config.RPZZone) *sidecarHarness {
+	t.Helper()
+	h := &sidecarHarness{
+		r:     newRPZ(t, mode, zones...),
+		c:     cache.New(&config.Config{CacheSize: 1024, Expire: 600}),
+		truth: map[string]string{},
+	}
+	t.Cleanup(h.c.Stop)
+	h.spy = &spyPolicy{r: h.r}
+	h.c.SetSidecarPolicy(h.spy)
+	h.c.SetQueryer(&chainQueryer{handlers: []middleware.Handler{h.c, h.authority()}})
+	return h
+}
+
+func (h *sidecarHarness) authority() middleware.Handler {
+	return middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		req := ch.Request.Msg()
+		resp := new(dns.Msg)
+		resp.SetReply(req)
+		resp.RecursionAvailable = true
+		if addr, ok := h.truth[req.Question[0].Name]; ok {
+			resp.Answer = []dns.RR{testA(req.Question[0].Name, addr)}
+		} else {
+			resp.Rcode = dns.RcodeNameError
+		}
+		_ = ch.Writer.WriteMsg(resp)
+		ch.Cancel()
+	})
+}
+
+func testA(name, addr string) *dns.A {
+	rr, err := dns.NewRR(name + " 300 IN A " + addr)
+	if err != nil {
+		panic(err)
+	}
+	return rr.(*dns.A)
+}
+
+// serve drives one query; bytePath allows the direct-pack byte serve.
+func (h *sidecarHarness) serve(t *testing.T, qname, clientAddr string, bytePath bool) *mock.Writer {
+	t.Helper()
+	q := new(dns.Msg)
+	q.SetQuestion(qname, dns.TypeA)
+	q.RecursionDesired = true
+	raw, err := q.Pack()
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := new(middleware.Request)
+	if !req.ParseWire(raw, time.Now(), nil) {
+		t.Fatal("refused")
+	}
+	w := mock.NewWriter("udp", clientAddr)
+	ch := middleware.NewChain([]middleware.Handler{h.r, h.c, h.authority()})
+	ch.ResetWire(w, req)
+	if bytePath {
+		ch.AllowDirectPack()
+	}
+	ch.Next(context.Background())
+	return w
+}
+
+// cacheStore reaches the concrete store behind the wiring interface.
+func (h *sidecarHarness) cacheStore() *cache.Store {
+	return h.c.Store().(*cache.Store)
+}
+
+// storedEntry reads the cache's stored entry for qname.
+func (h *sidecarHarness) storedEntry(t *testing.T, qname string) *cache.CacheEntry {
+	t.Helper()
+	key := cache.CacheKey{
+		Question: dns.Question{Name: qname, Qtype: dns.TypeA, Qclass: dns.ClassINET},
+	}.Hash()
+	entry, ok := h.cacheStore().LookupByKey(key)
+	if !ok {
+		t.Fatalf("%s: no cached entry", qname)
+	}
+	return entry
+}
+
+// storedTruth reads the cache's stored answer for qname.
+func (h *sidecarHarness) storedTruth(t *testing.T, qname string) *dns.Msg {
+	t.Helper()
+	req := new(dns.Msg)
+	req.SetQuestion(qname, dns.TypeA)
+	req.RecursionDesired = true
+	m, found := h.cacheStore().Get(req)
+	if !found {
+		t.Fatalf("%s: no cached answer", qname)
+	}
+	return m
+}
+
+// TestTruthInCacheRewriteToClient pins §5.6 item 1: the client is
+// rewritten, the cache stores the resolver's truth untouched — on the
+// miss and on every hit after it.
+func TestTruthInCacheRewriteToClient(t *testing.T) {
+	h := newSidecarHarness(t, "enforce", config.RPZZone{Name: "resp", File: writeZone(t, respTestZone)})
+	h.truth["bad.test."] = "203.0.113.10"
+
+	for _, pass := range []string{"miss", "hit"} {
+		w := h.serve(t, "bad.test.", "192.0.2.1:40000", true)
+		if !w.Written() || w.Rcode() != dns.RcodeNameError {
+			t.Fatalf("%s: client not rewritten: rcode=%d", pass, w.Rcode())
+		}
+	}
+
+	stored := h.storedTruth(t, "bad.test.")
+	if len(stored.Answer) != 1 || stored.Answer[0].(*dns.A).A.String() != "203.0.113.10" {
+		t.Fatalf("the cache does not hold the truth: %v", stored.Answer)
+	}
+}
+
+// TestNoneCandidatesServeBytes pins the fast-path half: a hit whose
+// sidecar matched nothing serves on the byte path — the commit-time
+// count is the proof it stayed there.
+func TestNoneCandidatesServeBytes(t *testing.T) {
+	h := newSidecarHarness(t, "enforce", config.RPZZone{Name: "resp", File: writeZone(t, respTestZone)})
+	h.truth["clean.test."] = "198.51.100.1"
+
+	h.serve(t, "clean.test.", "192.0.2.1:40000", true)
+	before := h.spy.countHits
+	w := h.serve(t, "clean.test.", "192.0.2.1:40000", true)
+	if !w.Written() || len(w.Msg().Answer) != 1 {
+		t.Fatal("clean hit did not answer the truth")
+	}
+	if h.spy.countHits != before+1 {
+		t.Fatalf("clean hit did not serve bytes (count %d -> %d)", before, h.spy.countHits)
+	}
+}
+
+// TestP0HeldQNAMEOverridesANoneSidecar is the review's P0 scenario
+// verbatim: zone 1 carries response-IP rules that do NOT match the
+// answer, zone 2's QNAME rule does — the query answers NXDOMAIN on the
+// miss AND on the hit, never the stored truth.
+func TestP0HeldQNAMEOverridesANoneSidecar(t *testing.T) {
+	h := newSidecarHarness(t, "enforce",
+		config.RPZZone{Name: "resp", File: writeZone(t, respTestZone)},
+		config.RPZZone{Name: "names", File: writeZone(t, qnameTestZone)},
+	)
+	h.truth["victim.example.com."] = "198.51.100.7" // matches no response rule
+
+	for _, pass := range []string{"miss", "hit"} {
+		w := h.serve(t, "victim.example.com.", "192.0.2.1:40000", true)
+		if !w.Written() || w.Rcode() != dns.RcodeNameError {
+			t.Fatalf("%s: held QNAME candidate lost to a none sidecar: rcode=%d", pass, w.Rcode())
+		}
+	}
+	stored := h.storedTruth(t, "victim.example.com.")
+	if len(stored.Answer) != 1 {
+		t.Fatal("the truth was not cached under the rewrite")
+	}
+}
+
+// TestPerClientOutcomesOverOneEntry pins the C3 scenario: a CLIENT-IP
+// PASSTHRU client reads the truth from the same entry a plain client is
+// rewritten from.
+func TestPerClientOutcomesOverOneEntry(t *testing.T) {
+	const mixedZone = `
+rpz.test. IN SOA ns.rpz.test. admin.rpz.test. 3 3600 900 604800 300
+32.9.2.0.192.rpz-client-ip.rpz.test. IN CNAME rpz-passthru.
+24.0.113.0.203.rpz-ip.rpz.test.      IN CNAME .
+`
+	h := newSidecarHarness(t, "enforce", config.RPZZone{Name: "mixed", File: writeZone(t, mixedZone)})
+	h.truth["bad.test."] = "203.0.113.10"
+
+	// The plain client primes the entry and is rewritten.
+	if w := h.serve(t, "bad.test.", "192.0.2.55:40000", true); w.Rcode() != dns.RcodeNameError {
+		t.Fatalf("plain client not rewritten: %d", w.Rcode())
+	}
+	// The exempted client reads the truth from the same entry.
+	w := h.serve(t, "bad.test.", "192.0.2.9:40000", true)
+	if w.Rcode() != dns.RcodeSuccess || len(w.Msg().Answer) != 1 {
+		t.Fatalf("PASSTHRU client did not get the truth: rcode=%d", w.Rcode())
+	}
+	// And the plain client keeps being rewritten afterwards.
+	if w := h.serve(t, "bad.test.", "192.0.2.55:40000", true); w.Rcode() != dns.RcodeNameError {
+		t.Fatalf("plain client served the truth after the exempted read: %d", w.Rcode())
+	}
+}
+
+// TestReloadReevaluatesStaleSidecars pins §5.6 item 5 end to end: an
+// entry stamped "none" under generation N must not keep serving bytes
+// after a reload whose rules newly match it — the first serve under N+1
+// re-evaluates and answers from the fresh result.
+func TestReloadReevaluatesStaleSidecars(t *testing.T) {
+	// The initial rules miss 198.51.100.20; the reload adds a rule that
+	// hits it.
+	path := writeZone(t, respTestZone)
+	h := newSidecarHarness(t, "enforce", config.RPZZone{Name: "resp", File: path})
+	h.truth["moving.test."] = "198.51.100.20"
+
+	h.serve(t, "moving.test.", "192.0.2.1:40000", true)
+	if w := h.serve(t, "moving.test.", "192.0.2.1:40000", true); w.Rcode() != dns.RcodeSuccess {
+		t.Fatalf("pre-reload hit: %d", w.Rcode())
+	}
+
+	writeZoneTo(t, path, respTestZone+"32.20.100.51.198.rpz-ip.rpz.test. IN CNAME .\n")
+	h.r.reload(0)
+
+	if w := h.serve(t, "moving.test.", "192.0.2.1:40000", true); w.Rcode() != dns.RcodeNameError {
+		t.Fatalf("a stale none sidecar kept serving the truth after the reload: %d", w.Rcode())
+	}
+}
+
+// TestAdmissionDoorsLeaveEvaluatedSidecars pins the §6 bullet with the
+// real evaluator: an entry admitted through the store's direct door
+// carries a generation-stamped match list.
+func TestAdmissionDoorsLeaveEvaluatedSidecars(t *testing.T) {
+	h := newSidecarHarness(t, "enforce", config.RPZZone{Name: "resp", File: writeZone(t, respTestZone)})
+
+	resp := new(dns.Msg)
+	resp.SetQuestion("direct.test.", dns.TypeA)
+	resp.Response = true
+	resp.Answer = []dns.RR{testA("direct.test.", "203.0.113.10")}
+	h.c.Store().(middleware.CutStore).SetFromResponseWithCut(resp, false, time.Time{}, 0)
+
+	sc := h.storedEntry(t, "direct.test.").Sidecar()
+	if sc == nil {
+		t.Fatal("the direct admission door left an unevaluated entry")
+	}
+	rm, ok := sc.Value.(*rpzengine.ResponseMatches)
+	if !ok || rm.Gen != h.r.store.Load().Gen || len(rm.List) != 1 {
+		t.Fatalf("sidecar: %+v", sc.Value)
+	}
+}
+
+// TestCountingParityAcrossPaths pins the §6 counting bullet: the same
+// query over the same entry counts the same zone, trigger, action and
+// outcome whether the byte path or the decoded path served it.
+func TestCountingParityAcrossPaths(t *testing.T) {
+	h := newSidecarHarness(t, "enforce", config.RPZZone{Name: "resp", File: writeZone(t, respTestZone)})
+	h.truth["pass.test."] = "198.51.100.9" // the /32 PASSTHRU rule
+
+	counter := actionTotal.WithLabelValues("resp", rpzengine.TriggerResponseIP, "passthru", "enforced")
+	h.serve(t, "pass.test.", "192.0.2.1:40000", true) // miss: the wrap counts
+
+	base := testutil.ToFloat64(counter)
+	h.serve(t, "pass.test.", "192.0.2.1:40000", true) // byte-path hit
+	byteDelta := testutil.ToFloat64(counter) - base
+
+	base = testutil.ToFloat64(counter)
+	h.serve(t, "pass.test.", "192.0.2.1:40000", false) // decoded hit
+	decodedDelta := testutil.ToFloat64(counter) - base
+
+	if byteDelta != 1 || decodedDelta != 1 {
+		t.Fatalf("counting parity broken: byte=%v decoded=%v", byteDelta, decodedDelta)
+	}
+}
+
+// TestChaseFoldCountsAZoneOnce pins the fold: two segments matching the
+// same zone through different rules count that zone once, with the
+// rank-best match.
+func TestChaseFoldCountsAZoneOnce(t *testing.T) {
+	h := newSidecarHarness(t, "enforce", config.RPZZone{Name: "resp", File: writeZone(t, respTestZone)})
+	s := h.r.store.Load()
+
+	seg1 := s.EvaluateResponse([]dns.RR{testA("a.test.", "203.0.113.1")})  // /24 NXDOMAIN
+	seg2 := s.EvaluateResponse([]dns.RR{testA("b.test.", "198.51.100.9")}) // /32 PASSTHRU
+	var chain middleware.SidecarChain
+	chain.Append(&middleware.Sidecar{Value: seg1})
+	chain.Append(&middleware.Sidecar{Value: seg2})
+
+	counter := actionTotal.WithLabelValues("resp", rpzengine.TriggerResponseIP, "passthru", "enforced")
+	other := actionTotal.WithLabelValues("resp", rpzengine.TriggerResponseIP, "nxdomain", "enforced")
+	baseP, baseN := testutil.ToFloat64(counter), testutil.ToFloat64(other)
+	h.r.CountWireChase(chain)
+	if d := testutil.ToFloat64(counter) - baseP; d != 1 {
+		t.Fatalf("rank-best (/32 passthru) counted %v times", d)
+	}
+	if d := testutil.ToFloat64(other) - baseN; d != 0 {
+		t.Fatalf("the same zone was counted twice across segments (+%v nxdomain)", d)
+	}
+}
+
+// TestShadowObservesResponseMatches pins shadow on the response side:
+// nothing rewritten, the winner observed — both paths.
+func TestShadowObservesResponseMatches(t *testing.T) {
+	h := newSidecarHarness(t, "shadow", config.RPZZone{Name: "resp", File: writeZone(t, respTestZone)})
+	h.truth["bad.test."] = "203.0.113.10"
+
+	counter := actionTotal.WithLabelValues("resp", rpzengine.TriggerResponseIP, "nxdomain", "observed")
+	base := testutil.ToFloat64(counter)
+
+	if w := h.serve(t, "bad.test.", "192.0.2.1:40000", true); w.Rcode() != dns.RcodeSuccess {
+		t.Fatalf("shadow rewrote: %d", w.Rcode())
+	}
+	if w := h.serve(t, "bad.test.", "192.0.2.1:40000", true); w.Rcode() != dns.RcodeSuccess {
+		t.Fatalf("shadow rewrote the hit: %d", w.Rcode())
+	}
+	if d := testutil.ToFloat64(counter) - base; d != 2 {
+		t.Fatalf("shadow observed %v matches over miss+hit, want 2", d)
+	}
+}
+
+// writeZoneTo rewrites a zone fixture file in place.
+func writeZoneTo(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestEarlierResponseZoneDisplacesLaterQNAME is the other half of §5.4:
+// zone order outranks trigger type, so a held QNAME match in zone 2
+// loses to zone 1's response-IP match when the answer arrives. The two
+// rules prescribe different actions, so a wrong winner cannot pass.
+func TestEarlierResponseZoneDisplacesLaterQNAME(t *testing.T) {
+	const nodataQnameZone = `
+rpz.test. IN SOA ns.rpz.test. admin.rpz.test. 4 3600 900 604800 300
+victim.example.com.rpz.test. IN CNAME *.
+`
+	h := newSidecarHarness(t, "enforce",
+		config.RPZZone{Name: "resp", File: writeZone(t, respTestZone)},
+		config.RPZZone{Name: "names", File: writeZone(t, nodataQnameZone)},
+	)
+	h.truth["victim.example.com."] = "203.0.113.10" // matches zone 1's /24 NXDOMAIN
+
+	for _, pass := range []string{"miss", "hit"} {
+		w := h.serve(t, "victim.example.com.", "192.0.2.1:40000", true)
+		if !w.Written() || w.Rcode() != dns.RcodeNameError {
+			t.Fatalf("%s: zone 1's response match did not displace zone 2's QNAME (rcode=%d, want NXDOMAIN)", pass, w.Rcode())
+		}
+	}
+}
+
+// TestConcurrentReloadAndPolicedServe is the §6 -race bullet over the
+// full pipeline: readers serve a policed name while a writer reloads the
+// zone between two rule generations; every answer must be one
+// generation's whole outcome.
+func TestConcurrentReloadAndPolicedServe(t *testing.T) {
+	path := writeZone(t, respTestZone)
+	h := newSidecarHarness(t, "enforce", config.RPZZone{Name: "resp", File: path})
+	h.truth["bad.test."] = "203.0.113.10"
+	h.serve(t, "bad.test.", "192.0.2.1:40000", true) // prime the entry
+
+	// Generation A: the /24 rule says NXDOMAIN. Generation B: NODATA.
+	const genB = `
+rpz.test. IN SOA ns.rpz.test. admin.rpz.test. 9 3600 900 604800 300
+24.0.113.0.203.rpz-ip.rpz.test. IN CNAME *.
+`
+	stop := make(chan struct{})
+	torn := make(chan string, 8)
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(stop)
+		for i := range 60 {
+			if i%2 == 0 {
+				writeZoneTo(t, path, genB)
+			} else {
+				writeZoneTo(t, path, respTestZone)
+			}
+			h.r.reload(0)
+		}
+	}()
+	for range 3 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				w := h.serve(t, "bad.test.", "192.0.2.1:40000", true)
+				if !w.Written() {
+					torn <- "no answer"
+					return
+				}
+				rc := w.Rcode()
+				nodata := rc == dns.RcodeSuccess && len(w.Msg().Answer) == 0
+				if rc != dns.RcodeNameError && !nodata {
+					torn <- "neither generation's outcome: rcode=" + dns.RcodeToString[rc]
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	select {
+	case msg := <-torn:
+		t.Fatal(msg)
+	default:
+	}
+}

--- a/middleware/rpz/sidecar_test.go
+++ b/middleware/rpz/sidecar_test.go
@@ -342,28 +342,45 @@ func TestCountingParityAcrossPaths(t *testing.T) {
 	}
 }
 
-// TestChaseFoldCountsAZoneOnce pins the fold: two segments matching the
-// same zone through different rules count that zone once, with the
-// rank-best match.
-func TestChaseFoldCountsAZoneOnce(t *testing.T) {
+// TestChaseCountsAZoneOnceWithTheRankBest pins §5.6 item 4 end to end: a
+// chase whose composed answer matches one zone through two competing
+// rules counts that zone exactly once, with the rule-4 best — the gate
+// sends any matching chase to the decoded path, whose composed answer
+// the wrap evaluates whole, so the dedupe holds by construction.
+func TestChaseCountsAZoneOnceWithTheRankBest(t *testing.T) {
 	h := newSidecarHarness(t, "enforce", config.RPZZone{Name: "resp", File: writeZone(t, respTestZone)})
-	s := h.r.store.Load()
 
-	seg1 := s.EvaluateResponse([]dns.RR{testA("a.test.", "203.0.113.1")})  // /24 NXDOMAIN
-	seg2 := s.EvaluateResponse([]dns.RR{testA("b.test.", "198.51.100.9")}) // /32 PASSTHRU
-	var chain middleware.SidecarChain
-	chain.Append(&middleware.Sidecar{Value: seg1})
-	chain.Append(&middleware.Sidecar{Value: seg2})
+	alias := new(dns.Msg)
+	alias.SetQuestion("alias.chase.test.", dns.TypeA)
+	alias.Response = true
+	cn, err := dns.NewRR("alias.chase.test. 300 IN CNAME t.chase.test.")
+	if err != nil {
+		t.Fatal(err)
+	}
+	alias.Answer = []dns.RR{cn}
+	h.cacheStore().SetFromResponseWithCut(alias, false, time.Time{}, 0)
+
+	target := new(dns.Msg)
+	target.SetQuestion("t.chase.test.", dns.TypeA)
+	target.Response = true
+	// Two addresses under one zone's competing rules: the /24 says
+	// NXDOMAIN, the /32 says PASSTHRU — rule 4 picks the /32.
+	target.Answer = []dns.RR{testA("t.chase.test.", "203.0.113.5"), testA("t.chase.test.", "198.51.100.9")}
+	h.cacheStore().SetFromResponseWithCut(target, false, time.Time{}, 0)
 
 	counter := actionTotal.WithLabelValues("resp", rpzengine.TriggerResponseIP, "passthru", "enforced")
 	other := actionTotal.WithLabelValues("resp", rpzengine.TriggerResponseIP, "nxdomain", "enforced")
 	baseP, baseN := testutil.ToFloat64(counter), testutil.ToFloat64(other)
-	h.r.CountWireChase(chain)
+
+	w := h.serve(t, "alias.chase.test.", "192.0.2.1:40000", true)
+	if !w.Written() || w.Rcode() != dns.RcodeSuccess {
+		t.Fatalf("PASSTHRU chase did not serve the truth: rcode=%d", w.Rcode())
+	}
 	if d := testutil.ToFloat64(counter) - baseP; d != 1 {
-		t.Fatalf("rank-best (/32 passthru) counted %v times", d)
+		t.Fatalf("rank-best (/32 passthru) counted %v times, want 1", d)
 	}
 	if d := testutil.ToFloat64(other) - baseN; d != 0 {
-		t.Fatalf("the same zone was counted twice across segments (+%v nxdomain)", d)
+		t.Fatalf("the zone was counted twice across the chase (+%v nxdomain)", d)
 	}
 }
 
@@ -478,5 +495,112 @@ rpz.test. IN SOA ns.rpz.test. admin.rpz.test. 9 3600 900 604800 300
 	case msg := <-torn:
 		t.Fatal(msg)
 	default:
+	}
+}
+
+// TestFinalWinnerSilencesLaterResponseZones pins the winner-bounded cut
+// across the phases' seam: a final query-time winner in zone 0 leaves
+// response zones after it uncounted — in shadow, where the query
+// continues, exactly as in enforce, where it never leaves rpz. Anything
+// else makes the two modes' counters incomparable.
+func TestFinalWinnerSilencesLaterResponseZones(t *testing.T) {
+	const qnameFirstZone = `
+rpz.test. IN SOA ns.rpz.test. admin.rpz.test. 6 3600 900 604800 300
+victim.example.com.rpz.test. IN CNAME .
+`
+	respAfter := actionTotal.WithLabelValues("resp", rpzengine.TriggerResponseIP, "nxdomain", "observed")
+
+	for _, mode := range []string{"shadow", "enforce"} {
+		h := newSidecarHarness(t, mode,
+			config.RPZZone{Name: "names", File: writeZone(t, qnameFirstZone)},
+			config.RPZZone{Name: "resp", File: writeZone(t, respTestZone)},
+		)
+		h.truth["victim.example.com."] = "203.0.113.10" // matches zone 1's response rule
+
+		base := testutil.ToFloat64(respAfter)
+		h.serve(t, "victim.example.com.", "192.0.2.1:40000", true) // miss
+		h.serve(t, "victim.example.com.", "192.0.2.1:40000", true) // hit
+		if d := testutil.ToFloat64(respAfter) - base; d != 0 {
+			t.Fatalf("%s: a response zone past the final winner was counted %v times", mode, d)
+		}
+	}
+}
+
+// TestCleanServesAllocateNoMoreWithResponseRules pins §5.11 against the
+// two allocation regressions the review found: with response rules
+// configured, the all-candidates-none wire hit and the clean admission
+// must cost exactly what a qname-only configuration costs — the wrap is
+// pooled and the explicit none is the generation's shared sentinel.
+func TestCleanServesAllocateNoMoreWithResponseRules(t *testing.T) {
+	const qnameOnlyZone = `
+rpz.test. IN SOA ns.rpz.test. admin.rpz.test. 7 3600 900 604800 300
+victim.example.com.rpz.test. IN CNAME .
+`
+	measure := func(h *sidecarHarness) (hit, admit float64) {
+		h.truth["clean.test."] = "198.51.100.1"
+		h.serve(t, "clean.test.", "192.0.2.1:40000", true) // prime
+
+		q := new(dns.Msg)
+		q.SetQuestion("clean.test.", dns.TypeA)
+		q.RecursionDesired = true
+		raw, err := q.Pack()
+		if err != nil {
+			t.Fatal(err)
+		}
+		req := new(middleware.Request)
+		if !req.ParseWire(raw, time.Now(), nil) {
+			t.Fatal("refused")
+		}
+		w := mock.NewWriter("udp", "192.0.2.1:40000")
+		ch := middleware.NewChain([]middleware.Handler{h.r, h.c, h.authority()})
+		hit = testing.AllocsPerRun(200, func() {
+			ch.ResetWire(w, req)
+			ch.AllowDirectPack()
+			ch.Next(context.Background())
+		})
+
+		resp := new(dns.Msg)
+		resp.SetQuestion("admit.test.", dns.TypeA)
+		resp.Response = true
+		resp.Answer = []dns.RR{testA("admit.test.", "198.51.100.1")}
+		admit = testing.AllocsPerRun(200, func() {
+			h.cacheStore().SetFromResponseWithCut(resp, false, time.Time{}, 0)
+		})
+		return hit, admit
+	}
+
+	base := newSidecarHarness(t, "enforce", config.RPZZone{Name: "names", File: writeZone(t, qnameOnlyZone)})
+	baseHit, baseAdmit := measure(base)
+	resp := newSidecarHarness(t, "enforce", config.RPZZone{Name: "resp", File: writeZone(t, respTestZone)})
+	respHit, respAdmit := measure(resp)
+
+	if respHit > baseHit {
+		t.Fatalf("clean wire hit allocates %.1f with response rules vs %.1f without", respHit, baseHit)
+	}
+	if respAdmit > baseAdmit {
+		t.Fatalf("clean admission allocates %.1f with response rules vs %.1f without", respAdmit, baseAdmit)
+	}
+}
+
+// TestExplicitNoneIsTheSharedSentinel pins the none representation
+// directly: two clean admissions carry the same sidecar object — the
+// generation's sentinel — not one allocation each.
+func TestExplicitNoneIsTheSharedSentinel(t *testing.T) {
+	h := newSidecarHarness(t, "enforce", config.RPZZone{Name: "resp", File: writeZone(t, respTestZone)})
+
+	for _, name := range []string{"one.none.test.", "two.none.test."} {
+		resp := new(dns.Msg)
+		resp.SetQuestion(name, dns.TypeA)
+		resp.Response = true
+		resp.Answer = []dns.RR{testA(name, "198.51.100.1")}
+		h.cacheStore().SetFromResponseWithCut(resp, false, time.Time{}, 0)
+	}
+	one := h.storedEntry(t, "one.none.test.").Sidecar()
+	two := h.storedEntry(t, "two.none.test.").Sidecar()
+	if one == nil || one != two {
+		t.Fatal("clean admissions do not share the generation's none sentinel")
+	}
+	if one != h.r.store.Load().none {
+		t.Fatal("the stamped none is not the published generation's own")
 	}
 }

--- a/middleware/rpz/sidecar_test.go
+++ b/middleware/rpz/sidecar_test.go
@@ -8,8 +8,10 @@ import (
 	"time"
 
 	"github.com/miekg/dns"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/metric"
 	"github.com/semihalev/sdns/internal/mock"
 	rpzengine "github.com/semihalev/sdns/internal/rpz"
 	"github.com/semihalev/sdns/middleware"
@@ -154,6 +156,33 @@ func (h *sidecarHarness) serve(t *testing.T, qname, clientAddr string, bytePath 
 	return w
 }
 
+// wireServed reads the cache's byte-fast-path counter for one outcome
+// ("served" for exact hits, "chase_served" for compositions) through the
+// prometheus registry — the only honest way to tell a byte serve from a
+// decoded one: on a direct-pack chain even decoded WriteMsg reaches the
+// transport as raw bytes, so the transport cannot testify.
+func wireServed(t *testing.T, outcome string) float64 {
+	t.Helper()
+	metric.FlushAll()
+	fams, err := prometheus.DefaultGatherer.Gather()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range fams {
+		if f.GetName() != "dns_cache_wire_fastpath_total" {
+			continue
+		}
+		for _, m := range f.GetMetric() {
+			for _, l := range m.GetLabel() {
+				if l.GetName() == "outcome" && l.GetValue() == outcome {
+					return m.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+	return 0
+}
+
 // cacheStore reaches the concrete store behind the wiring interface.
 func (h *sidecarHarness) cacheStore() *cache.Store {
 	return h.c.Store().(*cache.Store)
@@ -206,20 +235,19 @@ func TestTruthInCacheRewriteToClient(t *testing.T) {
 }
 
 // TestNoneCandidatesServeBytes pins the fast-path half: a hit whose
-// sidecar matched nothing serves on the byte path — the commit-time
-// count is the proof it stayed there.
+// sidecar matched nothing serves on the byte path.
 func TestNoneCandidatesServeBytes(t *testing.T) {
 	h := newSidecarHarness(t, "enforce", config.RPZZone{Name: "resp", File: writeZone(t, respTestZone)})
 	h.truth["clean.test."] = "198.51.100.1"
 
 	h.serve(t, "clean.test.", "192.0.2.1:40000", true)
-	before := h.spy.countHits
+	before := wireServed(t, "served")
 	w := h.serve(t, "clean.test.", "192.0.2.1:40000", true)
 	if !w.Written() || len(w.Msg().Answer) != 1 {
 		t.Fatal("clean hit did not answer the truth")
 	}
-	if h.spy.countHits != before+1 {
-		t.Fatalf("clean hit did not serve bytes (count %d -> %d)", before, h.spy.countHits)
+	if wireServed(t, "served")-before != 1 {
+		t.Fatal("clean hit did not serve on the byte fast path")
 	}
 }
 
@@ -321,7 +349,11 @@ func TestAdmissionDoorsLeaveEvaluatedSidecars(t *testing.T) {
 
 // TestCountingParityAcrossPaths pins the §6 counting bullet: the same
 // query over the same entry counts the same zone, trigger, action and
-// outcome whether the byte path or the decoded path served it.
+// outcome whether the byte path or the decoded path served it — and the
+// byte leg is proven to actually BE the byte path: a matched PASSTHRU
+// hit serves raw bytes, counted through the gate's memoized decision at
+// the commit, with no decode anywhere (§5.6's field-reads-and-counters
+// serve flow).
 func TestCountingParityAcrossPaths(t *testing.T) {
 	h := newSidecarHarness(t, "enforce", config.RPZZone{Name: "resp", File: writeZone(t, respTestZone)})
 	h.truth["pass.test."] = "198.51.100.9" // the /32 PASSTHRU rule
@@ -330,12 +362,24 @@ func TestCountingParityAcrossPaths(t *testing.T) {
 	h.serve(t, "pass.test.", "192.0.2.1:40000", true) // miss: the wrap counts
 
 	base := testutil.ToFloat64(counter)
-	h.serve(t, "pass.test.", "192.0.2.1:40000", true) // byte-path hit
+	servedBase := wireServed(t, "served")
+	w := h.serve(t, "pass.test.", "192.0.2.1:40000", true)
 	byteDelta := testutil.ToFloat64(counter) - base
+	if wireServed(t, "served")-servedBase != 1 {
+		t.Fatal("the matched PASSTHRU hit decoded; §5.11 wants it on the wire path")
+	}
+	if !w.Written() || w.Rcode() != dns.RcodeSuccess || len(w.Msg().Answer) != 1 {
+		t.Fatal("byte-path hit did not serve the truth")
+	}
 
 	base = testutil.ToFloat64(counter)
-	h.serve(t, "pass.test.", "192.0.2.1:40000", false) // decoded hit
+	servedBase = wireServed(t, "served")
+	w = h.serve(t, "pass.test.", "192.0.2.1:40000", false) // decoded hit
 	decodedDelta := testutil.ToFloat64(counter) - base
+	if wireServed(t, "served")-servedBase != 0 {
+		t.Fatal("the decoded leg served bytes; the parity comparison measured nothing")
+	}
+	_ = w
 
 	if byteDelta != 1 || decodedDelta != 1 {
 		t.Fatalf("counting parity broken: byte=%v decoded=%v", byteDelta, decodedDelta)
@@ -396,8 +440,13 @@ func TestShadowObservesResponseMatches(t *testing.T) {
 	if w := h.serve(t, "bad.test.", "192.0.2.1:40000", true); w.Rcode() != dns.RcodeSuccess {
 		t.Fatalf("shadow rewrote: %d", w.Rcode())
 	}
-	if w := h.serve(t, "bad.test.", "192.0.2.1:40000", true); w.Rcode() != dns.RcodeSuccess {
+	servedBase := wireServed(t, "served")
+	w := h.serve(t, "bad.test.", "192.0.2.1:40000", true)
+	if w.Rcode() != dns.RcodeSuccess {
 		t.Fatalf("shadow rewrote the hit: %d", w.Rcode())
+	}
+	if wireServed(t, "served")-servedBase != 1 {
+		t.Fatal("shadow's matched hit decoded; observation must not cost the wire path")
 	}
 	if d := testutil.ToFloat64(counter) - base; d != 2 {
 		t.Fatalf("shadow observed %v matches over miss+hit, want 2", d)

--- a/middleware/rpz/sidecar_test.go
+++ b/middleware/rpz/sidecar_test.go
@@ -3,6 +3,7 @@ package rpz
 import (
 	"context"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -651,5 +652,88 @@ func TestExplicitNoneIsTheSharedSentinel(t *testing.T) {
 	}
 	if one != h.r.store.Load().none {
 		t.Fatal("the stamped none is not the published generation's own")
+	}
+}
+
+// TestVanishedRulesStillCountHeldObservations pins the review's P1: a
+// policed wrap installed while response triggers existed carries
+// disabled query-time observations; a reload that drops the last
+// response trigger before the judge must not shortcut past them — they
+// count under any generation, so the judge still produces the decision
+// token and the commit still counts exactly once.
+func TestVanishedRulesStillCountHeldObservations(t *testing.T) {
+	const disabledQnameZone = `
+rpz.test. IN SOA ns.rpz.test. admin.rpz.test. 8 3600 900 604800 300
+victim.example.com.rpz.test. IN CNAME *.
+`
+	// The zone is disabled; its QNAME match is an observation.
+	h := newSidecarHarness(t, "enforce", config.RPZZone{
+		Name: "obs", File: writeZone(t, disabledQnameZone), Policy: "disabled",
+	})
+	s := h.r.store.Load()
+	if s.HasResponseIP() {
+		t.Fatal("fixture must have no response rules at judge time")
+	}
+	held := rpzengine.ZoneMatch{
+		ZoneIdx: 0, Zone: s.Zones[0],
+		Rule: &rpzengine.Rule{Action: rpzengine.ActionNODATA}, Trigger: rpzengine.TriggerQNAME,
+	}
+	wrap := &responseWrap{r: h.r, mode: wrapPoliced, heldObserved: []rpzengine.ZoneMatch{held}}
+
+	counter := actionTotal.WithLabelValues("obs", rpzengine.TriggerQNAME, "nodata", "observed")
+	base := testutil.ToFloat64(counter)
+	if v := wrap.JudgeWireHit(nil); v != middleware.WireHitServe {
+		t.Fatalf("verdict = %v, want Serve", v)
+	}
+	wrap.CountWireHit(nil)
+	if d := testutil.ToFloat64(counter) - base; d != 1 {
+		t.Fatalf("the held observation was dropped with the vanished rules: counted %v times", d)
+	}
+	// Exactly once: a second commit without a new judge counts nothing.
+	wrap.CountWireHit(nil)
+	if d := testutil.ToFloat64(counter) - base; d != 1 {
+		t.Fatalf("the decision was counted twice: %v", d)
+	}
+}
+
+// TestAbandonedDecisionIsNotCountedLater pins the review's P2: a judge
+// that memoized a decision and was abandoned before its commit must not
+// leak that memo into a later judge's commit — every judge voids the
+// token first, and only its own Serve re-arms it.
+func TestAbandonedDecisionIsNotCountedLater(t *testing.T) {
+	h := newSidecarHarness(t, "shadow", config.RPZZone{Name: "resp", File: writeZone(t, respTestZone)})
+	s := h.r.store.Load()
+	sc := &middleware.Sidecar{Value: &rpzengine.ResponseMatches{
+		Gen:  s.Gen,
+		List: s.EvaluateResponseList([]dns.RR{testA("x.test.", "203.0.113.10")}),
+	}}
+	wrap := &responseWrap{r: h.r, mode: wrapPoliced}
+
+	// Judge 1 memoizes a shadow observation and is then abandoned.
+	if v := wrap.JudgeWireHit(sc); v != middleware.WireHitServe {
+		t.Fatalf("first verdict = %v, want Serve", v)
+	}
+
+	// The world changes: the reload drops every response rule.
+	const qnameOnly = `
+rpz.test. IN SOA ns.rpz.test. admin.rpz.test. 9 3600 900 604800 300
+victim.example.com.rpz.test. IN CNAME .
+`
+	z, err := rpzengine.LoadZone("resp", strings.NewReader(qnameOnly), "reload", rpzengine.OverrideGiven, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	h.r.publishStore(&rpzengine.Store{Zones: []*rpzengine.Zone{z}})
+
+	// Judge 2 finds nothing to decide; the commit after it must count
+	// nothing — never judge 1's stale memo.
+	counter := actionTotal.WithLabelValues("resp", rpzengine.TriggerResponseIP, "nxdomain", "observed")
+	base := testutil.ToFloat64(counter)
+	if v := wrap.JudgeWireHit(sc); v != middleware.WireHitServe {
+		t.Fatalf("second verdict = %v, want Serve", v)
+	}
+	wrap.CountWireHit(sc)
+	if d := testutil.ToFloat64(counter) - base; d != 0 {
+		t.Fatalf("an abandoned judge's decision was counted by a later commit: %v", d)
 	}
 }

--- a/middleware/sidecar.go
+++ b/middleware/sidecar.go
@@ -85,13 +85,17 @@ func (c *SidecarChain) At(i int) *Sidecar { return c.scs[i] }
 // Composite denial classes (subtree cuts, failure state) carry no stored
 // records and are never gated.
 //
-// The Judge methods are pure decisions computed from the sidecars alone —
-// per-query policy state belongs to the policy middleware's own
-// query-time hold, which steers queries off the byte path entirely by
-// withholding its writer's wire capability. Accounting is separate: the
-// Count methods fire exactly once per byte-served hit, after the bytes
-// were committed to the transport — the only point where a byte serve
-// can no longer fall back to the decoded path and be counted twice.
+// The Judge methods are deterministic decisions over the sidecars and —
+// for a per-query gate obtained through QueryPolicyGate — that query's
+// own policy state. A per-query gate may memoize the decision it judged;
+// the matching Count method then records exactly that decision, which is
+// what keeps a judge/commit pair coherent across a concurrent policy
+// reload. Accounting fires exactly once per byte-served hit, after the
+// bytes were committed to the transport — the only point where a byte
+// serve can no longer fall back to the decoded path and be counted
+// twice. Queries whose policy work must all happen on the decoded path
+// are steered off the byte path by the policy writer withholding its
+// wire capability.
 type WireHitGate interface {
 	// JudgeWireHit judges a single-entry byte serve. sc is the entry's
 	// sidecar; nil means unevaluated.
@@ -105,6 +109,17 @@ type WireHitGate interface {
 	CountWireHit(sc *Sidecar)
 	// CountWireChase is CountWireHit for a committed chase composition.
 	CountWireChase(sidecars SidecarChain)
+}
+
+// QueryPolicyGate is implemented by a policy middleware's response
+// writer to carry this query's own gate — the channel through which
+// query-time state (held candidates, a decision that already fell, an
+// exemption) reaches the byte-serve judgment. When the writer offers
+// one, the cache consults it instead of the globally wired gate, judge
+// and count alike, for the whole hit. A nil return falls back to the
+// global gate.
+type QueryPolicyGate interface {
+	QueryWireHitGate() WireHitGate
 }
 
 // SidecarPolicyProvider is implemented by the handler that owns response


### PR DESCRIPTION
The final trigger phase of task #32, built on #601's Store seam exactly as docs/rpz-design.md §5.6 prescribes: **the cache stores the truth, policy state rides beside entries, and the action is chosen at serve time.**

## Engine (internal/rpz)

- `rpz-ip` owners parse with CLIENT-IP's encoding (shared insert core, two filings) into their own family-separated LPM tables — an A record is never judged by a v6 rule.
- `EvaluateResponse` computes one rule-4 best match per zone over an answer's A/AAAA records (longest prefix; equal → numerically smaller 128-bit address, v4 mapped +96), **uniformly over enabled, disabled, and shadow zones** — the winner is the query's property, never the entry's. Local Data candidates are deep copies; nothing in a candidate points into any store.
- `Merge` is the serve-time selection: rule 1 over enabled zones, rule 2 (CLIENT-IP > QNAME > IP) within one, disabled observes without consuming, winner-bounded output for counting.
- `FoldResponseLists` collapses a chase's segment lists to one rank-best match per zone.
- Stores carry a generation, assigned at every publish through one seam.

## Middleware (middleware/rpz)

- **Evaluator**: stamps every admission with the generation-tagged match list; nil when no zone carries response rules — the seam stays off entirely.
- **Gate**: stale generation → Restamp (the decoded serve re-evaluates); none → Serve; enforcing non-PASSTHRU winner → Decode; counting fires only on the committed byte serve.
- **§5.4 hold**: a query-time match is final immediately iff no earlier zone carries response triggers. Held candidates ride a response wrap that withholds the wire capability, merges held + fresh candidates over the outgoing message, counts winner-bounded, and applies the action in enforce (synthesis reuses phase 1's own paths).
- The wrap installs only when response rules exist, so the **qname-only zero-allocation pin stands unchanged**; with response rules live the per-query wrap is the serve-path cost §5.11's bench A/B measures before enforce anywhere.

## §6 exit criteria, as tests

Truth stored byte-identical under a rewrite (miss + hit) · the P0 scenario verbatim (held QNAME survives a none sidecar) · its inverse with competing actions (earlier response zone displaces later QNAME) · CLIENT-IP PASSTHRU client reads the truth from the same entry a plain client is rewritten from · reload re-evaluates stale sidecars on the next hit · every admission door leaves evaluated sidecars · counting parity across byte and decoded paths · chase fold counts a zone once with the rank-best match · shadow observes without rewriting on both paths · concurrent reload+serve under `-race` · old-generation collectibility proven by a finalizer on the store's own record while a deep-copied candidate lives on.

**9/9 guard mutations killed** (generation check, deep copy, hold, wire-hiding, uniform list, fold dedupe, rule 4, disabled consumption, wrap rewrite). Full suite, `-race`, vet, lint clean.

## Still gated before enforce

The §5.11 bench A/B repeated with sidecars live, and the shadow soak — both operational steps after merge, per the design's rollout discipline.