### PR TITLE
RPZ: let a file zone name its apex, so real vendor feeds load

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ Each `[[rpz.zone]]` entry (a zone is fed exactly one way — `file` or `source`)
 | **name**     | Zone label used in metrics, logs, and the EDE text. Required, unique across zones |
 | **file**     | Path to a local policy zone file. Reloaded automatically when the file is replaced — the file's directory is watched, so atomic renames are caught. Best practice: deploy the file in its own directory |
 | **source**   | AXFR primary (`host:port`) of a vendor feed. The feed keeps itself current on the zone's own SOA schedule: probe on refresh, transfer on serial change, retry on retry, and withdraw past expire |
-| **origin**   | The policy zone's apex as an FQDN. Required with `source`; refused with `file` (the file's own SOA names the apex) |
+| **origin**   | The policy zone's apex as an FQDN. Required with `source`. Optional with `file`, and usually needed: feeds distributed as files commonly write their SOA as `@` with every rule relative to it, leaving the apex to the consuming server — such a file cannot be parsed without it. A file whose SOA carries an absolute owner needs none |
 | **tsig_key** | `name:algorithm:base64-secret` for signed transfers. Algorithms: `hmac-sha1`, `hmac-sha224`, `hmac-sha256`, `hmac-sha384`, `hmac-sha512`. Only meaningful with `source` |
 | **policy**   | Per-zone action override; default `given`. See the override list below |
 | **cname**    | Walled-garden target FQDN; required exactly when `policy = "cname"` |

--- a/config/config.go
+++ b/config/config.go
@@ -1061,6 +1061,10 @@ emptyzones = [
 # name = "badfeed"
 # file = "/var/lib/sdns/badfeed.zone"
 # policy = "given"
+# Add origin when the file writes its SOA as "@" with rules relative to
+# it — the common shape for downloaded feeds, which leave the apex to the
+# consuming server. A file whose SOA carries an absolute owner needs none.
+# origin = "rpz.vendor.example."
 # An AXFR-fed zone instead names its primary and apex (and never a file);
 # it follows the feed's own SOA schedule and withdraws its rules past SOA
 # expire. tsig_key ("name:algorithm:base64-secret") signs the transfer

--- a/config/validate.go
+++ b/config/validate.go
@@ -1779,13 +1779,20 @@ func (c *Config) validateRPZ(add func(string, ...any)) {
 			add("%s: either file or source is required", where)
 			continue
 		}
+		// A file zone may name its apex here: feeds distributed as files
+		// commonly write "@" for the SOA and every rule relative to it,
+		// leaving the origin to the consuming server's configuration.
+		// Without one such a file cannot be parsed at all, so this is a
+		// setting operators need, not a contradiction.
 		if zc.Origin != "" {
-			add("%s: origin is set but the zone is file-fed; the file's own SOA names the apex", where)
+			if _, valid := dns.IsDomainName(zc.Origin); !valid || !dns.IsFqdn(zc.Origin) {
+				add("%s: origin = %q: must be a fully qualified domain name", where, zc.Origin)
+			}
 		}
 		if zc.TsigKey != "" {
 			add("%s: tsig_key is set but the zone is file-fed; only transfers are signed", where)
 		}
-		z, err := rpz.LoadZoneFile(zc.Name, zc.File, policy, dns.CanonicalName(zc.Cname))
+		z, err := rpz.LoadZoneFile(zc.Name, zc.File, policy, dns.CanonicalName(zc.Cname), zc.Origin)
 		if err != nil {
 			add("%s: %v", where, err)
 			continue

--- a/config/validate_rpz_test.go
+++ b/config/validate_rpz_test.go
@@ -166,8 +166,27 @@ func TestValidateRPZSourceZones(t *testing.T) {
 		}
 	})
 
