### PR TITLE
RPZ coverage-gap round: the untested real paths

### DIFF
--- a/internal/rpz/responseip_test.go
+++ b/internal/rpz/responseip_test.go
@@ -315,3 +315,66 @@ func TestFoldResponseLists(t *testing.T) {
 		t.Fatalf("fold is order-sensitive: %+v", folded)
 	}
 }
+
+// TestInsertResponseIPSharedSemantics pins that the response trigger
+// inherited the address-rule filing discipline whole: Local Data merges
+// at one prefix, a conflicting action class is skipped, the bare marker
+// owns no address, and an unknown rpz-* action is skipped.
+func TestInsertResponseIPSharedSemantics(t *testing.T) {
+	z, err := LoadZone("sem", strings.NewReader(`
+rpz.test. IN SOA ns.rpz.test. admin.rpz.test. 1 3600 900 604800 300
+24.0.2.0.192.rpz-ip.rpz.test. IN A 203.0.113.1
+24.0.2.0.192.rpz-ip.rpz.test. IN A 203.0.113.2
+24.0.2.0.192.rpz-ip.rpz.test. IN CNAME .
+rpz-ip.rpz.test.              IN CNAME .
+32.9.9.9.9.rpz-ip.rpz.test.   IN CNAME rpz-bogus.
+`), "sem.zone", OverrideGiven, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if z.RulesResponseIP != 1 {
+		t.Fatalf("RulesResponseIP = %d, want 1 (skips: %v)", z.RulesResponseIP, z.Skipped)
+	}
+	s := &Store{Zones: []*Zone{z}}
+	rm := s.EvaluateResponse([]dns.RR{answerA("192.0.2.9")})
+	if len(rm.List) != 1 || rm.List[0].Action != ActionLocalData || len(rm.List[0].Local) != 2 {
+		t.Fatalf("local-data merge broken: %+v", rm.List)
+	}
+	want := map[string]int{SkipConflict: 1, SkipOwnerEncoding: 1, SkipUnknownAction: 1}
+	for reason, n := range want {
+		if z.Skipped[reason] != n {
+			t.Fatalf("skip %s = %d, want %d (all: %v)", reason, z.Skipped[reason], n, z.Skipped)
+		}
+	}
+}
+
+// TestFoldOrdersAcrossZones pins the fold's ordering with more than one
+// zone: whatever order the segment lists arrive in, the folded output is
+// ascending by zone index — the shape Merge's single walk requires.
+func TestFoldOrdersAcrossZones(t *testing.T) {
+	z0 := loadResponseIPZone(t)
+	z1 := loadResponseIPZone(t)
+	s := &Store{Zones: []*Zone{z0, z1}}
+
+	both := s.EvaluateResponseList([]dns.RR{answerA("192.0.2.1")}) // matches zones 0 and 1
+	onlyLater := []ResponseMatch{both[1]}
+	onlyEarlier := []ResponseMatch{both[0]}
+
+	folded := FoldResponseLists(onlyLater, onlyEarlier)
+	if len(folded) != 2 || folded[0].ZoneIdx != 0 || folded[1].ZoneIdx != 1 {
+		t.Fatalf("fold output not ascending by zone: %+v", folded)
+	}
+}
+
+// TestTriggerRankOrdering pins precedence rule 2's ladder directly.
+func TestTriggerRankOrdering(t *testing.T) {
+	if triggerRank(TriggerClientIP) <= triggerRank(TriggerQNAME) {
+		t.Fatal("CLIENT-IP must outrank QNAME")
+	}
+	if triggerRank(TriggerQNAME) <= triggerRank(TriggerResponseIP) {
+		t.Fatal("QNAME must outrank IP")
+	}
+	if triggerRank(TriggerResponseIP) <= triggerRank("nonsense") {
+		t.Fatal("IP must outrank the unknown")
+	}
+}

--- a/middleware/rpz/coverage_gaps_test.go
+++ b/middleware/rpz/coverage_gaps_test.go
@@ -1,0 +1,195 @@
+package rpz
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/mock"
+	rpzengine "github.com/semihalev/sdns/internal/rpz"
+	"github.com/semihalev/sdns/middleware"
+)
+
+// The coverage-gap round: paths the arc's tests drove only indirectly
+// or not at all — the feed's real lifecycle loop, the neutral global
+// gate's exempt-query contract, the response wrap's remaining actions,
+// and the decoded request path.
+
+// serveProto is serve with the transport under test.
+func (h *sidecarHarness) serveProto(t *testing.T, qname, proto string) *mock.Writer {
+	t.Helper()
+	q := new(dns.Msg)
+	q.SetQuestion(qname, dns.TypeA)
+	q.RecursionDesired = true
+	raw, err := q.Pack()
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := new(middleware.Request)
+	if !req.ParseWire(raw, time.Now(), nil) {
+		t.Fatal("refused")
+	}
+	w := mock.NewWriter(proto, "192.0.2.1:40000")
+	ch := middleware.NewChain([]middleware.Handler{h.r, h.c, h.authority()})
+	ch.ResetWire(w, req)
+	ch.AllowDirectPack()
+	ch.Next(context.Background())
+	return w
+}
+
+// TestResponseActionsEndToEnd drives the wrap's remaining actions over
+// real resolutions: DROP swallows the reply, TCP-Only truncates UDP and
+// passes other transports, NODATA empties the answer, and Local Data
+// answers with the rule's records on the client's qname.
+func TestResponseActionsEndToEnd(t *testing.T) {
+	const actionZone = `
+rpz.test. IN SOA ns.rpz.test. admin.rpz.test. 1 3600 900 604800 300
+24.0.113.0.203.rpz-ip.rpz.test. IN CNAME rpz-drop.
+24.0.100.51.198.rpz-ip.rpz.test. IN CNAME rpz-tcp-only.
+24.0.2.0.192.rpz-ip.rpz.test.   IN CNAME *.
+16.0.0.0.10.rpz-ip.rpz.test.    IN A 203.0.113.53
+`
+	h := newSidecarHarness(t, "enforce", config.RPZZone{Name: "act", File: writeZone(t, actionZone)})
+	h.truth["dropme.test."] = "203.0.113.5"
+	h.truth["tcpme.test."] = "198.51.100.5"
+	h.truth["nodatame.test."] = "192.0.2.5"
+	h.truth["localme.test."] = "10.0.1.2"
+
+	for _, pass := range []string{"miss", "hit"} {
+		if w := h.serve(t, "dropme.test.", "192.0.2.1:40000", true); w.Written() {
+			t.Fatalf("%s: DROP wrote a reply", pass)
+		}
+		w := h.serve(t, "tcpme.test.", "192.0.2.1:40000", true)
+		if !w.Written() || !w.Msg().Truncated || len(w.Msg().Answer) != 0 {
+			t.Fatalf("%s: TCP-Only over UDP must truncate emptily: tc=%v answers=%d", pass, w.Msg().Truncated, len(w.Msg().Answer))
+		}
+		w = h.serve(t, "nodatame.test.", "192.0.2.1:40000", true)
+		if w.Rcode() != dns.RcodeSuccess || len(w.Msg().Answer) != 0 || w.Msg().AuthenticatedData {
+			t.Fatalf("%s: NODATA broken: rcode=%d answers=%d", pass, w.Rcode(), len(w.Msg().Answer))
+		}
+		w = h.serve(t, "localme.test.", "192.0.2.1:40000", true)
+		if w.Rcode() != dns.RcodeSuccess || len(w.Msg().Answer) != 1 {
+			t.Fatalf("%s: Local Data broken: rcode=%d answers=%d", pass, w.Rcode(), len(w.Msg().Answer))
+		}
+		a := w.Msg().Answer[0].(*dns.A)
+		if a.Hdr.Name != "localme.test." || a.A.String() != "203.0.113.53" {
+			t.Fatalf("%s: Local Data owner/rdata: %v", pass, a)
+		}
+	}
+
+	// A non-UDP transport already satisfies TCP-Only: the truth flows.
+	w := h.serveProto(t, "tcpme.test.", "tcp")
+	if w.Rcode() != dns.RcodeSuccess || len(w.Msg().Answer) != 1 || w.Msg().Truncated {
+		t.Fatalf("TCP-Only over TCP must pass the truth: rcode=%d tc=%v", w.Rcode(), w.Msg().Truncated)
+	}
+}
+
+// TestNeutralGateServesExemptQueriesUntouched pins the global gate's
+// contract — the gate un-wrapped (exempt) queries reach: entries stay
+// healthy (stale restamps) but even a matching sidecar serves the truth
+// and counts nothing, because policy does not apply to those queries.
+func TestNeutralGateServesExemptQueriesUntouched(t *testing.T) {
+	h := newSidecarHarness(t, "enforce", config.RPZZone{Name: "resp", File: writeZone(t, respTestZone)})
+	s := h.r.store.Load()
+
+	matching := &middleware.Sidecar{Value: &rpzengine.ResponseMatches{
+		Gen:  s.Gen,
+		List: s.EvaluateResponseList([]dns.RR{testA("x.test.", "203.0.113.10")}),
+	}}
+	if v := h.r.JudgeWireHit(matching); v != middleware.WireHitServe {
+		t.Fatalf("a matching entry must still serve an exempt query: %v", v)
+	}
+	if v := h.r.JudgeWireHit(nil); v != middleware.WireHitRestamp {
+		t.Fatalf("an unevaluated entry must restamp: %v", v)
+	}
+	stale := &middleware.Sidecar{Value: &rpzengine.ResponseMatches{Gen: s.Gen - 1}}
+	if v := h.r.JudgeWireHit(stale); v != middleware.WireHitRestamp {
+		t.Fatalf("a stale entry must restamp: %v", v)
+	}
+
+	var chain middleware.SidecarChain
+	chain.Append(matching)
+	if v := h.r.JudgeWireChase(chain); v != middleware.WireHitServe {
+		t.Fatalf("chase with fresh segments must serve: %v", v)
+	}
+	var staleChain middleware.SidecarChain
+	staleChain.Append(stale)
+	if v := h.r.JudgeWireChase(staleChain); v != middleware.WireHitRestamp {
+		t.Fatalf("chase with a stale segment must restamp: %v", v)
+	}
+
+	// Counting nothing is the whole point.
+	counter := actionTotal.WithLabelValues("resp", rpzengine.TriggerResponseIP, "nxdomain", "enforced")
+	base := testutil.ToFloat64(counter)
+	h.r.CountWireHit(matching)
+	h.r.CountWireChase(chain)
+	if d := testutil.ToFloat64(counter) - base; d != 0 {
+		t.Fatalf("the neutral gate counted an exempt query: %v", d)
+	}
+
+	// Without response rules everything serves, whatever the sidecar.
+	bare := newRPZ(t, "enforce", config.RPZZone{Name: "plain", File: writeZone(t, testZone)})
+	if v := bare.JudgeWireHit(nil); v != middleware.WireHitServe {
+		t.Fatalf("no response rules must mean Serve: %v", v)
+	}
+	if v := bare.WireHitGate().JudgeWireChase(middleware.SidecarChain{}); v != middleware.WireHitServe {
+		t.Fatalf("no response rules must mean Serve for chases too: %v", v)
+	}
+}
+
+// TestDecodedRequestsSeeTheSamePolicy drives the Msg-born request path
+// (ch.Reset, not ResetWire): the decoded key build must reach the same
+// verdicts the wire-born path does.
+func TestDecodedRequestsSeeTheSamePolicy(t *testing.T) {
+	r := testRPZ(t, "enforce")
+
+	q := new(dns.Msg)
+	q.SetQuestion("nx.example.com.", dns.TypeA)
+	q.RecursionDesired = true
+	passed := false
+	next := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		passed = true
+		ch.Cancel()
+	})
+	w := mock.NewWriter("udp", "192.0.2.1:40000")
+	ch := middleware.NewChain([]middleware.Handler{r, next})
+	ch.Reset(w, q)
+	ch.Next(context.Background())
+
+	if passed || !w.Written() || w.Rcode() != dns.RcodeNameError {
+		t.Fatalf("decoded request escaped policy: passed=%v rcode=%d", passed, w.Rcode())
+	}
+}
+
+// TestAXFRFeedRunLoopLifecycle runs the feed's real schedule loop: the
+// first transfer lands without being hand-driven, and cancelling the
+// context ends the loop.
+func TestAXFRFeedRunLoopLifecycle(t *testing.T) {
+	srv := startFeedServer(t, "", "")
+	r, feed := feedUnderTest(t, srv, "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() { defer close(done); feed.run(ctx) }()
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		if _, passed := serve(t, r, "blocked.example.com.", dns.TypeA, "udp", true); !passed {
+			break // the first transfer landed and the rule enforces
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("the run loop never completed its first transfer")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("cancelling the context did not end the run loop")
+	}
+}


### PR DESCRIPTION
Follow-up to the coverage look: a function-level gap analysis over `internal/rpz` and `middleware/rpz`, closing only the gaps that name genuine behavior — no line chasing.

**New pins:**
- The AXFR feed's **schedule loop runs live** for the first time (first transfer lands unassisted; context cancel ends the loop). Every earlier test hand-drove cycles.
- The **neutral global gate's exempt-query contract**: matching sidecars still serve, stale ones still restamp, counters never move.
- The response wrap's **DROP / TCP-Only / NODATA / Local Data** arms end-to-end (miss + hit), including TCP-Only passing the truth over TCP and Local Data answering on the client's qname. The DROP swallow and the transport check are mutation-verified.
- The **decoded (Msg-born) request path** — previously never exercised; wire-born and decoded requests provably reach the same verdicts.
- Engine: response-trigger **filing semantics** (Local Data merge, conflict skip, bare marker, unknown action), **multi-zone fold ordering**, and the **trigger rank ladder**.

**Numbers:** internal/rpz 76.8% → 79.7%, middleware/rpz 81.0% → **88.1%**. The engine's remaining per-package 0% functions (loaders, ParseTSIGKey, store predicates) are covered from the middleware/config packages' tests; in-package smoke for them would inflate a number without pinning anything.

Full suite, `-race`, vet, lint clean.