-	t.Run("origin and tsig are refused on file zones", func(t *testing.T) {
-		wantRPZProblem(t, rpzConfig(RPZZone{Name: "feed", File: good, Origin: "z."}), "file-fed")
+	t.Run("tsig is refused on file zones", func(t *testing.T) {
 		wantRPZProblem(t, rpzConfig(RPZZone{Name: "feed", File: good, TsigKey: "k.:a.:YQ=="}), "only transfers are signed")
+	})
+
+	t.Run("a file zone may name its apex, and it must be an FQDN", func(t *testing.T) {
+		// The shape feeds are actually distributed in: the SOA is "@"
+		// and every rule hangs off it, so the file alone cannot say what
+		// zone it is — the origin does.
+		relative := rpzZoneFile(t, `
+$TTL 30
+@ SOA rpz.vendor.example. hostmaster.vendor.example. 1 300 1800 604800 30
+  NS localhost.
+bad.example.com CNAME .
+`)
+		withOrigin := RPZZone{Name: "vendor", File: relative, Origin: "rpz.vendor.example."}
+		if err := rpzConfig(withOrigin).Validate(); err != nil {
+			t.Fatalf("a relative feed with its origin was refused: %v", err)
+		}
+		// Without the origin the same file cannot be parsed at all.
+		wantRPZProblem(t, rpzConfig(RPZZone{Name: "vendor", File: relative}), "bad owner name")
+		// And a non-FQDN origin is a config error, not a silent default.
+		wantRPZProblem(t, rpzConfig(RPZZone{Name: "vendor", File: relative, Origin: "rpz.vendor.example"}), "fully qualified")
 	})
 }

--- a/contrib/linux/sdns.conf
+++ b/contrib/linux/sdns.conf
@@ -424,6 +424,10 @@ emptyzones = [
 # name = "badfeed"
 # file = "/var/lib/sdns/badfeed.zone"
 # policy = "given"
+# Add origin when the file writes its SOA as "@" with rules relative to
+# it — the common shape for downloaded feeds, which leave the apex to the
+# consuming server. A file whose SOA carries an absolute owner needs none.
+# origin = "rpz.vendor.example."
 # An AXFR-fed zone instead names its primary and apex (and never a file);
 # it follows the feed's own SOA schedule and withdraws its rules past SOA
 # expire. tsig_key ("name:algorithm:base64-secret") signs the transfer

--- a/internal/rpz/parse.go
+++ b/internal/rpz/parse.go
@@ -82,19 +82,38 @@ const responseIPMarker = "rpz-ip"
 // LoadZoneFile parses one policy zone file into a compiled Zone. name is
 // the config label; policy and cnameTarget come from the zone's config
 // entry (cnameTarget canonical, used only with OverrideCNAME).
-func LoadZoneFile(name, path string, policy Override, cnameTarget string) (*Zone, error) {
+//
+// origin is the apex the file's relative names hang from, canonical, and
+// may be empty. Feeds distributed as files commonly write their SOA as
+// "@" and every rule relative to it, because the consuming server is
+// expected to supply the origin from its own configuration — so a file
+// that names no apex of its own is not malformed, it is the ordinary
+// shape, and the operator's `origin` setting is what completes it. A
+// file whose SOA carries an absolute owner needs none.
+func LoadZoneFile(name, path string, policy Override, cnameTarget, origin string) (*Zone, error) {
 	f, err := os.Open(path) //nolint:gosec // G304 - the operator's configured policy file
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close() //nolint:errcheck // read-only descriptor
 
-	return LoadZone(name, f, path, policy, cnameTarget)
+	// Canonicalized here rather than by callers: dns.CanonicalName("")
+	// is the root, so a caller that canonicalizes an unset origin would
+	// hand the parser "." and a relative feed would load silently under
+	// the root instead of failing for want of an apex.
+	if origin != "" {
+		origin = dns.CanonicalName(origin)
+	}
+	return loadZone(name, f, path, policy, cnameTarget, origin)
 }
 
-// LoadZone is LoadZoneFile over a reader; file names the source in parse
-// errors.
+// LoadZone is LoadZoneFile over a reader, for zones that name their own
+// apex; file names the source in parse errors.
 func LoadZone(name string, r io.Reader, file string, policy Override, cnameTarget string) (*Zone, error) {
+	return loadZone(name, r, file, policy, cnameTarget, "")
+}
+
+func loadZone(name string, r io.Reader, file string, policy Override, cnameTarget, origin string) (*Zone, error) {
 	z := &Zone{
 		Name:        name,
 		Policy:      policy,
@@ -109,7 +128,7 @@ func LoadZone(name string, r io.Reader, file string, policy Override, cnameTarge
 	// there is refused as not a zone.
 	var pending []dns.RR
 
-	zp := dns.NewZoneParser(r, "", file)
+	zp := dns.NewZoneParser(r, origin, file)
 	for rr, ok := zp.Next(); ok; rr, ok = zp.Next() {
 		if z.Origin == "" {
 			if soa, isSOA := rr.(*dns.SOA); isSOA {

--- a/internal/rpz/rpz_test.go
+++ b/internal/rpz/rpz_test.go
@@ -2,6 +2,8 @@ package rpz
 
 import (
 	"net/netip"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -298,4 +300,73 @@ func TestMatchQNAMEMissAllocatesNothing(t *testing.T) {
 	}); allocs != 0 {
 		t.Fatalf("a miss cost %.0f allocations, want 0", allocs)
 	}
+}
+
+// TestLoadZoneFileRelativeNames pins the shape feeds are actually
+// distributed in: the SOA written as "@" with every rule relative to it,
+// the origin supplied by the consuming server rather than the file. This
+// is what a real vendor feed looks like, and without the origin it does
+// not parse at all.
+func TestLoadZoneFileRelativeNames(t *testing.T) {
+	const vendorShape = `
+$TTL 30
+@ SOA rpz.vendor.example. hostmaster.vendor.example. 1 300 1800 604800 30
+  NS localhost.
+malware.example.com CNAME .
+phish.example.net CNAME .
+`
+	path := filepath.Join(t.TempDir(), "vendor.zone")
+	if err := os.WriteFile(path, []byte(vendorShape), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := LoadZoneFile("v", path, OverrideGiven, "", ""); err == nil {
+		t.Fatal("a relative feed parsed without an origin; it names no apex")
+	}
+
+	z, err := LoadZoneFile("v", path, OverrideGiven, "", "rpz.vendor.example.")
+	if err != nil {
+		t.Fatalf("relative feed with its origin: %v", err)
+	}
+	if z.Origin != "rpz.vendor.example." {
+		t.Fatalf("origin = %q", z.Origin)
+	}
+	if z.Rules != 2 {
+		t.Fatalf("rules = %d, want 2 (skipped: %v)", z.Rules, z.Skipped)
+	}
+	// The rules must be reachable under the qnames they name, not under
+	// the origin-suffixed spelling the file carries.
+	s := storeOf(z)
+	match := func(qname string) *Rule {
+		canon, offs, n := canonFor(t, qname)
+		w, _ := s.Match(canon, offs[:], n, netip.Addr{})
+		return w.Rule
+	}
+	for _, qname := range []string{"malware.example.com.", "phish.example.net."} {
+		if match(qname) == nil {
+			t.Fatalf("%s did not match", qname)
+		}
+	}
+	if match("innocent.example.org.") != nil {
+		t.Fatal("an unlisted name matched")
+	}
+
+	// A file that names its own apex still needs no origin.
+	if _, err := LoadZoneFile("f", writeFixture(t, testAbsoluteZone), OverrideGiven, "", ""); err != nil {
+		t.Fatalf("absolute feed without origin: %v", err)
+	}
+}
+
+const testAbsoluteZone = `
+rpz.self. IN SOA ns.rpz.self. admin.rpz.self. 1 3600 900 604800 300
+blocked.example.com.rpz.self. IN CNAME .
+`
+
+func writeFixture(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "zone")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
 }

--- a/middleware/rpz/reload.go
+++ b/middleware/rpz/reload.go
@@ -94,7 +94,7 @@ func (r *RPZ) reload(idx int) {
 	if zc.Cname != "" {
 		target = dns.CanonicalName(zc.Cname)
 	}
-	z, err := rpz.LoadZoneFile(zc.Name, zc.File, policy, target)
+	z, err := rpz.LoadZoneFile(zc.Name, zc.File, policy, target, zc.Origin)
 	if err != nil {
 		reloadErrors.WithLabelValues(zc.Name).Inc()
 		zlog.Warn("RPZ zone reload failed; the previous rules keep serving", "zone", zc.Name, "error", err.Error())

--- a/middleware/rpz/rpz.go
+++ b/middleware/rpz/rpz.go
@@ -103,7 +103,7 @@ func loadZone(zc config.RPZZone) *rpz.Zone {
 	if zc.Cname != "" {
 		target = dns.CanonicalName(zc.Cname)
 	}
-	z, err := rpz.LoadZoneFile(zc.Name, zc.File, policy, target)
+	z, err := rpz.LoadZoneFile(zc.Name, zc.File, policy, target, zc.Origin)
 	if err != nil {
 		zlog.Error("RPZ zone failed to load and will filter nothing", "zone", zc.Name, "file", zc.File, "error", err.Error())
 		reloadErrors.WithLabelValues(zc.Name).Inc()


### PR DESCRIPTION
Found by taking a live feed and pointing sdns at it, before touching production.

## The gap

The abuse.ch URLhaus RPZ — and the shape feeds are generally distributed in — writes its SOA as `@` with every rule relative to it, leaving the apex to the consuming server's configuration (BIND takes it from the `zone` statement). sdns insisted the file name its own apex, so the feed could not be loaded at all:

```
rpz.zone[0]: rpz zone "urlhaus": urlhaus.zone: dns: bad owner name: "@" at line: 2:2
```

The validator even refused the `origin` setting that would have said it — "the file's own SOA names the apex" — which holds for files we generate and fails for the ones operators subscribe to.

**This is a missing capability, not a regression.** v1.8.2 fails loudly on such a config: `sdns -t` exits 1, and a server started without the gate refuses to come up. Verified both by running it. Nothing silently misfilters.

## The change

A file zone may carry an `origin`, which becomes the parse-time apex for its relative names. A file whose SOA is absolute still needs none and its path is untouched.

The canonicalization sits in the loader rather than at the three call sites, because `dns.CanonicalName("")` is the **root**: a caller canonicalizing an unset origin hands the parser `"."` and a relative feed then loads *silently under the root* instead of failing for want of an apex. That bug existed in my first draft of this change and the new test caught it.

## Verification

- The real URLhaus feed now passes `sdns -t`: **371 rules**, one record skipped (its NS, correctly classified as not-action-data).
- Regression test pins both directions: the vendor shape must refuse without an origin and compile with one, and its rules must be reachable under the qnames they name.
- Config gate pins that a non-FQDN origin is an error, not a silent default; `tsig_key` on a file zone stays refused.
- README and the packaged sample config document when the setting is needed.
- Full suite, vet, lint clean.