### PR TITLE
cache: serve only what the cache vouches for, and a denial's TTL is a ceiling

### DIFF
--- a/docs/_docs/configuration/cache.md
+++ b/docs/_docs/configuration/cache.md
@@ -143,6 +143,9 @@ of zero. Zero tells the client not to reuse the answer, and a cache that says so
 while reusing it is contradicting itself; for a denial RFC 2308 §5 rules it out
 directly. An entry down to its last fraction of a second is served as one
 second, which is the finest a DNS message can express, and then it is gone.
+The one exception is a delegation lease in its last fraction of a second:
+that bound is the parent's, not this cache's to round, so the answer goes out
+with a TTL of zero rather than a second the parent never granted.
 
 The two mechanisms that *reuse* a denial for names it was never asked about are
 bounded the same way, and were already. Both are on by default and both are

--- a/docs/_docs/configuration/cache.md
+++ b/docs/_docs/configuration/cache.md
@@ -64,13 +64,24 @@ A name that does not exist is an answer worth keeping, and RFC 2308 says how
 long for: the lifetime comes from the SOA in the denial, bounded by the smaller
 of its TTL and its MINIMUM field.
 
-The plain negative entry — the cached NXDOMAIN or NODATA itself — is held like
-any other answer, which means the same five-second floor the rest of the cache
-applies. A denial whose proof is shorter than that is still held for five
-seconds.
+That value is a ceiling, not a target. RFC 2308 says how long a resolver *may*
+cache the denial, so sdns applies no minimum on top of it: a zone that
+publishes a one-second negative TTL gets one second, and a denial carrying no
+lifetime at all is not cached.
+
+Ordinary answers do take a five-second floor. The difference is who is being
+overruled. A negative TTL is the zone's own statement about how long its denial
+holds, and raising it substitutes the resolver's judgement for the only party
+entitled to make that call. The floor on a positive answer overrules nobody —
+it is the resolver deciding how often to re-ask for a short-lived record, which
+is its own business.
+
+A denial arriving without an SOA is not cached either. There is nothing to
+derive a lifetime from, and RFC 2308 is explicit that caching it anyway is what
+lets two misconfigured servers pass the denial back and forth indefinitely.
 
 The two mechanisms that *reuse* a denial for names it was never asked about are
-bounded harder, and deliberately so. Both are on by default and both are
+bounded the same way, and were already. Both are on by default and both are
 covered under
 [Resolution and DNSSEC]({{ '/docs/configuration/resolution/' | relative_url }}):
 RFC 8020 lets one NXDOMAIN answer every name beneath it, and RFC 8198 answers

--- a/docs/_docs/configuration/cache.md
+++ b/docs/_docs/configuration/cache.md
@@ -38,6 +38,34 @@ served past the point the parent's grant expires. That is why a long-TTL record
 under a short-lived delegation can come back with less than you expected — the
 cut, not the record, is the binding constraint.
 
+## What a hit contains
+
+A hit is served from what the cache stored, and the cache stores only what it
+can vouch for. Four things follow from that, and they are visible from a
+client.
+
+An entry keeps the signatures that cover its records inside their validity
+period. A signature that has lapsed, or one whose inception has not arrived,
+goes out in the first response exactly as the authority sent it and is absent
+from every hit. This is what a key rollover looks like from the outside: the
+outgoing key's signature disappears from cached answers as soon as it expires,
+while the incoming key's keeps the answer authenticated.
+
+An explicit `RRSIG` query is the one case where the signatures are the answer
+itself, so such an answer is cached only when every signature in it can be
+kept. Otherwise each query for it goes upstream.
+
+A signed RRset in the additional section, a mail exchanger's address for
+instance, is served complete with its signatures or not at all. It stays only
+when its signatures cover the whole of the entry's lifetime and its records
+arrived with at least that much TTL; a shorter-lived one is left out rather
+than served past what its signature permits. Unsigned glue is unaffected.
+
+A query without the DO bit receives no `RRSIG`, `NSEC` or `NSEC3` record it did
+not ask for, in any section, on a miss and on a hit alike, and from a
+synthesized denial as well (RFC 4035 §3.2.1). A query for one of those types
+keeps exactly that type and loses the others.
+
 ## Serving expired answers
 
 ```toml
@@ -95,6 +123,16 @@ signature expires. The floor never lifts an entry past that, so a signed record
 that arrives with a one-second TTL is held for one second. An answer served
 after its signature has lapsed is bogus to every validator downstream, which is
 not a freshness question at all.
+
+Which signature sets that bound matters. A signature counts only inside its own
+validity period, and only for the RRset it covers, under the zone that made
+it. During a key rollover an RRset carries a signature from the outgoing key
+beside one from the incoming key; once the outgoing one expires it bounds
+nothing, because the incoming one still covers the RRset, and the answer is
+held for as long as that one permits. An RRset that no valid signature covers
+is not admitted at all. Signatures in the additional section bound neither the
+lifetime nor the AD bit: what the resolver vouches for is the answer and
+authority sections (RFC 4035 §3.2.3).
 
 The lower bound is settled once, where all of that evidence is in hand, and
 every layer after it may only shorten. A second floor applied at admission

--- a/docs/_docs/configuration/cache.md
+++ b/docs/_docs/configuration/cache.md
@@ -88,11 +88,23 @@ denial is not the same case: there the TTL is a zone's statement about a name
 it is authoritative for.
 
 The floor is a preference, not a right, and it stops at anything the protocol
-fixes. On signed data RFC 4035 §5.3.3 caps the lifetime at the smallest of the
-RRSIG's header TTL, its Original TTL and the time left before it expires, and
-the floor never lifts an entry past that. An answer served after its signature
-has lapsed is bogus to every validator downstream, which is not a freshness
-question at all.
+fixes. On signed data RFC 4035 §5.3.3 caps the lifetime at the smallest of four
+values, and none of them may be exceeded: the RRset's TTL as received, the
+RRSIG's own TTL, the RRSIG's Original TTL field, and the time left before the
+signature expires. The floor never lifts an entry past that, so a signed record
+that arrives with a one-second TTL is held for one second. An answer served
+after its signature has lapsed is bogus to every validator downstream, which is
+not a freshness question at all.
+
+The lower bound is settled once, where all of that evidence is in hand, and
+every layer after it may only shorten. A second floor applied at admission
+cannot see any of it, and would quietly undo the work.
+
+One consequence worth stating: an answer this cache serves never carries a TTL
+of zero. Zero tells the client not to reuse the answer, and a cache that says so
+while reusing it is contradicting itself; for a denial RFC 2308 §5 rules it out
+directly. An entry down to its last fraction of a second is served as one
+second, which is the finest a DNS message can express, and then it is gone.
 
 The two mechanisms that *reuse* a denial for names it was never asked about are
 bounded the same way, and were already. Both are on by default and both are

--- a/docs/_docs/configuration/cache.md
+++ b/docs/_docs/configuration/cache.md
@@ -69,16 +69,30 @@ cache the denial, so sdns applies no minimum on top of it: a zone that
 publishes a one-second negative TTL gets one second, and a denial carrying no
 lifetime at all is not cached.
 
-Ordinary answers do take a five-second floor. The difference is who is being
-overruled. A negative TTL is the zone's own statement about how long its denial
-holds, and raising it substitutes the resolver's judgement for the only party
-entitled to make that call. The floor on a positive answer overrules nobody —
-it is the resolver deciding how often to re-ask for a short-lived record, which
-is its own business.
+A denial does not have to arrive as an empty answer to be one. The common shape
+on the wire is a CNAME chain that never reaches the type you asked for, and the
+SOA at the end of it is what says how long that holds — not the alias TTL in
+front of it.
 
-A denial arriving without an SOA is not cached either. There is nothing to
+A denial arriving without an SOA is not cached at all. There is nothing to
 derive a lifetime from, and RFC 2308 is explicit that caching it anyway is what
 lets two misconfigured servers pass the denial back and forth indefinitely.
+
+Ordinary answers do take a five-second floor, and it is worth being straight
+about what that is: RFC 1035 §3.2.1 makes a record's TTL the point at which the
+source should be consulted again, so holding a one-second record for five is a
+deliberate deviation. It is a defensible one, about this resolver's own data
+and nobody else's namespace, and it is the difference between a hot short-TTL
+name being re-resolved on every single query or once every five seconds. A
+denial is not the same case: there the TTL is a zone's statement about a name
+it is authoritative for.
+
+The floor is a preference, not a right, and it stops at anything the protocol
+fixes. On signed data RFC 4035 §5.3.3 caps the lifetime at the smallest of the
+RRSIG's header TTL, its Original TTL and the time left before it expires, and
+the floor never lifts an entry past that. An answer served after its signature
+has lapsed is bogus to every validator downstream, which is not a freshness
+question at all.
 
 The two mechanisms that *reuse* a denial for names it was never asked about are
 bounded the same way, and were already. Both are on by default and both are

--- a/internal/dnsname/canonical_key_test.go
+++ b/internal/dnsname/canonical_key_test.go
@@ -1,0 +1,33 @@
+package dnsname
+
+import "testing"
+
+// TestAppendCanonicalKeyAgreesWithCanonicalCompare pins the key to the
+// comparison: names the comparison orders equal share a key, names it keeps
+// apart do not. Escaped and plain spellings, rooted and unrooted, ASCII
+// case merge; a Kelvin sign — which a Unicode fold turns into k — stays a
+// different name, as it is on the wire.
+func TestAppendCanonicalKeyAgreesWithCanonicalCompare(t *testing.T) {
+	key := func(name string) string {
+		var buf [64]byte
+		return string(AppendCanonicalKey(buf[:0], name))
+	}
+	for _, tc := range []struct {
+		a, b string
+		same bool
+	}{
+		{"target.example.", `t\097rget.example.`, true},
+		{"k.example.", "k.example", true},
+		{"K.EXAMPLE.", "k.example.", true},
+		{"a\\.b.example.", "a.b.example.", false},
+		{"K.example.", "k.example.", false},
+		{".", "", true},
+	} {
+		if got := key(tc.a) == key(tc.b); got != tc.same {
+			t.Errorf("%q vs %q: same key = %v, want %v", tc.a, tc.b, got, tc.same)
+		}
+		if got := CanonicalCompare(tc.a, tc.b) == 0; got != tc.same {
+			t.Errorf("%q vs %q: CanonicalCompare equal = %v, want %v", tc.a, tc.b, got, tc.same)
+		}
+	}
+}

--- a/internal/dnsname/dnsname.go
+++ b/internal/dnsname/dnsname.go
@@ -110,6 +110,13 @@ func Suffixes(name string) iter.Seq[int] {
 // verdict is the rightmost pair that differed — right-to-left order without
 // offset arrays, so the frame stays flat instead of carrying two of them.
 func CanonicalCompare(a, b string) int {
+	// Identical spellings are equal names, and they are what a response
+	// carries: one owner, spelled one way, on every record and signature
+	// of an RRset. A byte comparison settles that case before the label
+	// walk, which admission otherwise paid several times per response.
+	if a == b {
+		return 0
+	}
 	ca, cb := canonicalLabelCount(a), canonicalLabelCount(b)
 	offA, offB := 0, 0
 	for i := ca; i > cb; i-- {

--- a/internal/dnsname/dnsname.go
+++ b/internal/dnsname/dnsname.go
@@ -248,3 +248,35 @@ func equalFold(a, b string) bool {
 	}
 	return true
 }
+
+// AppendCanonicalKey appends the canonical identity of a presentation name
+// to dst: each label as the octets it decodes to, ASCII-folded and
+// length-prefixed, then the root. Two names get the same key exactly when
+// CanonicalCompare orders them equal — escaped and plain spellings, rooted
+// and unrooted, ASCII case — and a fold that is not the wire's never merges
+// what the wire keeps apart: a Kelvin sign is not a k. For the places a
+// comparison cannot serve, a map keyed by string(key).
+func AppendCanonicalKey(dst []byte, name string) []byte {
+	labels := canonicalLabelCount(name)
+	off := 0
+	for i := labels; i > 0; i-- {
+		var label string
+		label, off = canonicalLabel(name, off, i == 1)
+		dst = append(dst, 0)
+		at := len(dst) - 1
+		n := 0
+		for j := 0; j < len(label); {
+			var oct byte
+			oct, j = decodeOctet(label, j)
+			if oct >= 'A' && oct <= 'Z' {
+				oct |= 'a' - 'A'
+			}
+			dst = append(dst, oct)
+			n++
+		}
+		// A wire label holds at most 63 octets; a hand-built name past 255
+		// wraps, and only needs a key consistent with itself.
+		dst[at] = byte(n) //nolint:gosec // G115 - see above
+	}
+	return append(dst, 0)
+}

--- a/internal/dnsutil/cache_ttl.go
+++ b/internal/dnsutil/cache_ttl.go
@@ -35,74 +35,79 @@ func CalculateCacheTTL(msg *dns.Msg, respType ResponseType) time.Duration {
 		return MinCacheTTL
 	}
 
+	// A denial carries its lifetime in the SOA of the authority section, and
+	// RFC 2308 §5 says one arriving without that record should not be cached
+	// at all: there is nothing to derive a lifetime from, and holding it on a
+	// guess is what lets a pair of misconfigured servers loop the denial
+	// between them forever. Checked on the SOA itself rather than on the
+	// message being empty, because an NXDOMAIN that carries an alias chain and
+	// no SOA has records aplenty and still says nothing about how long it
+	// holds.
+	if isNegative && !hasSOA(msg) {
+		return 0
+	}
+
 	// Handle empty responses
 	if !hasRecords(msg) {
-		// A denial carries its lifetime in the SOA of the authority section.
-		// With no records at all there is nothing to derive one from, and RFC
-		// 2308 §5 says such a response should not be cached: without an SOA
-		// there is no way to stop a pair of misconfigured servers looping the
-		// denial between them forever.
-		if isNegative {
-			return 0
-		}
 		return MinCacheTTL
 	}
 
-	// Find minimum TTL across all sections
-	minTTL := MaxCacheTTL
+	// Two bounds, tracked apart. recordTTL is what the records themselves
+	// advertise, and for a denial the SOA's MINIMUM alongside it. hardTTL is
+	// what RFC 4035 §5.3.3 fixes for signed data: the smallest of every
+	// signature's header TTL, its Original TTL field, and the time left before
+	// it expires.
+	//
+	// They are kept apart because only one of them is negotiable. The floor
+	// applied at the end is this resolver's freshness preference and may lift a
+	// short recordTTL, but it must never lift anything past hardTTL. An entry
+	// served after its signature has lapsed is bogus to every validator
+	// downstream, and no local policy is entitled to decide otherwise.
+	recordTTL := MaxCacheTTL
+	hardTTL := MaxCacheTTL
 	now := time.Now()
 
-	// Check Answer section
-	for _, rr := range msg.Answer {
-		if ttl := getTTL(rr); ttl < minTTL {
-			minTTL = ttl
+	// negativeSOA folds in the RFC 2308 cap, min(SOA header TTL, SOA.Minttl):
+	// a denial with SOA header TTL 86400 and Minttl 300 must not be cached for
+	// a day. It applies to the authority section of a negative answer only.
+	bound := func(rr dns.RR, negativeSOA bool) {
+		if ttl := getTTL(rr); ttl < recordTTL {
+			recordTTL = ttl
 		}
-		// Check RRSIG expiration
-		if sig, ok := rr.(*dns.RRSIG); ok {
-			if ttl := getRRSIGTTL(sig, now); ttl < minTTL {
-				minTTL = ttl
-			}
-		}
-	}
-
-	// Check Authority section. For negative responses, RFC 2308
-	// caps the cache TTL at min(SOA header TTL, SOA.Minttl) — a
-	// response with SOA header TTL 86400 and Minttl 300 must not
-	// be cached for a day.
-	for _, rr := range msg.Ns {
-		if ttl := getTTL(rr); ttl < minTTL {
-			minTTL = ttl
-		}
-		if isNegative {
+		if negativeSOA {
 			if soa, ok := rr.(*dns.SOA); ok {
-				if ttl := time.Duration(soa.Minttl) * time.Second; ttl < minTTL {
-					minTTL = ttl
+				if ttl := time.Duration(soa.Minttl) * time.Second; ttl < recordTTL {
+					recordTTL = ttl
 				}
 			}
 		}
-		// Check RRSIG expiration
 		if sig, ok := rr.(*dns.RRSIG); ok {
-			if ttl := getRRSIGTTL(sig, now); ttl < minTTL {
-				minTTL = ttl
+			if ttl := getRRSIGTTL(sig, now); ttl < hardTTL {
+				hardTTL = ttl
 			}
 		}
 	}
 
-	// Check Additional section (excluding OPT)
+	for _, rr := range msg.Answer {
+		bound(rr, false)
+	}
+	for _, rr := range msg.Ns {
+		bound(rr, isNegative)
+	}
 	for _, rr := range msg.Extra {
 		// Skip OPT pseudo-records
 		if rr.Header().Rrtype == dns.TypeOPT {
 			continue
 		}
-		if ttl := getTTL(rr); ttl < minTTL {
-			minTTL = ttl
-		}
-		// Check RRSIG expiration
-		if sig, ok := rr.(*dns.RRSIG); ok {
-			if ttl := getRRSIGTTL(sig, now); ttl < minTTL {
-				minTTL = ttl
-			}
-		}
+		bound(rr, false)
+	}
+
+	minTTL := recordTTL
+	if hardTTL < minTTL {
+		minTTL = hardTTL
+	}
+	if minTTL < 0 {
+		minTTL = 0
 	}
 
 	// Apply bounds
@@ -115,19 +120,25 @@ func CalculateCacheTTL(msg *dns.Msg, respType ResponseType) time.Duration {
 	// publishes a one-second negative TTL means one second, and holding it for
 	// five is the resolver overriding the only party entitled to decide. Zero
 	// is a real answer here, and the caller declines to admit the entry.
-	//
-	// Positive answers keep the floor. Nothing derives it from a zone's own
-	// statement about its data, so nothing is being overridden: it is the
-	// resolver's own guard against re-resolving a one-second record on every
-	// query, and RFC 1035 §3.2.1 leaves that latitude.
 	if isNegative {
-		if minTTL < 0 {
-			return 0
-		}
 		return minTTL
 	}
 
+	// Positive answers take a floor, and it is a deliberate deviation rather
+	// than a right: RFC 1035 §3.2.1 makes a record's TTL the time after which
+	// the source should be consulted again, so holding a one-second record for
+	// five seconds is this resolver choosing not to re-resolve on every query.
+	// It is a defensible local policy about local data.
+	//
+	// It is not a licence to outlive a signature. hardTTL is fixed by the
+	// protocol, and the floor stops there: past that bound the records are
+	// bogus to anything that validates them, which is not a freshness question
+	// at all. Unsigned data leaves hardTTL at the maximum, so the floor
+	// applies to it exactly as before.
 	if minTTL < MinCacheTTL {
+		if hardTTL < MinCacheTTL {
+			return minTTL
+		}
 		return MinCacheTTL
 	}
 
@@ -155,28 +166,30 @@ func getTTL(rr dns.RR) time.Duration {
 	return time.Duration(rr.Header().Ttl) * time.Second
 }
 
-// getRRSIGTTL calculates the effective TTL for a RRSIG record based on its expiration time.
-// The cache TTL should not exceed the time until the signature expires.
+// getRRSIGTTL returns the hard ceiling one signature places on the data it
+// covers. RFC 4035 §5.3.3 names three bounds and the answer is the smallest:
+// the RRSIG's own header TTL, its Original TTL field, and the time left before
+// it expires. The Original TTL is not decoration — it is what the signature
+// was computed over, so a signer that publishes a large header TTL and a small
+// original one has authorised the small one, and reading only the header let a
+// denial whose signature said one second live for an hour.
+//
+// A lapsed signature bounds the data at zero. Returning the cache floor here
+// made it a floor wearing a bound's clothes, granting five more seconds of
+// life to material whose proof had already run out.
 func getRRSIGTTL(sig *dns.RRSIG, now time.Time) time.Duration {
-	// Get the regular TTL from the record
-	recordTTL := time.Duration(sig.Header().Ttl) * time.Second
+	ttl := time.Duration(sig.Header().Ttl) * time.Second
 
-	// Calculate time until expiration
-	expireTime := time.Unix(int64(sig.Expiration), 0)
-	timeUntilExpire := expireTime.Sub(now)
+	if orig := time.Duration(sig.OrigTtl) * time.Second; orig < ttl {
+		ttl = orig
+	}
 
-	// An expired signature bounds the answer at zero. Returning the floor here
-	// made it a floor wearing a bound's clothes: on the denial path, which
-	// takes no floor of its own, it was the one thing still granting five more
-	// seconds of life to data whose proof had already lapsed. Positive answers
-	// land on their own floor immediately afterwards, so they see no change.
-	if timeUntilExpire <= 0 {
+	if untilExpiry := time.Unix(int64(sig.Expiration), 0).Sub(now); untilExpiry < ttl {
+		ttl = untilExpiry
+	}
+
+	if ttl < 0 {
 		return 0
 	}
-
-	// Return the minimum of record TTL and time until expiration
-	if timeUntilExpire < recordTTL {
-		return timeUntilExpire
-	}
-	return recordTTL
+	return ttl
 }

--- a/internal/dnsutil/cache_ttl.go
+++ b/internal/dnsutil/cache_ttl.go
@@ -95,12 +95,6 @@ func CalculateCacheTTL(msg *dns.Msg, respType ResponseType) time.Duration {
 				}
 			}
 		}
-		if sig, ok := rr.(*dns.RRSIG); ok {
-			signed = true
-			if ttl := getRRSIGTTL(sig, now); ttl < hardTTL {
-				hardTTL = ttl
-			}
-		}
 	}
 
 	for _, rr := range msg.Answer {
@@ -116,6 +110,17 @@ func CalculateCacheTTL(msg *dns.Msg, respType ResponseType) time.Duration {
 		}
 		bound(rr, false)
 	}
+
+	// The signature bound is taken per RRset, and within an RRset from the
+	// signature that still permits the most. Folding every signature into one
+	// minimum let a lapsed sibling speak for an RRset another signature still
+	// covers, which is exactly the shape of a key rollover.
+	eachSignedRRset([][]dns.RR{msg.Answer, msg.Ns, msg.Extra}, now, func(_ bool, usable time.Duration) {
+		signed = true
+		if usable < hardTTL {
+			hardTTL = usable
+		}
+	})
 
 	// RFC 4035 §5.3.3 names four values and the served lifetime may exceed
 	// none of them: the RRset's TTL as received, the RRSIG's TTL, its Original

--- a/internal/dnsutil/cache_ttl.go
+++ b/internal/dnsutil/cache_ttl.go
@@ -36,6 +36,13 @@ func CalculateCacheTTL(msg *dns.Msg, respType ResponseType) time.Duration {
 		// hammering broken servers, but not too long in case it's temporary
 		// Default to 30 seconds, but this will be capped by the negative cache max TTL
 		return 30 * time.Second
+	case TypeExpiredSignature:
+		// Nothing. The signatures over this data lapsed before it arrived, so
+		// there is no interval during which it may be relied on, and the
+		// default's five seconds handed the classification straight back what
+		// it had just refused. The store already declines it; this is what
+		// stops the client that caused the miss from being invited to keep it.
+		return 0
 	default:
 		// Other response types get minimal cache time
 		return MinCacheTTL

--- a/internal/dnsutil/cache_ttl.go
+++ b/internal/dnsutil/cache_ttl.go
@@ -20,9 +20,15 @@ const (
 func CalculateCacheTTL(msg *dns.Msg, respType ResponseType) time.Duration {
 	// Only cache successful responses and negative responses (NXDOMAIN/NODATA)
 	isNegative := false
+	isReferral := false
 	switch respType {
 	case TypeSuccess:
 		// Continue with TTL calculation
+	case TypeReferral:
+		// A referral used to return the floor without ever looking at its
+		// records, so a signed delegation's expiry and Original TTL bounded
+		// nothing. It walks the sections now; its lifetime stays what it was.
+		isReferral = true
 	case TypeNXDomain, TypeNoRecords:
 		isNegative = true
 	case TypeServerFailure:
@@ -65,6 +71,7 @@ func CalculateCacheTTL(msg *dns.Msg, respType ResponseType) time.Duration {
 	// downstream, and no local policy is entitled to decide otherwise.
 	recordTTL := MaxCacheTTL
 	hardTTL := MaxCacheTTL
+	signed := false
 	now := time.Now()
 
 	// negativeSOA folds in the RFC 2308 cap, min(SOA header TTL, SOA.Minttl):
@@ -82,6 +89,7 @@ func CalculateCacheTTL(msg *dns.Msg, respType ResponseType) time.Duration {
 			}
 		}
 		if sig, ok := rr.(*dns.RRSIG); ok {
+			signed = true
 			if ttl := getRRSIGTTL(sig, now); ttl < hardTTL {
 				hardTTL = ttl
 			}
@@ -100,6 +108,15 @@ func CalculateCacheTTL(msg *dns.Msg, respType ResponseType) time.Duration {
 			continue
 		}
 		bound(rr, false)
+	}
+
+	// RFC 4035 §5.3.3 names four values and the served lifetime may exceed
+	// none of them: the RRset's TTL as received, the RRSIG's TTL, its Original
+	// TTL, and the time left before it expires. The first is a record TTL, so
+	// on signed data the floor may not lift that either. A signed A record with
+	// a one-second TTL was being held for five.
+	if signed && recordTTL < hardTTL {
+		hardTTL = recordTTL
 	}
 
 	minTTL := recordTTL
@@ -122,6 +139,15 @@ func CalculateCacheTTL(msg *dns.Msg, respType ResponseType) time.Duration {
 	// is a real answer here, and the caller declines to admit the entry.
 	if isNegative {
 		return minTTL
+	}
+
+	// A referral is held briefly whatever its NS records advertise, which is
+	// what it has always done, but never past a signature it carries.
+	if isReferral {
+		if hardTTL < MinCacheTTL {
+			return hardTTL
+		}
+		return MinCacheTTL
 	}
 
 	// Positive answers take a floor, and it is a deliberate deviation rather

--- a/internal/dnsutil/cache_ttl.go
+++ b/internal/dnsutil/cache_ttl.go
@@ -85,6 +85,15 @@ func CalculateCacheTTL(msg *dns.Msg, respType ResponseType) time.Duration {
 	// a denial with SOA header TTL 86400 and Minttl 300 must not be cached for
 	// a day. It applies to the authority section of a negative answer only.
 	bound := func(rr dns.RR, negativeSOA bool) {
+		// A signature's header TTL is a bound only while the signature is
+		// usable, and eachSignedRRset applies it then, alongside its
+		// Original TTL and its expiry. Read here it spoke for signatures
+		// that walk had rightly set aside: a lapsed sibling or a glue
+		// signature carrying a header TTL of zero was zeroing the lifetime
+		// of an answer whose live signature permitted an hour.
+		if _, isSig := rr.(*dns.RRSIG); isSig {
+			return
+		}
 		if ttl := getTTL(rr); ttl < recordTTL {
 			recordTTL = ttl
 		}
@@ -111,10 +120,12 @@ func CalculateCacheTTL(msg *dns.Msg, respType ResponseType) time.Duration {
 		bound(rr, false)
 	}
 
-	// The signature bound is taken per RRset, and within an RRset from the
-	// signature that still permits the most. Folding every signature into one
-	// minimum let a lapsed sibling speak for an RRset another signature still
-	// covers, which is exactly the shape of a key rollover.
+	// The signature bound is taken per RRset, from its signatures that are
+	// still usable, and among those from the one that permits the least —
+	// a downstream validator picks its own signature to verify with. Folding
+	// every signature into one minimum let a lapsed sibling speak for an
+	// RRset another signature still covers, which is exactly the shape of a
+	// key rollover.
 	//
 	// The additional section is left out, as it is for AD: RFC 4035 §3.2.3
 	// makes the answer and authority sections what this resolver vouches

--- a/internal/dnsutil/cache_ttl.go
+++ b/internal/dnsutil/cache_ttl.go
@@ -18,6 +18,17 @@ const (
 // It scans all resource records and returns the minimum TTL found, with bounds checking.
 // For DNSSEC-signed responses, it also considers RRSIG expiration times.
 func CalculateCacheTTL(msg *dns.Msg, respType ResponseType) time.Duration {
+	return CalculateCacheTTLAt(msg, respType, time.Now())
+}
+
+// CalculateCacheTTLAt is CalculateCacheTTL measured at now. Admission passes
+// the one instant it anchors the entry at, so the lifetime, the entry's
+// stored time and every decision taken against that lifetime — which
+// additional signatures it can carry — read the same clock: a lifetime
+// measured a moment earlier than the entry it bounds is that moment too
+// long, and a signature sharing the answer's own validity window fell short
+// of it by exactly that much.
+func CalculateCacheTTLAt(msg *dns.Msg, respType ResponseType, now time.Time) time.Duration {
 	// Only cache successful responses and negative responses (NXDOMAIN/NODATA)
 	isNegative := false
 	isReferral := false
@@ -79,7 +90,6 @@ func CalculateCacheTTL(msg *dns.Msg, respType ResponseType) time.Duration {
 	recordTTL := MaxCacheTTL
 	hardTTL := MaxCacheTTL
 	signed := false
-	now := time.Now()
 
 	// negativeSOA folds in the RFC 2308 cap, min(SOA header TTL, SOA.Minttl):
 	// a denial with SOA header TTL 86400 and Minttl 300 must not be cached for

--- a/internal/dnsutil/cache_ttl.go
+++ b/internal/dnsutil/cache_ttl.go
@@ -37,6 +37,14 @@ func CalculateCacheTTL(msg *dns.Msg, respType ResponseType) time.Duration {
 
 	// Handle empty responses
 	if !hasRecords(msg) {
+		// A denial carries its lifetime in the SOA of the authority section.
+		// With no records at all there is nothing to derive one from, and RFC
+		// 2308 §5 says such a response should not be cached: without an SOA
+		// there is no way to stop a pair of misconfigured servers looping the
+		// denial between them forever.
+		if isNegative {
+			return 0
+		}
 		return MinCacheTTL
 	}
 
@@ -98,11 +106,29 @@ func CalculateCacheTTL(msg *dns.Msg, respType ResponseType) time.Duration {
 	}
 
 	// Apply bounds
-	if minTTL < MinCacheTTL {
-		return MinCacheTTL
-	}
 	if minTTL > MaxCacheTTL {
 		return MaxCacheTTL
+	}
+
+	// RFC 2308 §5 makes the SOA-derived lifetime a ceiling: it says how long a
+	// resolver *may* cache the denial. A floor inverts that — a zone that
+	// publishes a one-second negative TTL means one second, and holding it for
+	// five is the resolver overriding the only party entitled to decide. Zero
+	// is a real answer here, and the caller declines to admit the entry.
+	//
+	// Positive answers keep the floor. Nothing derives it from a zone's own
+	// statement about its data, so nothing is being overridden: it is the
+	// resolver's own guard against re-resolving a one-second record on every
+	// query, and RFC 1035 §3.2.1 leaves that latitude.
+	if isNegative {
+		if minTTL < 0 {
+			return 0
+		}
+		return minTTL
+	}
+
+	if minTTL < MinCacheTTL {
+		return MinCacheTTL
 	}
 
 	return minTTL
@@ -139,9 +165,13 @@ func getRRSIGTTL(sig *dns.RRSIG, now time.Time) time.Duration {
 	expireTime := time.Unix(int64(sig.Expiration), 0)
 	timeUntilExpire := expireTime.Sub(now)
 
-	// If signature has already expired, return minimum TTL
+	// An expired signature bounds the answer at zero. Returning the floor here
+	// made it a floor wearing a bound's clothes: on the denial path, which
+	// takes no floor of its own, it was the one thing still granting five more
+	// seconds of life to data whose proof had already lapsed. Positive answers
+	// land on their own floor immediately afterwards, so they see no change.
 	if timeUntilExpire <= 0 {
-		return MinCacheTTL
+		return 0
 	}
 
 	// Return the minimum of record TTL and time until expiration

--- a/internal/dnsutil/cache_ttl.go
+++ b/internal/dnsutil/cache_ttl.go
@@ -232,6 +232,19 @@ func getTTL(rr dns.RR) time.Duration {
 // A lapsed signature bounds the data at zero. Returning the cache floor here
 // made it a floor wearing a bound's clothes, granting five more seconds of
 // life to material whose proof had already run out.
+// SignatureLifetime reports whether sig is within its validity period at now
+// and, if so, the longest lifetime it permits the RRset it covers: the least
+// of its header TTL, its Original TTL and the time left before it expires
+// (RFC 4035 §5.3.3). The same two questions eachSignedRRset answers per
+// RRset, asked of one signature, for a caller deciding whether an entry of a
+// given lifetime can carry it.
+func SignatureLifetime(sig *dns.RRSIG, now time.Time) (time.Duration, bool) {
+	if !sig.ValidityPeriod(now) {
+		return 0, false
+	}
+	return getRRSIGTTL(sig, now), true
+}
+
 func getRRSIGTTL(sig *dns.RRSIG, now time.Time) time.Duration {
 	ttl := time.Duration(sig.Header().Ttl) * time.Second
 

--- a/internal/dnsutil/cache_ttl.go
+++ b/internal/dnsutil/cache_ttl.go
@@ -115,7 +115,13 @@ func CalculateCacheTTL(msg *dns.Msg, respType ResponseType) time.Duration {
 	// signature that still permits the most. Folding every signature into one
 	// minimum let a lapsed sibling speak for an RRset another signature still
 	// covers, which is exactly the shape of a key rollover.
-	eachSignedRRset([][]dns.RR{msg.Answer, msg.Ns, msg.Extra}, now, func(_ bool, usable time.Duration) {
+	//
+	// The additional section is left out, as it is for AD: RFC 4035 §3.2.3
+	// makes the answer and authority sections what this resolver vouches
+	// for, and nothing validates glue. A lapsed signature over an additional
+	// record was zeroing the lifetime of a fully covered answer and sending
+	// every query for it back upstream. Its record TTLs still bound below.
+	eachSignedRRset([][]dns.RR{msg.Answer, msg.Ns}, now, func(_ bool, usable time.Duration) {
 		signed = true
 		if usable < hardTTL {
 			hardTTL = usable

--- a/internal/dnsutil/cache_ttl_test.go
+++ b/internal/dnsutil/cache_ttl_test.go
@@ -190,6 +190,11 @@ func TestGetRRSIGTTL(t *testing.T) {
 			expectedTTL: 1 * time.Hour,
 		},
 		{
+			// Zero, not the floor. This function reports a bound, and a
+			// lapsed signature bounds the data at nothing; the floor is
+			// applied afterwards and only to the response types that take
+			// one. Returning MinCacheTTL here used to be the last thing
+			// granting a denial five more seconds on an expired proof.
 			name: "Signature already expired",
 			sig: &dns.RRSIG{
 				Hdr: dns.RR_Header{
@@ -197,7 +202,7 @@ func TestGetRRSIGTTL(t *testing.T) {
 				},
 				Expiration: uint32(now.Add(-1 * time.Hour).Unix()), //nolint:gosec // G115 - Unix timestamp
 			},
-			expectedTTL: MinCacheTTL,
+			expectedTTL: 0,
 		},
 	}
 

--- a/internal/dnsutil/cache_ttl_test.go
+++ b/internal/dnsutil/cache_ttl_test.go
@@ -37,6 +37,7 @@ func TestCalculateCacheTTLWithRRSIG(t *testing.T) {
 							Class:  dns.ClassINET,
 							Ttl:    3600, // 1 hour
 						},
+						OrigTtl:     3600,
 						TypeCovered: dns.TypeA,
 						Expiration:  uint32(now.Add(10 * time.Minute).Unix()), //nolint:gosec // G115 - Unix timestamp fits in uint32 for valid dates
 						Inception:   uint32(now.Add(-1 * time.Hour).Unix()),   //nolint:gosec // G115 - Unix timestamp fits in uint32 for valid dates
@@ -66,6 +67,7 @@ func TestCalculateCacheTTLWithRRSIG(t *testing.T) {
 							Class:  dns.ClassINET,
 							Ttl:    300, // 5 minutes
 						},
+						OrigTtl:     300,
 						TypeCovered: dns.TypeA,
 						Expiration:  uint32(now.Add(2 * time.Hour).Unix()),  //nolint:gosec // G115 - Unix timestamp fits in uint32 for valid dates
 						Inception:   uint32(now.Add(-1 * time.Hour).Unix()), //nolint:gosec // G115 - Unix timestamp fits in uint32 for valid dates
@@ -95,14 +97,21 @@ func TestCalculateCacheTTLWithRRSIG(t *testing.T) {
 							Class:  dns.ClassINET,
 							Ttl:    3600,
 						},
+						OrigTtl:     3600,
 						TypeCovered: dns.TypeA,
 						Expiration:  uint32(now.Add(-1 * time.Hour).Unix()), //nolint:gosec // G115 - Unix timestamp fits in uint32 for valid dates
 						Inception:   uint32(now.Add(-2 * time.Hour).Unix()), //nolint:gosec // G115 - Unix timestamp fits in uint32 for valid dates
 					},
 				},
 			},
-			respType:    TypeSuccess,
-			expectedTTL: MinCacheTTL, // Should use minimum TTL
+			respType: TypeSuccess,
+			// Zero, not the floor. A lapsed signature is a bound the protocol
+			// fixes (RFC 4035 §5.3.3), and the cache's own minimum is not
+			// entitled to lift an answer past it. The floor used to win here
+			// and bought the expired data another five seconds. In the running
+			// server this shape never arrives as a success anyway,
+			// ClassifyResponse names it TypeExpiredSignature first.
+			expectedTTL: 0,
 		},
 		{
 			name: "Multiple RRSIGs with different expirations",
@@ -124,6 +133,7 @@ func TestCalculateCacheTTLWithRRSIG(t *testing.T) {
 							Class:  dns.ClassINET,
 							Ttl:    3600,
 						},
+						OrigTtl:     3600,
 						TypeCovered: dns.TypeA,
 						Algorithm:   dns.RSASHA256,
 						Expiration:  uint32(now.Add(30 * time.Minute).Unix()), //nolint:gosec // G115 - Unix timestamp fits in uint32 for valid dates
@@ -136,6 +146,7 @@ func TestCalculateCacheTTLWithRRSIG(t *testing.T) {
 							Class:  dns.ClassINET,
 							Ttl:    3600,
 						},
+						OrigTtl:     3600,
 						TypeCovered: dns.TypeA,
 						Algorithm:   dns.ECDSAP256SHA256,
 						Expiration:  uint32(now.Add(15 * time.Minute).Unix()), //nolint:gosec // G115 - Unix timestamp fits in uint32 for valid dates
@@ -175,6 +186,7 @@ func TestGetRRSIGTTL(t *testing.T) {
 				Hdr: dns.RR_Header{
 					Ttl: 7200, // 2 hours
 				},
+				OrigTtl:    7200,
 				Expiration: uint32(now.Add(1 * time.Hour).Unix()), //nolint:gosec // G115 - Unix timestamp fits in uint32 for valid dates
 			},
 			expectedTTL: 1 * time.Hour,
@@ -185,6 +197,7 @@ func TestGetRRSIGTTL(t *testing.T) {
 				Hdr: dns.RR_Header{
 					Ttl: 3600, // 1 hour
 				},
+				OrigTtl:    3600,
 				Expiration: uint32(now.Add(2 * time.Hour).Unix()), //nolint:gosec // G115 - Unix timestamp
 			},
 			expectedTTL: 1 * time.Hour,
@@ -200,6 +213,7 @@ func TestGetRRSIGTTL(t *testing.T) {
 				Hdr: dns.RR_Header{
 					Ttl: 3600,
 				},
+				OrigTtl:    3600,
 				Expiration: uint32(now.Add(-1 * time.Hour).Unix()), //nolint:gosec // G115 - Unix timestamp
 			},
 			expectedTTL: 0,

--- a/internal/dnsutil/canonical_identity_test.go
+++ b/internal/dnsutil/canonical_identity_test.go
@@ -1,0 +1,105 @@
+package dnsutil
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// TestSiblingIdentityIsTheWireName is the canonical-identity matrix for
+// sibling grouping. Two spellings of one wire name — escaped and plain,
+// rooted and unrooted, ASCII case — are one RRset, so a live signature
+// under either covers an expired one under the other. A Kelvin sign is not a
+// k: the Unicode fold says so, the wire does not, and a live signature under
+// the one must not rescue an expired RRset under the other. Owner and signer
+// both, on the inline path and past it through the map, in both wire orders.
+func TestSiblingIdentityIsTheWireName(t *testing.T) {
+	now := time.Now()
+	sig := func(owner, signer string, until time.Duration) dns.RR {
+		return &dns.RRSIG{
+			Hdr:         dns.RR_Header{Name: owner, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 3600},
+			TypeCovered: dns.TypeA, OrigTtl: 3600, SignerName: signer,
+			Inception:  uint32(now.Add(-2 * time.Hour).Unix()), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+			Expiration: uint32(now.Add(until).Unix()),          //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+		}
+	}
+	a := func(owner string) dns.RR {
+		return &dns.A{Hdr: dns.RR_Header{Name: owner, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 3600}, A: []byte{192, 0, 2, 1}}
+	}
+	// filler puts n distinct signed RRsets ahead of the pair, so the pair
+	// is grouped past the inline capacity, through the map.
+	filler := func(n int) []dns.RR {
+		var rrs []dns.RR
+		for i := range n {
+			owner := fmt.Sprintf("f%d.example.", i)
+			rrs = append(rrs, a(owner), sig(owner, "example.", time.Hour))
+		}
+		return rrs
+	}
+
+	type spelling struct {
+		name     string
+		a, b     string
+		siblings bool
+	}
+	owners := []spelling{
+		{"escaped and plain", "target.example.", `t\097rget.example.`, true},
+		{"rooted and unrooted", "k.example.", "k.example", true},
+		{"ASCII case", "K.EXAMPLE.", "k.example.", true},
+		{"Kelvin sign and k", "K.example.", "k.example.", false},
+	}
+	signers := []spelling{
+		{"ASCII case", "EXAMPLE.", "example.", true},
+		{"escaped and plain", `ex\097mple.`, "example.", true},
+		{"Kelvin sign and k", "Keep.example.", "keep.example.", false},
+	}
+
+	check := func(t *testing.T, records []dns.RR, siblings bool) {
+		t.Helper()
+		msg := new(dns.Msg)
+		msg.SetQuestion("k.example.", dns.TypeA)
+		msg.Answer = records
+		if got := HasExpiredSignatures(msg, now); got == siblings {
+			t.Errorf("HasExpiredSignatures = %v, want %v", got, !siblings)
+		}
+		ttl := CalculateCacheTTL(msg, TypeSuccess)
+		if siblings && ttl < 59*time.Minute {
+			t.Errorf("lifetime %v, want the live sibling's hour", ttl)
+		}
+		if !siblings && ttl != 0 {
+			t.Errorf("lifetime %v, want nothing: an RRset is uncovered", ttl)
+		}
+	}
+
+	for _, path := range []struct {
+		name string
+		pad  int
+	}{{"inline", 0}, {"past the inline capacity", signedRRsetInline + 1}} {
+		for _, o := range owners {
+			for _, order := range []string{"expired first", "live first"} {
+				t.Run(fmt.Sprintf("owner %s, %s, %s", o.name, path.name, order), func(t *testing.T) {
+					expired, live := sig(o.a, "example.", -time.Hour), sig(o.b, "example.", time.Hour)
+					pair := []dns.RR{a(o.a), expired, live}
+					if order == "live first" {
+						pair = []dns.RR{a(o.a), live, expired}
+					}
+					check(t, append(filler(path.pad), pair...), o.siblings)
+				})
+			}
+		}
+		for _, s := range signers {
+			for _, order := range []string{"expired first", "live first"} {
+				t.Run(fmt.Sprintf("signer %s, %s, %s", s.name, path.name, order), func(t *testing.T) {
+					expired, live := sig("k.example.", s.a, -time.Hour), sig("k.example.", s.b, time.Hour)
+					pair := []dns.RR{a("k.example."), expired, live}
+					if order == "live first" {
+						pair = []dns.RR{a("k.example."), live, expired}
+					}
+					check(t, append(filler(path.pad), pair...), s.siblings)
+				})
+			}
+		}
+	}
+}

--- a/internal/dnsutil/clear_dnssec_additional_test.go
+++ b/internal/dnsutil/clear_dnssec_additional_test.go
@@ -75,3 +75,45 @@ func TestClearDNSSECKeepsOnlyTheTypeAskedFor(t *testing.T) {
 		})
 	}
 }
+
+// TestClearDNSSECInPlaceMatchesAndAllocatesNothing pins the in-place
+// variant to the same rule as ClearDNSSEC, compacting the message's own
+// sections without allocating — it runs on every DO=0 aggressive hit.
+func TestClearDNSSECInPlaceMatchesAndAllocatesNothing(t *testing.T) {
+	build := func(qtype uint16) *dns.Msg {
+		m := new(dns.Msg)
+		m.SetQuestion("m.example.", qtype)
+		m.Ns = []dns.RR{
+			&dns.SOA{Hdr: dns.RR_Header{Name: "example.", Rrtype: dns.TypeSOA, Class: dns.ClassINET, Ttl: 300}, Ns: "ns.example.", Mbox: "hostmaster.example.", Minttl: 300},
+			&dns.RRSIG{Hdr: dns.RR_Header{Name: "example.", Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 300}, TypeCovered: dns.TypeSOA, SignerName: "example."},
+			&dns.NSEC{Hdr: dns.RR_Header{Name: "a.example.", Rrtype: dns.TypeNSEC, Class: dns.ClassINET, Ttl: 300}, NextDomain: "z.example."},
+			&dns.RRSIG{Hdr: dns.RR_Header{Name: "a.example.", Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 300}, TypeCovered: dns.TypeNSEC, SignerName: "example."},
+		}
+		return m
+	}
+	for _, qtype := range []uint16{dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC} {
+		want := ClearDNSSEC(build(qtype))
+		got := build(qtype)
+		backing := &got.Ns[0]
+		ClearDNSSECInPlace(got)
+		if len(got.Ns) != len(want.Ns) {
+			t.Fatalf("qtype %d: in place kept %d records, ClearDNSSEC kept %d", qtype, len(got.Ns), len(want.Ns))
+		}
+		for i := range got.Ns {
+			if got.Ns[i].String() != want.Ns[i].String() {
+				t.Fatalf("qtype %d: record %d differs: %v vs %v", qtype, i, got.Ns[i], want.Ns[i])
+			}
+		}
+		if len(got.Ns) > 0 && &got.Ns[0] != backing {
+			t.Fatalf("qtype %d: in place did not compact the message's own slice", qtype)
+		}
+	}
+
+	m := build(dns.TypeA)
+	if allocs := testing.AllocsPerRun(100, func() {
+		m.Ns = m.Ns[:4]
+		ClearDNSSECInPlace(m)
+	}); allocs != 0 {
+		t.Errorf("in-place filter allocated %v times, want none", allocs)
+	}
+}

--- a/internal/dnsutil/clear_dnssec_additional_test.go
+++ b/internal/dnsutil/clear_dnssec_additional_test.go
@@ -117,3 +117,67 @@ func TestClearDNSSECInPlaceMatchesAndAllocatesNothing(t *testing.T) {
 		t.Errorf("in-place filter allocated %v times, want none", allocs)
 	}
 }
+
+// TestClearDNSSECInPlaceAcrossSectionsAndTypes widens the in-place variant's
+// pin to every section and to NSEC3, and to the order the aggressive cache
+// runs it in: a DO=0 answer compacted in place must not thin the records a
+// later DO=1 answer is built from, which holds because each synthesis copies
+// its records into a fresh slice — pinned here by compacting one message and
+// checking the source it was built from is whole.
+func TestClearDNSSECInPlaceAcrossSectionsAndTypes(t *testing.T) {
+	source := func() []dns.RR {
+		return []dns.RR{
+			&dns.A{Hdr: dns.RR_Header{Name: "a.example.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300}, A: []byte{192, 0, 2, 1}},
+			&dns.RRSIG{Hdr: dns.RR_Header{Name: "a.example.", Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 300}, TypeCovered: dns.TypeA, SignerName: "example."},
+			&dns.NSEC3{Hdr: dns.RR_Header{Name: "hash.example.", Rrtype: dns.TypeNSEC3, Class: dns.ClassINET, Ttl: 300}, Hash: 1, Iterations: 0, NextDomain: "HASH2"},
+			&dns.RRSIG{Hdr: dns.RR_Header{Name: "hash.example.", Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 300}, TypeCovered: dns.TypeNSEC3, SignerName: "example."},
+		}
+	}
+	synthesize := func(qtype uint16, from []dns.RR) *dns.Msg {
+		m := new(dns.Msg)
+		m.SetQuestion("a.example.", qtype)
+		for _, rr := range from {
+			m.Answer = append(m.Answer, dns.Copy(rr))
+			m.Ns = append(m.Ns, dns.Copy(rr))
+			m.Extra = append(m.Extra, dns.Copy(rr))
+		}
+		return m
+	}
+	count := func(rrs []dns.RR, rrtype uint16) int {
+		n := 0
+		for _, rr := range rrs {
+			if rr.Header().Rrtype == rrtype {
+				n++
+			}
+		}
+		return n
+	}
+
+	kept := source()
+	for _, tc := range []struct {
+		name                        string
+		qtype                       uint16
+		wantA, wantRRSIG, wantNSEC3 int
+	}{
+		{"ordinary question", dns.TypeA, 1, 0, 0},
+		{"question for RRSIG", dns.TypeRRSIG, 1, 2, 0},
+		{"question for NSEC3", dns.TypeNSEC3, 1, 0, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := ClearDNSSECInPlace(synthesize(tc.qtype, kept))
+			for name, section := range map[string][]dns.RR{"answer": m.Answer, "authority": m.Ns, "additional": m.Extra} {
+				if count(section, dns.TypeA) != tc.wantA || count(section, dns.TypeRRSIG) != tc.wantRRSIG || count(section, dns.TypeNSEC3) != tc.wantNSEC3 {
+					t.Errorf("%s section: %v", name, section)
+				}
+			}
+			// The source a DO=1 answer would be built from next is whole.
+			if len(kept) != 4 {
+				t.Fatalf("in-place compaction reached the source records: %v", kept)
+			}
+			do1 := synthesize(tc.qtype, kept)
+			if count(do1.Ns, dns.TypeRRSIG) != 2 || count(do1.Ns, dns.TypeNSEC3) != 1 {
+				t.Errorf("a DO=1 answer built after the compaction is thinned: %v", do1.Ns)
+			}
+		})
+	}
+}

--- a/internal/dnsutil/clear_dnssec_additional_test.go
+++ b/internal/dnsutil/clear_dnssec_additional_test.go
@@ -6,17 +6,22 @@ import (
 	"github.com/miekg/dns"
 )
 
-// TestClearDNSSECStripsTheAdditionalSection pins ClearDNSSEC on the section it
-// used to leave alone: a DO=0 response carries no authenticating record it
-// was not asked for (RFC 4035 §3.2.1), the additional section included, and
-// the records those signatures covered stay. An explicit RRSIG question is
-// still returned untouched.
-func TestClearDNSSECStripsTheAdditionalSection(t *testing.T) {
+// TestClearDNSSECKeepsOnlyTheTypeAskedFor pins ClearDNSSEC's exception as
+// RFC 4035 §3.2.1 states it: a DO=0 response carries no authenticating
+// record it was not asked for, in any section, and the one type the question
+// named is kept wherever it appears. A query for RRSIG keeps its signatures
+// and loses the NSEC that came along as a proof; a query for NSEC keeps the
+// NSEC and loses the signatures; an ordinary query loses all of them, the
+// additional section included, and keeps the records they covered.
+func TestClearDNSSECKeepsOnlyTheTypeAskedFor(t *testing.T) {
 	rrsig := func(owner string, covered uint16) dns.RR {
 		return &dns.RRSIG{
 			Hdr:         dns.RR_Header{Name: owner, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 300},
 			TypeCovered: covered, SignerName: "example.",
 		}
+	}
+	nsec := func(owner string) dns.RR {
+		return &dns.NSEC{Hdr: dns.RR_Header{Name: owner, Rrtype: dns.TypeNSEC, Class: dns.ClassINET, Ttl: 300}, NextDomain: "z.example."}
 	}
 	build := func(qtype uint16) *dns.Msg {
 		m := new(dns.Msg)
@@ -24,28 +29,49 @@ func TestClearDNSSECStripsTheAdditionalSection(t *testing.T) {
 		m.Answer = []dns.RR{
 			&dns.MX{Hdr: dns.RR_Header{Name: "mx.example.", Rrtype: dns.TypeMX, Class: dns.ClassINET, Ttl: 300}, Preference: 10, Mx: "target.example."},
 			rrsig("mx.example.", dns.TypeMX),
+			nsec("mx.example."),
+			rrsig("mx.example.", dns.TypeNSEC),
 		}
+		m.Ns = []dns.RR{nsec("example."), rrsig("example.", dns.TypeNSEC)}
 		m.Extra = []dns.RR{
 			&dns.A{Hdr: dns.RR_Header{Name: "target.example.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300}, A: []byte{192, 0, 2, 1}},
 			rrsig("target.example.", dns.TypeA),
-			&dns.NSEC{Hdr: dns.RR_Header{Name: "target.example.", Rrtype: dns.TypeNSEC, Class: dns.ClassINET, Ttl: 300}, NextDomain: "z.example."},
+			nsec("target.example."),
 		}
 		return m
 	}
-
-	m := ClearDNSSEC(build(dns.TypeMX))
-	for _, rr := range append(append([]dns.RR{}, m.Answer...), m.Extra...) {
-		switch rr.(type) {
-		case *dns.RRSIG, *dns.NSEC, *dns.NSEC3:
-			t.Errorf("%s survived ClearDNSSEC", rr.Header().String())
+	count := func(m *dns.Msg, rrtype uint16) int {
+		n := 0
+		for _, section := range [][]dns.RR{m.Answer, m.Ns, m.Extra} {
+			for _, rr := range section {
+				if rr.Header().Rrtype == rrtype {
+					n++
+				}
+			}
 		}
-	}
-	if len(m.Extra) != 1 {
-		t.Fatalf("additional section holds %d records, want the address alone", len(m.Extra))
+		return n
 	}
 
-	whole := ClearDNSSEC(build(dns.TypeRRSIG))
-	if len(whole.Answer) != 2 || len(whole.Extra) != 3 {
-		t.Fatal("an explicit RRSIG question was not returned untouched")
+	for _, tc := range []struct {
+		name                            string
+		qtype                           uint16
+		wantRRSIG, wantNSEC, wantOthers int
+	}{
+		{"an ordinary question loses every authenticating record", dns.TypeMX, 0, 0, 2},
+		{"a question for RRSIG keeps the signatures and nothing else", dns.TypeRRSIG, 4, 0, 2},
+		{"a question for NSEC keeps the NSEC and nothing else", dns.TypeNSEC, 0, 3, 2},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := ClearDNSSEC(build(tc.qtype))
+			if got := count(m, dns.TypeRRSIG); got != tc.wantRRSIG {
+				t.Errorf("%d RRSIG records kept, want %d", got, tc.wantRRSIG)
+			}
+			if got := count(m, dns.TypeNSEC); got != tc.wantNSEC {
+				t.Errorf("%d NSEC records kept, want %d", got, tc.wantNSEC)
+			}
+			if got := count(m, dns.TypeMX) + count(m, dns.TypeA); got != tc.wantOthers {
+				t.Errorf("%d covered records kept, want %d", got, tc.wantOthers)
+			}
+		})
 	}
 }

--- a/internal/dnsutil/clear_dnssec_additional_test.go
+++ b/internal/dnsutil/clear_dnssec_additional_test.go
@@ -1,0 +1,51 @@
+package dnsutil
+
+import (
+	"testing"
+
+	"github.com/miekg/dns"
+)
+
+// TestClearDNSSECStripsTheAdditionalSection pins ClearDNSSEC on the section it
+// used to leave alone: a DO=0 response carries no authenticating record it
+// was not asked for (RFC 4035 §3.2.1), the additional section included, and
+// the records those signatures covered stay. An explicit RRSIG question is
+// still returned untouched.
+func TestClearDNSSECStripsTheAdditionalSection(t *testing.T) {
+	rrsig := func(owner string, covered uint16) dns.RR {
+		return &dns.RRSIG{
+			Hdr:         dns.RR_Header{Name: owner, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 300},
+			TypeCovered: covered, SignerName: "example.",
+		}
+	}
+	build := func(qtype uint16) *dns.Msg {
+		m := new(dns.Msg)
+		m.SetQuestion("mx.example.", qtype)
+		m.Answer = []dns.RR{
+			&dns.MX{Hdr: dns.RR_Header{Name: "mx.example.", Rrtype: dns.TypeMX, Class: dns.ClassINET, Ttl: 300}, Preference: 10, Mx: "target.example."},
+			rrsig("mx.example.", dns.TypeMX),
+		}
+		m.Extra = []dns.RR{
+			&dns.A{Hdr: dns.RR_Header{Name: "target.example.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300}, A: []byte{192, 0, 2, 1}},
+			rrsig("target.example.", dns.TypeA),
+			&dns.NSEC{Hdr: dns.RR_Header{Name: "target.example.", Rrtype: dns.TypeNSEC, Class: dns.ClassINET, Ttl: 300}, NextDomain: "z.example."},
+		}
+		return m
+	}
+
+	m := ClearDNSSEC(build(dns.TypeMX))
+	for _, rr := range append(append([]dns.RR{}, m.Answer...), m.Extra...) {
+		switch rr.(type) {
+		case *dns.RRSIG, *dns.NSEC, *dns.NSEC3:
+			t.Errorf("%s survived ClearDNSSEC", rr.Header().String())
+		}
+	}
+	if len(m.Extra) != 1 {
+		t.Fatalf("additional section holds %d records, want the address alone", len(m.Extra))
+	}
+
+	whole := ClearDNSSEC(build(dns.TypeRRSIG))
+	if len(whole.Answer) != 2 || len(whole.Extra) != 3 {
+		t.Fatal("an explicit RRSIG question was not returned untouched")
+	}
+}

--- a/internal/dnsutil/helpers.go
+++ b/internal/dnsutil/helpers.go
@@ -140,16 +140,7 @@ func ClearOPT(msg *dns.Msg) *dns.Msg {
 // to strip (typical for non-DNSSEC responses), and reuses the slice backing
 // array when a filter is actually needed.
 func ClearDNSSEC(msg *dns.Msg) *dns.Msg {
-	// asked is the authenticating type the question named, if any. The
-	// packed body's DNSSEC verdict (prepareWireServe) leaves the same type
-	// out of account, so the two agree on what is payload.
-	asked := uint16(0)
-	if len(msg.Question) > 0 {
-		switch q := msg.Question[0].Qtype; q {
-		case dns.TypeRRSIG, dns.TypeNSEC, dns.TypeNSEC3:
-			asked = q
-		}
-	}
+	asked := explicitDNSSECType(msg)
 	drop := func(rr dns.RR) bool {
 		return isDNSSEC(rr) && rr.Header().Rrtype != asked
 	}
@@ -157,6 +148,44 @@ func ClearDNSSEC(msg *dns.Msg) *dns.Msg {
 	msg.Ns = filterOut(msg.Ns, drop)
 	msg.Extra = filterOut(msg.Extra, drop)
 	return msg
+}
+
+// ClearDNSSECInPlace is ClearDNSSEC for a message that owns its sections:
+// the same rule, compacting each section in place instead of allocating a
+// filtered copy. For an answer synthesized per hit, whose slices are its
+// own and are about to be handed out — filtering through a copy there was
+// an allocation on every DO=0 hit.
+func ClearDNSSECInPlace(msg *dns.Msg) *dns.Msg {
+	asked := explicitDNSSECType(msg)
+	compact := func(rrs []dns.RR) []dns.RR {
+		kept := rrs[:0]
+		for _, rr := range rrs {
+			if isDNSSEC(rr) && rr.Header().Rrtype != asked {
+				continue
+			}
+			kept = append(kept, rr)
+		}
+		return kept
+	}
+	msg.Answer = compact(msg.Answer)
+	msg.Ns = compact(msg.Ns)
+	msg.Extra = compact(msg.Extra)
+	return msg
+}
+
+// explicitDNSSECType is the authenticating type the question named, if
+// any: RRSIG, NSEC or NSEC3, zero otherwise. The packed body's DNSSEC
+// verdict (prepareWireServe) leaves the same type out of account, so the
+// two agree on what is payload.
+func explicitDNSSECType(msg *dns.Msg) uint16 {
+	if len(msg.Question) == 0 {
+		return 0
+	}
+	switch q := msg.Question[0].Qtype; q {
+	case dns.TypeRRSIG, dns.TypeNSEC, dns.TypeNSEC3:
+		return q
+	}
+	return 0
 }
 
 // filterOut returns a slice that contains every RR from rrs for which

--- a/internal/dnsutil/helpers.go
+++ b/internal/dnsutil/helpers.go
@@ -129,10 +129,13 @@ func ClearOPT(msg *dns.Msg) *dns.Msg {
 	return msg
 }
 
-// ClearDNSSEC removes RRSIG, NSEC and NSEC3 records from Answer and Ns
-// sections in place. Short-circuits when the sections already hold
-// nothing to strip (typical for non-DNSSEC responses), and reuses the
-// slice backing array when a filter is actually needed.
+// ClearDNSSEC removes RRSIG, NSEC and NSEC3 records from every section in
+// place — the additional section included, since RFC 4035 §3.2.1 has a
+// DO=0 response carry no authenticating records it was not asked for, and
+// a signed additional RRset is carried with its signature. Short-circuits
+// when the sections already hold nothing to strip (typical for non-DNSSEC
+// responses), and reuses the slice backing array when a filter is actually
+// needed.
 func ClearDNSSEC(msg *dns.Msg) *dns.Msg {
 	// An explicit RRSIG query must retain its RRSIG answers.
 	if len(msg.Question) > 0 && msg.Question[0].Qtype == dns.TypeRRSIG {
@@ -141,6 +144,7 @@ func ClearDNSSEC(msg *dns.Msg) *dns.Msg {
 
 	msg.Answer = filterOut(msg.Answer, isDNSSEC)
 	msg.Ns = filterOut(msg.Ns, isDNSSEC)
+	msg.Extra = filterOut(msg.Extra, isDNSSEC)
 	return msg
 }
 

--- a/internal/dnsutil/helpers.go
+++ b/internal/dnsutil/helpers.go
@@ -132,19 +132,30 @@ func ClearOPT(msg *dns.Msg) *dns.Msg {
 // ClearDNSSEC removes RRSIG, NSEC and NSEC3 records from every section in
 // place — the additional section included, since RFC 4035 §3.2.1 has a
 // DO=0 response carry no authenticating records it was not asked for, and
-// a signed additional RRset is carried with its signature. Short-circuits
-// when the sections already hold nothing to strip (typical for non-DNSSEC
-// responses), and reuses the slice backing array when a filter is actually
-// needed.
+// a signed additional RRset is carried with its signature. The one type
+// the question asked for by name is the exception, and only that type: a
+// query for RRSIG keeps its signatures and still loses the NSEC that came
+// along as a proof, a query for NSEC keeps the NSEC and loses the
+// signatures over it. Short-circuits when the sections already hold nothing
+// to strip (typical for non-DNSSEC responses), and reuses the slice backing
+// array when a filter is actually needed.
 func ClearDNSSEC(msg *dns.Msg) *dns.Msg {
-	// An explicit RRSIG query must retain its RRSIG answers.
-	if len(msg.Question) > 0 && msg.Question[0].Qtype == dns.TypeRRSIG {
-		return msg
+	// asked is the authenticating type the question named, if any. The
+	// packed body's DNSSEC verdict (prepareWireServe) leaves the same type
+	// out of account, so the two agree on what is payload.
+	asked := uint16(0)
+	if len(msg.Question) > 0 {
+		switch q := msg.Question[0].Qtype; q {
+		case dns.TypeRRSIG, dns.TypeNSEC, dns.TypeNSEC3:
+			asked = q
+		}
 	}
-
-	msg.Answer = filterOut(msg.Answer, isDNSSEC)
-	msg.Ns = filterOut(msg.Ns, isDNSSEC)
-	msg.Extra = filterOut(msg.Extra, isDNSSEC)
+	drop := func(rr dns.RR) bool {
+		return isDNSSEC(rr) && rr.Header().Rrtype != asked
+	}
+	msg.Answer = filterOut(msg.Answer, drop)
+	msg.Ns = filterOut(msg.Ns, drop)
+	msg.Extra = filterOut(msg.Extra, drop)
 	return msg
 }
 

--- a/internal/dnsutil/negative_ttl_test.go
+++ b/internal/dnsutil/negative_ttl_test.go
@@ -1,0 +1,175 @@
+package dnsutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// denial builds a negative response whose SOA carries the given header TTL and
+// MINIMUM field. RFC 2308 §5 derives the negative lifetime from the smaller of
+// the two, so every test below fixes one and varies the other.
+func denial(rcode int, soaTTL, soaMin uint32, extra ...dns.RR) *dns.Msg {
+	msg := new(dns.Msg)
+	msg.Rcode = rcode
+	msg.Ns = append([]dns.RR{
+		&dns.SOA{
+			Hdr: dns.RR_Header{
+				Name:   "example.org.",
+				Rrtype: dns.TypeSOA,
+				Class:  dns.ClassINET,
+				Ttl:    soaTTL,
+			},
+			Ns:     "ns1.example.org.",
+			Mbox:   "hostmaster.example.org.",
+			Minttl: soaMin,
+		},
+	}, extra...)
+	return msg
+}
+
+// TestNegativeTTLIsACeilingNotAFloor is the core of the RFC 2308 §5 contract:
+// the SOA-derived lifetime says how long a resolver *may* cache the denial, so
+// a value below the cache's own minimum has to survive intact. Four seconds
+// either side of MinCacheTTL, and zero, which means the zone granted nothing.
+func TestNegativeTTLIsACeilingNotAFloor(t *testing.T) {
+	// Both fields are exercised, and each case pins the other high so the
+	// value under test is unambiguously the one that won.
+	const high = 86400
+
+	for _, respType := range []ResponseType{TypeNXDomain, TypeNoRecords} {
+		rcode := dns.RcodeNameError
+		name := "NXDOMAIN"
+		if respType == TypeNoRecords {
+			rcode = dns.RcodeSuccess
+			name = "NODATA"
+		}
+
+		for _, seconds := range []uint32{0, 1, 4, 5} {
+			want := time.Duration(seconds) * time.Second
+
+			t.Run(name+"/MINIMUM", func(t *testing.T) {
+				got := CalculateCacheTTL(denial(rcode, high, seconds), respType)
+				if got != want {
+					t.Errorf("SOA MINIMUM %ds: got %v, want %v", seconds, got, want)
+				}
+			})
+
+			t.Run(name+"/header TTL", func(t *testing.T) {
+				got := CalculateCacheTTL(denial(rcode, seconds, high), respType)
+				if got != want {
+					t.Errorf("SOA header TTL %ds: got %v, want %v", seconds, got, want)
+				}
+			})
+		}
+	}
+}
+
+// TestNegativeTTLTakesTheSmallerSOAField is the rest of RFC 2308 §5: neither
+// field is authoritative alone. A test that only varied MINIMUM would pass
+// against an implementation that ignored the header TTL entirely.
+func TestNegativeTTLTakesTheSmallerSOAField(t *testing.T) {
+	if got, want := CalculateCacheTTL(denial(dns.RcodeNameError, 1, 4), TypeNXDomain), time.Second; got != want {
+		t.Errorf("header TTL 1s vs MINIMUM 4s: got %v, want %v", got, want)
+	}
+	if got, want := CalculateCacheTTL(denial(dns.RcodeNameError, 4, 1), TypeNXDomain), time.Second; got != want {
+		t.Errorf("header TTL 4s vs MINIMUM 1s: got %v, want %v", got, want)
+	}
+}
+
+// TestPositiveTTLKeepsTheFloor is the other half of the contract. The floor is
+// the resolver's own freshness policy for data a zone published normally, and
+// nothing about the negative change may reach it.
+func TestPositiveTTLKeepsTheFloor(t *testing.T) {
+	answer := func(ttl uint32) *dns.Msg {
+		msg := new(dns.Msg)
+		msg.Answer = []dns.RR{
+			&dns.A{
+				Hdr: dns.RR_Header{
+					Name:   "example.org.",
+					Rrtype: dns.TypeA,
+					Class:  dns.ClassINET,
+					Ttl:    ttl,
+				},
+				A: []byte{192, 0, 2, 1},
+			},
+		}
+		return msg
+	}
+
+	for _, seconds := range []uint32{0, 1, 4} {
+		if got := CalculateCacheTTL(answer(seconds), TypeSuccess); got != MinCacheTTL {
+			t.Errorf("positive answer with %ds TTL: got %v, want the %v floor", seconds, got, MinCacheTTL)
+		}
+	}
+	if got, want := CalculateCacheTTL(answer(5), TypeSuccess), MinCacheTTL; got != want {
+		t.Errorf("positive answer at the floor: got %v, want %v", got, want)
+	}
+	if got, want := CalculateCacheTTL(answer(60), TypeSuccess), time.Minute; got != want {
+		t.Errorf("positive answer above the floor: got %v, want %v", got, want)
+	}
+}
+
+// TestFailureTTLUnchanged pins the SERVFAIL lifetime, which is neither derived
+// from a zone nor floored, and must not move with the negative change.
+func TestFailureTTLUnchanged(t *testing.T) {
+	msg := new(dns.Msg)
+	msg.Rcode = dns.RcodeServerFailure
+	if got, want := CalculateCacheTTL(msg, TypeServerFailure), 30*time.Second; got != want {
+		t.Errorf("SERVFAIL: got %v, want %v", got, want)
+	}
+}
+
+// TestDenialWithoutSOAIsNotCacheable covers RFC 2308 §5's other rule: with no
+// SOA there is nothing to derive a lifetime from, and a denial cached anyway
+// is what lets two misconfigured servers loop it between them.
+func TestDenialWithoutSOAIsNotCacheable(t *testing.T) {
+	bare := new(dns.Msg)
+	bare.Rcode = dns.RcodeNameError
+	if got := CalculateCacheTTL(bare, TypeNXDomain); got != 0 {
+		t.Errorf("NXDOMAIN with no records: got %v, want 0", got)
+	}
+}
+
+// TestDenialNeverOutlivesItsSignature is the reason the floor mattered beyond
+// freshness: an entry served past its RRSIG expiration is bogus to every
+// downstream validator (RFC 4035 §5.3.3), and the floor was the only thing
+// still granting it time.
+func TestDenialNeverOutlivesItsSignature(t *testing.T) {
+	now := time.Now()
+	sig := func(expiresIn time.Duration) dns.RR {
+		return &dns.RRSIG{
+			Hdr: dns.RR_Header{
+				Name:   "example.org.",
+				Rrtype: dns.TypeRRSIG,
+				Class:  dns.ClassINET,
+				Ttl:    86400,
+			},
+			OrigTtl:    86400,
+			Expiration: uint32(now.Add(expiresIn).Unix()), //nolint:gosec // G115 - Unix timestamp fits in uint32 for valid dates
+		}
+	}
+
+	// A signature with one second left bounds the denial at one second, even
+	// though that is below the cache's minimum.
+	msg := denial(dns.RcodeNameError, 86400, 86400, sig(time.Second))
+	if got := CalculateCacheTTL(msg, TypeNXDomain); got > time.Second {
+		t.Errorf("signature expiring in 1s: got %v, want at most 1s", got)
+	}
+
+	// An already-lapsed signature bounds it at nothing.
+	msg = denial(dns.RcodeNameError, 86400, 86400, sig(-time.Hour))
+	if got := CalculateCacheTTL(msg, TypeNXDomain); got != 0 {
+		t.Errorf("expired signature: got %v, want 0", got)
+	}
+}
+
+// TestNegativeTTLStillCapped keeps the upper bound honest: dropping the floor
+// must not drop the maximum with it.
+func TestNegativeTTLStillCapped(t *testing.T) {
+	huge := uint32((MaxCacheTTL * 10).Seconds())
+	if got, want := CalculateCacheTTL(denial(dns.RcodeNameError, huge, huge), TypeNXDomain), MaxCacheTTL; got != want {
+		t.Errorf("oversized SOA: got %v, want the %v cap", got, want)
+	}
+}

--- a/internal/dnsutil/negative_ttl_test.go
+++ b/internal/dnsutil/negative_ttl_test.go
@@ -173,3 +173,141 @@ func TestNegativeTTLStillCapped(t *testing.T) {
 		t.Errorf("oversized SOA: got %v, want the %v cap", got, want)
 	}
 }
+
+// cnameTo builds an alias record for the chain fixtures below.
+func cnameTo(name, target string, ttl uint32) dns.RR {
+	return &dns.CNAME{
+		Hdr: dns.RR_Header{
+			Name:   name,
+			Rrtype: dns.TypeCNAME,
+			Class:  dns.ClassINET,
+			Ttl:    ttl,
+		},
+		Target: target,
+	}
+}
+
+func askedFor(msg *dns.Msg, qtype uint16) *dns.Msg {
+	msg.Question = []dns.Question{{
+		Name:   "alias.example.org.",
+		Qtype:  qtype,
+		Qclass: dns.ClassINET,
+	}}
+	return msg
+}
+
+// TestAliasChainEndingInNodataIsNegative covers the commonest denial shape on
+// the wire: the answer section carries a CNAME chain that never reaches the
+// type asked for, and the terminal SOA is what says how long that holds.
+// Reading the alias TTL instead treated the whole thing as an ordinary answer,
+// so the SOA's MINIMUM was never consulted and the positive floor applied.
+func TestAliasChainEndingInNodataIsNegative(t *testing.T) {
+	build := func(soaMin uint32) *dns.Msg {
+		msg := askedFor(new(dns.Msg), dns.TypeA)
+		msg.Answer = []dns.RR{cnameTo("alias.example.org.", "target.example.org.", 300)}
+		msg.Ns = denial(dns.RcodeSuccess, 300, soaMin).Ns
+		return msg
+	}
+
+	for _, seconds := range []uint32{0, 1, 4, 5} {
+		msg := build(seconds)
+
+		mt, _ := ClassifyResponse(msg, time.Now())
+		if mt != TypeNoRecords {
+			t.Fatalf("SOA MINIMUM %ds: classified %v, want TypeNoRecords", seconds, mt)
+		}
+
+		want := time.Duration(seconds) * time.Second
+		if got := CalculateCacheTTL(msg, mt); got != want {
+			t.Errorf("SOA MINIMUM %ds: got %v, want %v", seconds, got, want)
+		}
+	}
+
+	// A chain that does reach the type asked for is an ordinary answer, and
+	// keeps the floor. Without this the fix would swallow every alias.
+	resolved := askedFor(new(dns.Msg), dns.TypeA)
+	resolved.Answer = []dns.RR{
+		cnameTo("alias.example.org.", "target.example.org.", 300),
+		&dns.A{
+			Hdr: dns.RR_Header{Name: "target.example.org.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 1},
+			A:   []byte{192, 0, 2, 1},
+		},
+	}
+	if mt, _ := ClassifyResponse(resolved, time.Now()); mt != TypeSuccess {
+		t.Fatalf("a resolved alias classified %v, want TypeSuccess", mt)
+	}
+
+	// An explicit CNAME question is answered by the CNAME itself.
+	asked := askedFor(new(dns.Msg), dns.TypeCNAME)
+	asked.Answer = []dns.RR{cnameTo("alias.example.org.", "target.example.org.", 300)}
+	asked.Ns = denial(dns.RcodeSuccess, 300, 1).Ns
+	if mt, _ := ClassifyResponse(asked, time.Now()); mt != TypeSuccess {
+		t.Fatalf("an explicit CNAME question classified %v, want TypeSuccess", mt)
+	}
+}
+
+// TestDenialWithoutSOAIsNotCacheableInAnyShape is the rest of RFC 2308 §5. The
+// check has to look for the SOA itself: a denial carrying an alias chain and
+// no SOA is full of records and still says nothing about how long it holds.
+func TestDenialWithoutSOAIsNotCacheableInAnyShape(t *testing.T) {
+	withAlias := askedFor(new(dns.Msg), dns.TypeA)
+	withAlias.Rcode = dns.RcodeNameError
+	withAlias.Answer = []dns.RR{cnameTo("alias.example.org.", "target.example.org.", 60)}
+	if got := CalculateCacheTTL(withAlias, TypeNXDomain); got != 0 {
+		t.Errorf("NXDOMAIN carrying an alias and no SOA: got %v, want 0", got)
+	}
+
+	// Nothing at all is not a denial anyone can cache either, and it must not
+	// arrive at the positive floor by way of TypeSuccess.
+	bare := askedFor(new(dns.Msg), dns.TypeA)
+	if mt, _ := ClassifyResponse(bare, time.Now()); mt != TypeNotCacheable {
+		t.Errorf("empty NOERROR with no SOA classified %v, want TypeNotCacheable", mt)
+	}
+}
+
+// TestSignatureBoundsAreHard is RFC 4035 §5.3.3: the served lifetime may not
+// exceed the smallest of the RRSIG's header TTL, its Original TTL, and the
+// time left before it expires. Neither the record TTLs nor the cache's own
+// floor may lift it past that.
+func TestSignatureBoundsAreHard(t *testing.T) {
+	now := time.Now()
+	sig := func(hdrTTL, origTTL uint32, expiresIn time.Duration) dns.RR {
+		return &dns.RRSIG{
+			Hdr:        dns.RR_Header{Name: "example.org.", Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: hdrTTL},
+			OrigTtl:    origTTL,
+			Expiration: uint32(now.Add(expiresIn).Unix()), //nolint:gosec // G115 - Unix timestamp fits in uint32 for valid dates
+		}
+	}
+
+	// Original TTL is a bound in its own right. Reading only the header TTL
+	// let a denial whose signature authorised one second live for an hour.
+	msg := denial(dns.RcodeNameError, 86400, 86400, sig(86400, 1, time.Hour))
+	if got, want := CalculateCacheTTL(msg, TypeNXDomain), time.Second; got != want {
+		t.Errorf("RRSIG OrigTtl 1s: got %v, want %v", got, want)
+	}
+
+	// The positive floor may not lift a signature bound. A signature with two
+	// seconds left bounds the answer at two seconds, floor or no floor.
+	positive := askedFor(new(dns.Msg), dns.TypeA)
+	positive.Answer = []dns.RR{
+		&dns.A{
+			Hdr: dns.RR_Header{Name: "alias.example.org.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 3600},
+			A:   []byte{192, 0, 2, 1},
+		},
+		sig(3600, 3600, 2*time.Second),
+	}
+	if got := CalculateCacheTTL(positive, TypeSuccess); got > 2*time.Second {
+		t.Errorf("positive answer with a 2s signature: got %v, want at most 2s", got)
+	}
+
+	// Unsigned data still takes the floor, which is the whole point of keeping
+	// the two bounds apart.
+	unsigned := askedFor(new(dns.Msg), dns.TypeA)
+	unsigned.Answer = []dns.RR{&dns.A{
+		Hdr: dns.RR_Header{Name: "alias.example.org.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 1},
+		A:   []byte{192, 0, 2, 1},
+	}}
+	if got, want := CalculateCacheTTL(unsigned, TypeSuccess), MinCacheTTL; got != want {
+		t.Errorf("unsigned one-second answer: got %v, want the %v floor", got, want)
+	}
+}

--- a/internal/dnsutil/negative_ttl_test.go
+++ b/internal/dnsutil/negative_ttl_test.go
@@ -436,3 +436,135 @@ func TestSiblingSignatureKeepsTheRRsetAlive(t *testing.T) {
 		}
 	})
 }
+
+// TestSiblingIdentityAndValidity pins what makes two signatures siblings and
+// what makes one usable. A signature vouches for an RRset only while the
+// current time sits inside both of its bounds (RFC 4035 §5.3.1), only for
+// the RRset its signer owns (§5.3.2), and only in the section it arrived in.
+// Among usable siblings the shortest lifetime wins whichever order the wire
+// put them in, and a lapsed signature over glue bounds nothing.
+func TestSiblingIdentityAndValidity(t *testing.T) {
+	now := time.Now()
+	sig := func(owner, signer string, covered uint16, origTTL uint32, from, until time.Duration) dns.RR {
+		return &dns.RRSIG{
+			Hdr:         dns.RR_Header{Name: owner, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 3600},
+			TypeCovered: covered,
+			OrigTtl:     origTTL,
+			SignerName:  signer,
+			Inception:   uint32(now.Add(from).Unix()),  //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+			Expiration:  uint32(now.Add(until).Unix()), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+		}
+	}
+	a := func(owner string) dns.RR {
+		return &dns.A{
+			Hdr: dns.RR_Header{Name: owner, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 3600},
+			A:   []byte{192, 0, 2, 1},
+		}
+	}
+	ask := func(build func(*dns.Msg)) *dns.Msg {
+		msg := new(dns.Msg)
+		msg.SetQuestion("x.example.org.", dns.TypeA)
+		build(msg)
+		return msg
+	}
+
+	t.Run("a signature whose inception has not arrived covers nothing", func(t *testing.T) {
+		msg := ask(func(m *dns.Msg) {
+			m.Answer = []dns.RR{
+				a("x.example.org."),
+				sig("x.example.org.", "example.org.", dns.TypeA, 3600, -2*time.Hour, -time.Hour),
+				sig("x.example.org.", "example.org.", dns.TypeA, 3600, time.Hour, 2*time.Hour),
+			}
+		})
+		if !HasExpiredSignatures(msg, now) {
+			t.Error("a future signature rescued an RRset whose only other signature had lapsed")
+		}
+		if mt, _ := ClassifyResponse(msg, now); mt != TypeExpiredSignature {
+			t.Errorf("classified %v, want TypeExpiredSignature", mt)
+		}
+		if got := CalculateCacheTTL(msg, TypeSuccess); got != 0 {
+			t.Errorf("lifetime %v, want nothing: no signature is valid now", got)
+		}
+	})
+
+	t.Run("a sibling under another signer covers nothing", func(t *testing.T) {
+		// At a delegation the parent's NSEC over the child's name and the
+		// child's apex NSEC share owner, class and type. The parent's proof
+		// has lapsed; the child's live signature is not its sibling.
+		msg := ask(func(m *dns.Msg) {
+			m.Rcode = dns.RcodeNameError
+			m.Ns = []dns.RR{
+				&dns.SOA{
+					Hdr: dns.RR_Header{Name: "example.org.", Rrtype: dns.TypeSOA, Class: dns.ClassINET, Ttl: 300},
+					Ns:  "ns.example.org.", Mbox: "hostmaster.example.org.", Minttl: 300,
+				},
+				sig("example.org.", "example.org.", dns.TypeSOA, 300, -2*time.Hour, time.Hour),
+				&dns.NSEC{
+					Hdr:        dns.RR_Header{Name: "child.example.org.", Rrtype: dns.TypeNSEC, Class: dns.ClassINET, Ttl: 300},
+					NextDomain: "d.example.org.",
+					TypeBitMap: []uint16{dns.TypeNS, dns.TypeRRSIG, dns.TypeNSEC},
+				},
+				sig("child.example.org.", "example.org.", dns.TypeNSEC, 300, -2*time.Hour, -time.Hour),
+				sig("child.example.org.", "child.example.org.", dns.TypeNSEC, 300, -2*time.Hour, time.Hour),
+			}
+		})
+		if !HasExpiredSignatures(msg, now) {
+			t.Error("the child's live signature excused the parent's lapsed proof")
+		}
+		if got := CalculateCacheTTL(msg, TypeNXDomain); got != 0 {
+			t.Errorf("lifetime %v, want nothing: the proof's own signature lapsed", got)
+		}
+	})
+
+	t.Run("a sibling in another section covers nothing", func(t *testing.T) {
+		msg := ask(func(m *dns.Msg) {
+			m.Answer = []dns.RR{
+				a("x.example.org."),
+				sig("x.example.org.", "example.org.", dns.TypeA, 3600, -2*time.Hour, time.Hour),
+			}
+			m.Ns = []dns.RR{
+				a("x.example.org."),
+				sig("x.example.org.", "example.org.", dns.TypeA, 3600, -2*time.Hour, -time.Hour),
+			}
+		})
+		if !HasExpiredSignatures(msg, now) {
+			t.Error("a live answer signature excused the same RRset's lapsed copy in the authority section")
+		}
+		if got := CalculateCacheTTL(msg, TypeSuccess); got != 0 {
+			t.Errorf("lifetime %v, want nothing: an authority RRset is uncovered", got)
+		}
+	})
+
+	t.Run("a zero and an hour bound the same whichever comes first", func(t *testing.T) {
+		zero := sig("x.example.org.", "example.org.", dns.TypeA, 0, -2*time.Hour, time.Hour)
+		hour := sig("x.example.org.", "example.org.", dns.TypeA, 3600, -2*time.Hour, time.Hour)
+		for name, order := range map[string][]dns.RR{
+			"zero first": {a("x.example.org."), zero, hour},
+			"hour first": {a("x.example.org."), hour, zero},
+		} {
+			msg := ask(func(m *dns.Msg) { m.Answer = order })
+			if HasExpiredSignatures(msg, now) {
+				t.Errorf("%s: both signatures are valid, yet the RRset was reported lapsed", name)
+			}
+			if got := CalculateCacheTTL(msg, TypeSuccess); got != 0 {
+				t.Errorf("%s: lifetime %v, want nothing: a sibling authorises no lifetime", name, got)
+			}
+		}
+	})
+
+	t.Run("a lapsed signature over glue does not zero the answer", func(t *testing.T) {
+		msg := ask(func(m *dns.Msg) {
+			m.Answer = []dns.RR{
+				a("x.example.org."),
+				sig("x.example.org.", "example.org.", dns.TypeA, 3600, -2*time.Hour, time.Hour),
+			}
+			m.Extra = []dns.RR{
+				a("ns.example.org."),
+				sig("ns.example.org.", "example.org.", dns.TypeA, 3600, -2*time.Hour, -time.Hour),
+			}
+		})
+		if got := CalculateCacheTTL(msg, TypeSuccess); got < 59*time.Minute {
+			t.Errorf("lifetime %v, want the answer's own hour: glue is not the answer", got)
+		}
+	})
+}

--- a/internal/dnsutil/negative_ttl_test.go
+++ b/internal/dnsutil/negative_ttl_test.go
@@ -311,3 +311,128 @@ func TestSignatureBoundsAreHard(t *testing.T) {
 		t.Errorf("unsigned one-second answer: got %v, want the %v floor", got, want)
 	}
 }
+
+// TestSiblingSignatureKeepsTheRRsetAlive is the key-rollover case. An RRset
+// carries a signature from the outgoing key beside one from the incoming key
+// for as long as the rollover takes, and the outgoing one lapses first.
+//
+// Judging the message on the worst signature anywhere in it condemned every
+// such answer: AD stripped, lifetime zero, admission refused, while the
+// resolver's own validator (dnssec.VerifyRRSIG) was correctly accepting the
+// RRset on the strength of the sibling.
+func TestSiblingSignatureKeepsTheRRsetAlive(t *testing.T) {
+	now := time.Now()
+	sig := func(owner string, covered uint16, tag uint16, expiresIn time.Duration) dns.RR {
+		return &dns.RRSIG{
+			Hdr:         dns.RR_Header{Name: owner, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 3600},
+			TypeCovered: covered,
+			OrigTtl:     3600,
+			KeyTag:      tag,
+			Expiration:  uint32(now.Add(expiresIn).Unix()), //nolint:gosec // G115 - Unix timestamp fits in uint32 for valid dates
+		}
+	}
+	answer := func() dns.RR {
+		return &dns.A{
+			Hdr: dns.RR_Header{Name: "x.example.org.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 3600},
+			A:   []byte{192, 0, 2, 1},
+		}
+	}
+	ask := func(build func(*dns.Msg)) *dns.Msg {
+		msg := new(dns.Msg)
+		msg.SetQuestion("x.example.org.", dns.TypeA)
+		build(msg)
+		return msg
+	}
+
+	t.Run("a lapsed sibling condemns nothing", func(t *testing.T) {
+		msg := ask(func(m *dns.Msg) {
+			m.Answer = []dns.RR{
+				answer(),
+				sig("x.example.org.", dns.TypeA, 111, -time.Hour),
+				sig("x.example.org.", dns.TypeA, 222, time.Hour),
+			}
+		})
+		if HasExpiredSignatures(msg, now) {
+			t.Error("an RRset with a live signature was reported as lapsed")
+		}
+		mt, _ := ClassifyResponse(msg, now)
+		if mt != TypeSuccess {
+			t.Errorf("classified %v, want TypeSuccess", mt)
+		}
+		// Bounded by the sibling that is still good, not by the one that is not.
+		if got := CalculateCacheTTL(msg, mt); got < 59*time.Minute {
+			t.Errorf("lifetime %v, want the live sibling's hour", got)
+		}
+	})
+
+	t.Run("the same during a denial", func(t *testing.T) {
+		msg := ask(func(m *dns.Msg) {
+			m.Rcode = dns.RcodeNameError
+			m.Ns = []dns.RR{
+				&dns.SOA{
+					Hdr: dns.RR_Header{Name: "example.org.", Rrtype: dns.TypeSOA, Class: dns.ClassINET, Ttl: 300},
+					Ns:  "ns.example.org.", Mbox: "hostmaster.example.org.", Minttl: 300,
+				},
+				sig("example.org.", dns.TypeSOA, 111, -time.Hour),
+				sig("example.org.", dns.TypeSOA, 222, time.Hour),
+			}
+		})
+		if HasExpiredSignatures(msg, now) {
+			t.Error("a denial with a live signature was reported as lapsed")
+		}
+		if got, want := CalculateCacheTTL(msg, TypeNXDomain), 5*time.Minute; got != want {
+			t.Errorf("lifetime %v, want the SOA's %v", got, want)
+		}
+	})
+
+	t.Run("every sibling lapsed is still lapsed", func(t *testing.T) {
+		msg := ask(func(m *dns.Msg) {
+			m.Answer = []dns.RR{
+				answer(),
+				sig("x.example.org.", dns.TypeA, 111, -time.Hour),
+				sig("x.example.org.", dns.TypeA, 222, -time.Minute),
+			}
+		})
+		if !HasExpiredSignatures(msg, now) {
+			t.Error("an RRset with nothing left covering it was reported as usable")
+		}
+	})
+
+	t.Run("siblings are per RRset, not per message", func(t *testing.T) {
+		// The A RRset is covered; the AAAA RRset beside it is not. A live
+		// signature over one does not vouch for the other.
+		msg := ask(func(m *dns.Msg) {
+			m.Answer = []dns.RR{
+				answer(),
+				sig("x.example.org.", dns.TypeA, 222, time.Hour),
+				&dns.AAAA{Hdr: dns.RR_Header{
+					Name: "x.example.org.", Rrtype: dns.TypeAAAA,
+					Class: dns.ClassINET, Ttl: 3600,
+				}},
+				sig("x.example.org.", dns.TypeAAAA, 111, -time.Hour),
+			}
+		})
+		if !HasExpiredSignatures(msg, now) {
+			t.Error("an uncovered RRset was excused by a sibling covering a different type")
+		}
+	})
+
+	t.Run("the additional section does not withdraw AD", func(t *testing.T) {
+		// AD is a statement about the answer and authority sections
+		// (RFC 4035 §3.2.3). A lapsed signature over glue is not grounds for
+		// taking it back.
+		msg := ask(func(m *dns.Msg) {
+			m.Answer = []dns.RR{answer(), sig("x.example.org.", dns.TypeA, 222, time.Hour)}
+			m.Extra = []dns.RR{
+				&dns.A{Hdr: dns.RR_Header{
+					Name: "ns.example.org.", Rrtype: dns.TypeA,
+					Class: dns.ClassINET, Ttl: 3600,
+				}},
+				sig("ns.example.org.", dns.TypeA, 111, -time.Hour),
+			}
+		})
+		if HasExpiredSignatures(msg, now) {
+			t.Error("a lapsed glue signature withdrew AD from the answer")
+		}
+	})
+}

--- a/internal/dnsutil/negative_ttl_test.go
+++ b/internal/dnsutil/negative_ttl_test.go
@@ -1,6 +1,7 @@
 package dnsutil
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -565,6 +566,141 @@ func TestSiblingIdentityAndValidity(t *testing.T) {
 		})
 		if got := CalculateCacheTTL(msg, TypeSuccess); got < 59*time.Minute {
 			t.Errorf("lifetime %v, want the answer's own hour: glue is not the answer", got)
+		}
+	})
+}
+
+// TestSignatureHeaderTTLBoundsOnlyWhileUsable pins the record scan: a
+// signature's header TTL reaches the lifetime only through the usable
+// signature it belongs to. A lapsed sibling, or a glue signature, carrying a
+// header TTL of zero used to zero an answer whose live signature permitted an
+// hour.
+func TestSignatureHeaderTTLBoundsOnlyWhileUsable(t *testing.T) {
+	now := time.Now()
+	sig := func(owner string, hdrTTL uint32, until time.Duration) dns.RR {
+		return &dns.RRSIG{
+			Hdr:         dns.RR_Header{Name: owner, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: hdrTTL},
+			TypeCovered: dns.TypeA,
+			OrigTtl:     3600,
+			SignerName:  "example.org.",
+			Inception:   uint32(now.Add(-2 * time.Hour).Unix()), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+			Expiration:  uint32(now.Add(until).Unix()),          //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+		}
+	}
+	a := func(owner string) dns.RR {
+		return &dns.A{
+			Hdr: dns.RR_Header{Name: owner, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 3600},
+			A:   []byte{192, 0, 2, 1},
+		}
+	}
+	ask := func(build func(*dns.Msg)) *dns.Msg {
+		msg := new(dns.Msg)
+		msg.SetQuestion("x.example.org.", dns.TypeA)
+		build(msg)
+		return msg
+	}
+
+	t.Run("a lapsed sibling's header TTL bounds nothing", func(t *testing.T) {
+		msg := ask(func(m *dns.Msg) {
+			m.Answer = []dns.RR{
+				a("x.example.org."),
+				sig("x.example.org.", 0, -time.Hour),
+				sig("x.example.org.", 3600, time.Hour),
+			}
+		})
+		if HasExpiredSignatures(msg, now) {
+			t.Error("a live sibling covers the RRset, yet it was reported lapsed")
+		}
+		if got := CalculateCacheTTL(msg, TypeSuccess); got < 59*time.Minute {
+			t.Errorf("lifetime %v, want the live sibling's hour, not the lapsed one's zero header", got)
+		}
+	})
+
+	t.Run("a glue signature's header TTL bounds nothing", func(t *testing.T) {
+		msg := ask(func(m *dns.Msg) {
+			m.Answer = []dns.RR{a("x.example.org."), sig("x.example.org.", 3600, time.Hour)}
+			m.Extra = []dns.RR{a("ns.example.org."), sig("ns.example.org.", 0, time.Hour)}
+		})
+		if got := CalculateCacheTTL(msg, TypeSuccess); got < 59*time.Minute {
+			t.Errorf("lifetime %v, want the answer's hour: glue signatures do not bound it", got)
+		}
+	})
+
+	t.Run("a live signature's own header TTL still bounds", func(t *testing.T) {
+		msg := ask(func(m *dns.Msg) {
+			m.Answer = []dns.RR{a("x.example.org."), sig("x.example.org.", 30, time.Hour)}
+		})
+		if got, want := CalculateCacheTTL(msg, TypeSuccess), 30*time.Second; got != want {
+			t.Errorf("lifetime %v, want the signature's %v header TTL", got, want)
+		}
+	})
+}
+
+// TestEachSignedRRsetCostsNothingOnTheCommonPath pins the walk's price where
+// it runs several times per miss: an ordinary response, one or a few signed
+// RRsets, is grouped in place without allocating. Past the inline capacity
+// the walk indexes through a map and must still report every RRset exactly
+// once, with siblings that arrive after the switch matched to their RRset.
+func TestEachSignedRRsetCostsNothingOnTheCommonPath(t *testing.T) {
+	now := time.Now()
+	sig := func(owner string, tag uint16, until time.Duration) dns.RR {
+		return &dns.RRSIG{
+			Hdr:         dns.RR_Header{Name: owner, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 3600},
+			TypeCovered: dns.TypeA,
+			OrigTtl:     3600,
+			KeyTag:      tag,
+			SignerName:  "example.org.",
+			Inception:   uint32(now.Add(-2 * time.Hour).Unix()), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+			Expiration:  uint32(now.Add(until).Unix()),          //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+		}
+	}
+
+	t.Run("a rollover answer allocates nothing", func(t *testing.T) {
+		answer := []dns.RR{
+			sig("x.example.org.", 111, -time.Hour),
+			sig("x.example.org.", 222, time.Hour),
+		}
+		authority := []dns.RR{sig("example.org.", 333, time.Hour)}
+		reported := 0
+		allocs := testing.AllocsPerRun(100, func() {
+			reported = 0
+			eachSignedRRset([][]dns.RR{answer, authority}, now, func(bool, time.Duration) { reported++ })
+		})
+		if allocs != 0 {
+			t.Errorf("common path allocated %v times per walk, want none", allocs)
+		}
+		if reported != 2 {
+			t.Errorf("reported %d RRsets, want 2", reported)
+		}
+	})
+
+	t.Run("past the inline capacity every RRset is still reported once", func(t *testing.T) {
+		const n = signedRRsetInline + 4
+		var answer []dns.RR
+		// Every lapsed signature first, then every live sibling: the live
+		// half arrives after the walk has switched to the map, so each has
+		// to find the RRset its lapsed sibling opened.
+		for i := range n {
+			answer = append(answer, sig(fmt.Sprintf("r%d.example.org.", i), 111, -time.Hour))
+		}
+		for i := range n {
+			answer = append(answer, sig(fmt.Sprintf("R%d.EXAMPLE.ORG.", i), 222, time.Hour))
+		}
+		reported, lapsed := 0, 0
+		eachSignedRRset([][]dns.RR{answer}, now, func(covered bool, usable time.Duration) {
+			reported++
+			if !covered {
+				lapsed++
+			}
+			if usable < 59*time.Minute {
+				t.Errorf("usable %v, want the live sibling's hour", usable)
+			}
+		})
+		if reported != n {
+			t.Errorf("reported %d RRsets, want %d", reported, n)
+		}
+		if lapsed != 0 {
+			t.Errorf("%d RRsets reported lapsed after their live sibling arrived past the switch", lapsed)
 		}
 	})
 }

--- a/internal/dnsutil/response.go
+++ b/internal/dnsutil/response.go
@@ -74,6 +74,14 @@ func ClassifyResponse(msg *dns.Msg, now time.Time) (ResponseType, *dns.OPT) {
 			if hasExpiredSignatures(msg, now) {
 				return TypeExpiredSignature, opt
 			}
+			// An answer section that never reaches the type asked for is a
+			// NODATA answer wearing a CNAME chain, and the terminal denial is
+			// what decides its lifetime. Classifying it as a success read the
+			// alias TTL instead of the SOA the last hop returned, which is the
+			// commonest denial shape on the wire.
+			if !answerHasQType(msg) && hasSOA(msg) {
+				return TypeNoRecords, opt
+			}
 			return TypeSuccess, opt
 		}
 
@@ -87,12 +95,11 @@ func ClassifyResponse(msg *dns.Msg, now time.Time) (ResponseType, *dns.OPT) {
 			return TypeNoRecords, opt
 		}
 
-		// Certain queries without answers shouldn't be cached
-		if !shouldCache(msg) {
-			return TypeNotCacheable, opt
-		}
-
-		return TypeSuccess, opt
+		// Nothing at all: no answer, no delegation, no SOA. There is no
+		// lifetime to derive and nothing to serve, and RFC 2308 §5 wants a
+		// negative answer without an SOA left uncached rather than held on a
+		// guess.
+		return TypeNotCacheable, opt
 
 	case dns.RcodeNameError:
 		// NXDOMAIN - domain doesn't exist
@@ -166,12 +173,18 @@ func hasExpiredSignatures(msg *dns.Msg, now time.Time) bool {
 	return false
 }
 
-// shouldCache determines if a query type should be cached when empty.
-func shouldCache(msg *dns.Msg) bool {
+// answerHasQType reports whether the answer section carries a record of the
+// type that was asked for. A chain of CNAMEs and their signatures does not:
+// those are the road to the answer, not the answer.
+func answerHasQType(msg *dns.Msg) bool {
 	if len(msg.Question) == 0 {
 		return false
 	}
-
-	// Don't cache empty DNSKEY responses
-	return msg.Question[0].Qtype != dns.TypeDNSKEY
+	qtype := msg.Question[0].Qtype
+	for _, rr := range msg.Answer {
+		if rr.Header().Rrtype == qtype {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/dnsutil/response.go
+++ b/internal/dnsutil/response.go
@@ -2,6 +2,7 @@
 package dnsutil
 
 import (
+	"strings"
 	"time"
 
 	"github.com/miekg/dns"
@@ -140,48 +141,101 @@ func hasSOA(msg *dns.Msg) bool {
 	return false
 }
 
-// HasExpiredSignatures reports whether any RRSIG in msg has already expired.
+// HasExpiredSignatures reports whether some RRset in the answer or authority
+// section has run out of usable signatures.
 //
-// Exported because the classification cannot carry this on its own. A response
-// is named for what it is, a denial, a referral, an answer, and only the
-// NOERROR-with-records shape has anywhere to put "and its signatures lapsed".
-// An expired NXDOMAIN is still an NXDOMAIN. Callers that need the fact rather
-// than the name ask here.
+// Per RRset, and only when nothing covering it is left. An RRset may carry
+// several signatures, and during a key rollover it routinely carries one from
+// the outgoing key beside one from the incoming key. Validation already works
+// this way, dnssec.VerifyRRSIG fails an RRset only when no sibling signature
+// succeeds, and judging a message on the worst signature anywhere in it would
+// have stripped AD from every rollover answer and refused to cache it.
+//
+// The additional section is left out. AD is a statement about the answer and
+// authority sections (RFC 4035 §3.2.3), and a lapsed signature over glue is
+// not grounds for withdrawing it.
 func HasExpiredSignatures(msg *dns.Msg, now time.Time) bool {
-	return hasExpiredSignatures(msg, now)
+	exhausted := false
+	eachSignedRRset([][]dns.RR{msg.Answer, msg.Ns}, now, func(covered bool, _ time.Duration) {
+		if !covered {
+			exhausted = true
+		}
+	})
+	return exhausted
 }
 
-// hasExpiredSignatures checks if any RRSIG records have expired.
+// hasExpiredSignatures is the classifier's view of the same question.
 func hasExpiredSignatures(msg *dns.Msg, now time.Time) bool {
-	nowUnix := uint32(now.Unix()) //nolint:gosec // G115 - time conversion for DNS record
+	return HasExpiredSignatures(msg, now)
+}
 
-	checkRRSIG := func(rr dns.RR) bool {
-		if sig, ok := rr.(*dns.RRSIG); ok {
-			if sig.Expiration < nowUnix {
-				return true
+// eachSignedRRset calls fn once for every RRset in sections that carries a
+// signature, reporting whether any of that RRset's signatures is still within
+// its validity period, and the shortest lifetime those still-valid ones
+// permit.
+//
+// The two answers are separate because they are separate questions. Whether
+// the data may be called authenticated turns on the validity period alone;
+// how long it may be kept also takes in the signature's own TTL and its
+// Original TTL (RFC 4035 §5.3.3). A signature authorising no lifetime still
+// covers the RRset, so it bounds the TTL at nothing without withdrawing AD.
+//
+// Lapsed siblings are skipped rather than folded in, which is what a key
+// rollover needs. Among the survivors the shortest wins, because a downstream
+// validator picks its own signature to verify with and may pick that one.
+//
+// Grouping is by owner, class and covered type, which is what makes two
+// signatures siblings. Case-insensitive on the owner, as everything else that
+// compares names here is.
+func eachSignedRRset(sections [][]dns.RR, now time.Time, fn func(covered bool, usable time.Duration)) {
+	var sigs []*dns.RRSIG
+	for _, section := range sections {
+		for _, rr := range section {
+			if sig, ok := rr.(*dns.RRSIG); ok {
+				sigs = append(sigs, sig)
 			}
 		}
-		return false
 	}
 
-	// Check all sections
-	for _, rr := range msg.Answer {
-		if checkRRSIG(rr) {
-			return true
-		}
-	}
-	for _, rr := range msg.Ns {
-		if checkRRSIG(rr) {
-			return true
-		}
-	}
-	for _, rr := range msg.Extra {
-		if checkRRSIG(rr) {
-			return true
-		}
+	siblings := func(a, b *dns.RRSIG) bool {
+		return a.TypeCovered == b.TypeCovered &&
+			a.Hdr.Class == b.Hdr.Class &&
+			strings.EqualFold(a.Hdr.Name, b.Hdr.Name)
 	}
 
-	return false
+	// Quadratic, over a handful of records. A response carries one signature
+	// per RRset outside a rollover and a few during one, so the map this
+	// would otherwise need costs more than the comparisons.
+	for i, sig := range sigs {
+		reported := false
+		for j := range i {
+			if siblings(sigs[j], sig) {
+				reported = true
+				break
+			}
+		}
+		if reported {
+			continue
+		}
+
+		covered := false
+		usable := time.Duration(0)
+		for j := i; j < len(sigs); j++ {
+			if !siblings(sigs[j], sig) {
+				continue
+			}
+			if time.Unix(int64(sigs[j].Expiration), 0).Sub(now) <= 0 {
+				// Spent. It says nothing about the RRset while a sibling
+				// still covers it, and if none does, covered stays false.
+				continue
+			}
+			covered = true
+			if ttl := getRRSIGTTL(sigs[j], now); usable == 0 || ttl < usable {
+				usable = ttl
+			}
+		}
+		fn(covered, usable)
+	}
 }
 
 // answerHasQType reports whether the answer section carries a record of the

--- a/internal/dnsutil/response.go
+++ b/internal/dnsutil/response.go
@@ -2,7 +2,6 @@
 package dnsutil
 
 import (
-	"strings"
 	"time"
 
 	"github.com/miekg/dns"
@@ -170,8 +169,8 @@ func hasExpiredSignatures(msg *dns.Msg, now time.Time) bool {
 }
 
 // signedRRset names the RRset a signature belongs to, which is what makes two
-// signatures siblings. Every field has to agree. Owner and signer fold case,
-// as everything else that compares names here does. The signer is part of
+// signatures siblings. Every field has to agree. Owner and signer are DNS
+// names, compared and keyed as the wire would. The signer is part of
 // the identity because RFC 4035 §5.3.2 ties a signature to the zone that
 // made it: at a delegation the parent's NSEC over the child's name and the
 // child's own apex NSEC share owner, class and type while being different
@@ -204,23 +203,35 @@ type signedRRsetState struct {
 	bounded bool
 }
 
+// is reports whether sig belongs to this RRset. Names compare as DNS names
+// (dnsname.CanonicalCompare): escapes decoded, case folded over ASCII only.
+// A text fold is wrong in both directions — an escaped spelling of the same
+// owner was a different RRset, and a Kelvin sign, which the Unicode fold
+// turns into a k, was the same one, so a live signature under one wire
+// name vouched for an expired RRset under another and kept AD on it.
 func (s *signedRRsetState) is(section int, sig *dns.RRSIG) bool {
 	return s.section == section &&
 		s.first.TypeCovered == sig.TypeCovered &&
 		s.first.Hdr.Class == sig.Hdr.Class &&
-		strings.EqualFold(s.first.Hdr.Name, sig.Hdr.Name) &&
-		strings.EqualFold(s.first.SignerName, sig.SignerName)
+		dnsname.CanonicalCompare(s.first.Hdr.Name, sig.Hdr.Name) == 0 &&
+		dnsname.CanonicalCompare(s.first.SignerName, sig.SignerName) == 0
 }
 
 func (s *signedRRsetState) identity() signedRRset {
 	return signedRRsetIdentity(s.section, s.first)
 }
 
+// signedRRsetIdentity is the map form of is: the names as the canonical
+// keys the comparison agrees with, so the two paths group identically.
+// Each key is built in its own fresh slice. Building both in one stack
+// buffer and converting each to a string left the owner aliasing the
+// buffer the signer then overwrote; this runs only past the inline
+// capacity, where the map already allocates.
 func signedRRsetIdentity(section int, sig *dns.RRSIG) signedRRset {
 	return signedRRset{
 		section: section,
-		owner:   strings.ToLower(sig.Hdr.Name),
-		signer:  strings.ToLower(sig.SignerName),
+		owner:   string(dnsname.AppendCanonicalKey(nil, sig.Hdr.Name)),
+		signer:  string(dnsname.AppendCanonicalKey(nil, sig.SignerName)),
 		class:   sig.Hdr.Class,
 		covered: sig.TypeCovered,
 	}

--- a/internal/dnsutil/response.go
+++ b/internal/dnsutil/response.go
@@ -140,6 +140,17 @@ func hasSOA(msg *dns.Msg) bool {
 	return false
 }
 
+// HasExpiredSignatures reports whether any RRSIG in msg has already expired.
+//
+// Exported because the classification cannot carry this on its own. A response
+// is named for what it is, a denial, a referral, an answer, and only the
+// NOERROR-with-records shape has anywhere to put "and its signatures lapsed".
+// An expired NXDOMAIN is still an NXDOMAIN. Callers that need the fact rather
+// than the name ask here.
+func HasExpiredSignatures(msg *dns.Msg, now time.Time) bool {
+	return hasExpiredSignatures(msg, now)
+}
+
 // hasExpiredSignatures checks if any RRSIG records have expired.
 func hasExpiredSignatures(msg *dns.Msg, now time.Time) bool {
 	nowUnix := uint32(now.Unix()) //nolint:gosec // G115 - time conversion for DNS record

--- a/internal/dnsutil/response.go
+++ b/internal/dnsutil/response.go
@@ -169,6 +169,36 @@ func hasExpiredSignatures(msg *dns.Msg, now time.Time) bool {
 	return HasExpiredSignatures(msg, now)
 }
 
+// signedRRset names the RRset a signature belongs to, which is what makes two
+// signatures siblings. Every field has to agree. Owner and signer fold case,
+// as everything else that compares names here does. The signer is part of
+// the identity because RFC 4035 §5.3.2 ties a signature to the zone that
+// made it: at a delegation the parent's NSEC over the child's name and the
+// child's own apex NSEC share owner, class and type while being different
+// RRsets under different keys, and one must not vouch for the other. The
+// section is part of it for the same reason — the same owner and type can
+// sit in the authority section as a proof and in the additional section as
+// glue, and those are different data.
+type signedRRset struct {
+	section int
+	owner   string
+	signer  string
+	class   uint16
+	covered uint16
+}
+
+type signedRRsetState struct {
+	// covered: some signature in its validity period vouches for the RRset.
+	covered bool
+	// usable: the shortest lifetime the covering signatures permit, and
+	// bounded says whether any set it. Zero is a real value here (a
+	// signature with an Original TTL of zero authorises no lifetime), so
+	// it cannot double as the unset sentinel: with it, the wire order of
+	// two siblings decided between a zero and an hour.
+	usable  time.Duration
+	bounded bool
+}
+
 // eachSignedRRset calls fn once for every RRset in sections that carries a
 // signature, reporting whether any of that RRset's signatures is still within
 // its validity period, and the shortest lifetime those still-valid ones
@@ -180,61 +210,60 @@ func hasExpiredSignatures(msg *dns.Msg, now time.Time) bool {
 // Original TTL (RFC 4035 §5.3.3). A signature authorising no lifetime still
 // covers the RRset, so it bounds the TTL at nothing without withdrawing AD.
 //
-// Lapsed siblings are skipped rather than folded in, which is what a key
-// rollover needs. Among the survivors the shortest wins, because a downstream
+// Validity is the validator's own test, RRSIG.ValidityPeriod, and it checks
+// both ends: RFC 4035 §5.3.1 requires the current time to sit within the
+// inception and expiration bounds, so a signature whose inception has not
+// arrived is no more use than one that has lapsed. Siblings outside the
+// period are skipped rather than folded in, which is what a key rollover
+// needs. Among the survivors the shortest wins, because a downstream
 // validator picks its own signature to verify with and may pick that one.
 //
-// Grouping is by owner, class and covered type, which is what makes two
-// signatures siblings. Case-insensitive on the owner, as everything else that
-// compares names here is.
+// One pass, grouped through a map. A response carries a handful of
+// signatures, but the sibling test was quadratic in that count, and a
+// response filled to the wire limit with distinct signed RRsets made it
+// pay for it. Callbacks come in order of first appearance.
 func eachSignedRRset(sections [][]dns.RR, now time.Time, fn func(covered bool, usable time.Duration)) {
-	var sigs []*dns.RRSIG
-	for _, section := range sections {
-		for _, rr := range section {
-			if sig, ok := rr.(*dns.RRSIG); ok {
-				sigs = append(sigs, sig)
+	var (
+		groups map[signedRRset]*signedRRsetState
+		order  []signedRRset
+	)
+	for section, records := range sections {
+		for _, rr := range records {
+			sig, ok := rr.(*dns.RRSIG)
+			if !ok {
+				continue
+			}
+			id := signedRRset{
+				section: section,
+				owner:   strings.ToLower(sig.Hdr.Name),
+				signer:  strings.ToLower(sig.SignerName),
+				class:   sig.Hdr.Class,
+				covered: sig.TypeCovered,
+			}
+			state := groups[id]
+			if state == nil {
+				if groups == nil {
+					groups = make(map[signedRRset]*signedRRsetState)
+				}
+				state = &signedRRsetState{}
+				groups[id] = state
+				order = append(order, id)
+			}
+			if !sig.ValidityPeriod(now) {
+				// Outside its period, spent or not yet begun. It says
+				// nothing about the RRset while a sibling still covers it,
+				// and if none does, covered stays false.
+				continue
+			}
+			state.covered = true
+			if ttl := getRRSIGTTL(sig, now); !state.bounded || ttl < state.usable {
+				state.usable, state.bounded = ttl, true
 			}
 		}
 	}
-
-	siblings := func(a, b *dns.RRSIG) bool {
-		return a.TypeCovered == b.TypeCovered &&
-			a.Hdr.Class == b.Hdr.Class &&
-			strings.EqualFold(a.Hdr.Name, b.Hdr.Name)
-	}
-
-	// Quadratic, over a handful of records. A response carries one signature
-	// per RRset outside a rollover and a few during one, so the map this
-	// would otherwise need costs more than the comparisons.
-	for i, sig := range sigs {
-		reported := false
-		for j := range i {
-			if siblings(sigs[j], sig) {
-				reported = true
-				break
-			}
-		}
-		if reported {
-			continue
-		}
-
-		covered := false
-		usable := time.Duration(0)
-		for j := i; j < len(sigs); j++ {
-			if !siblings(sigs[j], sig) {
-				continue
-			}
-			if time.Unix(int64(sigs[j].Expiration), 0).Sub(now) <= 0 {
-				// Spent. It says nothing about the RRset while a sibling
-				// still covers it, and if none does, covered stays false.
-				continue
-			}
-			covered = true
-			if ttl := getRRSIGTTL(sigs[j], now); usable == 0 || ttl < usable {
-				usable = ttl
-			}
-		}
-		fn(covered, usable)
+	for _, id := range order {
+		state := groups[id]
+		fn(state.covered, state.usable)
 	}
 }
 

--- a/internal/dnsutil/response.go
+++ b/internal/dnsutil/response.go
@@ -187,7 +187,12 @@ type signedRRset struct {
 	covered uint16
 }
 
+// signedRRsetState is one RRset's standing while the signatures are walked.
+// Its identity is read off the first signature seen for it, compared in
+// place, so the common path folds no names and allocates nothing.
 type signedRRsetState struct {
+	section int
+	first   *dns.RRSIG
 	// covered: some signature in its validity period vouches for the RRset.
 	covered bool
 	// usable: the shortest lifetime the covering signatures permit, and
@@ -198,6 +203,34 @@ type signedRRsetState struct {
 	usable  time.Duration
 	bounded bool
 }
+
+func (s *signedRRsetState) is(section int, sig *dns.RRSIG) bool {
+	return s.section == section &&
+		s.first.TypeCovered == sig.TypeCovered &&
+		s.first.Hdr.Class == sig.Hdr.Class &&
+		strings.EqualFold(s.first.Hdr.Name, sig.Hdr.Name) &&
+		strings.EqualFold(s.first.SignerName, sig.SignerName)
+}
+
+func (s *signedRRsetState) identity() signedRRset {
+	return signedRRsetIdentity(s.section, s.first)
+}
+
+func signedRRsetIdentity(section int, sig *dns.RRSIG) signedRRset {
+	return signedRRset{
+		section: section,
+		owner:   strings.ToLower(sig.Hdr.Name),
+		signer:  strings.ToLower(sig.SignerName),
+		class:   sig.Hdr.Class,
+		covered: sig.TypeCovered,
+	}
+}
+
+// signedRRsetInline is how many distinct signed RRsets are tracked in place
+// before the walk switches to a map. A response carries one or two outside
+// a rollover and a few more during one; only a message stuffed with distinct
+// signed RRsets goes past it.
+const signedRRsetInline = 8
 
 // eachSignedRRset calls fn once for every RRset in sections that carries a
 // signature, reporting whether any of that RRset's signatures is still within
@@ -218,52 +251,69 @@ type signedRRsetState struct {
 // needs. Among the survivors the shortest wins, because a downstream
 // validator picks its own signature to verify with and may pick that one.
 //
-// One pass, grouped through a map. A response carries a handful of
-// signatures, but the sibling test was quadratic in that count, and a
-// response filled to the wire limit with distinct signed RRsets made it
-// pay for it. Callbacks come in order of first appearance.
+// One pass. Up to signedRRsetInline distinct RRsets live in a stack array
+// and are matched by comparing names in place, which is every ordinary
+// response at no allocation; past that the walk indexes what it has through
+// a map of folded identities, so a response filled to the wire limit with
+// distinct signed RRsets stays linear instead of paying a quadratic sibling
+// scan. This runs more than once on a miss, so the cheap path matters.
+// Callbacks come in order of first appearance.
 func eachSignedRRset(sections [][]dns.RR, now time.Time, fn func(covered bool, usable time.Duration)) {
-	var (
-		groups map[signedRRset]*signedRRsetState
-		order  []signedRRset
-	)
+	var inline [signedRRsetInline]signedRRsetState
+	groups := inline[:0]
+	var index map[signedRRset]int
+
 	for section, records := range sections {
 		for _, rr := range records {
 			sig, ok := rr.(*dns.RRSIG)
 			if !ok {
 				continue
 			}
-			id := signedRRset{
-				section: section,
-				owner:   strings.ToLower(sig.Hdr.Name),
-				signer:  strings.ToLower(sig.SignerName),
-				class:   sig.Hdr.Class,
-				covered: sig.TypeCovered,
-			}
-			state := groups[id]
-			if state == nil {
-				if groups == nil {
-					groups = make(map[signedRRset]*signedRRsetState)
+
+			at := -1
+			if index == nil {
+				for i := range groups {
+					if groups[i].is(section, sig) {
+						at = i
+						break
+					}
 				}
-				state = &signedRRsetState{}
-				groups[id] = state
-				order = append(order, id)
+				if at < 0 && len(groups) == signedRRsetInline {
+					index = make(map[signedRRset]int, 2*signedRRsetInline)
+					for i := range groups {
+						index[groups[i].identity()] = i
+					}
+				}
 			}
+			if at < 0 && index != nil {
+				id := signedRRsetIdentity(section, sig)
+				if i, ok := index[id]; ok {
+					at = i
+				} else {
+					groups = append(groups, signedRRsetState{section: section, first: sig})
+					at = len(groups) - 1
+					index[id] = at
+				}
+			} else if at < 0 {
+				groups = append(groups, signedRRsetState{section: section, first: sig})
+				at = len(groups) - 1
+			}
+
 			if !sig.ValidityPeriod(now) {
 				// Outside its period, spent or not yet begun. It says
 				// nothing about the RRset while a sibling still covers it,
 				// and if none does, covered stays false.
 				continue
 			}
+			state := &groups[at]
 			state.covered = true
 			if ttl := getRRSIGTTL(sig, now); !state.bounded || ttl < state.usable {
 				state.usable, state.bounded = ttl, true
 			}
 		}
 	}
-	for _, id := range order {
-		state := groups[id]
-		fn(state.covered, state.usable)
+	for i := range groups {
+		fn(groups[i].covered, groups[i].usable)
 	}
 }
 

--- a/internal/dnsutil/response_test.go
+++ b/internal/dnsutil/response_test.go
@@ -199,14 +199,18 @@ func TestClassifyResponse(t *testing.T) {
 			hasOpt:       false,
 		},
 		{
-			name: "Success with no answers and no NS/SOA - cacheable query type",
+			// No answer, no delegation, no SOA. There is nothing to serve and
+			// nothing to derive a lifetime from, and RFC 2308 §5 wants a
+			// negative answer without an SOA left uncached. This used to be
+			// classified a success and held for the cache's minimum.
+			name: "Success with no answers and no NS/SOA",
 			msg: func() *dns.Msg {
 				m := new(dns.Msg)
 				m.SetQuestion("example.com.", dns.TypeA)
 				m.Rcode = dns.RcodeSuccess
 				return m
 			}(),
-			expectedType: TypeSuccess, // A query is cacheable even without answers
+			expectedType: TypeNotCacheable,
 			hasOpt:       false,
 		},
 	}
@@ -439,59 +443,6 @@ func TestHasExpiredSignatures(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			result := hasExpiredSignatures(tt.msg, now)
-			if !reflect.DeepEqual(tt.expected, result) {
-				t.Errorf("result = %v, want %v", result, tt.expected)
-			}
-		})
-	}
-}
-
-func TestShouldCache(t *testing.T) {
-	tests := []struct {
-		name     string
-		msg      *dns.Msg
-		expected bool
-	}{
-		{
-			name: "A query - should cache",
-			msg: func() *dns.Msg {
-				m := new(dns.Msg)
-				m.SetQuestion("example.com.", dns.TypeA)
-				return m
-			}(),
-			expected: true,
-		},
-		{
-			name: "AAAA query - should cache",
-			msg: func() *dns.Msg {
-				m := new(dns.Msg)
-				m.SetQuestion("example.com.", dns.TypeAAAA)
-				return m
-			}(),
-			expected: true,
-		},
-		{
-			name: "DNSKEY query - should not cache",
-			msg: func() *dns.Msg {
-				m := new(dns.Msg)
-				m.SetQuestion("example.com.", dns.TypeDNSKEY)
-				return m
-			}(),
-			expected: false,
-		},
-		{
-			name: "Empty question - should not cache",
-			msg: func() *dns.Msg {
-				m := new(dns.Msg)
-				return m
-			}(),
-			expected: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := shouldCache(tt.msg)
 			if !reflect.DeepEqual(tt.expected, result) {
 				t.Errorf("result = %v, want %v", result, tt.expected)
 			}

--- a/internal/dnsutil/response_test.go
+++ b/internal/dnsutil/response_test.go
@@ -393,6 +393,11 @@ func TestHasExpiredSignatures(t *testing.T) {
 			expected: true,
 		},
 		{
+			// AD is a statement about the answer and authority sections
+			// (RFC 4035 §3.2.3), so a lapsed signature over additional
+			// records is not grounds for withdrawing it. This asked the
+			// opposite, from when the check was a flat scan of all three
+			// sections. The lifetime bound still takes the section in.
 			name: "Expired RRSIG in extra",
 			msg: func() *dns.Msg {
 				m := new(dns.Msg)
@@ -406,7 +411,7 @@ func TestHasExpiredSignatures(t *testing.T) {
 				}
 				return m
 			}(),
-			expected: true,
+			expected: false,
 		},
 		{
 			name: "Valid RRSIG",

--- a/middleware/cache/admission_pack_test.go
+++ b/middleware/cache/admission_pack_test.go
@@ -31,10 +31,16 @@ func admissionMsg(tb testing.TB) *dns.Msg {
 	m.Id = 7 // pinned: admission stores the message as handed over
 	m.Response = true
 	m.AuthenticatedData = true
+	// Validity relative to now: a fixed expiration lapsed one day, and an
+	// entry admitted with AD over a lapsed signature has the bit normalised
+	// away, which is a different wire from the reference.
+	now := time.Now()
 	m.Answer = []dns.RR{
 		rr("www.example.com. 300 IN A 192.0.2.1"),
-		rr("www.example.com. 300 IN RRSIG A 8 3 300 20260901000000 " +
-			"20260801000000 12345 example.com. AwEAAcQ8"),
+		rr(fmt.Sprintf("www.example.com. 300 IN RRSIG A 8 3 300 %s %s 12345 example.com. AwEAAcQ8",
+			dns.TimeToString(uint32(now.Add(30*24*time.Hour).Unix())),  //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+			dns.TimeToString(uint32(now.Add(-30*24*time.Hour).Unix())), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+		)),
 	}
 	m.Ns = []dns.RR{
 		rr("example.com. 3600 IN NS ns1.example.com."),

--- a/middleware/cache/alias_hit_honesty_test.go
+++ b/middleware/cache/alias_hit_honesty_test.go
@@ -1,0 +1,105 @@
+package cache
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/middleware"
+)
+
+// TestAliasHitAppliesTheOutgoingChecksToTheChasedTarget pins the hit path
+// against the miss path for an alias whose target is not cached. The chase
+// resolves the target through the internal sub-query, whose own write skips
+// the outgoing checks as every internal write does, so the merged records
+// reached the client raw: the target at its full TTL, with AD, and with a
+// lapsed signature in the answer. The hit now applies what a miss applies,
+// AD withdrawn when a signature has lapsed and TTLs bounded by the merged
+// records.
+func TestAliasHitAppliesTheOutgoingChecksToTheChasedTarget(t *testing.T) {
+	const alias, target = "a.rev.example.", "b.rev.example."
+	now := time.Now()
+
+	for _, tc := range []struct {
+		name      string
+		expiresIn time.Duration
+		wantAD    bool
+		maxTTL    uint32
+		wantRRSIG bool
+	}{
+		{"target signed for two more seconds", 2 * time.Second, true, 2, true},
+		{"target signature lapsed an hour ago", -time.Hour, false, 0, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			c := New(&config.Config{CacheSize: 1024, Expire: 600})
+			defer c.Stop()
+
+			aliasResp := new(dns.Msg)
+			aliasResp.SetQuestion(alias, dns.TypeA)
+			aliasResp.Response = true
+			aliasResp.AuthenticatedData = true
+			aliasResp.Answer = []dns.RR{&dns.CNAME{
+				Hdr:    dns.RR_Header{Name: alias, Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 3600},
+				Target: target,
+			}}
+			c.store.SetFromResponse(aliasResp, false, time.Time{})
+
+			targetHandler := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+				resp := new(dns.Msg)
+				resp.SetReply(ch.Request.Msg())
+				resp.AuthenticatedData = true
+				resp.Answer = []dns.RR{
+					&dns.A{Hdr: dns.RR_Header{Name: target, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 3600}, A: []byte{192, 0, 2, 7}},
+					&dns.RRSIG{
+						Hdr:         dns.RR_Header{Name: target, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 3600},
+						TypeCovered: dns.TypeA, Algorithm: 8, Labels: 3, OrigTtl: 3600, KeyTag: 1,
+						SignerName: "rev.example.", Signature: "MTIzNDU2Nzg5MGFiY2RlZg==",
+						Inception:  uint32(now.Add(-2 * time.Hour).Unix()), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+						Expiration: uint32(now.Add(tc.expiresIn).Unix()),   //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+					},
+				}
+				_ = ch.Writer.WriteMsg(resp)
+				ch.Cancel()
+			})
+			c.SetQueryer(&internalQueryer{handlers: []middleware.Handler{c, targetHandler}})
+
+			req := new(dns.Msg)
+			req.SetQuestion(alias, dns.TypeA)
+			req.RecursionDesired = true
+			w := mock.NewWriter("udp", "127.0.0.1:0")
+			chain := middleware.NewChain([]middleware.Handler{c, middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+				t.Fatal("the alias hit missed the cache")
+			})})
+			chain.Reset(w, req)
+			chain.Next(context.Background())
+			if !w.Written() {
+				t.Fatal("no response written")
+			}
+			served := w.Msg()
+
+			if served.AuthenticatedData != tc.wantAD {
+				t.Errorf("AD = %v, want %v", served.AuthenticatedData, tc.wantAD)
+			}
+			var a *dns.A
+			for _, rr := range served.Answer {
+				if r, ok := rr.(*dns.A); ok {
+					a = r
+				}
+			}
+			if a == nil {
+				t.Fatalf("the chased target is missing from the answer: %v", served.Answer)
+			}
+			if a.Hdr.Ttl > tc.maxTTL {
+				t.Errorf("the chased target served with TTL %d, want at most %d: bounded by its own signature", a.Hdr.Ttl, tc.maxTTL)
+			}
+			for _, rr := range served.Answer {
+				if rr.Header().Ttl > tc.maxTTL {
+					t.Errorf("%s served with TTL %d, want at most %d", rr.Header().String(), rr.Header().Ttl, tc.maxTTL)
+				}
+			}
+		})
+	}
+}

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -1861,7 +1861,13 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 	if depth := cnameChaseDepth(ctx); depth < maxCnameChaseDepth {
 		res = w.cache.additionalAnswer(withCnameChaseDepth(ctx, depth+1), res)
 	}
-	if chasedType, _ := dnsutil.ClassifyResponse(res, time.Now().UTC()); chasedType == dnsutil.TypeServerFailure {
+	// Re-classified, not merely re-checked. A CNAME that arrived as a success
+	// can come back from the chase as a terminal NXDOMAIN or NODATA, and
+	// keeping the pre-chase verdict meant the clamp below read the alias TTL
+	// while the SOA at the end of the chain said one second. The stores
+	// classify for themselves; this is the copy the client gets.
+	mt, _ = dnsutil.ClassifyResponse(res, time.Now().UTC())
+	if mt == dnsutil.TypeServerFailure {
 		return w.writeResolutionFailure(ctx, res)
 	}
 
@@ -2066,20 +2072,28 @@ func clampTTLsToEffective(res *dns.Msg, cutUntil time.Time, mt dnsutil.ResponseT
 	//
 	// Only downward. The derivation applies the positive floor, which is about
 	// how long this cache re-asks, and is no business of the client's.
-	// The same view the entry is bounded by. Walking the whole response
-	// instead pulled in material the entry never keeps, a DNSKEY consulted to
-	// validate the answer among it, and capped the answer at the lifetime of
-	// its own validation input. Provenance is not lineage.
-	if derived := dnsutil.CalculateCacheTTL(filterCacheableAnswer(res), mt); derived > 0 {
-		if ceiling < 0 || derived < ceiling {
-			ceiling = derived
-		}
+	// Every record being handed over, not the narrower set the entry keeps.
+	// The stored view drops the CNAME target's own RRset, which belongs to a
+	// different owner, and that RRset is in this message and is what the
+	// client will act on: a target expiring in two seconds went out under an
+	// alias advertising five minutes.
+	//
+	// Zero is folded in like any other value. It is a real ceiling, an SOA
+	// granting no lifetime or a signature whose Original TTL is zero, and
+	// treating it as "nothing found" left the first client holding, at its
+	// full advertised TTL, data this cache had just refused to admit.
+	derived := dnsutil.CalculateCacheTTL(res, mt)
+	if ceiling < 0 || derived < ceiling {
+		ceiling = derived
 	}
 	if ceiling < 0 {
 		return
 	}
 
-	secs := uint32(ceiling / time.Second) //nolint:gosec // G115 - bounded by MaxCacheTTL
+	// The same rounding a cache hit gets. The two paths answer the same
+	// question about the same records and disagreeing on the last fraction of
+	// a second is how one client is told nothing and the next is told one.
+	secs := servedSeconds(ceiling)
 	clamp := func(rrs []dns.RR) {
 		for _, rr := range rrs {
 			if rr.Header().Rrtype == dns.TypeOPT {

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -1701,7 +1701,13 @@ func (c *Cache) Set(key uint64, msg *dns.Msg) {
 	}
 	msgTTL := dnsutil.CalculateCacheTTL(filtered, mt)
 
-	ttl := c.positive.ttl.Calculate(msgTTL)
+	// See Store.setFromResponseWithKey: a denial the zone granted no lifetime
+	// is not admitted (RFC 2308 §5). Unreachable for a positive answer, which
+	// always arrives on its own floor.
+	ttl := c.positive.ttl.CalculateFor(mt, msgTTL)
+	if ttl <= 0 {
+		return
+	}
 
 	entry := NewCacheEntryWithKey(filtered, ttl, c.config.RateLimit, key)
 	if entry == nil {

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -1693,13 +1693,14 @@ func (c *Cache) Set(key uint64, msg *dns.Msg) {
 	}
 
 	filtered := filterCacheableAnswer(msg)
-	mt, _ := dnsutil.ClassifyResponse(filtered, time.Now().UTC())
+	now := time.Now()
+	mt, _ := dnsutil.ClassifyResponse(filtered, now)
 	if mt == dnsutil.TypeServerFailure {
 		// A compatibility Set runs no ladder, so it can vouch for no miss.
 		c.store.RecordFailure(filtered, netip.Prefix{}, FailureProvenance("response"), nil)
 		return
 	}
-	msgTTL := dnsutil.CalculateCacheTTL(filtered, mt)
+	msgTTL := dnsutil.CalculateCacheTTLAt(filtered, mt, now)
 
 	// See Store.setFromResponseWithKey: a denial the zone granted no lifetime
 	// is not admitted (RFC 2308 §5). Unreachable for a positive answer, which
@@ -1709,7 +1710,7 @@ func (c *Cache) Set(key uint64, msg *dns.Msg) {
 		return
 	}
 
-	entry := NewCacheEntryWithKey(filtered, ttl, c.config.RateLimit, key)
+	entry := newCacheEntryAt(filtered, ttl, c.config.RateLimit, key, now)
 	if entry == nil {
 		return
 	}

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -1973,7 +1973,7 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 	// the cut through the shared meta and is clamped at the real client
 	// write.
 	if !w.internal {
-		clampTTLsToCut(res, cutUntil)
+		clampTTLsToEffective(res, cutUntil, mt)
 	}
 
 	return w.ResponseWriter.WriteMsg(res)
@@ -2046,23 +2046,47 @@ func (w *ResponseWriter) recursionWorkFailure(fallback *dns.Msg) *dns.Msg {
 	)
 }
 
-// clampTTLsToCut lowers every record TTL in res to the delegation lease's
-// remaining seconds. A zero cut leaves the response untouched; a past cut
-// clamps to zero — the answer is still delivered, but nothing downstream is
-// invited to keep it. OPT is hop metadata whose TTL field is not a TTL.
-func clampTTLsToCut(res *dns.Msg, cutUntil time.Time) {
-	if cutUntil.IsZero() {
+// clampTTLsToEffective lowers every record TTL in res to the shortest bound
+// the answer is subject to: the delegation lease, and the lifetime the records
+// and their signatures themselves permit. A past cut clamps to zero — the
+// answer is still delivered, but nothing downstream is invited to keep it.
+// OPT is hop metadata whose TTL field is not a TTL.
+func clampTTLsToEffective(res *dns.Msg, cutUntil time.Time, mt dnsutil.ResponseType) {
+	ceiling := time.Duration(-1)
+	if !cutUntil.IsZero() {
+		ceiling = max(time.Until(cutUntil), 0)
+	}
+
+	// Everything the entry will be bounded by, applied to the copy the client
+	// is about to receive. Storing the short lifetime and advertising the long
+	// one made two different promises about the same records: a signed answer
+	// held for a second went out with the hour its records claimed, and a
+	// denial the SOA granted one second went out with three hundred. The first
+	// client's own cache then outlived the ceiling by the whole difference.
+	//
+	// Only downward. The derivation applies the positive floor, which is about
+	// how long this cache re-asks, and is no business of the client's.
+	// The same view the entry is bounded by. Walking the whole response
+	// instead pulled in material the entry never keeps, a DNSKEY consulted to
+	// validate the answer among it, and capped the answer at the lifetime of
+	// its own validation input. Provenance is not lineage.
+	if derived := dnsutil.CalculateCacheTTL(filterCacheableAnswer(res), mt); derived > 0 {
+		if ceiling < 0 || derived < ceiling {
+			ceiling = derived
+		}
+	}
+	if ceiling < 0 {
 		return
 	}
-	lease := max(time.Until(cutUntil), 0)
-	leaseSecs := uint32(lease.Seconds())
+
+	secs := uint32(ceiling / time.Second) //nolint:gosec // G115 - bounded by MaxCacheTTL
 	clamp := func(rrs []dns.RR) {
 		for _, rr := range rrs {
 			if rr.Header().Rrtype == dns.TypeOPT {
 				continue
 			}
-			if rr.Header().Ttl > leaseSecs {
-				rr.Header().Ttl = leaseSecs
+			if rr.Header().Ttl > secs {
+				rr.Header().Ttl = secs
 			}
 		}
 	}

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -1980,11 +1980,18 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 	// write.
 	if !w.internal {
 		// This resolver has determined the signatures lapsed, so it must not
-		// pass on a claim that the data is authenticated (RFC 4035 §5.3.3).
+		// pass on a claim that the data is authenticated (RFC 4035 §3.2.3).
 		// A forwarded answer carries whatever AD the upstream asserted, and
 		// relaying it here would let a client trust data we know is bogus.
 		// The clamp below reduces its TTL to zero; the bit is the other half.
-		if mt == dnsutil.TypeExpiredSignature {
+		//
+		// Asked as a fact about the records, not read off the classification.
+		// Only the NOERROR-with-records shape is ever *named* for an expired
+		// signature; a denial whose proof has lapsed is still classified a
+		// denial, so an expired NXDOMAIN, an empty NODATA and an alias chain
+		// ending in either all kept the bit while their TTLs were correctly
+		// clamped to nothing.
+		if dnsutil.HasExpiredSignatures(res, time.Now().UTC()) {
 			res.AuthenticatedData = false
 		}
 		clampTTLsToEffective(res, cutUntil, mt)

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -1704,7 +1704,7 @@ func (c *Cache) Set(key uint64, msg *dns.Msg) {
 	// See Store.setFromResponseWithKey: a denial the zone granted no lifetime
 	// is not admitted (RFC 2308 §5). Unreachable for a positive answer, which
 	// always arrives on its own floor.
-	ttl := c.positive.ttl.CalculateFor(mt, msgTTL)
+	ttl := c.positive.ttl.Bound(msgTTL)
 	if ttl <= 0 {
 		return
 	}

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -1444,7 +1444,11 @@ func (c *Cache) handleCacheHit(
 	// one question must cost one token however many entry objects it
 	// passed through.
 	limiter := entry.GetRateLimiter()
-	if !w.Internal() && limiter != nil && limiter != spent && !limiter.Allow() {
+	// Asked once and kept: the chase below needs the answer too, and a
+	// writer may make more of the question than a field read (a test double
+	// treats each call as a rendezvous).
+	internal := w.Internal()
+	if !internal && limiter != nil && limiter != spent && !limiter.Allow() {
 		ch.Cancel()
 		return true
 	}
@@ -1601,7 +1605,25 @@ func (c *Cache) handleCacheHit(
 	// chasing once the chain passes maxCnameChaseDepth. Replaces
 	// the pre-Phase-3d !w.Internal() guard.
 	if depth := cnameChaseDepth(ctx); depth < maxCnameChaseDepth {
+		answers, authority, rcode := len(msg.Answer), len(msg.Ns), msg.Rcode
 		msg = c.additionalAnswer(withCnameChaseDepth(ctx, depth+1), msg)
+		// The chase may have merged records the entry never vouched for: a
+		// target resolved fresh by the internal sub-query, whose own write
+		// skipped the outgoing checks as every internal write does. Those
+		// records reach the client through this write alone, so it applies
+		// what WriteMsg applies on a miss: AD withdrawn when a signature
+		// has lapsed, and every TTL bounded by the merged records and the
+		// request's cut. Without it a hit on an alias served the target at
+		// its raw TTL, with AD, and with its lapsed signature.
+		if !internal && (len(msg.Answer) != answers || len(msg.Ns) != authority || msg.Rcode != rcode) {
+			now := time.Now().UTC()
+			mt, _ := dnsutil.ClassifyResponse(msg, now)
+			var cut time.Time
+			if meta := middleware.ResponseMetaFrom(ctx); meta != nil {
+				cut, _ = meta.Cut()
+			}
+			honestOutgoing(msg, cut, mt, now)
+		}
 	}
 
 	_ = w.WriteMsg(msg)
@@ -1703,8 +1725,8 @@ func (c *Cache) Set(key uint64, msg *dns.Msg) {
 	msgTTL := dnsutil.CalculateCacheTTLAt(filtered, mt, now)
 
 	// See Store.setFromResponseWithKey: a denial the zone granted no lifetime
-	// is not admitted (RFC 2308 §5). Unreachable for a positive answer, which
-	// always arrives on its own floor.
+	// is not admitted (RFC 2308 §5), and neither is a signed positive answer
+	// whose signature fixes its lifetime at zero.
 	ttl := c.positive.ttl.Bound(msgTTL)
 	if ttl <= 0 {
 		return
@@ -1992,10 +2014,7 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 		// denial, so an expired NXDOMAIN, an empty NODATA and an alias chain
 		// ending in either all kept the bit while their TTLs were correctly
 		// clamped to nothing.
-		if dnsutil.HasExpiredSignatures(res, time.Now().UTC()) {
-			res.AuthenticatedData = false
-		}
-		clampTTLsToEffective(res, cutUntil, mt)
+		honestOutgoing(res, cutUntil, mt, time.Now().UTC())
 	}
 
 	return w.ResponseWriter.WriteMsg(res)
@@ -2068,6 +2087,19 @@ func (w *ResponseWriter) recursionWorkFailure(fallback *dns.Msg) *dns.Msg {
 	)
 }
 
+// honestOutgoing applies, to a message about to leave for an external client,
+// the two facts this resolver has established about it: AD is withdrawn when
+// an answer or authority RRset has no usable signature left (RFC 4035
+// §3.2.3), and every TTL is lowered to the shortest bound the records are
+// subject to. The miss path runs it from WriteMsg; the hit path runs it after
+// an alias chase merged records the entry never vouched for.
+func honestOutgoing(res *dns.Msg, cutUntil time.Time, mt dnsutil.ResponseType, now time.Time) {
+	if dnsutil.HasExpiredSignatures(res, now) {
+		res.AuthenticatedData = false
+	}
+	clampTTLsToEffective(res, cutUntil, mt)
+}
+
 // clampTTLsToEffective lowers every record TTL in res to the shortest bound
 // the answer is subject to: the delegation lease, and the lifetime the records
 // and their signatures themselves permit. A past cut clamps to zero — the
@@ -2099,6 +2131,7 @@ func clampTTLsToEffective(res *dns.Msg, cutUntil time.Time, mt dnsutil.ResponseT
 	// treating it as "nothing found" left the first client holding, at its
 	// full advertised TTL, data this cache had just refused to admit.
 	derived := dnsutil.CalculateCacheTTL(res, mt)
+	leaseBinding := ceiling >= 0 && derived >= ceiling
 	if ceiling < 0 || derived < ceiling {
 		ceiling = derived
 	}
@@ -2109,7 +2142,13 @@ func clampTTLsToEffective(res *dns.Msg, cutUntil time.Time, mt dnsutil.ResponseT
 	// The same rounding a cache hit gets. The two paths answer the same
 	// question about the same records and disagreeing on the last fraction of
 	// a second is how one client is told nothing and the next is told one.
+	// And the same exception: a sub-second delegation lease is not rounded
+	// up into a second the parent never granted; the answer goes out with
+	// nothing to keep, exactly as a hit in that state does (servedTTL).
 	secs := servedSeconds(ceiling)
+	if leaseBinding && ceiling < time.Second {
+		secs = 0
+	}
 	clamp := func(rrs []dns.RR) {
 		for _, rr := range rrs {
 			if rr.Header().Rrtype == dns.TypeOPT {

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -1979,6 +1979,14 @@ func (w *ResponseWriter) WriteMsg(res *dns.Msg) error {
 	// the cut through the shared meta and is clamped at the real client
 	// write.
 	if !w.internal {
+		// This resolver has determined the signatures lapsed, so it must not
+		// pass on a claim that the data is authenticated (RFC 4035 §5.3.3).
+		// A forwarded answer carries whatever AD the upstream asserted, and
+		// relaying it here would let a client trust data we know is bogus.
+		// The clamp below reduces its TTL to zero; the bit is the other half.
+		if mt == dnsutil.TypeExpiredSignature {
+			res.AuthenticatedData = false
+		}
 		clampTTLsToEffective(res, cutUntil, mt)
 	}
 

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/netip"
 	"slices"
-	"strings"
 	"sync"
 	"time"
 
@@ -14,6 +13,7 @@ import (
 	internalcache "github.com/semihalev/sdns/internal/cache"
 	"github.com/semihalev/sdns/internal/contextutil"
 	"github.com/semihalev/sdns/internal/debugenv"
+	"github.com/semihalev/sdns/internal/dnsname"
 	"github.com/semihalev/sdns/internal/dnsutil"
 	"github.com/semihalev/sdns/internal/ecs"
 	"github.com/semihalev/sdns/internal/metric"
@@ -2137,8 +2137,10 @@ func filterCacheableAnswer(res *dns.Msg) *dns.Msg {
 	}
 
 	keep := func(r dns.RR) bool {
+		// As DNS names: a text fold kept a record whose owner is
+		// wire-distinct from the question but folds to it in Unicode.
 		if r.Header().Rrtype == dns.TypeDNAME ||
-			strings.EqualFold(res.Question[0].Name, r.Header().Name) {
+			dnsname.CanonicalCompare(res.Question[0].Name, r.Header().Name) == 0 {
 			return true
 		}
 		rrsig, ok := r.(*dns.RRSIG)

--- a/middleware/cache/canonical_identity_test.go
+++ b/middleware/cache/canonical_identity_test.go
@@ -1,0 +1,115 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// TestAdmissionGroupsSiblingsByWireName carries the canonical-identity
+// matrix through admission to what a client sees: an RRset whose expired
+// signature is covered by a live sibling under another spelling of the
+// same wire name is admitted, served with AD and at the live signature's
+// lifetime; a Kelvin sign is another name, its RRset is uncovered, and the
+// answer is not admitted at all. Owner and signer both.
+func TestAdmissionGroupsSiblingsByWireName(t *testing.T) {
+	now := time.Now()
+	sig := func(owner, signer string, until time.Duration) dns.RR {
+		return &dns.RRSIG{
+			Hdr:         dns.RR_Header{Name: owner, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 3600},
+			TypeCovered: dns.TypeA, Algorithm: 8, Labels: 2, OrigTtl: 3600, KeyTag: 1,
+			SignerName: signer, Signature: "MTIzNDU2Nzg5MGFiY2RlZg==",
+			Inception:  uint32(now.Add(-2 * time.Hour).Unix()), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+			Expiration: uint32(now.Add(until).Unix()),          //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+		}
+	}
+	a := func(owner string) dns.RR {
+		return &dns.A{Hdr: dns.RR_Header{Name: owner, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 3600}, A: []byte{192, 0, 2, 1}}
+	}
+
+	for _, tc := range []struct {
+		name                      string
+		question, owner, live     string
+		signerExpired, signerLive string
+		admitted                  bool
+	}{
+		{"owner: escaped and plain", "target.example.", "target.example.", `t\097rget.example.`, "example.", "example.", true},
+		{"owner: ASCII case", "k.example.", "K.EXAMPLE.", "k.example.", "example.", "example.", true},
+		{"owner: Kelvin sign and k", "k.example.", "k.example.", "K.example.", "example.", "example.", false},
+		{"signer: ASCII case", "k.example.", "k.example.", "k.example.", "EXAMPLE.", "example.", true},
+		{"signer: Kelvin sign and k", "k.example.", "k.example.", "k.example.", "Keep.example.", "keep.example.", false},
+	} {
+		for _, order := range []string{"expired first", "live first"} {
+			t.Run(tc.name+", "+order, func(t *testing.T) {
+				s := newTestStore(t)
+				req := new(dns.Msg)
+				req.SetQuestion(tc.question, dns.TypeA)
+				req.SetEdns0(1232, true)
+				resp := new(dns.Msg)
+				resp.SetReply(req)
+				resp.AuthenticatedData = true
+				expired := sig(tc.owner, tc.signerExpired, -time.Hour)
+				live := sig(tc.live, tc.signerLive, time.Hour)
+				resp.Answer = []dns.RR{a(tc.owner), expired, live}
+				if order == "live first" {
+					resp.Answer = []dns.RR{a(tc.owner), live, expired}
+				}
+				s.SetFromResponse(resp, false, time.Time{})
+
+				entry, ok := s.LookupByKey(CacheKey{Question: req.Question[0], CD: false}.Hash())
+				if ok != tc.admitted {
+					t.Fatalf("admitted = %v, want %v", ok, tc.admitted)
+				}
+				if !tc.admitted {
+					return
+				}
+				served := entry.ToMsg(req)
+				if served == nil {
+					t.Fatal("entry did not serve")
+				}
+				if !served.AuthenticatedData {
+					t.Error("AD withdrawn from an answer whose every RRset is covered")
+				}
+				tags := 0
+				for _, rr := range served.Answer {
+					if s, ok := rr.(*dns.RRSIG); ok {
+						tags++
+						if s.Header().Ttl < 55 {
+							t.Errorf("served TTL %d, want the live signature's lifetime (store-capped at a minute)", s.Header().Ttl)
+						}
+					}
+				}
+				if tags != 1 {
+					t.Errorf("%d signatures served, want the live one alone", tags)
+				}
+			})
+		}
+	}
+}
+
+// TestCacheableAnswerMatchesTheQuestionAsAWireName pins the answer filter:
+// a record whose owner is the question's under another spelling is the
+// answer; one whose owner merely folds to it in Unicode is not.
+func TestCacheableAnswerMatchesTheQuestionAsAWireName(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		owner string
+		kept  bool
+	}{
+		{"ASCII case", "K.EXAMPLE.", true},
+		{"escaped", `\107.example.`, true},
+		{"Kelvin sign", "K.example.", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res := new(dns.Msg)
+			res.SetQuestion("k.example.", dns.TypeA)
+			res.Answer = []dns.RR{
+				&dns.A{Hdr: dns.RR_Header{Name: tc.owner, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300}, A: []byte{192, 0, 2, 1}},
+			}
+			if got := len(filterCacheableAnswer(res).Answer) == 1; got != tc.kept {
+				t.Errorf("record kept = %v, want %v", got, tc.kept)
+			}
+		})
+	}
+}

--- a/middleware/cache/composite_wire_test.go
+++ b/middleware/cache/composite_wire_test.go
@@ -145,20 +145,29 @@ func TestNXDomainCutWireServeParity(t *testing.T) {
 		t.Fatalf("stripped authority kept %v", strippedResp.Ns[0])
 	}
 
-	// An explicit RRSIG query names the DNSSEC type it wants: DO=0 still
-	// gets the full proof, on both paths.
+	// An explicit RRSIG query names the DNSSEC type it wants: at DO=0 it
+	// keeps the signatures and loses the NSEC that came along (RFC 4035
+	// §3.2.1). Neither wire template holds that shape — the stripped one
+	// was cut behind a SOA question — so the wire path declines and the
+	// Msg path shapes it.
 	reqRRSIG, qRRSIG := wireTestRequest(t, "d.gone.zone.test.", dns.TypeRRSIG, false)
-	bodyRRSIG, built := entry.serveWireInto(dst, reqRRSIG, false)
-	if !built {
-		t.Fatal("explicit-RRSIG wire synthesis refused")
-	}
-	rrsigResp := new(dns.Msg)
-	if err := rrsigResp.Unpack(bodyRRSIG); err != nil {
-		t.Fatalf("explicit-RRSIG body unpack: %v", err)
+	if _, built := entry.serveWireInto(dst, reqRRSIG, false); built {
+		t.Fatal("explicit-RRSIG DO=0 question served as bytes; it has no template")
 	}
 	msgRRSIG := entry.response(qRRSIG)
-	if len(rrsigResp.Ns) != len(proof.Ns) || len(msgRRSIG.Ns) != len(proof.Ns) {
-		t.Fatalf("explicit RRSIG query lost the signatures: wire %v msg %v", rrsigResp.Ns, msgRRSIG.Ns)
+	var soa, rrsig, nsec int
+	for _, rr := range msgRRSIG.Ns {
+		switch rr.Header().Rrtype {
+		case dns.TypeSOA:
+			soa++
+		case dns.TypeRRSIG:
+			rrsig++
+		case dns.TypeNSEC:
+			nsec++
+		}
+	}
+	if soa != 1 || rrsig != 2 || nsec != 0 {
+		t.Fatalf("explicit RRSIG query at DO=0: soa=%d rrsig=%d nsec=%d, want the SOA and its two signatures: %v", soa, rrsig, nsec, msgRRSIG.Ns)
 	}
 
 	if allocs := testing.AllocsPerRun(200, func() {

--- a/middleware/cache/denial_proof_cache.go
+++ b/middleware/cache/denial_proof_cache.go
@@ -1646,7 +1646,7 @@ func denialProofResponse(
 		}
 	}
 
-	ttl := uint32(remaining / time.Second) //nolint:gosec // lifetime is positive and capped at three hours
+	ttl := servedSeconds(remaining)
 	for _, rr := range response.Ns {
 		rr.Header().Ttl = ttl
 	}

--- a/middleware/cache/denial_proof_cache.go
+++ b/middleware/cache/denial_proof_cache.go
@@ -1656,9 +1656,10 @@ func denialProofResponse(
 	// depending on which rung of the negative ladder holds the state: the
 	// one authenticating type the question asked for by name stays, every
 	// other goes (RFC 4035 §3.2.1). The question is the client's, set by
-	// SetReply above, which is what the exception reads.
+	// SetReply above, which is what the exception reads. In place: the
+	// authority section was built just above and is this response's own.
 	if opt := req.IsEdns0(); opt == nil || !opt.Do() {
-		dnsutil.ClearDNSSEC(response)
+		dnsutil.ClearDNSSECInPlace(response)
 	}
 	return response, expires
 }

--- a/middleware/cache/denial_proof_cache.go
+++ b/middleware/cache/denial_proof_cache.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/internal/dnsname"
+	"github.com/semihalev/sdns/internal/dnsutil"
 	"github.com/semihalev/sdns/middleware/resolver/dnssec"
 )
 
@@ -1650,22 +1651,14 @@ func denialProofResponse(
 	for _, rr := range response.Ns {
 		rr.Header().Ttl = ttl
 	}
-	// An explicit RRSIG query keeps the signatures regardless of DO —
-	// the same exception the exact-entry and subtree-cut serves apply,
-	// so the answer does not change body depending on which rung of the
-	// negative ladder holds the state.
-	if opt := req.IsEdns0(); (opt == nil || !opt.Do()) &&
-		(len(req.Question) == 0 || req.Question[0].Qtype != dns.TypeRRSIG) {
-		kept := response.Ns[:0]
-		for _, rr := range response.Ns {
-			switch rr.Header().Rrtype {
-			case dns.TypeRRSIG, dns.TypeNSEC, dns.TypeNSEC3:
-				continue
-			default:
-				kept = append(kept, rr)
-			}
-		}
-		response.Ns = kept
+	// The DO=0 shape is ClearDNSSEC's, exactly as the exact-entry and
+	// subtree-cut serves apply it, so the answer does not change body
+	// depending on which rung of the negative ladder holds the state: the
+	// one authenticating type the question asked for by name stays, every
+	// other goes (RFC 4035 §3.2.1). The question is the client's, set by
+	// SetReply above, which is what the exception reads.
+	if opt := req.IsEdns0(); opt == nil || !opt.Do() {
+		dnsutil.ClearDNSSEC(response)
 	}
 	return response, expires
 }

--- a/middleware/cache/do_zero_synthetic_test.go
+++ b/middleware/cache/do_zero_synthetic_test.go
@@ -1,10 +1,14 @@
 package cache
 
 import (
+	"context"
 	"testing"
 	"time"
 
 	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/middleware"
 )
 
 // TestSynthesizedDenialKeepsOnlyTheTypeAskedFor pins the aggressive-cache
@@ -123,4 +127,95 @@ func TestNXDomainCutWireDeclinesExplicitDNSSECQuestionsAtDOZero(t *testing.T) {
 			}
 		})
 	}
+}
+
+// leaseSpy is a udp transport that counts the wire leases taken from it:
+// the chain writer's BeginWire leases from the transport when it offers
+// storage, so a lease here is a BeginWire the precheck let through.
+type leaseSpy struct {
+	*mock.Writer
+	leases int
+}
+
+func (s *leaseSpy) LeaseWire(need int) []byte {
+	s.leases++
+	return make([]byte, 0, need)
+}
+
+// TestCutPrecheckDeclinesExplicitDNSSECBeforeLeasing pins the cut's wire
+// precheck through the wrapper the live chain calls: a DO=0 question for
+// RRSIG, NSEC or NSEC3 is the Msg path's by design, so it is declined
+// before any lease is taken — counted as a DNSSEC-shape skip, never as a
+// build failure — while an ordinary DO=0 question leases once and serves.
+func TestCutPrecheckDeclinesExplicitDNSSECBeforeLeasing(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, Expire: 600})
+	defer c.Stop()
+
+	sig := func(owner string, covered uint16) dns.RR {
+		return &dns.RRSIG{
+			Hdr:         dns.RR_Header{Name: owner, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 300},
+			TypeCovered: covered, Algorithm: dns.RSASHA256, Labels: 2, OrigTtl: 300, KeyTag: 4242,
+			SignerName: "zone.test.", Signature: "Tm90QVJlYWxTaWduYXR1cmVCdXRWYWxpZEJhc2U2NA==",
+			Expiration: uint32(time.Now().Add(24 * time.Hour).Unix()), //nolint:gosec // test fixture
+			Inception:  uint32(time.Now().Add(-time.Hour).Unix()),     //nolint:gosec // test fixture
+		}
+	}
+	proof := new(dns.Msg)
+	proof.SetQuestion("gone.zone.test.", dns.TypeA)
+	proof.Rcode = dns.RcodeNameError
+	proof.Ns = []dns.RR{
+		&dns.SOA{
+			Hdr: dns.RR_Header{Name: "zone.test.", Rrtype: dns.TypeSOA, Class: dns.ClassINET, Ttl: 300},
+			Ns:  "ns.zone.test.", Mbox: "hostmaster.zone.test.", Serial: 1, Refresh: 3600, Retry: 600, Expire: 86400, Minttl: 300,
+		},
+		sig("zone.test.", dns.TypeSOA),
+		&dns.NSEC{
+			Hdr:        dns.RR_Header{Name: "glib.zone.test.", Rrtype: dns.TypeNSEC, Class: dns.ClassINET, Ttl: 300},
+			NextDomain: "help.zone.test.", TypeBitMap: []uint16{dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC},
+		},
+		sig("glib.zone.test.", dns.TypeNSEC),
+	}
+	if !c.store.RecordNXDomainCut(proof, "gone.zone.test.", "zone.test.", time.Time{}) {
+		t.Fatal("cut refused")
+	}
+
+	serve := func(t *testing.T, qtype uint16) (served bool, leases int, dnssecSkips, buildSkips int64) {
+		t.Helper()
+		req, _ := wireTestRequest(t, "sub.gone.zone.test.", qtype, false)
+		cut, ok := c.store.LookupNXDomainCutWire(req.WireName(), dns.ClassINET)
+		if !ok {
+			t.Fatal("wire lookup missed the covering cut")
+		}
+		spy := &leaseSpy{Writer: mock.NewWriter("udp", "198.51.100.77:40000")}
+		ch := middleware.NewChain(nil)
+		ch.ResetWire(spy, req)
+		ch.AllowDirectPack()
+		d0, b0 := wireSkipDNSSEC.Value(), wireSkipBuild.Value()
+		served = c.serveCutHitFromWire(context.Background(), ch, cut)
+		return served, spy.leases, wireSkipDNSSEC.Value() - d0, wireSkipBuild.Value() - b0
+	}
+
+	for _, qtype := range []uint16{dns.TypeRRSIG, dns.TypeNSEC, dns.TypeNSEC3} {
+		t.Run(dns.TypeToString[qtype]+" at DO=0 is declined before the lease", func(t *testing.T) {
+			served, leases, dnssecSkips, buildSkips := serve(t, qtype)
+			if served {
+				t.Fatal("served as bytes")
+			}
+			if leases != 0 {
+				t.Errorf("%d wire leases taken for a question the composer refuses", leases)
+			}
+			if dnssecSkips != 1 || buildSkips != 0 {
+				t.Errorf("skip counters: dnssec +%d build +%d, want dnssec +1 build +0", dnssecSkips, buildSkips)
+			}
+		})
+	}
+	t.Run("A at DO=0 leases once and serves", func(t *testing.T) {
+		served, leases, dnssecSkips, buildSkips := serve(t, dns.TypeA)
+		if !served {
+			t.Fatal("not served as bytes")
+		}
+		if leases != 1 || dnssecSkips != 0 || buildSkips != 0 {
+			t.Errorf("leases %d, skips dnssec +%d build +%d; want one lease and no skips", leases, dnssecSkips, buildSkips)
+		}
+	})
 }

--- a/middleware/cache/do_zero_synthetic_test.go
+++ b/middleware/cache/do_zero_synthetic_test.go
@@ -1,0 +1,126 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// TestSynthesizedDenialKeepsOnlyTheTypeAskedFor pins the aggressive-cache
+// synthesis to ClearDNSSEC's DO=0 shape: the one authenticating type the
+// question named stays, every other goes (RFC 4035 §3.2.1). The manual
+// filter it carried knew only the RRSIG exception, so a DO=0 question for
+// NSEC lost the very records it asked for while the RRSIG question kept the
+// proof it did not.
+func TestSynthesizedDenialKeepsOnlyTheTypeAskedFor(t *testing.T) {
+	now := time.Date(2026, time.July, 31, 12, 0, 0, 0, time.UTC)
+	fixture := newDenialProofNSECFixture(
+		t,
+		now,
+		"m.example.",
+		dns.TypeA,
+		dns.RcodeNameError,
+		"example.",
+		[2]string{"a.example.", "z.example."},
+		[2]string{"example.", "a.example."},
+	)
+	cache := newDenialProofTestCache(&now, 16, 8, maxDenialProofTTL)
+	if !cache.record(fixture.msg, "example.", now.Add(time.Hour)) {
+		t.Fatal("validated NSEC NXDOMAIN proof was not admitted")
+	}
+
+	for _, tc := range []struct {
+		name                         string
+		qtype                        uint16
+		wantNSEC, wantRRSIG, wantSOA int
+	}{
+		{"an ordinary question gets the SOA alone", dns.TypeA, 0, 0, 1},
+		{"a question for NSEC keeps the NSEC witnesses", dns.TypeNSEC, 2, 0, 1},
+		{"a question for RRSIG keeps the signatures", dns.TypeRRSIG, 0, 3, 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			request := denialProofTestRequest("m.example.", tc.qtype, false)
+			response, ok := cache.Lookup(request, nil)
+			if !ok || response.Rcode != dns.RcodeNameError {
+				t.Fatalf("DO=0 NXDOMAIN lookup = %#v, %v", response, ok)
+			}
+			if got := denialProofCountType(response.Ns, dns.TypeNSEC); got != tc.wantNSEC {
+				t.Errorf("%d NSEC records, want %d: %v", got, tc.wantNSEC, response.Ns)
+			}
+			if got := denialProofCountType(response.Ns, dns.TypeRRSIG); got != tc.wantRRSIG {
+				t.Errorf("%d RRSIG records, want %d: %v", got, tc.wantRRSIG, response.Ns)
+			}
+			if got := denialProofCountType(response.Ns, dns.TypeSOA); got != tc.wantSOA {
+				t.Errorf("%d SOA records, want %d: %v", got, tc.wantSOA, response.Ns)
+			}
+		})
+	}
+}
+
+// TestNXDomainCutWireDeclinesExplicitDNSSECQuestionsAtDOZero pins the cut's
+// wire template against the same rule. The stripped template was cut behind
+// a SOA question and holds no authenticating record at all, so a DO=0
+// question for RRSIG, NSEC or NSEC3 — which keeps the one type it named —
+// is handed to the Msg path, where ClearDNSSEC shapes it. Ordinary DO=0
+// questions and every DO=1 question still serve as bytes.
+func TestNXDomainCutWireDeclinesExplicitDNSSECQuestionsAtDOZero(t *testing.T) {
+	cut := newNXDomainCutCache(32, time.Hour)
+	sig := func(owner string, covered uint16) dns.RR {
+		return &dns.RRSIG{
+			Hdr:         dns.RR_Header{Name: owner, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 300},
+			TypeCovered: covered, Algorithm: dns.RSASHA256, Labels: 2, OrigTtl: 300, KeyTag: 4242,
+			SignerName: "zone.test.", Signature: "Tm90QVJlYWxTaWduYXR1cmVCdXRWYWxpZEJhc2U2NA==",
+			Expiration: uint32(time.Now().Add(24 * time.Hour).Unix()), //nolint:gosec // test fixture
+			Inception:  uint32(time.Now().Add(-time.Hour).Unix()),     //nolint:gosec // test fixture
+		}
+	}
+	proof := new(dns.Msg)
+	proof.SetQuestion("gone.zone.test.", dns.TypeA)
+	proof.Rcode = dns.RcodeNameError
+	proof.Ns = []dns.RR{
+		&dns.SOA{
+			Hdr: dns.RR_Header{Name: "zone.test.", Rrtype: dns.TypeSOA, Class: dns.ClassINET, Ttl: 300},
+			Ns:  "ns.zone.test.", Mbox: "hostmaster.zone.test.", Serial: 1, Refresh: 3600, Retry: 600, Expire: 86400, Minttl: 300,
+		},
+		sig("zone.test.", dns.TypeSOA),
+		&dns.NSEC{
+			Hdr:        dns.RR_Header{Name: "glib.zone.test.", Rrtype: dns.TypeNSEC, Class: dns.ClassINET, Ttl: 300},
+			NextDomain: "help.zone.test.", TypeBitMap: []uint16{dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC},
+		},
+		sig("glib.zone.test.", dns.TypeNSEC),
+	}
+	if !cut.record(proof, "gone.zone.test.", "zone.test.", time.Time{}) {
+		t.Fatal("cut refused")
+	}
+	probe, _ := wireTestRequest(t, "sub.gone.zone.test.", dns.TypeA, true)
+	entry, ok := cut.lookupWire(probe.WireName(), dns.ClassINET)
+	if !ok {
+		t.Fatal("wire lookup missed the covering cut")
+	}
+	if entry.wireFull == nil {
+		t.Fatal("fixture is wrong: the cut has no wire template")
+	}
+
+	for _, tc := range []struct {
+		name  string
+		qtype uint16
+		do    bool
+		want  bool
+	}{
+		{"A at DO=0 serves as bytes", dns.TypeA, false, true},
+		{"A at DO=1 serves as bytes", dns.TypeA, true, true},
+		{"NSEC at DO=0 goes to the Msg path", dns.TypeNSEC, false, false},
+		{"NSEC3 at DO=0 goes to the Msg path", dns.TypeNSEC3, false, false},
+		{"RRSIG at DO=0 goes to the Msg path", dns.TypeRRSIG, false, false},
+		{"NSEC at DO=1 serves as bytes", dns.TypeNSEC, true, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req, _ := wireTestRequest(t, "sub.gone.zone.test.", tc.qtype, tc.do)
+			_, served := entry.serveWireInto(make([]byte, 0, 4096), req, tc.do)
+			if served != tc.want {
+				t.Fatalf("served as bytes = %v, want %v", served, tc.want)
+			}
+		})
+	}
+}

--- a/middleware/cache/entry_ad_normalize_test.go
+++ b/middleware/cache/entry_ad_normalize_test.go
@@ -1,0 +1,57 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// TestEntryDropsADOverLapsedSignatures pins the defence in depth at the
+// packing seam: the response writer clears AD on the message it sends after
+// the stores have run, so an entry admitted with the bit set over data whose
+// signatures have lapsed would hand AD back on every later hit. The storable
+// view is normalised before packing, whatever path admitted it.
+func TestEntryDropsADOverLapsedSignatures(t *testing.T) {
+	now := time.Now()
+	const name = "lapsed.example."
+
+	req := new(dns.Msg)
+	req.SetQuestion(name, dns.TypeA)
+	resp := new(dns.Msg)
+	resp.SetReply(req)
+	resp.AuthenticatedData = true
+	resp.Answer = []dns.RR{
+		&dns.A{
+			Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300},
+			A:   []byte{192, 0, 2, 1},
+		},
+		&dns.RRSIG{
+			Hdr:         dns.RR_Header{Name: name, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 300},
+			TypeCovered: dns.TypeA,
+			Algorithm:   8,
+			Labels:      2,
+			OrigTtl:     300,
+			Expiration:  uint32(now.Add(-time.Hour).Unix()),     //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+			Inception:   uint32(now.Add(-2 * time.Hour).Unix()), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+			KeyTag:      1,
+			SignerName:  "example.",
+			Signature:   "MTIzNDU2Nzg5MGFiY2RlZg==",
+		},
+	}
+
+	entry := NewCacheEntryWithKey(resp, time.Minute, 0, 0)
+	if entry == nil {
+		t.Fatal("entry not built")
+	}
+	served := entry.ToMsg(req)
+	if served == nil {
+		t.Fatal("entry did not serve")
+	}
+	if served.AuthenticatedData {
+		t.Fatal("the entry kept AD over data whose signature had lapsed")
+	}
+	if !resp.AuthenticatedData {
+		t.Fatal("normalisation reached the caller's message; only the storable view may change")
+	}
+}

--- a/middleware/cache/entry_ignored_signatures_test.go
+++ b/middleware/cache/entry_ignored_signatures_test.go
@@ -1,0 +1,109 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// TestHitDoesNotReviveSignaturesTheEntryIgnores pins the stored view against
+// the hit paths. The entry's lifetime is bounded by its usable signatures
+// alone, and every hit path serves each record with the entry's remaining
+// lifetime as its TTL — so a signature the lifetime ignores, if stored,
+// comes back inflated: a lapsed sibling received with TTL 0 as an hour, a
+// glue signature the same, and one whose inception has not arrived revived
+// once it has. None of them are stored.
+func TestHitDoesNotReviveSignaturesTheEntryIgnores(t *testing.T) {
+	now := time.Now()
+	const name = "rollover.example."
+	sig := func(owner string, hdrTTL uint32, tag uint16, from, until time.Duration) dns.RR {
+		return &dns.RRSIG{
+			Hdr:         dns.RR_Header{Name: owner, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: hdrTTL},
+			TypeCovered: dns.TypeA,
+			Algorithm:   8,
+			Labels:      2,
+			OrigTtl:     3600,
+			KeyTag:      tag,
+			SignerName:  "example.",
+			Signature:   "MTIzNDU2Nzg5MGFiY2RlZg==",
+			Inception:   uint32(now.Add(from).Unix()),  //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+			Expiration:  uint32(now.Add(until).Unix()), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+		}
+	}
+	a := func(owner string) dns.RR {
+		return &dns.A{
+			Hdr: dns.RR_Header{Name: owner, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 3600},
+			A:   []byte{192, 0, 2, 1},
+		}
+	}
+
+	req := new(dns.Msg)
+	req.SetQuestion(name, dns.TypeA)
+	req.SetEdns0(1232, true)
+	resp := new(dns.Msg)
+	resp.SetReply(req)
+	resp.Answer = []dns.RR{
+		a(name),
+		sig(name, 0, 111, -2*time.Hour, -time.Hour),   // lapsed sibling, TTL 0
+		sig(name, 3600, 222, -2*time.Hour, time.Hour), // the live one
+		sig(name, 0, 333, time.Hour, 2*time.Hour),     // not yet valid
+	}
+	resp.Extra = []dns.RR{
+		a("ns.example."),
+		sig("ns.example.", 0, 444, -2*time.Hour, time.Hour), // live glue signature, TTL 0
+	}
+
+	entry := NewCacheEntryWithKey(resp, time.Hour, 0, 0)
+	if entry == nil {
+		t.Fatal("entry not built")
+	}
+	served := entry.ToMsg(req)
+	if served == nil {
+		t.Fatal("entry did not serve")
+	}
+
+	var tags []uint16
+	for _, rr := range served.Answer {
+		if s, ok := rr.(*dns.RRSIG); ok {
+			tags = append(tags, s.KeyTag)
+			if s.Header().Ttl == 0 {
+				t.Errorf("signature %d served with TTL 0", s.KeyTag)
+			}
+		}
+	}
+	if len(tags) != 1 || tags[0] != 222 {
+		t.Fatalf("answer signatures served: %v, want only the live 222", tags)
+	}
+	if len(served.Extra) != 1 {
+		t.Fatalf("additional section served %d records, want the glue alone", len(served.Extra))
+	}
+	if _, ok := served.Extra[0].(*dns.A); !ok {
+		t.Fatalf("additional section served %T, want the glue address", served.Extra[0])
+	}
+	if len(resp.Answer) != 4 || len(resp.Extra) != 2 {
+		t.Fatal("admission edited the caller's message; only the stored view may change")
+	}
+}
+
+// TestStorableRecordsPassesTheCommonShapeThrough pins the price: a response
+// with nothing to drop is stored from the caller's slice, not a copy.
+func TestStorableRecordsPassesTheCommonShapeThrough(t *testing.T) {
+	now := time.Now()
+	records := []dns.RR{
+		&dns.A{Hdr: dns.RR_Header{Name: "x.example.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300}, A: []byte{192, 0, 2, 1}},
+		&dns.RRSIG{
+			Hdr:         dns.RR_Header{Name: "x.example.", Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 300},
+			TypeCovered: dns.TypeA, SignerName: "example.",
+			Inception:  uint32(now.Add(-time.Hour).Unix()), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+			Expiration: uint32(now.Add(time.Hour).Unix()),  //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+		},
+	}
+	kept := storableRecords(records, now)
+	if len(kept) != len(records) || &kept[0] != &records[0] {
+		t.Fatal("a response with nothing to drop was copied")
+	}
+	if allocs := testing.AllocsPerRun(100, func() { storableRecords(records, now) }); allocs != 0 {
+		t.Errorf("common shape allocated %v times, want none", allocs)
+	}
+}

--- a/middleware/cache/entry_ignored_signatures_test.go
+++ b/middleware/cache/entry_ignored_signatures_test.go
@@ -347,3 +347,97 @@ func mustUnpack(t *testing.T, body []byte) *dns.Msg {
 	}
 	return m
 }
+
+// TestDOZeroBodyKeepsOnlyTheTypeAskedFor pins the wire path's DNSSEC verdict
+// to ClearDNSSEC's exception. A question for NSEC is answered with NSEC for
+// any DO, and the signatures over it go for DO=0; a question for RRSIG keeps
+// its signatures for any DO, and an NSEC that came along as a proof goes for
+// DO=0; a question for RRSIG answered with signatures alone has nothing to
+// strip and serves the stored body to both.
+func TestDOZeroBodyKeepsOnlyTheTypeAskedFor(t *testing.T) {
+	now := time.Now()
+	sig, _ := ignoredSigFixtures(now)
+	const name = "proof.example."
+	nsec := func() dns.RR {
+		return &dns.NSEC{
+			Hdr:        dns.RR_Header{Name: name, Rrtype: dns.TypeNSEC, Class: dns.ClassINET, Ttl: 3600},
+			NextDomain: "z.example.", TypeBitMap: []uint16{dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC},
+		}
+	}
+	nsecSig := func() dns.RR {
+		s := sig(name, 3600, 700, -2*time.Hour, time.Hour).(*dns.RRSIG)
+		s.TypeCovered = dns.TypeNSEC
+		return s
+	}
+	build := func(qtype uint16, answer []dns.RR) *CacheEntry {
+		t.Helper()
+		req := new(dns.Msg)
+		req.SetQuestion(name, qtype)
+		req.SetEdns0(1232, true)
+		resp := new(dns.Msg)
+		resp.SetReply(req)
+		resp.Answer = answer
+		entry := NewCacheEntryWithKey(resp, time.Hour, 0, 0)
+		if entry == nil {
+			t.Fatal("entry not built")
+		}
+		return entry
+	}
+	types := func(records []dns.RR) map[uint16]int {
+		got := map[uint16]int{}
+		for _, rr := range records {
+			got[rr.Header().Rrtype]++
+		}
+		return got
+	}
+
+	t.Run("NSEC asked for: the NSEC stays, its signature goes", func(t *testing.T) {
+		entry := build(dns.TypeNSEC, []dns.RR{nsec(), nsecSig()})
+		if entry.wireServe&wireHasDNSSEC == 0 {
+			t.Fatal("the signature did not mark the body as carrying DNSSEC")
+		}
+		body, _ := entry.wireBodyFor(false)
+		if body == nil {
+			t.Fatal("no DO=0 body")
+		}
+		if got := types(mustUnpack(t, body).Answer); got[dns.TypeNSEC] != 1 || got[dns.TypeRRSIG] != 0 {
+			t.Errorf("DO=0 answer types %v, want the NSEC alone", got)
+		}
+		do, _ := entry.wireBodyFor(true)
+		if got := types(mustUnpack(t, do).Answer); got[dns.TypeNSEC] != 1 || got[dns.TypeRRSIG] != 1 {
+			t.Errorf("DO=1 answer types %v, want the NSEC and its signature", got)
+		}
+	})
+
+	t.Run("RRSIG asked for: the signatures stay, the proof goes", func(t *testing.T) {
+		entry := build(dns.TypeRRSIG, []dns.RR{
+			sig(name, 3600, 701, -2*time.Hour, time.Hour),
+			sig(name, 3600, 702, -2*time.Hour, 2*time.Hour),
+			nsec(),
+		})
+		if entry.wireServe&wireHasDNSSEC == 0 {
+			t.Fatal("the NSEC did not mark the body as carrying DNSSEC")
+		}
+		body, _ := entry.wireBodyFor(false)
+		if body == nil {
+			t.Fatal("no DO=0 body")
+		}
+		if got := types(mustUnpack(t, body).Answer); got[dns.TypeRRSIG] != 2 || got[dns.TypeNSEC] != 0 {
+			t.Errorf("DO=0 answer types %v, want both signatures and no NSEC", got)
+		}
+	})
+
+	t.Run("RRSIG asked for and answered with signatures alone: nothing to strip", func(t *testing.T) {
+		entry := build(dns.TypeRRSIG, []dns.RR{
+			sig(name, 3600, 701, -2*time.Hour, time.Hour),
+			sig(name, 3600, 702, -2*time.Hour, 2*time.Hour),
+		})
+		if entry.wireServe&wireHasDNSSEC != 0 {
+			t.Fatal("an answer of nothing but the signatures asked for was marked as carrying DNSSEC to strip")
+		}
+		body, _ := entry.wireBodyFor(false)
+		if got := types(mustUnpack(t, body).Answer); got[dns.TypeRRSIG] != 2 {
+			t.Errorf("DO=0 answer types %v, want both signatures", got)
+		}
+	})
+}

--- a/middleware/cache/entry_ignored_signatures_test.go
+++ b/middleware/cache/entry_ignored_signatures_test.go
@@ -498,8 +498,10 @@ func TestAdditionalSignatureIsJudgedOnTheEntrysClock(t *testing.T) {
 		// the additional signature ends at the same instant. Through the
 		// store, which measures the lifetime and anchors the entry at one
 		// now — a second reading in between made this signature fall short
-		// by microseconds every time.
-		expires := now.Add(30 * time.Minute)
+		// by microseconds every time. The window ends under the test
+		// store's one-minute cap, so the two signatures really do set the
+		// same boundary and nothing else clamps it.
+		expires := now.Add(30 * time.Second)
 		s := newTestStore(t)
 		req := new(dns.Msg)
 		req.SetQuestion(name, dns.TypeMX)
@@ -585,5 +587,73 @@ func TestAdditionalMixedSignersGoWhole(t *testing.T) {
 	}
 	if tags := sigTags(served.Extra); len(tags) != 1 || tags[0] != 3 {
 		t.Errorf("additional signatures served: %v, want only the single-signer 3", tags)
+	}
+}
+
+// TestAdditionalRRsetKeepsItsReceivedTTL pins RFC 4035 §5.3.3's other
+// ceiling on the additional section: a signed RRset's lifetime may not
+// exceed the TTL it was received with. An unsigned answer takes the
+// positive floor, so an additional address received with a one-second TTL
+// and a long-lived signature was lifted to the floor, kept, and served at
+// it — with its signature. The tuple goes whole; one received with enough
+// TTL stays.
+func TestAdditionalRRsetKeepsItsReceivedTTL(t *testing.T) {
+	now := time.Now()
+	const name = "mx.example."
+	rrsig := func(owner string) dns.RR {
+		return &dns.RRSIG{
+			Hdr:         dns.RR_Header{Name: owner, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 3600},
+			TypeCovered: dns.TypeA, Algorithm: 8, Labels: 2, OrigTtl: 3600, KeyTag: 9,
+			SignerName: "example.", Signature: "MTIzNDU2Nzg5MGFiY2RlZg==",
+			Inception:  uint32(now.Add(-2 * time.Hour).Unix()), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+			Expiration: uint32(now.Add(2 * time.Hour).Unix()),  //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+		}
+	}
+	addr := func(owner string, ttl uint32) dns.RR {
+		return &dns.A{Hdr: dns.RR_Header{Name: owner, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: ttl}, A: []byte{192, 0, 2, 1}}
+	}
+
+	for _, tc := range []struct {
+		name string
+		ttl  uint32
+		kept bool
+	}{
+		{"received with one second, lifted to the floor: dropped with its signature", 1, false},
+		{"received with an hour: kept with its signature", 3600, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			s := newTestStore(t)
+			req := new(dns.Msg)
+			req.SetQuestion(name, dns.TypeMX)
+			req.SetEdns0(1232, true)
+			resp := new(dns.Msg)
+			resp.SetReply(req)
+			// Unsigned answer: the entry takes the positive floor.
+			resp.Answer = []dns.RR{
+				&dns.MX{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeMX, Class: dns.ClassINET, Ttl: 3600}, Preference: 10, Mx: "target.example."},
+			}
+			resp.Extra = []dns.RR{addr("target.example.", tc.ttl), rrsig("target.example.")}
+			s.SetFromResponse(resp, false, time.Time{})
+
+			entry, ok := s.LookupByKey(CacheKey{Question: req.Question[0], CD: false}.Hash())
+			if !ok {
+				t.Fatal("the answer was not cached")
+			}
+			served := entry.ToMsg(req)
+			if served == nil {
+				t.Fatal("entry did not serve")
+			}
+			if got := hasA(served.Extra, "target.example."); got != tc.kept {
+				t.Errorf("address carried = %v, want %v", got, tc.kept)
+			}
+			if got := len(sigTags(served.Extra)) == 1; got != tc.kept {
+				t.Errorf("signature carried = %v, want %v", got, tc.kept)
+			}
+			for _, rr := range served.Extra {
+				if h := rr.Header(); h.Ttl > tc.ttl {
+					t.Errorf("%s served at TTL %d, received with %d", h.Name, h.Ttl, tc.ttl)
+				}
+			}
+		})
 	}
 }

--- a/middleware/cache/entry_ignored_signatures_test.go
+++ b/middleware/cache/entry_ignored_signatures_test.go
@@ -7,17 +7,8 @@ import (
 	"github.com/miekg/dns"
 )
 
-// TestHitDoesNotReviveSignaturesTheEntryIgnores pins the stored view against
-// the hit paths. The entry's lifetime is bounded by its usable signatures
-// alone, and every hit path serves each record with the entry's remaining
-// lifetime as its TTL — so a signature the lifetime ignores, if stored,
-// comes back inflated: a lapsed sibling received with TTL 0 as an hour, a
-// glue signature the same, and one whose inception has not arrived revived
-// once it has. None of them are stored.
-func TestHitDoesNotReviveSignaturesTheEntryIgnores(t *testing.T) {
-	now := time.Now()
-	const name = "rollover.example."
-	sig := func(owner string, hdrTTL uint32, tag uint16, from, until time.Duration) dns.RR {
+func ignoredSigFixtures(now time.Time) (sig func(owner string, hdrTTL uint32, tag uint16, from, until time.Duration) dns.RR, a func(owner string) dns.RR) {
+	sig = func(owner string, hdrTTL uint32, tag uint16, from, until time.Duration) dns.RR {
 		return &dns.RRSIG{
 			Hdr:         dns.RR_Header{Name: owner, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: hdrTTL},
 			TypeCovered: dns.TypeA,
@@ -31,12 +22,57 @@ func TestHitDoesNotReviveSignaturesTheEntryIgnores(t *testing.T) {
 			Expiration:  uint32(now.Add(until).Unix()), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
 		}
 	}
-	a := func(owner string) dns.RR {
+	a = func(owner string) dns.RR {
 		return &dns.A{
 			Hdr: dns.RR_Header{Name: owner, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 3600},
 			A:   []byte{192, 0, 2, 1},
 		}
 	}
+	return sig, a
+}
+
+func serveFromEntry(t *testing.T, req, resp *dns.Msg, ttl time.Duration) *dns.Msg {
+	t.Helper()
+	entry := NewCacheEntryWithKey(resp, ttl, 0, 0)
+	if entry == nil {
+		t.Fatal("entry not built")
+	}
+	served := entry.ToMsg(req)
+	if served == nil {
+		t.Fatal("entry did not serve")
+	}
+	return served
+}
+
+func sigTags(records []dns.RR) []uint16 {
+	var tags []uint16
+	for _, rr := range records {
+		if s, ok := rr.(*dns.RRSIG); ok {
+			tags = append(tags, s.KeyTag)
+		}
+	}
+	return tags
+}
+
+func hasA(records []dns.RR, owner string) bool {
+	for _, rr := range records {
+		if r, ok := rr.(*dns.A); ok && r.Hdr.Name == owner {
+			return true
+		}
+	}
+	return false
+}
+
+// TestHitDoesNotReviveSignaturesTheEntryIgnores pins the stored view against
+// the hit paths. The entry's lifetime is bounded by its usable signatures
+// alone, and every hit path serves each record with the entry's remaining
+// lifetime as its TTL — so a signature the lifetime ignores, if stored,
+// comes back inflated: a lapsed sibling received with TTL 0 as an hour, and
+// one whose inception has not arrived revived once it has. Neither is stored.
+func TestHitDoesNotReviveSignaturesTheEntryIgnores(t *testing.T) {
+	now := time.Now()
+	sig, a := ignoredSigFixtures(now)
+	const name = "rollover.example."
 
 	req := new(dns.Msg)
 	req.SetQuestion(name, dns.TypeA)
@@ -49,56 +85,131 @@ func TestHitDoesNotReviveSignaturesTheEntryIgnores(t *testing.T) {
 		sig(name, 3600, 222, -2*time.Hour, time.Hour), // the live one
 		sig(name, 0, 333, time.Hour, 2*time.Hour),     // not yet valid
 	}
-	resp.Extra = []dns.RR{
-		a("ns.example."),
-		sig("ns.example.", 0, 444, -2*time.Hour, time.Hour), // live glue signature, TTL 0
-	}
 
-	entry := NewCacheEntryWithKey(resp, time.Hour, 0, 0)
-	if entry == nil {
-		t.Fatal("entry not built")
-	}
-	served := entry.ToMsg(req)
-	if served == nil {
-		t.Fatal("entry did not serve")
-	}
-
-	var tags []uint16
+	served := serveFromEntry(t, req, resp, time.Hour)
 	for _, rr := range served.Answer {
-		if s, ok := rr.(*dns.RRSIG); ok {
-			tags = append(tags, s.KeyTag)
-			if s.Header().Ttl == 0 {
-				t.Errorf("signature %d served with TTL 0", s.KeyTag)
-			}
+		if s, ok := rr.(*dns.RRSIG); ok && s.Header().Ttl == 0 {
+			t.Errorf("signature %d served with TTL 0", s.KeyTag)
 		}
 	}
-	if len(tags) != 1 || tags[0] != 222 {
+	if tags := sigTags(served.Answer); len(tags) != 1 || tags[0] != 222 {
 		t.Fatalf("answer signatures served: %v, want only the live 222", tags)
 	}
-	if len(served.Extra) != 1 {
-		t.Fatalf("additional section served %d records, want the glue alone", len(served.Extra))
-	}
-	if _, ok := served.Extra[0].(*dns.A); !ok {
-		t.Fatalf("additional section served %T, want the glue address", served.Extra[0])
-	}
-	if len(resp.Answer) != 4 || len(resp.Extra) != 2 {
+	if len(resp.Answer) != 4 {
 		t.Fatal("admission edited the caller's message; only the stored view may change")
 	}
+}
+
+// TestAdditionalRRsetTravelsWithItsSignature pins the additional section: a
+// signed RRset there is kept with its signature or removed with it (RFC 4035
+// §3.1.1), decided by whether the entry's lifetime can honour the signature.
+// The section bounds neither AD nor the lifetime, and every hit serves it at
+// the lifetime's TTL, so a signature permitting less would come back
+// inflated. A mail exchanger's address is the shape: signed in the zone,
+// carried as additional data.
+func TestAdditionalRRsetTravelsWithItsSignature(t *testing.T) {
+	now := time.Now()
+	sig, a := ignoredSigFixtures(now)
+	const name = "mx.example."
+
+	req := new(dns.Msg)
+	req.SetQuestion(name, dns.TypeMX)
+	req.SetEdns0(1232, true)
+	resp := new(dns.Msg)
+	resp.SetReply(req)
+	resp.Answer = []dns.RR{
+		&dns.MX{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeMX, Class: dns.ClassINET, Ttl: 3600}, Preference: 10, Mx: "short.example."},
+		&dns.RRSIG{
+			Hdr:         dns.RR_Header{Name: name, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 3600},
+			TypeCovered: dns.TypeMX, Algorithm: 8, Labels: 2, OrigTtl: 3600, KeyTag: 9,
+			SignerName: "example.", Signature: "MTIzNDU2Nzg5MGFiY2RlZg==",
+			Inception:  uint32(now.Add(-2 * time.Hour).Unix()), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+			Expiration: uint32(now.Add(time.Hour).Unix()),      //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+		},
+	}
+	resp.Extra = []dns.RR{
+		// Signed, but its signature permits less than the entry's hour.
+		a("short.example."),
+		sig("short.example.", 30, 444, -2*time.Hour, time.Hour),
+		// Signed, and its signature permits the hour — with a lapsed
+		// sibling beside it that leaves alone.
+		a("kept.example."),
+		sig("kept.example.", 3600, 555, -2*time.Hour, time.Hour),
+		sig("kept.example.", 0, 556, -2*time.Hour, -time.Hour),
+		// Unsigned, as real delegation glue is.
+		a("glue.example."),
+	}
+
+	served := serveFromEntry(t, req, resp, time.Hour)
+	if hasA(served.Extra, "short.example.") {
+		t.Error("an RRset whose signature could not be honoured was served without it")
+	}
+	if !hasA(served.Extra, "kept.example.") {
+		t.Error("an RRset whose signature could be honoured was dropped")
+	}
+	if !hasA(served.Extra, "glue.example.") {
+		t.Error("unsigned glue was dropped")
+	}
+	if tags := sigTags(served.Extra); len(tags) != 1 || tags[0] != 555 {
+		t.Errorf("additional signatures served: %v, want only 555", tags)
+	}
+	for _, rr := range served.Extra {
+		if rr.Header().Ttl == 0 {
+			t.Errorf("%s served with TTL 0", rr.Header().Name)
+		}
+	}
+	if len(resp.Extra) != 6 {
+		t.Fatal("admission edited the caller's message; only the stored view may change")
+	}
+}
+
+// TestExplicitRRSIGQuestionIsStoredWholeOrNotAtAll pins the one question
+// whose answer is the signatures themselves (RFC 4035 §3.2.1). A hit may not
+// return fewer of them than the first response did, so an answer the stored
+// view would thin is not stored, and one it would keep whole is.
+func TestExplicitRRSIGQuestionIsStoredWholeOrNotAtAll(t *testing.T) {
+	now := time.Now()
+	sig, _ := ignoredSigFixtures(now)
+	const name = "signed.example."
+
+	req := new(dns.Msg)
+	req.SetQuestion(name, dns.TypeRRSIG)
+	req.SetEdns0(1232, true)
+	req.CheckingDisabled = true
+
+	t.Run("lapsed and pending signatures keep the answer out of the cache", func(t *testing.T) {
+		resp := new(dns.Msg)
+		resp.SetReply(req)
+		resp.Answer = []dns.RR{
+			sig(name, 3600, 111, -2*time.Hour, -time.Hour),
+			sig(name, 3600, 222, -2*time.Hour, time.Hour),
+			sig(name, 3600, 333, time.Hour, 2*time.Hour),
+		}
+		if entry := NewCacheEntryWithKey(resp, time.Hour, 0, 0); entry != nil {
+			t.Fatal("an RRSIG answer the stored view would thin was cached")
+		}
+	})
+
+	t.Run("an answer of live signatures is cached whole", func(t *testing.T) {
+		resp := new(dns.Msg)
+		resp.SetReply(req)
+		resp.Answer = []dns.RR{
+			sig(name, 3600, 222, -2*time.Hour, time.Hour),
+			sig(name, 3600, 223, -2*time.Hour, 2*time.Hour),
+		}
+		served := serveFromEntry(t, req, resp, time.Hour)
+		if tags := sigTags(served.Answer); len(tags) != 2 {
+			t.Fatalf("served %v, want both signatures", tags)
+		}
+	})
 }
 
 // TestStorableRecordsPassesTheCommonShapeThrough pins the price: a response
 // with nothing to drop is stored from the caller's slice, not a copy.
 func TestStorableRecordsPassesTheCommonShapeThrough(t *testing.T) {
 	now := time.Now()
-	records := []dns.RR{
-		&dns.A{Hdr: dns.RR_Header{Name: "x.example.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300}, A: []byte{192, 0, 2, 1}},
-		&dns.RRSIG{
-			Hdr:         dns.RR_Header{Name: "x.example.", Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 300},
-			TypeCovered: dns.TypeA, SignerName: "example.",
-			Inception:  uint32(now.Add(-time.Hour).Unix()), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
-			Expiration: uint32(now.Add(time.Hour).Unix()),  //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
-		},
-	}
+	sig, a := ignoredSigFixtures(now)
+	records := []dns.RR{a("x.example."), sig("x.example.", 300, 1, -time.Hour, time.Hour)}
 	kept := storableRecords(records, now)
 	if len(kept) != len(records) || &kept[0] != &records[0] {
 		t.Fatal("a response with nothing to drop was copied")

--- a/middleware/cache/entry_ignored_signatures_test.go
+++ b/middleware/cache/entry_ignored_signatures_test.go
@@ -132,9 +132,11 @@ func TestAdditionalRRsetTravelsWithItsSignature(t *testing.T) {
 		a("short.example."),
 		sig("short.example.", 30, 444, -2*time.Hour, time.Hour),
 		// Signed, and its signature permits the hour — with a lapsed
-		// sibling beside it that leaves alone.
+		// sibling beside it that leaves alone. Its validity runs past the
+		// lifetime: the entry's clock is read after this fixture's, and
+		// the comparison is exact.
 		a("kept.example."),
-		sig("kept.example.", 3600, 555, -2*time.Hour, time.Hour),
+		sig("kept.example.", 3600, 555, -2*time.Hour, 2*time.Hour),
 		sig("kept.example.", 0, 556, -2*time.Hour, -time.Hour),
 		// Unsigned, as real delegation glue is.
 		a("glue.example."),
@@ -295,7 +297,7 @@ func TestDOZeroHitCarriesNoAdditionalSignature(t *testing.T) {
 				Expiration: uint32(now.Add(time.Hour).Unix()),      //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
 			})
 		}
-		resp.Extra = []dns.RR{a("target.example."), sig("target.example.", 3600, 600, -2*time.Hour, time.Hour)}
+		resp.Extra = []dns.RR{a("target.example."), sig("target.example.", 3600, 600, -2*time.Hour, 2*time.Hour)}
 		entry := NewCacheEntryWithKey(resp, time.Hour, 0, 0)
 		if entry == nil {
 			t.Fatal("entry not built")
@@ -440,4 +442,148 @@ func TestDOZeroBodyKeepsOnlyTheTypeAskedFor(t *testing.T) {
 			t.Errorf("DO=0 answer types %v, want both signatures", got)
 		}
 	})
+}
+
+// TestAdditionalSignatureIsJudgedOnTheEntrysClock pins the admission clock.
+// The lifetime, the entry's stored instant and the verdict on each
+// additional signature read the same now, so the comparison is exact: a
+// signature permitting one second is not carried by a two-second entry —
+// the tolerance that let it through served it a whole second past its
+// ceiling — and one sharing the answer's own validity window, which trailed
+// a lifetime measured a moment earlier by that moment, is carried.
+func TestAdditionalSignatureIsJudgedOnTheEntrysClock(t *testing.T) {
+	now := time.Now()
+	_, a := ignoredSigFixtures(now)
+	const name = "mx.example."
+	rrsig := func(owner string, covered uint16, hdrTTL uint32, expires time.Time) dns.RR {
+		return &dns.RRSIG{
+			Hdr:         dns.RR_Header{Name: owner, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: hdrTTL},
+			TypeCovered: covered, Algorithm: 8, Labels: 2, OrigTtl: hdrTTL, KeyTag: 9,
+			SignerName: "example.", Signature: "MTIzNDU2Nzg5MGFiY2RlZg==",
+			Inception:  uint32(now.Add(-2 * time.Hour).Unix()), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+			Expiration: uint32(expires.Unix()),                 //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+		}
+	}
+	mx := func(ttl uint32) dns.RR {
+		return &dns.MX{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeMX, Class: dns.ClassINET, Ttl: ttl}, Preference: 10, Mx: "target.example."}
+	}
+
+	t.Run("a one-second signature is not carried by a two-second entry", func(t *testing.T) {
+		req := new(dns.Msg)
+		req.SetQuestion(name, dns.TypeMX)
+		req.SetEdns0(1232, true)
+		resp := new(dns.Msg)
+		resp.SetReply(req)
+		resp.Answer = []dns.RR{mx(2)}
+		resp.Extra = []dns.RR{a("target.example."), rrsig("target.example.", dns.TypeA, 1, now.Add(time.Hour))}
+
+		entry := newCacheEntryAt(resp, 2*time.Second, 0, 0, now)
+		if entry == nil {
+			t.Fatal("entry not built")
+		}
+		served := entry.ToMsg(req)
+		if served == nil {
+			t.Fatal("entry did not serve")
+		}
+		if tags := sigTags(served.Extra); len(tags) != 0 {
+			t.Errorf("a one-second signature was carried by a two-second entry: %v", tags)
+		}
+		if hasA(served.Extra, "target.example.") {
+			t.Error("the RRset was served without the signature it arrived with")
+		}
+	})
+
+	t.Run("a signature sharing the answer's validity window is carried", func(t *testing.T) {
+		// The answer's own signature sets the lifetime to the window's end;
+		// the additional signature ends at the same instant. Through the
+		// store, which measures the lifetime and anchors the entry at one
+		// now — a second reading in between made this signature fall short
+		// by microseconds every time.
+		expires := now.Add(30 * time.Minute)
+		s := newTestStore(t)
+		req := new(dns.Msg)
+		req.SetQuestion(name, dns.TypeMX)
+		req.SetEdns0(1232, true)
+		resp := new(dns.Msg)
+		resp.SetReply(req)
+		resp.Answer = []dns.RR{mx(3600), rrsig(name, dns.TypeMX, 3600, expires)}
+		resp.Extra = []dns.RR{a("target.example."), rrsig("target.example.", dns.TypeA, 3600, expires)}
+		s.SetFromResponse(resp, false, time.Time{})
+
+		entry, ok := s.LookupByKey(CacheKey{Question: req.Question[0], CD: false}.Hash())
+		if !ok {
+			t.Fatal("the answer was not cached")
+		}
+		served := entry.ToMsg(req)
+		if served == nil {
+			t.Fatal("entry did not serve")
+		}
+		if tags := sigTags(served.Extra); len(tags) != 1 {
+			t.Errorf("a signature ending with the answer's own was dropped: %v", tags)
+		}
+		if !hasA(served.Extra, "target.example.") {
+			t.Error("the additional address was dropped")
+		}
+	})
+}
+
+// TestAdditionalMixedSignersGoWhole pins the delegation boundary in the
+// additional section: the parent's NSEC over the child's name and the
+// child's apex NSEC share owner, class and type, so on the wire they are
+// one RRset whose records cannot be told apart by signer. A live child
+// signature must not carry the parent's lapsed records with it (RFC 4035
+// §5.3.2); the tuple goes whole. A single-signer tuple beside it is judged
+// as before.
+func TestAdditionalMixedSignersGoWhole(t *testing.T) {
+	now := time.Now()
+	_, a := ignoredSigFixtures(now)
+	const name = "mx.example."
+	nsec := func(owner string) dns.RR {
+		return &dns.NSEC{
+			Hdr:        dns.RR_Header{Name: owner, Rrtype: dns.TypeNSEC, Class: dns.ClassINET, Ttl: 3600},
+			NextDomain: "z." + owner, TypeBitMap: []uint16{dns.TypeNS, dns.TypeRRSIG, dns.TypeNSEC},
+		}
+	}
+	rrsig := func(owner, signer string, covered uint16, tag uint16, until time.Duration) dns.RR {
+		return &dns.RRSIG{
+			Hdr:         dns.RR_Header{Name: owner, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 3600},
+			TypeCovered: covered, Algorithm: 8, Labels: 2, OrigTtl: 3600, KeyTag: tag,
+			SignerName: signer, Signature: "MTIzNDU2Nzg5MGFiY2RlZg==",
+			Inception:  uint32(now.Add(-2 * time.Hour).Unix()), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+			Expiration: uint32(now.Add(until).Unix()),          //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+		}
+	}
+
+	req := new(dns.Msg)
+	req.SetQuestion(name, dns.TypeMX)
+	req.SetEdns0(1232, true)
+	resp := new(dns.Msg)
+	resp.SetReply(req)
+	resp.Answer = []dns.RR{
+		&dns.MX{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeMX, Class: dns.ClassINET, Ttl: 3600}, Preference: 10, Mx: "target.example."},
+	}
+	resp.Extra = []dns.RR{
+		// The boundary: two NSEC records under one owner, the parent's
+		// signature lapsed, the child's live.
+		nsec("child.example."),
+		nsec("child.example."),
+		rrsig("child.example.", "example.", dns.TypeNSEC, 1, -time.Hour),
+		rrsig("child.example.", "child.example.", dns.TypeNSEC, 2, 2*time.Hour),
+		// A single-signer tuple, live: carried.
+		a("target.example."),
+		rrsig("target.example.", "example.", dns.TypeA, 3, 2*time.Hour),
+	}
+
+	served := serveFromEntry(t, req, resp, time.Hour)
+	for _, rr := range served.Extra {
+		if rr.Header().Name == "child.example." {
+			t.Errorf("a mixed-signer tuple was carried: %s", rr.Header().String())
+		}
+	}
+	if !hasA(served.Extra, "target.example.") {
+		t.Error("the single-signer RRset was dropped")
+	}
+	if tags := sigTags(served.Extra); len(tags) != 1 || tags[0] != 3 {
+		t.Errorf("additional signatures served: %v, want only the single-signer 3", tags)
+	}
 }

--- a/middleware/cache/entry_ignored_signatures_test.go
+++ b/middleware/cache/entry_ignored_signatures_test.go
@@ -657,3 +657,47 @@ func TestAdditionalRRsetKeepsItsReceivedTTL(t *testing.T) {
 		})
 	}
 }
+
+// TestAdditionalRRsetIsMatchedAsADNSName pins name matching in the
+// additional section to DNS-name equality: an owner spelled with an escaped
+// octet packs to the same wire name as its plain spelling, and a fold of the
+// presentation text did not see that, so a one-second address under one
+// spelling slipped past the received-TTL check made against its signature
+// under the other and was served past its TTL.
+func TestAdditionalRRsetIsMatchedAsADNSName(t *testing.T) {
+	now := time.Now()
+	const name = "mx.example."
+	s := newTestStore(t)
+	req := new(dns.Msg)
+	req.SetQuestion(name, dns.TypeMX)
+	req.SetEdns0(1232, true)
+	resp := new(dns.Msg)
+	resp.SetReply(req)
+	// Unsigned answer: the entry takes the positive floor.
+	resp.Answer = []dns.RR{
+		&dns.MX{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeMX, Class: dns.ClassINET, Ttl: 3600}, Preference: 10, Mx: "target.example."},
+	}
+	resp.Extra = []dns.RR{
+		&dns.A{Hdr: dns.RR_Header{Name: `t\097rget.example.`, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 1}, A: []byte{192, 0, 2, 1}},
+		&dns.RRSIG{
+			Hdr:         dns.RR_Header{Name: "target.example.", Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 3600},
+			TypeCovered: dns.TypeA, Algorithm: 8, Labels: 2, OrigTtl: 3600, KeyTag: 9,
+			SignerName: "example.", Signature: "MTIzNDU2Nzg5MGFiY2RlZg==",
+			Inception:  uint32(now.Add(-2 * time.Hour).Unix()), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+			Expiration: uint32(now.Add(2 * time.Hour).Unix()),  //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+		},
+	}
+	s.SetFromResponse(resp, false, time.Time{})
+
+	entry, ok := s.LookupByKey(CacheKey{Question: req.Question[0], CD: false}.Hash())
+	if !ok {
+		t.Fatal("the answer was not cached")
+	}
+	served := entry.ToMsg(req)
+	if served == nil {
+		t.Fatal("entry did not serve")
+	}
+	if len(served.Extra) != 0 {
+		t.Fatalf("a one-second signed address under an escaped spelling was carried: %v", served.Extra)
+	}
+}

--- a/middleware/cache/entry_ignored_signatures_test.go
+++ b/middleware/cache/entry_ignored_signatures_test.go
@@ -218,3 +218,132 @@ func TestStorableRecordsPassesTheCommonShapeThrough(t *testing.T) {
 		t.Errorf("common shape allocated %v times, want none", allocs)
 	}
 }
+
+// TestZeroLifetimeSignatureIsNeverKept pins the tolerance's floor: a
+// signature permitting nothing — a header TTL of zero, or an Original TTL of
+// zero — is RFC 4035 §5.3.3's ceiling exactly, and a one-second entry may
+// not serve it as one. Each field separately.
+func TestZeroLifetimeSignatureIsNeverKept(t *testing.T) {
+	now := time.Now()
+	_, a := ignoredSigFixtures(now)
+	const name = "mx.example."
+
+	for _, tc := range []struct {
+		name            string
+		hdrTTL, origTTL uint32
+	}{
+		{"header TTL zero", 0, 3600},
+		{"original TTL zero", 3600, 0},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			req := new(dns.Msg)
+			req.SetQuestion(name, dns.TypeMX)
+			req.SetEdns0(1232, true)
+			resp := new(dns.Msg)
+			resp.SetReply(req)
+			resp.Answer = []dns.RR{
+				&dns.MX{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeMX, Class: dns.ClassINET, Ttl: 1}, Preference: 10, Mx: "target.example."},
+			}
+			resp.Extra = []dns.RR{
+				a("target.example."),
+				&dns.RRSIG{
+					Hdr:         dns.RR_Header{Name: "target.example.", Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: tc.hdrTTL},
+					TypeCovered: dns.TypeA, Algorithm: 8, Labels: 2, OrigTtl: tc.origTTL, KeyTag: 7,
+					SignerName: "example.", Signature: "MTIzNDU2Nzg5MGFiY2RlZg==",
+					Inception:  uint32(now.Add(-2 * time.Hour).Unix()), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+					Expiration: uint32(now.Add(time.Hour).Unix()),      //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+				},
+			}
+
+			served := serveFromEntry(t, req, resp, time.Second)
+			if tags := sigTags(served.Extra); len(tags) != 0 {
+				t.Errorf("a signature permitting nothing was served: %v", tags)
+			}
+			if hasA(served.Extra, "target.example.") {
+				t.Error("the RRset was served without the signature it arrived with")
+			}
+		})
+	}
+}
+
+// TestDOZeroHitCarriesNoAdditionalSignature pins the DO=0 body on the wire
+// path: the entry keeps a signed additional RRset with its signature, and a
+// client that did not set DO must not receive that signature (RFC 4035
+// §3.2.1) — on the wire path as on the Msg path. Both shapes: an entry
+// signed in the answer as well, and one whose only signature is additional.
+func TestDOZeroHitCarriesNoAdditionalSignature(t *testing.T) {
+	now := time.Now()
+	sig, a := ignoredSigFixtures(now)
+	const name = "mx.example."
+
+	build := func(signedAnswer bool) *CacheEntry {
+		t.Helper()
+		req := new(dns.Msg)
+		req.SetQuestion(name, dns.TypeMX)
+		req.SetEdns0(1232, true)
+		resp := new(dns.Msg)
+		resp.SetReply(req)
+		resp.Answer = []dns.RR{
+			&dns.MX{Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeMX, Class: dns.ClassINET, Ttl: 3600}, Preference: 10, Mx: "target.example."},
+		}
+		if signedAnswer {
+			resp.Answer = append(resp.Answer, &dns.RRSIG{
+				Hdr:         dns.RR_Header{Name: name, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 3600},
+				TypeCovered: dns.TypeMX, Algorithm: 8, Labels: 2, OrigTtl: 3600, KeyTag: 9,
+				SignerName: "example.", Signature: "MTIzNDU2Nzg5MGFiY2RlZg==",
+				Inception:  uint32(now.Add(-2 * time.Hour).Unix()), //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+				Expiration: uint32(now.Add(time.Hour).Unix()),      //nolint:gosec // test timestamp is in DNSSEC's uint32 era.
+			})
+		}
+		resp.Extra = []dns.RR{a("target.example."), sig("target.example.", 3600, 600, -2*time.Hour, time.Hour)}
+		entry := NewCacheEntryWithKey(resp, time.Hour, 0, 0)
+		if entry == nil {
+			t.Fatal("entry not built")
+		}
+		return entry
+	}
+
+	for _, tc := range []struct {
+		name         string
+		signedAnswer bool
+	}{
+		{"signed in the answer too", true},
+		{"signed only in the additional section", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			entry := build(tc.signedAnswer)
+			if entry.wireServe&wireHasDNSSEC == 0 {
+				t.Fatal("the additional signature did not mark the body as carrying DNSSEC")
+			}
+			body, _ := entry.wireBodyFor(false)
+			if body == nil {
+				t.Fatal("no DO=0 body")
+			}
+			var served dns.Msg
+			if err := served.Unpack(body); err != nil {
+				t.Fatal(err)
+			}
+			if tags := sigTags(served.Extra); len(tags) != 0 {
+				t.Errorf("DO=0 body carries additional signatures %v", tags)
+			}
+			if tags := sigTags(served.Answer); len(tags) != 0 {
+				t.Errorf("DO=0 body carries answer signatures %v", tags)
+			}
+			if !hasA(served.Extra, "target.example.") {
+				t.Error("DO=0 body lost the additional address itself")
+			}
+			if do, _ := entry.wireBodyFor(true); len(sigTags(mustUnpack(t, do).Extra)) != 1 {
+				t.Error("DO=1 body lost the additional signature")
+			}
+		})
+	}
+}
+
+func mustUnpack(t *testing.T, body []byte) *dns.Msg {
+	t.Helper()
+	m := new(dns.Msg)
+	if err := m.Unpack(body); err != nil {
+		t.Fatal(err)
+	}
+	return m
+}

--- a/middleware/cache/entry_wire.go
+++ b/middleware/cache/entry_wire.go
@@ -170,8 +170,8 @@ func (e *CacheEntry) serveWireInto(
 	req *dns.Msg,
 	do bool,
 ) ([]byte, middleware.WireInfo, bool) {
-	remaining := e.remaining(time.Now())
-	if remaining <= 0 {
+	now := time.Now()
+	if e.remaining(now) <= 0 {
 		return nil, middleware.WireInfo{}, false
 	}
 
@@ -228,7 +228,7 @@ func (e *CacheEntry) serveWireInto(
 	// never authoritative, however the upstream marked it.
 	wire.ApplyReply(body, req.Id, req.Opcode, req.RecursionDesired, req.CheckingDisabled)
 
-	ttl := servedSeconds(remaining)
+	ttl := e.servedTTL(now)
 	off := question.End
 	for range int(header.ANCount) + int(header.NSCount) + int(header.ARCount) {
 		rr, ok := wire.ParseRR(body, off)
@@ -282,8 +282,8 @@ func (e *CacheEntry) serveWireIntoRequest(
 	req *middleware.Request,
 	do bool,
 ) ([]byte, middleware.WireInfo, bool) {
-	remaining := e.remaining(time.Now())
-	if remaining <= 0 {
+	now := time.Now()
+	if e.remaining(now) <= 0 {
 		return nil, middleware.WireInfo{}, false
 	}
 
@@ -316,7 +316,7 @@ func (e *CacheEntry) serveWireIntoRequest(
 
 	wire.ApplyReply(body, req.ID(), req.Opcode(), req.RD(), req.CD())
 
-	ttl := servedSeconds(remaining)
+	ttl := e.servedTTL(now)
 	off := question.End
 	for range int(header.ANCount) + int(header.NSCount) + int(header.ARCount) {
 		rr, ok := wire.ParseRR(body, off)

--- a/middleware/cache/entry_wire.go
+++ b/middleware/cache/entry_wire.go
@@ -226,7 +226,7 @@ func (e *CacheEntry) serveWireInto(
 	// never authoritative, however the upstream marked it.
 	wire.ApplyReply(body, req.Id, req.Opcode, req.RecursionDesired, req.CheckingDisabled)
 
-	ttl := uint32(remaining.Seconds())
+	ttl := servedSeconds(remaining)
 	off := question.End
 	for range int(header.ANCount) + int(header.NSCount) + int(header.ARCount) {
 		rr, ok := wire.ParseRR(body, off)
@@ -313,7 +313,7 @@ func (e *CacheEntry) serveWireIntoRequest(
 
 	wire.ApplyReply(body, req.ID(), req.Opcode(), req.RD(), req.CD())
 
-	ttl := uint32(remaining.Seconds())
+	ttl := servedSeconds(remaining)
 	off := question.End
 	for range int(header.ANCount) + int(header.NSCount) + int(header.ARCount) {
 		rr, ok := wire.ParseRR(body, off)

--- a/middleware/cache/entry_wire.go
+++ b/middleware/cache/entry_wire.go
@@ -24,11 +24,13 @@ const (
 
 // prepareWireServe records the byte-serving verdict. Admission strips OPT,
 // so any additional records in an eligible body are real RRs the TTL walk
-// covers. The DNSSEC flag is taken from the answer and authority sections
-// only — ClearDNSSEC never filters the additional section, and mirroring
-// that keeps the DO=0 wire body identical to the Msg path's. An explicit
-// RRSIG question is eligible too: its signatures are the payload, which
-// ClearDNSSEC leaves untouched for any DO.
+// covers. The DNSSEC flag is taken from every section, the additional one
+// included: ClearDNSSEC filters all three, and mirroring it is what keeps
+// the DO=0 wire body identical to the Msg path's — a signed additional
+// RRset the entry kept with its signature would otherwise reach a DO=0
+// client as bytes. An explicit RRSIG question is eligible too: its
+// signatures are the payload, which ClearDNSSEC leaves untouched for any
+// DO.
 func prepareWireServe(body []byte) wireServeFlags {
 	var flags wireServeFlags
 	header, ok := wire.ParseHeader(body)
@@ -48,11 +50,9 @@ func prepareWireServe(body []byte) wireServeFlags {
 		if !ok {
 			return 0
 		}
-		if i < answered {
-			switch rr.Type {
-			case dns.TypeRRSIG, dns.TypeNSEC, dns.TypeNSEC3:
-				flags |= wireHasDNSSEC
-			}
+		switch rr.Type {
+		case dns.TypeRRSIG, dns.TypeNSEC, dns.TypeNSEC3:
+			flags |= wireHasDNSSEC
 		}
 		if i < int(header.ANCount) {
 			if rr.Type == question.Qtype {

--- a/middleware/cache/entry_wire.go
+++ b/middleware/cache/entry_wire.go
@@ -24,13 +24,12 @@ const (
 
 // prepareWireServe records the byte-serving verdict. Admission strips OPT,
 // so any additional records in an eligible body are real RRs the TTL walk
-// covers. The DNSSEC flag is taken from every section, the additional one
-// included: ClearDNSSEC filters all three, and mirroring it is what keeps
-// the DO=0 wire body identical to the Msg path's — a signed additional
-// RRset the entry kept with its signature would otherwise reach a DO=0
-// client as bytes. An explicit RRSIG question is eligible too: its
-// signatures are the payload, which ClearDNSSEC leaves untouched for any
-// DO.
+// covers. The DNSSEC flag means "ClearDNSSEC would remove something", and
+// it is taken exactly the way ClearDNSSEC decides: from every section, the
+// additional one included, and leaving out the one authenticating type the
+// question asked for by name — that type is the payload, kept for any DO.
+// Mirroring the Msg path's filter is what keeps the DO=0 wire body
+// identical to it.
 func prepareWireServe(body []byte) wireServeFlags {
 	var flags wireServeFlags
 	header, ok := wire.ParseHeader(body)
@@ -52,7 +51,9 @@ func prepareWireServe(body []byte) wireServeFlags {
 		}
 		switch rr.Type {
 		case dns.TypeRRSIG, dns.TypeNSEC, dns.TypeNSEC3:
-			flags |= wireHasDNSSEC
+			if rr.Type != question.Qtype {
+				flags |= wireHasDNSSEC
+			}
 		}
 		if i < int(header.ANCount) {
 			if rr.Type == question.Qtype {
@@ -126,10 +127,11 @@ func (e *CacheEntry) wireEDEReserve() int {
 // verdict that goes with it. A client that asked for DNSSEC gets the stored
 // message; one that did not gets the stripped form, which is nil when the
 // entry has none — that client keeps the Msg path, which strips as it goes.
-// An explicit RRSIG question serves the stored message for any DO, exactly
-// as ClearDNSSEC leaves such a response untouched.
+// The DNSSEC flag already leaves out the type an explicit RRSIG, NSEC or
+// NSEC3 question asked for, so such an entry serves the stored message for
+// any DO unless it also carries authenticating records of another type.
 func (e *CacheEntry) wireBodyFor(do bool) ([]byte, wireServeFlags) {
-	if do || e.wireServe&wireHasDNSSEC == 0 || e.question.Qtype == dns.TypeRRSIG {
+	if do || e.wireServe&wireHasDNSSEC == 0 {
 		return e.wire, e.wireServe
 	}
 	if e.stripped == nil {
@@ -247,10 +249,11 @@ func (e *CacheEntry) serveWireInto(
 }
 
 // wireInfoFor assembles the reply facts the writer chain acts on. The
-// DNSSEC bit is suppressed for an explicit RRSIG question — its
-// signatures are the payload, and the edns layer must not divert such a
-// DO=0 reply back to the Msg path. The entry's Extended DNS Error rides
-// along for the OPT append.
+// DNSSEC bit is the body's flag, which already leaves out the type an
+// explicit RRSIG, NSEC or NSEC3 question asked for — that is the payload,
+// and the edns layer must not divert such a DO=0 reply back to the Msg
+// path over it. The entry's Extended DNS Error rides along for the OPT
+// append.
 func (e *CacheEntry) wireInfoFor(
 	header wire.Header,
 	flags wireServeFlags,
@@ -259,7 +262,7 @@ func (e *CacheEntry) wireInfoFor(
 	info := middleware.WireInfo{
 		Rcode:             header.Rcode(),
 		AuthenticatedData: authData,
-		HasDNSSEC:         flags&wireHasDNSSEC != 0 && e.question.Qtype != dns.TypeRRSIG,
+		HasDNSSEC:         flags&wireHasDNSSEC != 0,
 	}
 	if e.ede != nil {
 		info.HasEDE = true

--- a/middleware/cache/entry_wire_chase.go
+++ b/middleware/cache/entry_wire_chase.go
@@ -219,7 +219,7 @@ func (c *Cache) collectWireChase(
 			entry:   entry,
 			body:    body,
 			flags:   flags,
-			ttl:     uint32(remaining.Seconds()),
+			ttl:     servedSeconds(remaining),
 			anCount: int(header.ANCount),
 			ansOff:  question.End,
 			ad:      header.AD(),

--- a/middleware/cache/entry_wire_chase.go
+++ b/middleware/cache/entry_wire_chase.go
@@ -219,7 +219,7 @@ func (c *Cache) collectWireChase(
 			entry:   entry,
 			body:    body,
 			flags:   flags,
-			ttl:     servedSeconds(remaining),
+			ttl:     entry.servedTTL(now),
 			anCount: int(header.ANCount),
 			ansOff:  question.End,
 			ad:      header.AD(),
@@ -331,7 +331,7 @@ func composeWireChase(
 	info := middleware.WireInfo{
 		Rcode:             dns.RcodeSuccess,
 		AuthenticatedData: authData,
-		HasDNSSEC:         hasDNSSEC && req.Qtype() != dns.TypeRRSIG,
+		HasDNSSEC:         hasDNSSEC,
 	}
 	if alias.ede != nil {
 		info.HasEDE = true

--- a/middleware/cache/mixed_ttl_lineage_test.go
+++ b/middleware/cache/mixed_ttl_lineage_test.go
@@ -112,12 +112,17 @@ func TestMixedTTLRecordsServeTheAnswersOwnHorizon(t *testing.T) {
 			ch.Cancel()
 		}))
 
-		// First query: the records as resolved.
-		if got := answerTTL(first); got != 3600 {
-			t.Fatalf("first query A TTL = %d, want the authority's 3600", got)
-		}
-		// Second query: the entry's own horizon — min(A 3600, RRSIG 1800) —
+		// Both queries: the entry's own horizon, min(A 3600, RRSIG 1800), and
 		// not the consulted key's 30 seconds.
+		//
+		// The first used to get the A record's bare 3600 while every later one
+		// got 1800, two different promises about the same records, and the
+		// client that asked first was invited to hold the answer for half an
+		// hour past the signature bounding it. RFC 4035 §5.3.3 does not leave
+		// that to the resolver's discretion.
+		if got := answerTTL(first); got < 1700 || got > 1800 {
+			t.Fatalf("first query A TTL = %d, want ~1800, the signature's horizon", got)
+		}
 		if got := answerTTL(second); got < 1700 || got > 1800 {
 			t.Fatalf("second query A TTL = %d, want ~1800, not the key's 30", got)
 		}

--- a/middleware/cache/negative_lineage_test.go
+++ b/middleware/cache/negative_lineage_test.go
@@ -163,14 +163,15 @@ func assertChainInheritsTargetLifetime(
 	}
 }
 
-// TestExhaustedTargetLeavesNoCachedChain is the limit of the lineage rule. A
-// target denial with under a second left is served with its lifetime truncated
-// to zero, and a denial the zone grants no lifetime is not cacheable at all
-// (RFC 2308 §5) — so the answer merged from it must not be stored either.
+// TestExhaustedTargetLeavesNoCachedChain is the limit of the lineage rule: a
+// target denial down to its last fraction of a second, and an answer merged
+// from it that must not outlive what is left.
 //
-// This used to go the other way. The cache floor lifted that zero back to five
-// seconds, which cached a derived denial whose entire proof had run out, and
-// the lineage rule above was left to bound the damage rather than prevent it.
+// It used to be stored for five seconds. The floor lifted the target's spent
+// lifetime back to the cache minimum, so a derived denial resting on a proof
+// with nothing left in it was cached as if the proof were fresh, and the
+// lineage rule was left to bound the damage rather than prevent it. What
+// remains is the second the wire format cannot express any finer.
 func TestExhaustedTargetLeavesNoCachedChain(t *testing.T) {
 	c := New(&config.Config{CacheSize: 1024, Expire: 600})
 	defer c.Stop()
@@ -234,10 +235,14 @@ func TestExhaustedTargetLeavesNoCachedChain(t *testing.T) {
 	chain.Next(context.Background())
 
 	aliasKey := CacheKey{Question: req.Question[0], CD: false}.Hash()
-	if entry, ok := c.store.LookupByKey(aliasKey); ok {
+	entry, ok := c.store.LookupByKey(aliasKey)
+	if !ok {
+		return // nothing stored at all is the stronger outcome
+	}
+	if entry.ttl > time.Second {
 		t.Fatalf(
 			"an answer merged from an exhausted denial was cached for %v; "+
-				"the proof it rests on had nothing left", entry.ttl)
+				"the proof it rests on had under a second left", entry.ttl)
 	}
 }
 

--- a/middleware/cache/negative_lineage_test.go
+++ b/middleware/cache/negative_lineage_test.go
@@ -12,6 +12,15 @@ import (
 	"github.com/semihalev/sdns/middleware"
 )
 
+const (
+	// targetDenialTTL is the lifetime the authority hands out for the target
+	// denial, and targetRemaining is what is left of it by the time the alias
+	// chases it. Both are whole seconds because a denial is served with its
+	// remaining lifetime truncated to whole seconds.
+	targetDenialTTL = 30
+	targetRemaining = 4 * time.Second
+)
+
 // entryExpiry is the absolute instant past which an entry may not be served:
 // its own lifetime, further bounded by the delegation lease it inherited.
 func entryExpiry(e *CacheEntry) time.Time {
@@ -77,10 +86,10 @@ func assertChainInheritsTargetLifetime(
 		resp.Ns = []dns.RR{&dns.SOA{
 			Hdr: dns.RR_Header{
 				Name: "lineage.", Rrtype: dns.TypeSOA,
-				Class: dns.ClassINET, Ttl: 1,
+				Class: dns.ClassINET, Ttl: targetDenialTTL,
 			},
 			Ns: "ns.lineage.", Mbox: "hostmaster.lineage.",
-			Serial: 1, Refresh: 1, Retry: 1, Expire: 1, Minttl: 1,
+			Serial: 1, Refresh: 1, Retry: 1, Expire: 1, Minttl: targetDenialTTL,
 		}}
 		_ = ch.Writer.WriteMsg(resp)
 		ch.Cancel()
@@ -102,10 +111,18 @@ func assertChainInheritsTargetLifetime(
 	if !ok {
 		t.Fatal("the target denial was not cached")
 	}
-	// Age the target so it is near the end of its life when the alias asks
-	// for it — the state a cached denial spends most of its time in, and the
-	// one where the floor below has the most to extend.
-	targetEntry.stored = targetEntry.stored.Add(-targetEntry.ttl + time.Second)
+	// Age the target so it is late in its life when the alias asks for it —
+	// the state a cached denial spends most of its time in, and where a
+	// derived answer stored on its own terms would overhang the most.
+	//
+	// The remainder left here is deliberately more than a second. A denial is
+	// served with its remaining lifetime truncated to whole seconds, so a
+	// target with under a second left hands the chase an SOA of TTL zero, and
+	// a zero-lifetime denial is no longer cacheable at all (RFC 2308 §5) —
+	// the merged answer would never be stored and the rule below would go
+	// untested. That case is covered on its own in
+	// TestExhaustedTargetLeavesNoCachedChain.
+	targetEntry.stored = targetEntry.stored.Add(-targetEntry.ttl + targetRemaining)
 	targetExpiry := entryExpiry(targetEntry)
 
 	// The alias is resolved, and its chase finds the target in cache.
@@ -143,6 +160,84 @@ func assertChainInheritsTargetLifetime(
 				"  alias expires  %v\n  target expires %v\n  overhang       %v\n"+
 				"  alias cutUntil %v (zero means no bound was inherited)",
 			got, targetExpiry, got.Sub(targetExpiry), aliasEntry.cutUntil)
+	}
+}
+
+// TestExhaustedTargetLeavesNoCachedChain is the limit of the lineage rule. A
+// target denial with under a second left is served with its lifetime truncated
+// to zero, and a denial the zone grants no lifetime is not cacheable at all
+// (RFC 2308 §5) — so the answer merged from it must not be stored either.
+//
+// This used to go the other way. The cache floor lifted that zero back to five
+// seconds, which cached a derived denial whose entire proof had run out, and
+// the lineage rule above was left to bound the damage rather than prevent it.
+func TestExhaustedTargetLeavesNoCachedChain(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, Expire: 600})
+	defer c.Stop()
+
+	const alias, target = "alias.exhausted.", "target.exhausted."
+
+	targetHandler := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		resp := new(dns.Msg)
+		resp.SetReply(ch.Request.Msg())
+		resp.Rcode = dns.RcodeNameError
+		resp.Ns = []dns.RR{&dns.SOA{
+			Hdr: dns.RR_Header{
+				Name: "exhausted.", Rrtype: dns.TypeSOA,
+				Class: dns.ClassINET, Ttl: targetDenialTTL,
+			},
+			Ns: "ns.exhausted.", Mbox: "hostmaster.exhausted.",
+			Serial: 1, Refresh: 1, Retry: 1, Expire: 1, Minttl: targetDenialTTL,
+		}}
+		_ = ch.Writer.WriteMsg(resp)
+		ch.Cancel()
+	})
+
+	primeReq := new(dns.Msg)
+	primeReq.SetQuestion(target, dns.TypeA)
+	primeReq.RecursionDesired = true
+	primeChain := middleware.NewChain([]middleware.Handler{c, targetHandler})
+	primeChain.Reset(mock.NewWriter("udp", "127.0.0.1:0"), primeReq)
+	primeChain.Next(context.Background())
+
+	targetKey := CacheKey{Question: dns.Question{
+		Name: target, Qtype: dns.TypeA, Qclass: dns.ClassINET,
+	}, CD: false}.Hash()
+	targetEntry, ok := c.store.LookupByKey(targetKey)
+	if !ok {
+		t.Fatal("the target denial was not cached")
+	}
+	// Spend all but a fraction of a second, which is what the chase sees as
+	// a zero TTL.
+	targetEntry.stored = targetEntry.stored.Add(-targetEntry.ttl + 100*time.Millisecond)
+
+	c.SetQueryer(&internalQueryer{handlers: []middleware.Handler{c, targetHandler}})
+	outerHandler := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		resp := new(dns.Msg)
+		resp.SetReply(ch.Request.Msg())
+		resp.Answer = []dns.RR{&dns.CNAME{
+			Hdr: dns.RR_Header{
+				Name: alias, Rrtype: dns.TypeCNAME,
+				Class: dns.ClassINET, Ttl: 300,
+			},
+			Target: target,
+		}}
+		_ = ch.Writer.WriteMsg(resp)
+		ch.Cancel()
+	})
+
+	req := new(dns.Msg)
+	req.SetQuestion(alias, dns.TypeA)
+	req.RecursionDesired = true
+	chain := middleware.NewChain([]middleware.Handler{c, outerHandler})
+	chain.Reset(mock.NewWriter("udp", "127.0.0.1:0"), req)
+	chain.Next(context.Background())
+
+	aliasKey := CacheKey{Question: req.Question[0], CD: false}.Hash()
+	if entry, ok := c.store.LookupByKey(aliasKey); ok {
+		t.Fatalf(
+			"an answer merged from an exhausted denial was cached for %v; "+
+				"the proof it rests on had nothing left", entry.ttl)
 	}
 }
 

--- a/middleware/cache/negative_lineage_test.go
+++ b/middleware/cache/negative_lineage_test.go
@@ -178,7 +178,9 @@ func TestExhaustedTargetLeavesNoCachedChain(t *testing.T) {
 
 	const alias, target = "alias.exhausted.", "target.exhausted."
 
+	reached := 0
 	targetHandler := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		reached++
 		resp := new(dns.Msg)
 		resp.SetReply(ch.Request.Msg())
 		resp.Rcode = dns.RcodeNameError
@@ -231,8 +233,18 @@ func TestExhaustedTargetLeavesNoCachedChain(t *testing.T) {
 	req.SetQuestion(alias, dns.TypeA)
 	req.RecursionDesired = true
 	chain := middleware.NewChain([]middleware.Handler{c, outerHandler})
-	chain.Reset(mock.NewWriter("udp", "127.0.0.1:0"), req)
+	w := mock.NewWriter("udp", "127.0.0.1:0")
+	chain.Reset(w, req)
+	reached = 0
 	chain.Next(context.Background())
+	// The outcome below only means something if the chase ran: an exhausted
+	// target that was never asked for proves nothing about what a merge from
+	// it would have stored. The chase reads the cached denial, so the proof
+	// it ran is the target's SOA in the outer answer, or, had the entry gone
+	// in the meantime, the handler being asked again.
+	if reached == 0 && (!w.Written() || !hasTargetSOA(w.Msg())) {
+		t.Fatal("the chase never reached the target")
+	}
 
 	aliasKey := CacheKey{Question: req.Question[0], CD: false}.Hash()
 	entry, ok := c.store.LookupByKey(aliasKey)
@@ -536,4 +548,18 @@ func TestUnusedSubQueryLineageIsNotInherited(t *testing.T) {
 		t.Fatalf("the alias was bound to %v by a sub-query that produced "+
 			"nothing for it", got)
 	}
+}
+
+// hasTargetSOA reports whether an alias answer carries the SOA the chased
+// target's denial was merged from.
+func hasTargetSOA(msg *dns.Msg) bool {
+	if msg == nil {
+		return false
+	}
+	for _, rr := range msg.Ns {
+		if soa, ok := rr.(*dns.SOA); ok && soa.Hdr.Name == "exhausted." {
+			return true
+		}
+	}
+	return false
 }

--- a/middleware/cache/negative_ttl_test.go
+++ b/middleware/cache/negative_ttl_test.go
@@ -801,15 +801,50 @@ func TestClampRoundsLikeAHit(t *testing.T) {
 		return msg
 	}
 
+	// A sub-second lease is the parent's grant, and the round-up to one
+	// second is not applied to it on either path: the answer still goes
+	// out, from the first response and from a hit alike, with nothing to
+	// keep.
 	for _, lease := range []time.Duration{100 * time.Millisecond, 500 * time.Millisecond, 999 * time.Millisecond} {
 		res := build()
 		clampTTLsToEffective(res, time.Now().Add(lease), dnsutil.TypeSuccess)
+		if got := res.Answer[0].Header().Ttl; got != 0 {
+			t.Errorf("a %v lease clamped the first response to %d, want 0: the grant is under a second", lease, got)
+		}
 
-		got := res.Answer[0].Header().Ttl
-		want := servedSeconds(lease)
-		if got != want {
-			t.Errorf("a %v lease clamped the first response to %d, while a hit serves %d",
-				lease, got, want)
+		entry := NewCacheEntryWithKey(build(), time.Hour, 0, 0)
+		entry.cutUntil = time.Now().Add(lease)
+		req := new(dns.Msg)
+		req.SetQuestion("rounding.example.", dns.TypeA)
+		served := entry.ToMsg(req)
+		if served == nil {
+			t.Fatalf("a hit under a %v lease was not served; the grant has time left", lease)
+		}
+		if got := served.Answer[0].Header().Ttl; got != 0 {
+			t.Errorf("a hit under a %v lease served TTL %d, want 0: rounded past the grant", lease, got)
+		}
+	}
+
+	// A lease with whole seconds left is served at those seconds, on both
+	// paths, never rounded past them.
+	for _, lease := range []time.Duration{1500 * time.Millisecond, 2999 * time.Millisecond} {
+		res := build()
+		clampTTLsToEffective(res, time.Now().Add(lease), dnsutil.TypeSuccess)
+		want := uint32(lease / time.Second) //nolint:gosec // G115 - a test lease of seconds
+		if got := res.Answer[0].Header().Ttl; got != want {
+			t.Errorf("a %v lease clamped the first response to %d, want %d", lease, got, want)
+		}
+
+		entry := NewCacheEntryWithKey(build(), time.Hour, 0, 0)
+		entry.cutUntil = time.Now().Add(lease)
+		req := new(dns.Msg)
+		req.SetQuestion("rounding.example.", dns.TypeA)
+		served := entry.ToMsg(req)
+		if served == nil {
+			t.Fatalf("a hit under a %v lease was not served", lease)
+		}
+		if got := served.Answer[0].Header().Ttl; got != want {
+			t.Errorf("a hit under a %v lease served TTL %d, want %d", lease, got, want)
 		}
 	}
 

--- a/middleware/cache/negative_ttl_test.go
+++ b/middleware/cache/negative_ttl_test.go
@@ -1,10 +1,12 @@
 package cache
 
 import (
+	"net/netip"
 	"testing"
 	"time"
 
 	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
 	"github.com/semihalev/sdns/internal/dnsutil"
 )
 
@@ -114,28 +116,105 @@ func TestDenialAdmittedAtItsOwnLifetime(t *testing.T) {
 }
 
 // TestZeroLifetimeDenialIsNotAdmitted is criterion one: a denial the zone
-// granted no lifetime must not come back out of the cache. Admitting it with a
-// zero TTL would leave an entry every read has to discard.
+// granted no lifetime must never enter the cache at all.
+//
+// The assertion is on the store's occupancy, not on a lookup miss. Lookup
+// evicts an expired entry and reports a miss either way, so a test that only
+// asked it a question passed just as happily against a build with the
+// admission guard removed. PositiveLen sees the entry that should not be
+// there.
 func TestZeroLifetimeDenialIsNotAdmitted(t *testing.T) {
-	for _, nameError := range []bool{true, false} {
-		kind := "NODATA"
-		if nameError {
-			kind = "NXDOMAIN"
-		}
-		t.Run(kind, func(t *testing.T) {
-			store := newCeilingStore(t)
+	// Every door an answer can arrive through, since each one calls the
+	// bounds and the guard for itself.
+	doors := []struct {
+		name   string
+		admit  func(t *testing.T, s *Store, c *Cache, key uint64, req, resp *dns.Msg)
+		occupy func(s *Store, c *Cache) int
+	}{
+		{
+			name: "SetFromResponse",
+			admit: func(_ *testing.T, s *Store, _ *Cache, _ uint64, _, resp *dns.Msg) {
+				s.SetFromResponse(resp, false, time.Time{})
+			},
+			occupy: func(s *Store, _ *Cache) int { return s.PositiveLen() },
+		},
+		{
+			name: "scoped admission",
+			admit: func(_ *testing.T, s *Store, _ *Cache, key uint64, _, resp *dns.Msg) {
+				s.SetFromResponseScoped(key, resp, netip.MustParsePrefix("203.0.113.0/24"),
+					time.Time{}, 0)
+			},
+			occupy: func(s *Store, _ *Cache) int { return s.PositiveLen() },
+		},
+		{
+			name: "Cache.Set",
+			admit: func(_ *testing.T, _ *Store, c *Cache, key uint64, _, resp *dns.Msg) {
+				c.Set(key, resp)
+			},
+			occupy: func(_ *Store, c *Cache) int { return c.store.PositiveLen() },
+		},
+	}
 
-			// Zero in either field is zero: RFC 2308 takes the smaller.
-			for _, soa := range [][2]uint32{{0, 86400}, {86400, 0}, {0, 0}} {
-				req, resp := denialResponse("gone.example.org.", nameError, soa[0], soa[1])
-				store.SetFromResponse(resp, false, time.Time{})
-
-				if _, ok := store.Lookup(req); ok {
-					t.Fatalf("%s with SOA TTL %d / MINIMUM %d was served from cache",
-						kind, soa[0], soa[1])
-				}
+	for _, door := range doors {
+		for _, nameError := range []bool{true, false} {
+			kind := "NODATA"
+			if nameError {
+				kind = "NXDOMAIN"
 			}
-		})
+			t.Run(door.name+"/"+kind, func(t *testing.T) {
+				// Zero in either field is zero: RFC 2308 takes the smaller.
+				for _, soa := range [][2]uint32{{0, 86400}, {86400, 0}, {0, 0}} {
+					store := newCeilingStore(t)
+					c := New(&config.Config{CacheSize: 1024, Expire: 600})
+					defer c.Stop()
+
+					req, resp := denialResponse("gone.example.org.", nameError, soa[0], soa[1])
+					key := CacheKey{Question: req.Question[0], CD: false}.Hash()
+
+					before := door.occupy(store, c)
+					door.admit(t, store, c, key, req, resp)
+
+					if got := door.occupy(store, c); got != before {
+						t.Fatalf("%s with SOA TTL %d / MINIMUM %d was admitted: "+
+							"cache holds %d entries, was %d",
+							kind, soa[0], soa[1], got, before)
+					}
+					if _, ok := store.Lookup(req); ok {
+						t.Fatalf("%s with SOA TTL %d / MINIMUM %d was served from cache",
+							kind, soa[0], soa[1])
+					}
+				}
+			})
+		}
+	}
+}
+
+// TestZeroLifetimeDenialDoesNotReplace covers the refresh door. A prefetch
+// whose result comes back as a denial with no lifetime must leave the entry it
+// was refreshing alone rather than replacing it with something unservable.
+func TestZeroLifetimeDenialDoesNotReplace(t *testing.T) {
+	store := newCeilingStore(t)
+
+	req, live := denialResponse("fading.example.org.", true, 86400, 60)
+	store.SetFromResponse(live, false, time.Time{})
+
+	key := CacheKey{Question: req.Question[0], CD: false}.Hash()
+	existing, ok := store.Lookup(req)
+	if !ok {
+		t.Fatal("the seed denial was not admitted")
+	}
+
+	_, exhausted := denialResponse("fading.example.org.", true, 0, 0)
+	if store.ReplaceIfCurrent(key, existing, exhausted, time.Time{}, 0) {
+		t.Fatal("a zero-lifetime denial replaced a live entry")
+	}
+
+	after, ok := store.Lookup(req)
+	if !ok {
+		t.Fatal("the live entry was dropped by a refusal that should have left it alone")
+	}
+	if after != existing {
+		t.Fatal("the live entry was replaced rather than kept")
 	}
 }
 
@@ -167,5 +246,73 @@ func TestPositiveAdmissionKeepsTheFloor(t *testing.T) {
 	}
 	if entry.ttl != dnsutil.MinCacheTTL {
 		t.Fatalf("positive answer stored for %v, want the %v floor", entry.ttl, dnsutil.MinCacheTTL)
+	}
+}
+
+// TestAliasChainDenialAtStoreLevel is the alias-chain shape driven through
+// admission rather than through the derivation alone: the entry must carry the
+// terminal SOA's lifetime, and a zone that granted none must not be stored.
+func TestAliasChainDenialAtStoreLevel(t *testing.T) {
+	build := func(soaMin uint32) (*dns.Msg, *dns.Msg) {
+		req, resp := denialResponse("alias.example.org.", false, 86400, soaMin)
+		resp.Answer = []dns.RR{&dns.CNAME{
+			Hdr: dns.RR_Header{
+				Name:   "alias.example.org.",
+				Rrtype: dns.TypeCNAME,
+				Class:  dns.ClassINET,
+				Ttl:    300,
+			},
+			Target: "target.example.org.",
+		}}
+		return req, resp
+	}
+
+	for _, seconds := range []uint32{1, 4, 5} {
+		store := newCeilingStore(t)
+		req, resp := build(seconds)
+		store.SetFromResponse(resp, false, time.Time{})
+
+		entry, ok := store.Lookup(req)
+		if !ok {
+			t.Fatalf("SOA MINIMUM %ds: the alias denial was not admitted", seconds)
+		}
+		want := time.Duration(seconds) * time.Second
+		if entry.ttl != want {
+			t.Fatalf("SOA MINIMUM %ds: stored for %v, want %v (the alias TTL is 300s)",
+				seconds, entry.ttl, want)
+		}
+	}
+
+	store := newCeilingStore(t)
+	_, resp := build(0)
+	store.SetFromResponse(resp, false, time.Time{})
+	if got := store.PositiveLen(); got != 0 {
+		t.Fatalf("an alias denial with a zero SOA MINIMUM was admitted, cache holds %d", got)
+	}
+}
+
+// TestUncacheableResponseIsNotAdmitted closes the loop on the classification
+// change: a NOERROR carrying no answer, no delegation and no SOA is named
+// TypeNotCacheable, and the store has no case for it. Asserted rather than
+// assumed, because the derivation still returns a lifetime for that type and
+// only the store's silence keeps it out.
+func TestUncacheableResponseIsNotAdmitted(t *testing.T) {
+	store := newCeilingStore(t)
+
+	req := new(dns.Msg)
+	req.SetQuestion("hollow.example.org.", dns.TypeA)
+	resp := new(dns.Msg)
+	resp.SetReply(req)
+
+	if mt, _ := dnsutil.ClassifyResponse(resp, time.Now().UTC()); mt != dnsutil.TypeNotCacheable {
+		t.Fatalf("classified %v, want TypeNotCacheable", mt)
+	}
+
+	store.SetFromResponse(resp, false, time.Time{})
+	if got := store.PositiveLen(); got != 0 {
+		t.Fatalf("an uncacheable response was admitted, cache holds %d", got)
+	}
+	if _, ok := store.Lookup(req); ok {
+		t.Fatal("an uncacheable response was served from cache")
 	}
 }

--- a/middleware/cache/negative_ttl_test.go
+++ b/middleware/cache/negative_ttl_test.go
@@ -549,6 +549,7 @@ func TestFirstResponseCarriesTheEffectiveTTL(t *testing.T) {
 				out.SetReply(ch.Request.Msg())
 				out.Rcode = upstream.Rcode
 				out.Answer, out.Ns = upstream.Answer, upstream.Ns
+				out.AuthenticatedData = upstream.AuthenticatedData
 				_ = ch.Writer.WriteMsg(out)
 				ch.Cancel()
 			})})
@@ -669,6 +670,37 @@ func TestFirstResponseCarriesTheEffectiveTTL(t *testing.T) {
 		}}
 		if got := answerTTL(ask(t, up, name)); got > 1 {
 			t.Errorf("first client got TTL %d for an alias onto a denial granted 1s", got)
+		}
+	})
+
+	t.Run("a signature that lapsed before the answer arrived", func(t *testing.T) {
+		// A forwarding deployment relays whatever the upstream asserted. This
+		// resolver can see the signatures are spent, so it may neither invite
+		// the client to keep the data nor pass on the claim that it is
+		// authenticated. The store already declines it; the client used to be
+		// handed it anyway, with AD set and five seconds to hold it.
+		const name = "lapsed.first.example."
+		up := new(dns.Msg)
+		up.AuthenticatedData = true
+		up.Answer = []dns.RR{
+			&dns.A{
+				Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 3600},
+				A:   []byte{192, 0, 2, 1},
+			},
+			&dns.RRSIG{
+				Hdr:         dns.RR_Header{Name: name, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 3600},
+				TypeCovered: dns.TypeA,
+				OrigTtl:     3600,
+				Expiration:  uint32(time.Now().Add(-time.Hour).Unix()), //nolint:gosec // G115 - Unix timestamp fits in uint32 for valid dates
+			},
+		}
+
+		out := ask(t, up, name)
+		if got := answerTTL(out); got != 0 {
+			t.Errorf("first client got TTL %d for data whose signature has lapsed", got)
+		}
+		if out.AuthenticatedData {
+			t.Error("first client was told lapsed data is authenticated")
 		}
 	})
 

--- a/middleware/cache/negative_ttl_test.go
+++ b/middleware/cache/negative_ttl_test.go
@@ -58,33 +58,28 @@ func denialResponse(name string, nameError bool, soaTTL, soaMin uint32) (*dns.Ms
 	return req, resp
 }
 
-// TestTTLManagerDoesNotFloorDenials covers the second of the two stacked
-// floors on its own. The derivation can be correct and the denial still get
-// raised right back here, so this has to be asserted separately rather than
-// only through the store.
-func TestTTLManagerDoesNotFloorDenials(t *testing.T) {
+// TestAdmissionOnlyShortens pins the rule that keeps the two layers honest:
+// the lifetime is decided once, by the derivation that can see the SOA and the
+// signatures, and admission may only shorten it.
+//
+// A floor here looks harmless and is not. It cannot see that a signature has
+// two seconds left, so it lifted correctly-bounded answers back over their own
+// expiry, and the derivation's care was undone one call later.
+func TestAdmissionOnlyShortens(t *testing.T) {
 	tm := NewTTLManager(dnsutil.MinCacheTTL, time.Hour)
 
-	for _, mt := range []dnsutil.ResponseType{dnsutil.TypeNXDomain, dnsutil.TypeNoRecords} {
-		for _, seconds := range []int{0, 1, 4, 5} {
-			in := time.Duration(seconds) * time.Second
-			if got := tm.CalculateFor(mt, in); got != in {
-				t.Errorf("CalculateFor(%v, %v) = %v, want it left alone", mt, in, got)
-			}
-		}
-		if got, want := tm.CalculateFor(mt, 2*time.Hour), time.Hour; got != want {
-			t.Errorf("CalculateFor(%v, 2h) = %v, want the %v cap still applied", mt, got, want)
+	for _, seconds := range []int{0, 1, 2, 4, 5} {
+		in := time.Duration(seconds) * time.Second
+		if got := tm.Bound(in); got != in {
+			t.Errorf("Bound(%v) = %v, want it left alone", in, got)
 		}
 	}
 
-	// Everything that is not a denial keeps both bounds. TypeReferral matters
-	// here because referrals live in the same sub-cache as denials.
-	for _, mt := range []dnsutil.ResponseType{
-		dnsutil.TypeSuccess, dnsutil.TypeReferral, dnsutil.TypeServerFailure,
-	} {
-		if got, want := tm.CalculateFor(mt, time.Second), dnsutil.MinCacheTTL; got != want {
-			t.Errorf("CalculateFor(%v, 1s) = %v, want the %v floor kept", mt, got, want)
-		}
+	if got, want := tm.Bound(2*time.Hour), time.Hour; got != want {
+		t.Errorf("Bound(2h) = %v, want the %v cap", got, want)
+	}
+	if got := tm.Bound(-time.Second); got != 0 {
+		t.Errorf("Bound(-1s) = %v, want 0", got)
 	}
 }
 
@@ -314,5 +309,187 @@ func TestUncacheableResponseIsNotAdmitted(t *testing.T) {
 	}
 	if _, ok := store.Lookup(req); ok {
 		t.Fatal("an uncacheable response was served from cache")
+	}
+}
+
+// signedAnswer builds a positive answer whose RRSIG carries the given bounds.
+func signedAnswer(name string, recordTTL, sigTTL, origTTL uint32, expiresIn time.Duration) (*dns.Msg, *dns.Msg) {
+	req := new(dns.Msg)
+	req.SetQuestion(name, dns.TypeA)
+	resp := new(dns.Msg)
+	resp.SetReply(req)
+	resp.Answer = []dns.RR{
+		&dns.A{
+			Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: recordTTL},
+			A:   []byte{192, 0, 2, 1},
+		},
+		&dns.RRSIG{
+			Hdr:         dns.RR_Header{Name: name, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: sigTTL},
+			TypeCovered: dns.TypeA,
+			OrigTtl:     origTTL,
+			Expiration:  uint32(time.Now().Add(expiresIn).Unix()), //nolint:gosec // G115 - Unix timestamp fits in uint32 for valid dates
+		},
+	}
+	return req, resp
+}
+
+// TestSignedAnswerKeepsItsCeilingThroughAdmission is the end-to-end half of RFC
+// 4035 §5.3.3, and the half a helper test cannot reach. The derivation had the
+// bound right and admission raised it again: a signature with two seconds left
+// was stored for five, and the entry outlived the signature it rested on.
+//
+// Driven through every door, because each one bounds the lifetime for itself.
+func TestSignedAnswerKeepsItsCeilingThroughAdmission(t *testing.T) {
+	// name, record TTL, signature TTL, original TTL, expiry, and the ceiling
+	// all four of those imply.
+	cases := []struct {
+		what      string
+		recordTTL uint32
+		sigTTL    uint32
+		origTTL   uint32
+		expiresIn time.Duration
+		ceiling   time.Duration
+	}{
+		{"expiry is nearest", 3600, 3600, 3600, 2 * time.Second, 2 * time.Second},
+		{"original TTL is nearest", 3600, 3600, 1, time.Hour, time.Second},
+		{"signature TTL is nearest", 3600, 2, 3600, time.Hour, 2 * time.Second},
+		{"received RRset TTL is nearest", 1, 3600, 3600, time.Hour, time.Second},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.what, func(t *testing.T) {
+			// Store, the ordinary door.
+			store := newCeilingStore(t)
+			req, resp := signedAnswer("signed.example.org.", tc.recordTTL, tc.sigTTL, tc.origTTL, tc.expiresIn)
+			store.SetFromResponse(resp, false, time.Time{})
+			entry, ok := store.Lookup(req)
+			if !ok {
+				t.Fatal("the signed answer was not admitted")
+			}
+			if entry.ttl > tc.ceiling {
+				t.Errorf("SetFromResponse stored %v, want at most %v", entry.ttl, tc.ceiling)
+			}
+
+			// Scoped, the ECS door.
+			store = newCeilingStore(t)
+			req, resp = signedAnswer("signed.example.org.", tc.recordTTL, tc.sigTTL, tc.origTTL, tc.expiresIn)
+			key := CacheKey{Question: req.Question[0], CD: false}.Hash()
+			store.SetFromResponseScoped(key, resp, netip.MustParsePrefix("203.0.113.0/24"), time.Time{}, 0)
+			if entry, ok = store.Lookup(req); ok && entry.ttl > tc.ceiling {
+				t.Errorf("scoped admission stored %v, want at most %v", entry.ttl, tc.ceiling)
+			}
+
+			// The compatibility door.
+			c := New(&config.Config{CacheSize: 1024, Expire: 600})
+			defer c.Stop()
+			req, resp = signedAnswer("signed.example.org.", tc.recordTTL, tc.sigTTL, tc.origTTL, tc.expiresIn)
+			key = CacheKey{Question: req.Question[0], CD: false}.Hash()
+			c.Set(key, resp)
+			if entry, ok = c.store.Lookup(req); ok && entry.ttl > tc.ceiling {
+				t.Errorf("Cache.Set stored %v, want at most %v", entry.ttl, tc.ceiling)
+			}
+
+			// The refresh door.
+			store = newCeilingStore(t)
+			req, seed := signedAnswer("signed.example.org.", 3600, 3600, 3600, time.Hour)
+			store.SetFromResponse(seed, false, time.Time{})
+			existing, found := store.Lookup(req)
+			if !found {
+				t.Fatal("the seed answer was not admitted")
+			}
+			key = CacheKey{Question: req.Question[0], CD: false}.Hash()
+			_, refreshed := signedAnswer("signed.example.org.", tc.recordTTL, tc.sigTTL, tc.origTTL, tc.expiresIn)
+			if !store.ReplaceIfCurrent(key, existing, refreshed, time.Time{}, 0) {
+				t.Fatal("the refresh was refused")
+			}
+			if entry, ok = store.Lookup(req); ok && entry.ttl > tc.ceiling {
+				t.Errorf("ReplaceIfCurrent stored %v, want at most %v", entry.ttl, tc.ceiling)
+			}
+		})
+	}
+}
+
+// TestServedTTLIsNeverZero pins the wire-format half. An entry with a fraction
+// of a second left is alive, and telling the client zero would mean "do not
+// reuse this" from a cache that is reusing it; RFC 2308 §5 forbids it for a
+// denial outright.
+func TestServedTTLIsNeverZero(t *testing.T) {
+	for _, remaining := range []time.Duration{time.Nanosecond, 991 * time.Millisecond, time.Second - 1} {
+		if got := servedSeconds(remaining); got != 1 {
+			t.Errorf("servedSeconds(%v) = %d, want 1", remaining, got)
+		}
+	}
+	if got := servedSeconds(0); got != 0 {
+		t.Errorf("servedSeconds(0) = %d, want 0", got)
+	}
+	if got := servedSeconds(-time.Second); got != 0 {
+		t.Errorf("servedSeconds(-1s) = %d, want 0", got)
+	}
+	if got := servedSeconds(90 * time.Second); got != 90 {
+		t.Errorf("servedSeconds(90s) = %d, want 90", got)
+	}
+
+	// End to end: a live entry down to its last fraction still serves a
+	// usable TTL rather than telling the client not to cache it.
+	store := newCeilingStore(t)
+	req, resp := denialResponse("fading.example.org.", true, 86400, 60)
+	store.SetFromResponse(resp, false, time.Time{})
+	entry, ok := store.Lookup(req)
+	if !ok {
+		t.Fatal("the denial was not admitted")
+	}
+	entry.stored = entry.stored.Add(-entry.ttl + 991*time.Millisecond)
+
+	out := entry.ToMsg(req)
+	if out == nil {
+		t.Fatal("a live entry served nothing")
+	}
+	if len(out.Ns) == 0 || out.Ns[0].Header().Ttl == 0 {
+		t.Fatal("a denial with 991ms left was served with a TTL of zero")
+	}
+}
+
+// TestSignedReferralNeverOutlivesItsSignature covers the delegation path, which
+// used to return the cache minimum without ever looking at its records. A
+// referral is still short-lived whatever its NS records advertise; it just may
+// not outlive a signature it carries.
+func TestSignedReferralNeverOutlivesItsSignature(t *testing.T) {
+	referral := func(sigExpiresIn time.Duration) *dns.Msg {
+		req := new(dns.Msg)
+		req.SetQuestion("child.example.org.", dns.TypeA)
+		resp := new(dns.Msg)
+		resp.SetReply(req)
+		resp.Ns = []dns.RR{
+			&dns.NS{
+				Hdr: dns.RR_Header{Name: "example.org.", Rrtype: dns.TypeNS, Class: dns.ClassINET, Ttl: 172800},
+				Ns:  "ns.example.org.",
+			},
+		}
+		if sigExpiresIn > 0 {
+			resp.Ns = append(resp.Ns, &dns.RRSIG{
+				Hdr:         dns.RR_Header{Name: "example.org.", Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 172800},
+				TypeCovered: dns.TypeNS,
+				OrigTtl:     172800,
+				Expiration:  uint32(time.Now().Add(sigExpiresIn).Unix()), //nolint:gosec // G115 - Unix timestamp fits in uint32 for valid dates
+			})
+		}
+		return resp
+	}
+
+	signed := referral(2 * time.Second)
+	mt, _ := dnsutil.ClassifyResponse(signed, time.Now().UTC())
+	if mt != dnsutil.TypeReferral {
+		t.Fatalf("classified %v, want TypeReferral", mt)
+	}
+	if got := dnsutil.CalculateCacheTTL(signed, mt); got > 2*time.Second {
+		t.Errorf("signed referral: got %v, want at most the signature's 2s", got)
+	}
+
+	// An unsigned referral keeps the short lifetime it has always had, rather
+	// than picking up the two days its NS records advertise.
+	plain := referral(0)
+	mt, _ = dnsutil.ClassifyResponse(plain, time.Now().UTC())
+	if got, want := dnsutil.CalculateCacheTTL(plain, mt), dnsutil.MinCacheTTL; got != want {
+		t.Errorf("unsigned referral: got %v, want %v unchanged", got, want)
 	}
 }

--- a/middleware/cache/negative_ttl_test.go
+++ b/middleware/cache/negative_ttl_test.go
@@ -820,3 +820,109 @@ func TestClampRoundsLikeAHit(t *testing.T) {
 		t.Errorf("a spent lease clamped to %d, want 0", got)
 	}
 }
+
+// TestExpiredProofIsNeverAuthenticated is the matrix the positive case alone
+// could not cover.
+//
+// A response is classified for what it is: a denial, an alias chain, an
+// answer. Only the NOERROR-with-records shape has anywhere to record "and its
+// signatures lapsed", so an expired NXDOMAIN is still an NXDOMAIN and a guard
+// written against the classification never fired for it. Their lifetimes were
+// clamped to nothing, correctly, while the bit that says the client may trust
+// them went out set (RFC 4035 §3.2.3).
+func TestExpiredProofIsNeverAuthenticated(t *testing.T) {
+	const zone, name = "lapsed.example.", "x.lapsed.example."
+	past := uint32(time.Now().Add(-time.Hour).Unix()) //nolint:gosec // G115 - Unix timestamp fits in uint32 for valid dates
+
+	lapsedSig := func(owner string, covered uint16) dns.RR {
+		return &dns.RRSIG{
+			Hdr:         dns.RR_Header{Name: owner, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 3600},
+			TypeCovered: covered,
+			OrigTtl:     3600,
+			Expiration:  past,
+		}
+	}
+	soa := func() dns.RR {
+		return &dns.SOA{
+			Hdr: dns.RR_Header{Name: zone, Rrtype: dns.TypeSOA, Class: dns.ClassINET, Ttl: 300},
+			Ns:  "ns." + zone, Mbox: "hostmaster." + zone, Minttl: 300,
+		}
+	}
+
+	shapes := []struct {
+		what  string
+		build func(*dns.Msg)
+	}{
+		{"an answer", func(r *dns.Msg) {
+			r.Answer = []dns.RR{
+				&dns.A{
+					Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 3600},
+					A:   []byte{192, 0, 2, 1},
+				},
+				lapsedSig(name, dns.TypeA),
+			}
+		}},
+		{"an NXDOMAIN", func(r *dns.Msg) {
+			r.Rcode = dns.RcodeNameError
+			r.Ns = []dns.RR{soa(), lapsedSig(zone, dns.TypeSOA)}
+		}},
+		{"an empty NODATA", func(r *dns.Msg) {
+			r.Ns = []dns.RR{soa(), lapsedSig(zone, dns.TypeSOA)}
+		}},
+		{"an alias ending in a denial", func(r *dns.Msg) {
+			r.Rcode = dns.RcodeNameError
+			r.Answer = []dns.RR{&dns.CNAME{
+				Hdr:    dns.RR_Header{Name: name, Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+				Target: "target." + zone,
+			}}
+			r.Ns = []dns.RR{soa(), lapsedSig(zone, dns.TypeSOA)}
+		}},
+	}
+
+	for _, shape := range shapes {
+		for _, cd := range []bool{false, true} {
+			label := shape.what
+			if cd {
+				label += " (CD set)"
+			}
+			t.Run(label, func(t *testing.T) {
+				c := New(&config.Config{CacheSize: 1024, Expire: 600})
+				defer c.Stop()
+
+				req := new(dns.Msg)
+				req.SetQuestion(name, dns.TypeA)
+				req.CheckingDisabled = cd
+				w := mock.NewWriter("udp", "127.0.0.1:0")
+				ch := middleware.NewChain([]middleware.Handler{c, middleware.HandlerFunc(
+					func(_ context.Context, ch *middleware.Chain) {
+						resp := new(dns.Msg)
+						resp.SetReply(ch.Request.Msg())
+						shape.build(resp)
+						resp.AuthenticatedData = true
+						_ = ch.Writer.WriteMsg(resp)
+						ch.Cancel()
+					})})
+				ch.Reset(w, req)
+				ch.Next(context.Background())
+
+				if !w.Written() {
+					t.Fatal("no response written")
+				}
+				out := w.Msg()
+				if out.AuthenticatedData {
+					t.Error("a lapsed proof was presented as authenticated")
+				}
+				for _, section := range [][]dns.RR{out.Answer, out.Ns} {
+					for _, rr := range section {
+						if got := rr.Header().Ttl; got != 0 {
+							t.Errorf("%s carries TTL %d, want 0", dns.TypeToString[rr.Header().Rrtype], got)
+						}
+					}
+				}
+				if got := c.store.PositiveLen(); got != 0 {
+					t.Errorf("a lapsed proof was admitted, cache holds %d", got)
+				}
+			})
+		}
+	}
+}

--- a/middleware/cache/negative_ttl_test.go
+++ b/middleware/cache/negative_ttl_test.go
@@ -1,0 +1,171 @@
+package cache
+
+import (
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/internal/dnsutil"
+)
+
+// newCeilingStore mirrors production: the configured minimum is the same five
+// seconds the derivation uses, which is what makes the two floors stack. A
+// store with a smaller minimum would pass these tests against an
+// implementation that only fixed the derivation.
+func newCeilingStore(t *testing.T) *Store {
+	t.Helper()
+	cfg := CacheConfig{
+		Size:        1024,
+		PositiveTTL: time.Minute,
+		NegativeTTL: time.Minute,
+		MinTTL:      dnsutil.MinCacheTTL,
+		MaxTTL:      time.Hour,
+	}
+	metrics := &CacheMetrics{}
+	store := NewStore(
+		NewPositiveCache(cfg.Size/2, cfg.MinTTL, cfg.MaxTTL, metrics),
+		NewNegativeCache(cfg.Size/2, cfg.MinTTL, cfg.NegativeTTL, metrics),
+		cfg,
+	)
+	t.Cleanup(store.Stop)
+	return store
+}
+
+// denialResponse builds a cacheable denial for name with the given SOA header
+// TTL and MINIMUM. NXDOMAIN when nameError, NODATA otherwise.
+func denialResponse(name string, nameError bool, soaTTL, soaMin uint32) (*dns.Msg, *dns.Msg) {
+	req := new(dns.Msg)
+	req.SetQuestion(name, dns.TypeA)
+
+	resp := new(dns.Msg)
+	resp.SetReply(req)
+	if nameError {
+		resp.Rcode = dns.RcodeNameError
+	}
+	resp.Ns = []dns.RR{&dns.SOA{
+		Hdr: dns.RR_Header{
+			Name:   "example.org.",
+			Rrtype: dns.TypeSOA,
+			Class:  dns.ClassINET,
+			Ttl:    soaTTL,
+		},
+		Ns:     "ns1.example.org.",
+		Mbox:   "hostmaster.example.org.",
+		Minttl: soaMin,
+	}}
+	return req, resp
+}
+
+// TestTTLManagerDoesNotFloorDenials covers the second of the two stacked
+// floors on its own. The derivation can be correct and the denial still get
+// raised right back here, so this has to be asserted separately rather than
+// only through the store.
+func TestTTLManagerDoesNotFloorDenials(t *testing.T) {
+	tm := NewTTLManager(dnsutil.MinCacheTTL, time.Hour)
+
+	for _, mt := range []dnsutil.ResponseType{dnsutil.TypeNXDomain, dnsutil.TypeNoRecords} {
+		for _, seconds := range []int{0, 1, 4, 5} {
+			in := time.Duration(seconds) * time.Second
+			if got := tm.CalculateFor(mt, in); got != in {
+				t.Errorf("CalculateFor(%v, %v) = %v, want it left alone", mt, in, got)
+			}
+		}
+		if got, want := tm.CalculateFor(mt, 2*time.Hour), time.Hour; got != want {
+			t.Errorf("CalculateFor(%v, 2h) = %v, want the %v cap still applied", mt, got, want)
+		}
+	}
+
+	// Everything that is not a denial keeps both bounds. TypeReferral matters
+	// here because referrals live in the same sub-cache as denials.
+	for _, mt := range []dnsutil.ResponseType{
+		dnsutil.TypeSuccess, dnsutil.TypeReferral, dnsutil.TypeServerFailure,
+	} {
+		if got, want := tm.CalculateFor(mt, time.Second), dnsutil.MinCacheTTL; got != want {
+			t.Errorf("CalculateFor(%v, 1s) = %v, want the %v floor kept", mt, got, want)
+		}
+	}
+}
+
+// TestDenialAdmittedAtItsOwnLifetime is the end-to-end form of the contract:
+// the value the zone published survives both floors and reaches the entry.
+func TestDenialAdmittedAtItsOwnLifetime(t *testing.T) {
+	for _, nameError := range []bool{true, false} {
+		kind := "NODATA"
+		if nameError {
+			kind = "NXDOMAIN"
+		}
+		for _, seconds := range []uint32{1, 4, 5} {
+			t.Run(kind, func(t *testing.T) {
+				store := newCeilingStore(t)
+				req, resp := denialResponse("absent.example.org.", nameError, 86400, seconds)
+				store.SetFromResponse(resp, false, time.Time{})
+
+				entry, ok := store.Lookup(req)
+				if !ok {
+					t.Fatalf("%s with a %ds SOA was not admitted", kind, seconds)
+				}
+				want := time.Duration(seconds) * time.Second
+				if entry.ttl != want {
+					t.Fatalf("%s stored for %v, want the zone's own %v", kind, entry.ttl, want)
+				}
+			})
+		}
+	}
+}
+
+// TestZeroLifetimeDenialIsNotAdmitted is criterion one: a denial the zone
+// granted no lifetime must not come back out of the cache. Admitting it with a
+// zero TTL would leave an entry every read has to discard.
+func TestZeroLifetimeDenialIsNotAdmitted(t *testing.T) {
+	for _, nameError := range []bool{true, false} {
+		kind := "NODATA"
+		if nameError {
+			kind = "NXDOMAIN"
+		}
+		t.Run(kind, func(t *testing.T) {
+			store := newCeilingStore(t)
+
+			// Zero in either field is zero: RFC 2308 takes the smaller.
+			for _, soa := range [][2]uint32{{0, 86400}, {86400, 0}, {0, 0}} {
+				req, resp := denialResponse("gone.example.org.", nameError, soa[0], soa[1])
+				store.SetFromResponse(resp, false, time.Time{})
+
+				if _, ok := store.Lookup(req); ok {
+					t.Fatalf("%s with SOA TTL %d / MINIMUM %d was served from cache",
+						kind, soa[0], soa[1])
+				}
+			}
+		})
+	}
+}
+
+// TestPositiveAdmissionKeepsTheFloor is criterion three at the store level.
+// Denials share the positive sub-cache with ordinary answers, so a change made
+// on the sub-cache rather than on the response type would show up right here.
+func TestPositiveAdmissionKeepsTheFloor(t *testing.T) {
+	store := newCeilingStore(t)
+
+	req := new(dns.Msg)
+	req.SetQuestion("present.example.org.", dns.TypeA)
+	resp := new(dns.Msg)
+	resp.SetReply(req)
+	resp.Answer = []dns.RR{&dns.A{
+		Hdr: dns.RR_Header{
+			Name:   "present.example.org.",
+			Rrtype: dns.TypeA,
+			Class:  dns.ClassINET,
+			Ttl:    1,
+		},
+		A: []byte{192, 0, 2, 1},
+	}}
+
+	store.SetFromResponse(resp, false, time.Time{})
+
+	entry, ok := store.Lookup(req)
+	if !ok {
+		t.Fatal("a one-second positive answer was not admitted")
+	}
+	if entry.ttl != dnsutil.MinCacheTTL {
+		t.Fatalf("positive answer stored for %v, want the %v floor", entry.ttl, dnsutil.MinCacheTTL)
+	}
+}

--- a/middleware/cache/negative_ttl_test.go
+++ b/middleware/cache/negative_ttl_test.go
@@ -580,6 +580,98 @@ func TestFirstResponseCarriesTheEffectiveTTL(t *testing.T) {
 		}
 	})
 
+	t.Run("a zone that granted no lifetime at all", func(t *testing.T) {
+		// Zero is a ceiling, not a missing one. The cache declines to admit
+		// this, and the client used to be handed it at the SOA's full three
+		// hundred seconds regardless.
+		const name = "nolife.first.example."
+		up := new(dns.Msg)
+		up.Rcode = dns.RcodeNameError
+		up.Ns = []dns.RR{&dns.SOA{
+			Hdr: dns.RR_Header{
+				Name: "first.example.", Rrtype: dns.TypeSOA,
+				Class: dns.ClassINET, Ttl: 300,
+			},
+			Ns: "ns.first.example.", Mbox: "hostmaster.first.example.", Minttl: 0,
+		}}
+		if got := authorityTTL(ask(t, up, name)); got != 0 {
+			t.Errorf("first client got TTL %d for a denial the SOA grants no lifetime", got)
+		}
+	})
+
+	t.Run("a signature whose original TTL is zero", func(t *testing.T) {
+		const name = "zerosig.first.example."
+		up := new(dns.Msg)
+		up.AuthenticatedData = true
+		up.Answer = []dns.RR{
+			&dns.A{
+				Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 3600},
+				A:   []byte{192, 0, 2, 1},
+			},
+			&dns.RRSIG{
+				Hdr:         dns.RR_Header{Name: name, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 3600},
+				TypeCovered: dns.TypeA,
+				OrigTtl:     0,
+				Expiration:  uint32(time.Now().Add(time.Hour).Unix()), //nolint:gosec // G115 - Unix timestamp fits in uint32 for valid dates
+			},
+		}
+		if got := answerTTL(ask(t, up, name)); got != 0 {
+			t.Errorf("first client got TTL %d for data its signature authorises for none", got)
+		}
+	})
+
+	t.Run("an alias onto a target about to expire", func(t *testing.T) {
+		// The target's RRset belongs to a different owner, so the stored view
+		// drops it. It is still in this message and still what the client
+		// acts on, and it expires in two seconds while the alias in front of
+		// it advertises five minutes.
+		const name, target = "alias.first.example.", "target.first.example."
+		up := new(dns.Msg)
+		up.AuthenticatedData = true
+		up.Answer = []dns.RR{
+			&dns.CNAME{
+				Hdr:    dns.RR_Header{Name: name, Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+				Target: target,
+			},
+			&dns.A{
+				Hdr: dns.RR_Header{Name: target, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 3600},
+				A:   []byte{192, 0, 2, 1},
+			},
+			&dns.RRSIG{
+				Hdr:         dns.RR_Header{Name: target, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 3600},
+				TypeCovered: dns.TypeA,
+				OrigTtl:     3600,
+				Expiration:  uint32(time.Now().Add(2 * time.Second).Unix()), //nolint:gosec // G115 - Unix timestamp fits in uint32 for valid dates
+			},
+		}
+		if got := answerTTL(ask(t, up, name)); got > 2 {
+			t.Errorf("first client got TTL %d for an alias onto a target bounded at 2s", got)
+		}
+	})
+
+	t.Run("an alias that ends in a denial", func(t *testing.T) {
+		// The chase turns a success into a terminal NXDOMAIN. Classifying
+		// once, before it ran, left the clamp reading the alias TTL while the
+		// SOA at the end of the chain said one second.
+		const name = "aliasgone.first.example."
+		up := new(dns.Msg)
+		up.Rcode = dns.RcodeNameError
+		up.Answer = []dns.RR{&dns.CNAME{
+			Hdr:    dns.RR_Header{Name: name, Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+			Target: "target.first.example.",
+		}}
+		up.Ns = []dns.RR{&dns.SOA{
+			Hdr: dns.RR_Header{
+				Name: "first.example.", Rrtype: dns.TypeSOA,
+				Class: dns.ClassINET, Ttl: 300,
+			},
+			Ns: "ns.first.example.", Mbox: "hostmaster.first.example.", Minttl: 1,
+		}}
+		if got := answerTTL(ask(t, up, name)); got > 1 {
+			t.Errorf("first client got TTL %d for an alias onto a denial granted 1s", got)
+		}
+	})
+
 	t.Run("a denial the zone granted one second", func(t *testing.T) {
 		const name = "gone.first.example."
 		up := new(dns.Msg)
@@ -595,4 +687,104 @@ func TestFirstResponseCarriesTheEffectiveTTL(t *testing.T) {
 			t.Errorf("first client got TTL %d for a denial the SOA grants for 1s", got)
 		}
 	})
+}
+
+// TestChasedDenialBoundsTheFirstResponse exercises the case the fixtures above
+// cannot: the upstream answer is a success carrying only an alias, and the
+// chase is what turns it into a denial. Classifying once, before the chase ran,
+// left the client clamp reading the alias TTL while the SOA at the end of the
+// chain granted one second.
+func TestChasedDenialBoundsTheFirstResponse(t *testing.T) {
+	const name, target = "chased.example.", "target.chased.example."
+
+	c := New(&config.Config{CacheSize: 1024, Expire: 600})
+	defer c.Stop()
+
+	// The target resolves to a denial the zone grants for one second.
+	targetHandler := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		resp := new(dns.Msg)
+		resp.SetReply(ch.Request.Msg())
+		resp.Rcode = dns.RcodeNameError
+		resp.Ns = []dns.RR{&dns.SOA{
+			Hdr: dns.RR_Header{
+				Name: "chased.example.", Rrtype: dns.TypeSOA,
+				Class: dns.ClassINET, Ttl: 300,
+			},
+			Ns: "ns.chased.example.", Mbox: "hostmaster.chased.example.", Minttl: 1,
+		}}
+		_ = ch.Writer.WriteMsg(resp)
+		ch.Cancel()
+	})
+	c.SetQueryer(&internalQueryer{handlers: []middleware.Handler{c, targetHandler}})
+
+	// The outer answer is a plain success: an alias, and nothing else.
+	req := new(dns.Msg)
+	req.SetQuestion(name, dns.TypeA)
+	w := mock.NewWriter("udp", "127.0.0.1:0")
+	ch := middleware.NewChain([]middleware.Handler{c, middleware.HandlerFunc(
+		func(_ context.Context, ch *middleware.Chain) {
+			resp := new(dns.Msg)
+			resp.SetReply(ch.Request.Msg())
+			resp.Answer = []dns.RR{&dns.CNAME{
+				Hdr:    dns.RR_Header{Name: name, Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300},
+				Target: target,
+			}}
+			_ = ch.Writer.WriteMsg(resp)
+			ch.Cancel()
+		})})
+	ch.Reset(w, req)
+	ch.Next(context.Background())
+
+	if !w.Written() {
+		t.Fatal("no response written")
+	}
+	out := w.Msg()
+	if len(out.Answer) == 0 {
+		t.Fatal("no answer section")
+	}
+	if got := out.Answer[0].Header().Ttl; got > 1 {
+		t.Errorf("first client got TTL %d; the chase ended in a denial granted 1s", got)
+	}
+}
+
+// TestClampRoundsLikeAHit pins the two paths to one rule. The clamp on the
+// first response and the TTL written on every later hit answer the same
+// question about the same records, and they disagreed on the last fraction of
+// a second: one told the client nothing, the next told it one.
+//
+// Driven through the delegation lease, whose deadline is an absolute instant
+// this test can place with sub-second precision. A signature cannot: RRSIG
+// expiration is a whole-second timestamp.
+func TestClampRoundsLikeAHit(t *testing.T) {
+	build := func() *dns.Msg {
+		msg := new(dns.Msg)
+		msg.SetQuestion("rounding.example.", dns.TypeA)
+		msg.Answer = []dns.RR{&dns.A{
+			Hdr: dns.RR_Header{
+				Name: "rounding.example.", Rrtype: dns.TypeA,
+				Class: dns.ClassINET, Ttl: 3600,
+			},
+			A: []byte{192, 0, 2, 1},
+		}}
+		return msg
+	}
+
+	for _, lease := range []time.Duration{100 * time.Millisecond, 500 * time.Millisecond, 999 * time.Millisecond} {
+		res := build()
+		clampTTLsToEffective(res, time.Now().Add(lease), dnsutil.TypeSuccess)
+
+		got := res.Answer[0].Header().Ttl
+		want := servedSeconds(lease)
+		if got != want {
+			t.Errorf("a %v lease clamped the first response to %d, while a hit serves %d",
+				lease, got, want)
+		}
+	}
+
+	// A lease already spent is zero on both paths.
+	res := build()
+	clampTTLsToEffective(res, time.Now().Add(-time.Second), dnsutil.TypeSuccess)
+	if got := res.Answer[0].Header().Ttl; got != 0 {
+		t.Errorf("a spent lease clamped to %d, want 0", got)
+	}
 }

--- a/middleware/cache/negative_ttl_test.go
+++ b/middleware/cache/negative_ttl_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"context"
 	"net/netip"
 	"testing"
 	"time"
@@ -8,6 +9,8 @@ import (
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/config"
 	"github.com/semihalev/sdns/internal/dnsutil"
+	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/middleware"
 )
 
 // newCeilingStore mirrors production: the configured minimum is the same five
@@ -370,12 +373,20 @@ func TestSignedAnswerKeepsItsCeilingThroughAdmission(t *testing.T) {
 				t.Errorf("SetFromResponse stored %v, want at most %v", entry.ttl, tc.ceiling)
 			}
 
-			// Scoped, the ECS door.
+			// Scoped, the ECS door. A scoped entry is filed and verified
+			// under the scope it was admitted with, so it has to be asked for
+			// the same way; looking it up unscoped simply misses, which is
+			// how this door quietly went untested.
 			store = newCeilingStore(t)
 			req, resp = signedAnswer("signed.example.org.", tc.recordTTL, tc.sigTTL, tc.origTTL, tc.expiresIn)
-			key := CacheKey{Question: req.Question[0], CD: false}.Hash()
-			store.SetFromResponseScoped(key, resp, netip.MustParsePrefix("203.0.113.0/24"), time.Time{}, 0)
-			if entry, ok = store.Lookup(req); ok && entry.ttl > tc.ceiling {
+			scope := netip.MustParsePrefix("203.0.113.0/24")
+			want := CacheKey{Question: req.Question[0], CD: false, Scope: scope}
+			store.SetFromResponseScoped(want.Hash(), resp, scope, time.Time{}, 0)
+			entry, ok = store.LookupByKeyVerified(want.Hash(), want)
+			if !ok {
+				t.Fatal("scoped admission stored nothing")
+			}
+			if entry.ttl > tc.ceiling {
 				t.Errorf("scoped admission stored %v, want at most %v", entry.ttl, tc.ceiling)
 			}
 
@@ -383,9 +394,13 @@ func TestSignedAnswerKeepsItsCeilingThroughAdmission(t *testing.T) {
 			c := New(&config.Config{CacheSize: 1024, Expire: 600})
 			defer c.Stop()
 			req, resp = signedAnswer("signed.example.org.", tc.recordTTL, tc.sigTTL, tc.origTTL, tc.expiresIn)
-			key = CacheKey{Question: req.Question[0], CD: false}.Hash()
+			key := CacheKey{Question: req.Question[0], CD: false}.Hash()
 			c.Set(key, resp)
-			if entry, ok = c.store.Lookup(req); ok && entry.ttl > tc.ceiling {
+			entry, ok = c.store.Lookup(req)
+			if !ok {
+				t.Fatal("Cache.Set stored nothing")
+			}
+			if entry.ttl > tc.ceiling {
 				t.Errorf("Cache.Set stored %v, want at most %v", entry.ttl, tc.ceiling)
 			}
 
@@ -402,7 +417,11 @@ func TestSignedAnswerKeepsItsCeilingThroughAdmission(t *testing.T) {
 			if !store.ReplaceIfCurrent(key, existing, refreshed, time.Time{}, 0) {
 				t.Fatal("the refresh was refused")
 			}
-			if entry, ok = store.Lookup(req); ok && entry.ttl > tc.ceiling {
+			entry, ok = store.Lookup(req)
+			if !ok {
+				t.Fatal("ReplaceIfCurrent left nothing behind")
+			}
+			if entry.ttl > tc.ceiling {
 				t.Errorf("ReplaceIfCurrent stored %v, want at most %v", entry.ttl, tc.ceiling)
 			}
 		})
@@ -492,4 +511,88 @@ func TestSignedReferralNeverOutlivesItsSignature(t *testing.T) {
 	if got, want := dnsutil.CalculateCacheTTL(plain, mt), dnsutil.MinCacheTTL; got != want {
 		t.Errorf("unsigned referral: got %v, want %v unchanged", got, want)
 	}
+}
+
+// TestFirstResponseCarriesTheEffectiveTTL is the client-facing half of the
+// bound. The entry was already stored with the short lifetime; the answer
+// handed to the client that caused the miss still advertised what the records
+// claimed, so that one client was invited to hold the data long after every
+// bound had run out, and every later client got a different number for the
+// same records.
+func TestFirstResponseCarriesTheEffectiveTTL(t *testing.T) {
+	answerTTL := func(msg *dns.Msg) uint32 {
+		t.Helper()
+		if len(msg.Answer) == 0 {
+			t.Fatal("no answer section")
+		}
+		return msg.Answer[0].Header().Ttl
+	}
+	authorityTTL := func(msg *dns.Msg) uint32 {
+		t.Helper()
+		if len(msg.Ns) == 0 {
+			t.Fatal("no authority section")
+		}
+		return msg.Ns[0].Header().Ttl
+	}
+
+	ask := func(t *testing.T, upstream *dns.Msg, qname string) *dns.Msg {
+		t.Helper()
+		c := New(&config.Config{CacheSize: 1024, Expire: 600})
+		t.Cleanup(c.Stop)
+
+		req := new(dns.Msg)
+		req.SetQuestion(qname, dns.TypeA)
+		w := mock.NewWriter("udp", "127.0.0.1:0")
+		ch := middleware.NewChain([]middleware.Handler{c, middleware.HandlerFunc(
+			func(_ context.Context, ch *middleware.Chain) {
+				out := upstream.Copy()
+				out.SetReply(ch.Request.Msg())
+				out.Rcode = upstream.Rcode
+				out.Answer, out.Ns = upstream.Answer, upstream.Ns
+				_ = ch.Writer.WriteMsg(out)
+				ch.Cancel()
+			})})
+		ch.Reset(w, req)
+		ch.Next(context.Background())
+		if !w.Written() {
+			t.Fatal("no response written")
+		}
+		return w.Msg()
+	}
+
+	t.Run("a signature about to expire", func(t *testing.T) {
+		const name = "signed.first.example."
+		up := new(dns.Msg)
+		up.Answer = []dns.RR{
+			&dns.A{
+				Hdr: dns.RR_Header{Name: name, Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 3600},
+				A:   []byte{192, 0, 2, 1},
+			},
+			&dns.RRSIG{
+				Hdr:         dns.RR_Header{Name: name, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 3600},
+				TypeCovered: dns.TypeA,
+				OrigTtl:     3600,
+				Expiration:  uint32(time.Now().Add(2 * time.Second).Unix()), //nolint:gosec // G115 - Unix timestamp fits in uint32 for valid dates
+			},
+		}
+		if got := answerTTL(ask(t, up, name)); got > 2 {
+			t.Errorf("first client got TTL %d for data its signature bounds at 2s", got)
+		}
+	})
+
+	t.Run("a denial the zone granted one second", func(t *testing.T) {
+		const name = "gone.first.example."
+		up := new(dns.Msg)
+		up.Rcode = dns.RcodeNameError
+		up.Ns = []dns.RR{&dns.SOA{
+			Hdr: dns.RR_Header{
+				Name: "first.example.", Rrtype: dns.TypeSOA,
+				Class: dns.ClassINET, Ttl: 300,
+			},
+			Ns: "ns.first.example.", Mbox: "hostmaster.first.example.", Minttl: 1,
+		}}
+		if got := authorityTTL(ask(t, up, name)); got > 1 {
+			t.Errorf("first client got TTL %d for a denial the SOA grants for 1s", got)
+		}
+	})
 }

--- a/middleware/cache/nxdomain_cut.go
+++ b/middleware/cache/nxdomain_cut.go
@@ -513,10 +513,11 @@ func (e *nxDomainCutEntry) response(req *dns.Msg) *dns.Msg {
 		rr.Header().Ttl = ttl
 	}
 
-	// An explicit RRSIG query keeps the signatures regardless of DO —
-	// the client named the DNSSEC type it wants (same exception the
-	// exact-entry serve applies).
-	if opt := req.IsEdns0(); (opt == nil || !opt.Do()) && req.Question[0].Qtype != dns.TypeRRSIG {
+	// The DO=0 shape is ClearDNSSEC's, the same as the exact-entry serve's:
+	// the one authenticating type the question named stays, every other
+	// goes (RFC 4035 §3.2.1). The wire template declines these questions
+	// and lands here for exactly this.
+	if opt := req.IsEdns0(); opt == nil || !opt.Do() {
 		resp = dnsutil.ClearDNSSEC(resp)
 	}
 	return resp

--- a/middleware/cache/nxdomain_cut.go
+++ b/middleware/cache/nxdomain_cut.go
@@ -508,7 +508,7 @@ func (e *nxDomainCutEntry) response(req *dns.Msg) *dns.Msg {
 	resp.Answer = nil
 	resp.Extra = nil
 
-	ttl := uint32(remaining / time.Second) //nolint:gosec // positive duration bounded by configured cache TTL
+	ttl := servedSeconds(remaining)
 	for _, rr := range resp.Ns {
 		rr.Header().Ttl = ttl
 	}

--- a/middleware/cache/nxdomain_cut_wire.go
+++ b/middleware/cache/nxdomain_cut_wire.go
@@ -216,10 +216,18 @@ func (c *Cache) serveCutHitFromWire(
 		return false
 	}
 
-	// The DO test mirrors serveWireInto's, RRSIG exception included, so
-	// this precheck never rejects a template the composer would pick.
+	// The DO test mirrors serveWireInto's, the explicit-question decline
+	// included, so this precheck never leases a body the composer would
+	// refuse: a DO=0 question for RRSIG, NSEC or NSEC3 is the Msg path's
+	// by design, and leasing for it only to abort counted a deliberate
+	// fallback as a build failure.
 	tmpl := cut.wireFull
-	if !capability.DO && ch.Request.Qtype() != dns.TypeRRSIG {
+	if !capability.DO {
+		switch ch.Request.Qtype() {
+		case dns.TypeRRSIG, dns.TypeNSEC, dns.TypeNSEC3:
+			wireSkipDNSSEC.Inc()
+			return false
+		}
 		tmpl = cut.wireStripped
 	}
 	if tmpl == nil {

--- a/middleware/cache/nxdomain_cut_wire.go
+++ b/middleware/cache/nxdomain_cut_wire.go
@@ -152,7 +152,7 @@ func (e *nxDomainCutEntry) serveWireInto(
 		return nil, false
 	}
 
-	ttl := uint32(remaining / time.Second) //nolint:gosec // positive duration bounded by the cut TTL
+	ttl := servedSeconds(remaining)
 	off := question.End
 	for range int(header.NSCount) {
 		rr, parsed := wire.ParseRR(tmpl, off)

--- a/middleware/cache/nxdomain_cut_wire.go
+++ b/middleware/cache/nxdomain_cut_wire.go
@@ -125,7 +125,15 @@ func (e *nxDomainCutEntry) serveWireInto(
 		return nil, false
 	}
 	tmpl := e.wireFull
-	if !do && req.Qtype() != dns.TypeRRSIG {
+	if !do {
+		// The stripped template was cut behind a SOA question, so it holds
+		// no authenticating record at all. A DO=0 question for RRSIG, NSEC
+		// or NSEC3 keeps the one type it named (RFC 4035 §3.2.1), which
+		// neither template is: the Msg path shapes that answer.
+		switch req.Qtype() {
+		case dns.TypeRRSIG, dns.TypeNSEC, dns.TypeNSEC3:
+			return nil, false
+		}
 		tmpl = e.wireStripped
 	}
 	if tmpl == nil || cap(dst) < wire.HeaderLen {

--- a/middleware/cache/store.go
+++ b/middleware/cache/store.go
@@ -663,8 +663,9 @@ func (s *Store) setFromResponseWithKey(key uint64, resp *dns.Msg, scope netip.Pr
 		// A denial the zone granted no lifetime is not cacheable at all (RFC
 		// 2308 §5). Admitting it with a zero TTL would occupy a slot that
 		// every later read has to discard, and the entry could never be
-		// served — the guard cannot fire for a positive answer, which always
-		// arrives on its own floor.
+		// served. A positive answer reaches zero too when a signature fixes
+		// it there, an Original TTL of zero or a signature in its last
+		// second, and this guard is what keeps that one out.
 		ttl := capTTL(s.positive.ttl.Bound(msgTTL))
 		if ttl > 0 {
 			if entry := newEntry(filtered, ttl); entry != nil {

--- a/middleware/cache/store.go
+++ b/middleware/cache/store.go
@@ -662,7 +662,7 @@ func (s *Store) setFromResponseWithKey(key uint64, resp *dns.Msg, scope netip.Pr
 		// every later read has to discard, and the entry could never be
 		// served — the guard cannot fire for a positive answer, which always
 		// arrives on its own floor.
-		ttl := capTTL(s.positive.ttl.CalculateFor(mt, msgTTL))
+		ttl := capTTL(s.positive.ttl.Bound(msgTTL))
 		if ttl > 0 {
 			if entry := newEntry(filtered, ttl); entry != nil {
 				s.positive.Set(key, entry)
@@ -733,7 +733,7 @@ func (s *Store) ReplaceIfCurrent(key uint64, expected *CacheEntry, resp *dns.Msg
 		// A refresh that comes back as a denial with no zone-granted lifetime
 		// is dropped rather than stored. The entry it would have replaced
 		// keeps its own remaining TTL and re-resolves when that runs out.
-		ttl := s.positive.ttl.CalculateFor(mt, msgTTL)
+		ttl := s.positive.ttl.Bound(msgTTL)
 		if ttl <= 0 {
 			return false
 		}

--- a/middleware/cache/store.go
+++ b/middleware/cache/store.go
@@ -657,9 +657,16 @@ func (s *Store) setFromResponseWithKey(key uint64, resp *dns.Msg, scope netip.Pr
 
 	switch mt {
 	case dnsutil.TypeSuccess, dnsutil.TypeReferral, dnsutil.TypeNXDomain, dnsutil.TypeNoRecords:
-		ttl := capTTL(s.positive.ttl.Calculate(msgTTL))
-		if entry := newEntry(filtered, ttl); entry != nil {
-			s.positive.Set(key, entry)
+		// A denial the zone granted no lifetime is not cacheable at all (RFC
+		// 2308 §5). Admitting it with a zero TTL would occupy a slot that
+		// every later read has to discard, and the entry could never be
+		// served — the guard cannot fire for a positive answer, which always
+		// arrives on its own floor.
+		ttl := capTTL(s.positive.ttl.CalculateFor(mt, msgTTL))
+		if ttl > 0 {
+			if entry := newEntry(filtered, ttl); entry != nil {
+				s.positive.Set(key, entry)
+			}
 		}
 		// A scoped write has no source prefix here (only its already-hashed
 		// cache key), so it must not reset the unrelated global failure
@@ -723,7 +730,14 @@ func (s *Store) ReplaceIfCurrent(key uint64, expected *CacheEntry, resp *dns.Msg
 
 	switch mt {
 	case dnsutil.TypeSuccess, dnsutil.TypeReferral, dnsutil.TypeNXDomain, dnsutil.TypeNoRecords:
-		entry := inherit(NewCacheEntryWithKey(filtered, s.positive.ttl.Calculate(msgTTL), s.cfg.RateLimit, key))
+		// A refresh that comes back as a denial with no zone-granted lifetime
+		// is dropped rather than stored. The entry it would have replaced
+		// keeps its own remaining TTL and re-resolves when that runs out.
+		ttl := s.positive.ttl.CalculateFor(mt, msgTTL)
+		if ttl <= 0 {
+			return false
+		}
+		entry := inherit(NewCacheEntryWithKey(filtered, ttl, s.cfg.RateLimit, key))
 		if entry == nil {
 			return false
 		}

--- a/middleware/cache/store.go
+++ b/middleware/cache/store.go
@@ -609,9 +609,12 @@ func (s *Store) SetFromResponseScoped(key uint64, resp *dns.Msg, scope netip.Pre
 }
 
 func (s *Store) setFromResponseWithKey(key uint64, resp *dns.Msg, scope netip.Prefix, cutUntil time.Time, cutKey uint64, keyCD bool) {
-	mt, _ := dnsutil.ClassifyResponse(resp, time.Now().UTC())
+	// One clock for the whole admission: classification, the lifetime, the
+	// entry's stored instant and what it may carry all read now.
+	now := time.Now()
+	mt, _ := dnsutil.ClassifyResponse(resp, now)
 	filtered := filterCacheableAnswer(resp)
-	msgTTL := dnsutil.CalculateCacheTTL(filtered, mt)
+	msgTTL := dnsutil.CalculateCacheTTLAt(filtered, mt, now)
 
 	scope = normalizeKeyScope(scope)
 	scoped := scope.IsValid()
@@ -632,9 +635,9 @@ func (s *Store) setFromResponseWithKey(key uint64, resp *dns.Msg, scope netip.Pr
 	newEntry := func(msg *dns.Msg, ttl time.Duration) *CacheEntry {
 		var e *CacheEntry
 		if scoped {
-			e = NewScopedCacheEntry(msg, ttl, s.cfg.RateLimit, scope)
+			e = newScopedCacheEntryAt(msg, ttl, s.cfg.RateLimit, scope, now)
 		} else {
-			e = NewCacheEntryWithKey(msg, ttl, s.cfg.RateLimit, key)
+			e = newCacheEntryAt(msg, ttl, s.cfg.RateLimit, key, now)
 		}
 		if e == nil {
 			// Unpackable response: never cacheable, callers skip the write.
@@ -708,9 +711,12 @@ func (s *Store) ReplaceIfCurrent(key uint64, expected *CacheEntry, resp *dns.Msg
 		return false
 	}
 
-	mt, _ := dnsutil.ClassifyResponse(resp, time.Now().UTC())
+	// One clock for the whole admission: classification, the lifetime, the
+	// entry's stored instant and what it may carry all read now.
+	now := time.Now()
+	mt, _ := dnsutil.ClassifyResponse(resp, now)
 	filtered := filterCacheableAnswer(resp)
-	msgTTL := dnsutil.CalculateCacheTTL(filtered, mt)
+	msgTTL := dnsutil.CalculateCacheTTLAt(filtered, mt, now)
 
 	// A replacement takes over the key expected occupies, so it inherits
 	// that key's CD partition and ECS scope. A refresh that carried the
@@ -737,13 +743,13 @@ func (s *Store) ReplaceIfCurrent(key uint64, expected *CacheEntry, resp *dns.Msg
 		if ttl <= 0 {
 			return false
 		}
-		entry := inherit(NewCacheEntryWithKey(filtered, ttl, s.cfg.RateLimit, key))
+		entry := inherit(newCacheEntryAt(filtered, ttl, s.cfg.RateLimit, key, now))
 		if entry == nil {
 			return false
 		}
 		return s.positive.cache.CompareAndSwap(key, expected, entry)
 	case dnsutil.TypeServerFailure:
-		entry := inherit(NewCacheEntryWithKey(filtered, s.negative.ttl.Calculate(msgTTL), s.cfg.RateLimit, key))
+		entry := inherit(newCacheEntryAt(filtered, s.negative.ttl.Calculate(msgTTL), s.cfg.RateLimit, key, now))
 		if entry == nil {
 			return false
 		}

--- a/middleware/cache/types.go
+++ b/middleware/cache/types.go
@@ -300,10 +300,10 @@ func NewCacheEntryWithKey(msg *dns.Msg, ttl time.Duration, rateLimit int, key ui
 // interdependent, so records cannot be cut out of a packed message without
 // re-encoding it.
 func (e *CacheEntry) prepareStripped(msgCopy *dns.Msg) {
-	// An explicit RRSIG question keeps its signatures for any DO —
-	// ClearDNSSEC would return the message unchanged, so the stripped
-	// body would only duplicate the stored one.
-	if e.wireServe&wireHasDNSSEC == 0 || e.question.Qtype == dns.TypeRRSIG {
+	// The flag already leaves out the type an explicit RRSIG, NSEC or NSEC3
+	// question asked for: without it ClearDNSSEC would return the message
+	// unchanged, and the stripped body would only duplicate the stored one.
+	if e.wireServe&wireHasDNSSEC == 0 {
 		return
 	}
 

--- a/middleware/cache/types.go
+++ b/middleware/cache/types.go
@@ -709,14 +709,19 @@ func storableAdditional(records []dns.RR, now time.Time, lifetime time.Duration)
 	over := func(sig *dns.RRSIG, name string, class, rrtype uint16) bool {
 		return sig.TypeCovered == rrtype && sig.Hdr.Class == class && strings.EqualFold(sig.Hdr.Name, name)
 	}
-	// condemned: a signed RRset the entry cannot carry honestly. Either
-	// nothing left signs it, or its signatures name more than one signer.
+	// condemned: a signed RRset the entry cannot carry honestly. Nothing
+	// left signs it; or its signatures name more than one signer; or its
+	// own records were received with less TTL than the entry's lifetime.
+	//
 	// The second is the delegation boundary, where the parent's NSEC over
 	// the child's name and the child's apex NSEC share owner, class and
 	// type (RFC 4035 §5.3.2): on the wire that is one RRset, its records
 	// cannot be told apart by signer, and a live child signature was
-	// carrying the parent's lapsed records with it. Such a tuple goes
-	// whole, signatures included.
+	// carrying the parent's lapsed records with it. The third is §5.3.3's
+	// other ceiling, the RRset's TTL as received: an unsigned answer takes
+	// the positive floor, and a signed additional address received with a
+	// one-second TTL was lifted to it and served at five. Such a tuple
+	// goes whole, signatures included.
 	condemned := func(name string, class, rrtype uint16) bool {
 		signed, kept := false, false
 		var signer string
@@ -730,7 +735,20 @@ func storableAdditional(records []dns.RR, now time.Time, lifetime time.Duration)
 			signed, signer = true, j.sig.SignerName
 			kept = kept || j.kept
 		}
-		return signed && !kept
+		if !signed {
+			return false
+		}
+		if !kept {
+			return true
+		}
+		for _, rr := range records {
+			h := rr.Header()
+			if h.Rrtype == rrtype && h.Class == class && strings.EqualFold(h.Name, name) &&
+				time.Duration(h.Ttl)*time.Second < lifetime {
+				return true
+			}
+		}
+		return false
 	}
 
 	extra := make([]dns.RR, 0, len(records))

--- a/middleware/cache/types.go
+++ b/middleware/cache/types.go
@@ -3,12 +3,12 @@ package cache
 import (
 	"errors"
 	"net/netip"
-	"strings"
 	"sync/atomic"
 	"time"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/internal/cache"
+	"github.com/semihalev/sdns/internal/dnsname"
 	"github.com/semihalev/sdns/internal/dnsutil"
 	"github.com/semihalev/sdns/middleware"
 	// Aliased: this file's local "wire" is the packed body itself.
@@ -706,8 +706,14 @@ func storableAdditional(records []dns.RR, now time.Time, lifetime time.Duration)
 			sigs = append(sigs, judged{sig: sig, kept: honours(sig)})
 		}
 	}
+	// Names compare as DNS names, not as text: an owner spelled with an
+	// escaped octet packs to the same wire name as its plain spelling, and
+	// a case fold of the presentation form does not see that — a record
+	// received under one spelling slipped past the TTL check made against
+	// its signature under the other.
+	sameName := func(a, b string) bool { return dnsname.CanonicalCompare(a, b) == 0 }
 	over := func(sig *dns.RRSIG, name string, class, rrtype uint16) bool {
-		return sig.TypeCovered == rrtype && sig.Hdr.Class == class && strings.EqualFold(sig.Hdr.Name, name)
+		return sig.TypeCovered == rrtype && sig.Hdr.Class == class && sameName(sig.Hdr.Name, name)
 	}
 	// condemned: a signed RRset the entry cannot carry honestly. Nothing
 	// left signs it; or its signatures name more than one signer; or its
@@ -729,7 +735,7 @@ func storableAdditional(records []dns.RR, now time.Time, lifetime time.Duration)
 			if !over(j.sig, name, class, rrtype) {
 				continue
 			}
-			if signed && !strings.EqualFold(signer, j.sig.SignerName) {
+			if signed && !sameName(signer, j.sig.SignerName) {
 				return true
 			}
 			signed, signer = true, j.sig.SignerName
@@ -743,7 +749,7 @@ func storableAdditional(records []dns.RR, now time.Time, lifetime time.Duration)
 		}
 		for _, rr := range records {
 			h := rr.Header()
-			if h.Rrtype == rrtype && h.Class == class && strings.EqualFold(h.Name, name) &&
+			if h.Rrtype == rrtype && h.Class == class && sameName(h.Name, name) &&
 				time.Duration(h.Ttl)*time.Second < lifetime {
 				return true
 			}

--- a/middleware/cache/types.go
+++ b/middleware/cache/types.go
@@ -186,7 +186,11 @@ func NewCacheEntry(msg *dns.Msg, ttl time.Duration, rateLimit int) *CacheEntry {
 // invalid scope leaves the entry shared, matching CacheKey.Hash, which
 // collapses /0 to the unscoped key.
 func NewScopedCacheEntry(msg *dns.Msg, ttl time.Duration, rateLimit int, scope netip.Prefix) *CacheEntry {
-	e := NewCacheEntryWithKey(msg, ttl, rateLimit, 0)
+	return newScopedCacheEntryAt(msg, ttl, rateLimit, scope, time.Now())
+}
+
+func newScopedCacheEntryAt(msg *dns.Msg, ttl time.Duration, rateLimit int, scope netip.Prefix, now time.Time) *CacheEntry {
+	e := newCacheEntryAt(msg, ttl, rateLimit, 0, now)
 	if e == nil {
 		return nil
 	}
@@ -211,9 +215,18 @@ func (e *CacheEntry) PrefetchEligible() bool { return !e.scoped() }
 // thin, which a hit may not answer with fewer signatures than the first
 // response did. Callers treat nil as "not cacheable" either way.
 func NewCacheEntryWithKey(msg *dns.Msg, ttl time.Duration, rateLimit int, key uint64) *CacheEntry {
+	return newCacheEntryAt(msg, ttl, rateLimit, key, time.Now())
+}
+
+// newCacheEntryAt is NewCacheEntryWithKey anchored at now: the instant the
+// entry is stored at, the one its ttl was measured at, and the one every
+// decision about what the entry may carry is taken at. One clock, so a
+// lifetime and the signatures judged against it never disagree by the
+// moment between two readings. Monotonic, never UTC-converted: a backward
+// wall-clock step must not extend the entry.
+func newCacheEntryAt(msg *dns.Msg, ttl time.Duration, rateLimit int, key uint64, now time.Time) *CacheEntry {
 	// Assemble the storable view and filter out OPT records (matching V1
 	// behavior): OPT is per-client hop metadata the serve path rebuilds.
-	now := time.Now().UTC()
 	msgCopy := new(dns.Msg)
 	msgCopy.MsgHdr = msg.MsgHdr
 	msgCopy.Question = msg.Question
@@ -267,10 +280,10 @@ func NewCacheEntryWithKey(msg *dns.Msg, ttl time.Duration, rateLimit int, key ui
 
 	entry := &CacheEntry{
 		wire: wire,
-		// Keep the monotonic clock reading. Converting to UTC strips it and
-		// would let a backward wall-clock adjustment extend both the TTL and
-		// an inherited delegation cut.
-		stored:     time.Now(),
+		// The anchoring instant, monotonic reading kept. Converting to UTC
+		// strips it and would let a backward wall-clock adjustment extend
+		// both the TTL and an inherited delegation cut.
+		stored:     now,
 		ttl:        ttl,
 		origTTL:    uint32(ttl.Seconds()),
 		rateLimit:  rateLimit,
@@ -671,42 +684,53 @@ func storableAdditional(records []dns.RR, now time.Time, lifetime time.Duration)
 	var ede *dns.EDNS0_EDE
 
 	// honours reports whether the entry's lifetime stays within what sig
-	// permits. Within a second of it counts: the lifetime was measured a
-	// moment before this check, so a signature sharing the answer's own
-	// validity window trails it by that moment, and a served TTL is whole
-	// seconds anyway — the last fraction is the wire's granularity, which
-	// servedSeconds already concedes. Not so for a signature permitting
-	// nothing at all: a header or Original TTL of zero is RFC 4035 §5.3.3's
-	// ceiling exactly, and the tolerance was letting a one-second entry
-	// serve it as one.
+	// permits — exactly. The lifetime and this check read the same clock
+	// (newCacheEntryAt), so there is no measurement gap to forgive, and a
+	// served TTL rounds only at the serve point: RFC 4035 §5.3.3's ceiling
+	// is not a place for tolerance, a one-second signature admitted to a
+	// two-second entry was served past it whole.
 	honours := func(sig *dns.RRSIG) bool {
 		permits, valid := dnsutil.SignatureLifetime(sig, now)
-		return valid && permits > 0 && permits+time.Second >= lifetime
+		return valid && permits >= lifetime
 	}
 
-	// Signatures the entry cannot carry, and those it can. Both are empty
-	// on the common path, an unsigned additional section, and cost nothing.
-	var unsafe, safe []*dns.RRSIG
+	// Every signature, with its verdict. Empty on the common path, an
+	// unsigned additional section, and costs nothing there.
+	type judged struct {
+		sig  *dns.RRSIG
+		kept bool
+	}
+	var sigs []judged
 	for _, rr := range records {
 		if sig, ok := rr.(*dns.RRSIG); ok {
-			if honours(sig) {
-				safe = append(safe, sig)
-			} else {
-				unsafe = append(unsafe, sig)
-			}
+			sigs = append(sigs, judged{sig: sig, kept: honours(sig)})
 		}
 	}
-	covers := func(sigs []*dns.RRSIG, name string, class, rrtype uint16) bool {
-		for _, sig := range sigs {
-			if sig.TypeCovered == rrtype && sig.Hdr.Class == class && strings.EqualFold(sig.Hdr.Name, name) {
+	over := func(sig *dns.RRSIG, name string, class, rrtype uint16) bool {
+		return sig.TypeCovered == rrtype && sig.Hdr.Class == class && strings.EqualFold(sig.Hdr.Name, name)
+	}
+	// condemned: a signed RRset the entry cannot carry honestly. Either
+	// nothing left signs it, or its signatures name more than one signer.
+	// The second is the delegation boundary, where the parent's NSEC over
+	// the child's name and the child's apex NSEC share owner, class and
+	// type (RFC 4035 §5.3.2): on the wire that is one RRset, its records
+	// cannot be told apart by signer, and a live child signature was
+	// carrying the parent's lapsed records with it. Such a tuple goes
+	// whole, signatures included.
+	condemned := func(name string, class, rrtype uint16) bool {
+		signed, kept := false, false
+		var signer string
+		for _, j := range sigs {
+			if !over(j.sig, name, class, rrtype) {
+				continue
+			}
+			if signed && !strings.EqualFold(signer, j.sig.SignerName) {
 				return true
 			}
+			signed, signer = true, j.sig.SignerName
+			kept = kept || j.kept
 		}
-		return false
-	}
-	// condemned: a signed RRset with nothing left to sign it.
-	condemned := func(name string, class, rrtype uint16) bool {
-		return len(unsafe) > 0 && covers(unsafe, name, class, rrtype) && !covers(safe, name, class, rrtype)
+		return signed && !kept
 	}
 
 	extra := make([]dns.RR, 0, len(records))
@@ -725,7 +749,7 @@ func storableAdditional(records []dns.RR, now time.Time, lifetime time.Duration)
 			}
 			continue
 		case *dns.RRSIG:
-			if !honours(r) {
+			if !honours(r) || condemned(r.Hdr.Name, r.Hdr.Class, r.TypeCovered) {
 				continue
 			}
 		default:

--- a/middleware/cache/types.go
+++ b/middleware/cache/types.go
@@ -129,11 +129,37 @@ func (e *CacheEntry) remaining(now time.Time) time.Duration {
 	return rem
 }
 
+// servedSeconds is the TTL written into an answer this cache is serving.
+//
+// A hit never carries a TTL of zero. Zero tells the client the answer must not
+// be reused, while this cache is doing exactly that, and for a denial RFC 2308
+// §5 forbids reusing one whose lifetime has reached zero at all. An entry with
+// 991ms left was reported alive and then served with a TTL of zero.
+//
+// The last fraction of a second rounds up, which is the only thing a
+// whole-second field leaves to do once the entry is still alive. It is bounded
+// by that fraction: the entry stops being served at its own expiry either way.
+func servedSeconds(remaining time.Duration) uint32 {
+	if remaining <= 0 {
+		return 0
+	}
+	if secs := remaining / time.Second; secs > 0 {
+		return uint32(secs) //nolint:gosec // G115 - bounded by MaxCacheTTL
+	}
+	return 1
+}
+
 // remainingBounds returns the two independent lifetimes that remaining folds
 // together: the answer TTL and the delegation lease. A zero cutUntil is
 // unbounded and therefore returns zero for leaseRemaining; callers must check
 // cutUntil before interpreting that value as an expired lease.
 func (e *CacheEntry) remainingBounds(now time.Time) (ttlRemaining, leaseRemaining time.Duration) {
+	// Both are exact. Quantising the age here to whole seconds was tried and
+	// is wrong twice over: it lets an answer outlive the delegation lease,
+	// which is a security bound (GHSA-mqfw-f48p-2vc8), and it keeps an entry
+	// whose own lifetime is under a second alive for a full one. Whether the
+	// entry is alive is a question about time; what TTL to write is a question
+	// about the wire format, and servedSeconds answers that one.
 	ttlRemaining = e.ttl - now.Sub(e.stored)
 	if !e.cutUntil.IsZero() {
 		leaseRemaining = e.cutUntil.Sub(now)
@@ -320,7 +346,7 @@ func (e *CacheEntry) ToMsg(req *dns.Msg) *dns.Msg {
 	}
 
 	// Update TTLs
-	ttl := uint32(remainingTTL.Seconds())
+	ttl := servedSeconds(remainingTTL)
 	for _, rr := range resp.Answer {
 		rr.Header().Ttl = ttl
 	}
@@ -521,20 +547,19 @@ func (tm TTLManager) Calculate(msgTTL time.Duration) time.Duration {
 	return msgTTL
 }
 
-// (TTLManager).CalculateFor returns the effective TTL for a response of this
-// type. A denial takes its RFC 2308 lifetime as a ceiling and is bounded from
-// above only: the configured minimum is the resolver's own freshness policy,
-// and applying it to a denial would hold that denial past what the zone's SOA
-// authorised. Everything else keeps both bounds.
+// (TTLManager).Bound applies the upper bound to a lifetime that has already
+// been decided, and nothing else.
 //
-// The distinction has to be drawn on the response type rather than on which
-// sub-cache the entry lands in: NXDOMAIN and NODATA are stored in the positive
-// cache alongside ordinary answers, and the cache named `negative` holds
-// SERVFAIL. Bounding by sub-cache would floor every denial right back.
-func (tm TTLManager) CalculateFor(mt dnsutil.ResponseType, msgTTL time.Duration) time.Duration {
-	if mt != dnsutil.TypeNXDomain && mt != dnsutil.TypeNoRecords {
-		return tm.Calculate(msgTTL)
-	}
+// It deliberately carries no floor. dnsutil.CalculateCacheTTL is the only place
+// that knows what may not be lifted: a signature with two seconds left, an SOA
+// that granted one. A second floor here cannot see any of that, and it does not
+// merely duplicate the first one, it undoes it. A signed answer correctly
+// bounded to two seconds on the way in was admitted for five, and served after
+// its signature had lapsed.
+//
+// The rule this leaves is simple enough to keep: the lower bound is decided
+// once, where the evidence is, and every layer after it may only shorten.
+func (tm TTLManager) Bound(msgTTL time.Duration) time.Duration {
 	if msgTTL < 0 {
 		return 0
 	}

--- a/middleware/cache/types.go
+++ b/middleware/cache/types.go
@@ -521,6 +521,29 @@ func (tm TTLManager) Calculate(msgTTL time.Duration) time.Duration {
 	return msgTTL
 }
 
+// (TTLManager).CalculateFor returns the effective TTL for a response of this
+// type. A denial takes its RFC 2308 lifetime as a ceiling and is bounded from
+// above only: the configured minimum is the resolver's own freshness policy,
+// and applying it to a denial would hold that denial past what the zone's SOA
+// authorised. Everything else keeps both bounds.
+//
+// The distinction has to be drawn on the response type rather than on which
+// sub-cache the entry lands in: NXDOMAIN and NODATA are stored in the positive
+// cache alongside ordinary answers, and the cache named `negative` holds
+// SERVFAIL. Bounding by sub-cache would floor every denial right back.
+func (tm TTLManager) CalculateFor(mt dnsutil.ResponseType, msgTTL time.Duration) time.Duration {
+	if mt != dnsutil.TypeNXDomain && mt != dnsutil.TypeNoRecords {
+		return tm.Calculate(msgTTL)
+	}
+	if msgTTL < 0 {
+		return 0
+	}
+	if msgTTL > tm.max {
+		return tm.max
+	}
+	return msgTTL
+}
+
 // CacheMetrics tracks cache performance metrics.
 type CacheMetrics struct {
 	hits       atomic.Int64

--- a/middleware/cache/types.go
+++ b/middleware/cache/types.go
@@ -131,14 +131,20 @@ func (e *CacheEntry) remaining(now time.Time) time.Duration {
 
 // servedSeconds is the TTL written into an answer this cache is serving.
 //
-// A hit never carries a TTL of zero. Zero tells the client the answer must not
-// be reused, while this cache is doing exactly that, and for a denial RFC 2308
-// §5 forbids reusing one whose lifetime has reached zero at all. An entry with
-// 991ms left was reported alive and then served with a TTL of zero.
+// A hit never carries a TTL of zero: that tells the client not to reuse an
+// answer the cache is reusing, and RFC 2308 §5 rules it out for a denial
+// outright. The last fraction of a second therefore rounds up to one.
 //
-// The last fraction of a second rounds up, which is the only thing a
-// whole-second field leaves to do once the entry is still alive. It is bounded
-// by that fraction: the entry stops being served at its own expiry either way.
+// Retiring such an entry instead was tried and does not work. An entry admitted
+// for exactly one second, which is what a zone publishing a one-second SOA
+// MINIMUM asks for, is already under a second by the time anything looks it up,
+// so the rule that refuses to serve it also makes every one-second lifetime
+// uncacheable. Honouring the zone's one second and then never using it is not a
+// stricter reading, it is a pointless one.
+//
+// What is left is the granularity of the wire format: a client can hold the
+// last fraction of a second past the bound, because a DNS TTL cannot express
+// less. This cache stops serving at the bound exactly.
 func servedSeconds(remaining time.Duration) uint32 {
 	if remaining <= 0 {
 		return 0

--- a/middleware/cache/types.go
+++ b/middleware/cache/types.go
@@ -205,8 +205,11 @@ func (e *CacheEntry) scoped() bool { return e.scope.IsValid() }
 func (e *CacheEntry) PrefetchEligible() bool { return !e.scoped() }
 
 // NewCacheEntryWithKey creates a new cache entry with a specific key for rate
-// limiting. A message that cannot be packed returns nil — such a response was
-// never servable on the wire, so declining to cache it is the safe outcome.
+// limiting. It returns nil for a message that cannot be packed — such a
+// response was never servable on the wire, so declining to cache it is the
+// safe outcome — and for an explicit RRSIG answer the stored view would
+// thin, which a hit may not answer with fewer signatures than the first
+// response did. Callers treat nil as "not cacheable" either way.
 func NewCacheEntryWithKey(msg *dns.Msg, ttl time.Duration, rateLimit int, key uint64) *CacheEntry {
 	// Assemble the storable view and filter out OPT records (matching V1
 	// behavior): OPT is per-client hop metadata the serve path rebuilds.
@@ -672,10 +675,13 @@ func storableAdditional(records []dns.RR, now time.Time, lifetime time.Duration)
 	// moment before this check, so a signature sharing the answer's own
 	// validity window trails it by that moment, and a served TTL is whole
 	// seconds anyway — the last fraction is the wire's granularity, which
-	// servedSeconds already concedes.
+	// servedSeconds already concedes. Not so for a signature permitting
+	// nothing at all: a header or Original TTL of zero is RFC 4035 §5.3.3's
+	// ceiling exactly, and the tolerance was letting a one-second entry
+	// serve it as one.
 	honours := func(sig *dns.RRSIG) bool {
 		permits, valid := dnsutil.SignatureLifetime(sig, now)
-		return valid && permits+time.Second >= lifetime
+		return valid && permits > 0 && permits+time.Second >= lifetime
 	}
 
 	// Signatures the entry cannot carry, and those it can. Both are empty

--- a/middleware/cache/types.go
+++ b/middleware/cache/types.go
@@ -119,7 +119,8 @@ func (e *CacheEntry) CompareAndStampSidecar(prev, next *middleware.Sidecar) bool
 }
 
 // remaining returns the entry's effective remaining lifetime at now:
-// the stored TTL minus elapsed time, further bounded by cutUntil.
+// the stored TTL minus elapsed time, further bounded by cutUntil. It says
+// whether the entry may be served; servedTTL says what TTL to write.
 func (e *CacheEntry) remaining(now time.Time) time.Duration {
 	rem, leaseRem := e.remainingBounds(now)
 	if !e.cutUntil.IsZero() {
@@ -128,6 +129,27 @@ func (e *CacheEntry) remaining(now time.Time) time.Duration {
 		}
 	}
 	return rem
+}
+
+// servedTTL is the TTL a hit writes at now: servedSeconds of the entry's
+// remaining lifetime, with one exception. When the delegation lease is the
+// binding bound it is a security bound, the parent's grant
+// (GHSA-mqfw-f48p-2vc8), and its last fraction of a second is not rounded up
+// into a whole second the parent never granted: the answer goes out with a
+// TTL of zero, nothing to keep. The round-up is the entry's own concession
+// about its own lifetime. A one-second lease stays servable for its second
+// this way, where declining the hit instead made it unservable from the
+// moment it was stored; the stale path, which RFC 8767 forbids a zero,
+// declines the same remainder.
+func (e *CacheEntry) servedTTL(now time.Time) uint32 {
+	rem, leaseRem := e.remainingBounds(now)
+	if !e.cutUntil.IsZero() && leaseRem < rem {
+		if leaseRem < time.Second {
+			return 0
+		}
+		rem = leaseRem
+	}
+	return servedSeconds(rem)
 }
 
 // servedSeconds is the TTL written into an answer this cache is serving.
@@ -145,7 +167,10 @@ func (e *CacheEntry) remaining(now time.Time) time.Duration {
 //
 // What is left is the granularity of the wire format: a client can hold the
 // last fraction of a second past the bound, because a DNS TTL cannot express
-// less. This cache stops serving at the bound exactly.
+// less. This cache stops serving at the bound exactly. That concession is
+// the entry's own to make, about its own lifetime; servedTTL withholds it
+// from a delegation lease, so a client is never rounded past the parent's
+// grant.
 func servedSeconds(remaining time.Duration) uint32 {
 	if remaining <= 0 {
 		return 0
@@ -380,7 +405,7 @@ func (e *CacheEntry) ToMsg(req *dns.Msg) *dns.Msg {
 	}
 
 	// Update TTLs
-	ttl := servedSeconds(remainingTTL)
+	ttl := e.servedTTL(now)
 	for _, rr := range resp.Answer {
 		rr.Header().Ttl = ttl
 	}

--- a/middleware/cache/types.go
+++ b/middleware/cache/types.go
@@ -215,6 +215,16 @@ func NewCacheEntryWithKey(msg *dns.Msg, ttl time.Duration, rateLimit int, key ui
 	msgCopy.Answer = msg.Answer
 	msgCopy.Ns = msg.Ns
 
+	// An entry never carries AD over data whose signatures have lapsed
+	// (RFC 4035 §3.2.3). The writer clears the bit on the response it sends,
+	// but it does so after the stores, and an entry that kept the bit would
+	// hand it back on every later hit. Normalised here, on the storable view
+	// and before packing, so no admission path can miss it. Checked only
+	// when the bit is set: unsigned and unvalidated data pays nothing.
+	if msgCopy.AuthenticatedData && dnsutil.HasExpiredSignatures(msg, time.Now().UTC()) {
+		msgCopy.AuthenticatedData = false
+	}
+
 	var ede *dns.EDNS0_EDE
 
 	// Filter Extra section to remove OPT records but preserve EDE

--- a/middleware/cache/types.go
+++ b/middleware/cache/types.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"errors"
 	"net/netip"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -225,6 +226,16 @@ func NewCacheEntryWithKey(msg *dns.Msg, ttl time.Duration, rateLimit int, key ui
 	msgCopy.Answer = storableRecords(msg.Answer, now)
 	msgCopy.Ns = storableRecords(msg.Ns, now)
 
+	// An explicit RRSIG question asks for the signatures themselves, and
+	// the lapsed and pending ones are as much the answer as the live one
+	// (RFC 4035 §3.2.1): the record is the data, so a hit may not answer
+	// with fewer than the first response did. If storing would drop any,
+	// the answer is not stored.
+	if len(msg.Question) > 0 && msg.Question[0].Qtype == dns.TypeRRSIG &&
+		(len(msgCopy.Answer) != len(msg.Answer) || len(msgCopy.Ns) != len(msg.Ns)) {
+		return nil
+	}
+
 	// An entry never carries AD over data whose signatures have lapsed
 	// (RFC 4035 §3.2.3). The writer clears the bit on the response it sends,
 	// but it does so after the stores, and an entry that kept the bit would
@@ -236,32 +247,8 @@ func NewCacheEntryWithKey(msg *dns.Msg, ttl time.Duration, rateLimit int, key ui
 	}
 
 	var ede *dns.EDNS0_EDE
-
-	// Filter Extra section to remove OPT records but preserve EDE. Its
-	// signatures go too: the additional section bounds neither AD nor the
-	// entry's lifetime (RFC 4035 §3.2.3, nothing validates glue), so a glue
-	// signature's TTL would be inflated on every hit the same way.
 	if len(msg.Extra) > 0 {
-		extra := make([]dns.RR, 0, len(msg.Extra))
-		for _, rr := range msg.Extra {
-			switch opt := rr.(type) {
-			case *dns.OPT:
-				// Extract EDE from OPT record if present. By value: the
-				// long-lived entry must not alias an option inside the
-				// caller's live message.
-				for _, option := range opt.Option {
-					if e, ok := option.(*dns.EDNS0_EDE); ok {
-						private := *e
-						ede = &private
-						break
-					}
-				}
-			case *dns.RRSIG:
-			default:
-				extra = append(extra, rr)
-			}
-		}
-		msgCopy.Extra = extra
+		msgCopy.Extra, ede = storableAdditional(msg.Extra, now, ttl)
 	}
 
 	// Name compression keeps the stored form smaller than the upstream wire.
@@ -659,4 +646,89 @@ func storableRecords(records []dns.RR, now time.Time) []dns.RR {
 		kept = append(kept, rr)
 	}
 	return kept
+}
+
+// storableAdditional returns the additional section as the entry stores it:
+// without the OPT, whose EDE is returned by value, and with every signed
+// RRset either kept with its signatures or removed with them.
+//
+// The additional section bounds neither AD nor the entry's lifetime (RFC
+// 4035 §3.2.3; nothing validates it), and every hit serves each record with
+// that lifetime as its TTL. So a signature here can be kept only when it
+// permits at least the entry's lifetime — a live one carrying a shorter TTL
+// would be handed out inflated, and one outside its validity period would be
+// handed out at all. A signed RRset does not go on without its signature,
+// either: RFC 4035 §3.1.1 has the two travel together, and a mail exchanger's
+// address that arrived signed and was served bare on the next hit is a
+// different answer. An RRset none of whose signatures can be kept leaves with
+// them; a lapsed sibling beside a signature that can be kept leaves alone, as
+// it does in the answer. Unsigned records already bound the lifetime through
+// their own TTLs and stay.
+func storableAdditional(records []dns.RR, now time.Time, lifetime time.Duration) ([]dns.RR, *dns.EDNS0_EDE) {
+	var ede *dns.EDNS0_EDE
+
+	// honours reports whether the entry's lifetime stays within what sig
+	// permits. Within a second of it counts: the lifetime was measured a
+	// moment before this check, so a signature sharing the answer's own
+	// validity window trails it by that moment, and a served TTL is whole
+	// seconds anyway — the last fraction is the wire's granularity, which
+	// servedSeconds already concedes.
+	honours := func(sig *dns.RRSIG) bool {
+		permits, valid := dnsutil.SignatureLifetime(sig, now)
+		return valid && permits+time.Second >= lifetime
+	}
+
+	// Signatures the entry cannot carry, and those it can. Both are empty
+	// on the common path, an unsigned additional section, and cost nothing.
+	var unsafe, safe []*dns.RRSIG
+	for _, rr := range records {
+		if sig, ok := rr.(*dns.RRSIG); ok {
+			if honours(sig) {
+				safe = append(safe, sig)
+			} else {
+				unsafe = append(unsafe, sig)
+			}
+		}
+	}
+	covers := func(sigs []*dns.RRSIG, name string, class, rrtype uint16) bool {
+		for _, sig := range sigs {
+			if sig.TypeCovered == rrtype && sig.Hdr.Class == class && strings.EqualFold(sig.Hdr.Name, name) {
+				return true
+			}
+		}
+		return false
+	}
+	// condemned: a signed RRset with nothing left to sign it.
+	condemned := func(name string, class, rrtype uint16) bool {
+		return len(unsafe) > 0 && covers(unsafe, name, class, rrtype) && !covers(safe, name, class, rrtype)
+	}
+
+	extra := make([]dns.RR, 0, len(records))
+	for _, rr := range records {
+		switch r := rr.(type) {
+		case *dns.OPT:
+			// Extract EDE from OPT record if present. By value: the
+			// long-lived entry must not alias an option inside the
+			// caller's live message.
+			for _, option := range r.Option {
+				if e, ok := option.(*dns.EDNS0_EDE); ok {
+					private := *e
+					ede = &private
+					break
+				}
+			}
+			continue
+		case *dns.RRSIG:
+			if !honours(r) {
+				continue
+			}
+		default:
+			h := r.Header()
+			if condemned(h.Name, h.Class, h.Rrtype) {
+				continue
+			}
+		}
+		extra = append(extra, rr)
+	}
+	return extra, ede
 }

--- a/middleware/cache/types.go
+++ b/middleware/cache/types.go
@@ -209,11 +209,21 @@ func (e *CacheEntry) PrefetchEligible() bool { return !e.scoped() }
 func NewCacheEntryWithKey(msg *dns.Msg, ttl time.Duration, rateLimit int, key uint64) *CacheEntry {
 	// Assemble the storable view and filter out OPT records (matching V1
 	// behavior): OPT is per-client hop metadata the serve path rebuilds.
+	now := time.Now().UTC()
 	msgCopy := new(dns.Msg)
 	msgCopy.MsgHdr = msg.MsgHdr
 	msgCopy.Question = msg.Question
-	msgCopy.Answer = msg.Answer
-	msgCopy.Ns = msg.Ns
+	// The entry keeps only the signatures it vouches for. Every hit path
+	// serves these bytes with each record's TTL set to the entry's remaining
+	// lifetime, and that lifetime is bounded by the usable signatures alone
+	// (dnsutil.CalculateCacheTTL): a signature outside its validity period
+	// — a rollover's lapsed sibling, or one whose inception has not arrived
+	// — was received with whatever TTL it carried and would be handed out
+	// on the next hit with the entry's, a zero returned as an hour, and the
+	// not-yet-valid one revived once its inception passed. The uncached
+	// first response still carries them as the authority sent them.
+	msgCopy.Answer = storableRecords(msg.Answer, now)
+	msgCopy.Ns = storableRecords(msg.Ns, now)
 
 	// An entry never carries AD over data whose signatures have lapsed
 	// (RFC 4035 §3.2.3). The writer clears the bit on the response it sends,
@@ -221,17 +231,21 @@ func NewCacheEntryWithKey(msg *dns.Msg, ttl time.Duration, rateLimit int, key ui
 	// hand it back on every later hit. Normalised here, on the storable view
 	// and before packing, so no admission path can miss it. Checked only
 	// when the bit is set: unsigned and unvalidated data pays nothing.
-	if msgCopy.AuthenticatedData && dnsutil.HasExpiredSignatures(msg, time.Now().UTC()) {
+	if msgCopy.AuthenticatedData && dnsutil.HasExpiredSignatures(msg, now) {
 		msgCopy.AuthenticatedData = false
 	}
 
 	var ede *dns.EDNS0_EDE
 
-	// Filter Extra section to remove OPT records but preserve EDE
+	// Filter Extra section to remove OPT records but preserve EDE. Its
+	// signatures go too: the additional section bounds neither AD nor the
+	// entry's lifetime (RFC 4035 §3.2.3, nothing validates glue), so a glue
+	// signature's TTL would be inflated on every hit the same way.
 	if len(msg.Extra) > 0 {
 		extra := make([]dns.RR, 0, len(msg.Extra))
 		for _, rr := range msg.Extra {
-			if opt, ok := rr.(*dns.OPT); ok {
+			switch opt := rr.(type) {
+			case *dns.OPT:
 				// Extract EDE from OPT record if present. By value: the
 				// long-lived entry must not alias an option inside the
 				// caller's live message.
@@ -242,7 +256,8 @@ func NewCacheEntryWithKey(msg *dns.Msg, ttl time.Duration, rateLimit int, key ui
 						break
 					}
 				}
-			} else {
+			case *dns.RRSIG:
+			default:
 				extra = append(extra, rr)
 			}
 		}
@@ -620,4 +635,28 @@ func (m *CacheMetrics) Prefetch() {
 // (*CacheMetrics).Stats stats returns current metrics.
 func (m *CacheMetrics) Stats() (hits, misses, evictions, prefetches int64) {
 	return m.hits.Load(), m.misses.Load(), m.evictions.Load(), m.prefetches.Load()
+}
+
+// storableRecords returns records without the signatures that are outside
+// their validity period at now. The common shape, nothing to drop, passes
+// the caller's slice through untouched — this runs on every admission, and
+// a response carries a lapsed or not-yet-valid signature only mid-rollover.
+func storableRecords(records []dns.RR, now time.Time) []dns.RR {
+	drop := 0
+	for _, rr := range records {
+		if sig, ok := rr.(*dns.RRSIG); ok && !sig.ValidityPeriod(now) {
+			drop++
+		}
+	}
+	if drop == 0 {
+		return records
+	}
+	kept := make([]dns.RR, 0, len(records)-drop)
+	for _, rr := range records {
+		if sig, ok := rr.(*dns.RRSIG); ok && !sig.ValidityPeriod(now) {
+			continue
+		}
+		kept = append(kept, rr)
+	}
+	return kept
 }

--- a/middleware/forwarder/forwarder_test.go
+++ b/middleware/forwarder/forwarder_test.go
@@ -657,35 +657,49 @@ func startTruncatingForwarderServers(t *testing.T) (
 		_ = w.WriteMsg(resp)
 	})
 	// The forwarder retries TCP against the same server address, so both
-	// listeners must hold the same port. Only one of the two draws it from
-	// :0, and it is the TCP one on purpose: a port the kernel hands out for
-	// TCP is one TCP can bind, whereas a port drawn for UDP carries no such
-	// promise for TCP — on Windows it can sit inside a range excluded for
-	// the other protocol, where the bind fails with a permission error.
-	// Drawing on the constrained side turns the likely failure into the
-	// unlikely one; the redraw covers what is left.
+	// listeners must hold the same port, and only one of them can draw it
+	// from :0. Windows keeps per-protocol exclusion ranges, so a port one
+	// protocol is given is not necessarily one the other may bind; the bind
+	// fails there with a permission error rather than "in use".
+	//
+	// Which side draws is alternated rather than fixed. Ten consecutive
+	// TCP-first draws failed on a CI runner, which is what a fixed choice
+	// looks like when the allocator hands out a sequential run inside one
+	// exclusion block: every redraw lands in the same place. The two
+	// protocols allocate from different state, so letting each take a turn
+	// means a block that swallows one side's run does not swallow the
+	// other's.
+	const attempts = 64
 	var (
 		packet   net.PacketConn
 		listener net.Listener
 	)
 	for attempt := 1; ; attempt++ {
 		var err error
-		listener, err = net.Listen("tcp", "127.0.0.1:0")
-		if err != nil {
-			t.Fatalf("listen TCP: %v", err)
-		}
-		host, port, err := net.SplitHostPort(listener.Addr().String())
-		if err != nil {
+		if attempt%2 == 1 {
+			listener, err = net.Listen("tcp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatalf("listen TCP: %v", err)
+			}
+			packet, err = net.ListenPacket("udp", listener.Addr().String())
+			if err == nil {
+				break
+			}
 			_ = listener.Close()
-			t.Fatalf("split TCP address: %v", err)
+		} else {
+			packet, err = net.ListenPacket("udp", "127.0.0.1:0")
+			if err != nil {
+				t.Fatalf("listen UDP: %v", err)
+			}
+			listener, err = net.Listen("tcp", packet.LocalAddr().String())
+			if err == nil {
+				break
+			}
+			_ = packet.Close()
 		}
-		packet, err = net.ListenPacket("udp", net.JoinHostPort(host, port))
-		if err == nil {
-			break
-		}
-		_ = listener.Close()
-		if attempt == 10 {
-			t.Fatalf("listen UDP on TCP port after %d attempts: %v", attempt, err)
+		if attempt == attempts {
+			t.Fatalf("no loopback port both transports would accept in %d attempts: %v",
+				attempts, err)
 		}
 	}
 	udpServer := &dns.Server{Net: "udp", PacketConn: packet, Handler: udpMux}


### PR DESCRIPTION
The cache serves only what it vouches for, at a TTL it can honour, with no DNSSEC record a DO=0 client did not ask for. That is the one rule every change here enforces. It started as a fix to the negative TTL floor and grew, under review, into the signature and stored-view rules that the same invariant requires.

## 1. A denial's TTL is a ceiling, not a floor

RFC 2308 §5 derives a denial's lifetime from the SOA, the smaller of its header TTL and its MINIMUM field, and says how long a resolver *may* cache it. sdns raised anything shorter to five seconds. A zone publishing a one-second negative TTL means one second.

- The floor was applied twice, in the derivation (`MinCacheTTL`) and again in `TTLManager` on the way to admission. Both are gone for denials. Positive answers keep the floor: a negative TTL is the zone's statement about its denial, a floor on a positive answer is only the resolver deciding how often to re-ask.
- A denial the zone granted no lifetime is not admitted, and neither is an answer merged from an exhausted denial. A denial arriving without a SOA is not cached.
- The lifetime is settled once at admission, every client is told the same TTL the first was told, and a hit never carries a zero TTL: the last fraction of a second rounds up to one, which is the wire's granularity. The one exception is a delegation lease in its last fraction of a second, which is the parent's bound to round, not the cache's: the answer goes out with a TTL of zero, on the first response and on every hit path alike.
- An expired signature bounds the data at zero rather than at the floor (RFC 4035 §5.3.3).

## 2. Which signatures vouch for an RRset

`eachSignedRRset` groups a response's signatures per RRset and reports, for each, whether any signature still covers it and the shortest lifetime the covering ones permit.

- A signature counts only inside its validity period, both ends, through the validator's own `RRSIG.ValidityPeriod` (RFC 4035 §5.3.1). A signature whose inception has not arrived rescues nothing.
- Two signatures are siblings only when section, owner, signer, class and covered type all agree. The signer matters at a delegation, where the parent's NSEC over the child's name and the child's apex NSEC share owner and type (§5.3.2). The section matters because an authority proof and additional glue can share both.
- Names compare as DNS names (`dnsname.CanonicalCompare`): escapes decoded, case folded over ASCII only. A text fold was wrong in both directions, an escaped spelling was a different RRset and a Kelvin sign was the same one as a k. Identical spellings short-circuit on a byte comparison.
- Among usable siblings the shortest lifetime wins, in either wire order. Zero is a real value (an Original TTL of zero authorises nothing), tracked apart from "unset".
- Single pass. Up to eight distinct RRsets live in a stack array with no allocation; past that the walk indexes through a map keyed on the same canonical form.

## 3. The entry's lifetime

`CalculateCacheTTL` takes two bounds apart: what the records advertise, and what the usable signatures fix (header TTL, Original TTL, time to expiry). The floor may lift the first, never the second.

- RRSIG header TTLs reach the lifetime only through usable signatures. A lapsed sibling or a glue signature carrying a header TTL of zero was zeroing a fully covered answer.
- The additional section bounds neither AD nor the lifetime (RFC 4035 §3.2.3, nothing validates glue). Its record TTLs still bound.
- Admission reads one clock: classification, the lifetime, the entry's stored instant and every decision about what the entry may carry (`CalculateCacheTTLAt`, `newCacheEntryAt`). Two readings a moment apart made a signature sharing the answer's validity window fall short by microseconds.

## 4. What the entry stores

Every hit path serves the packed entry with each record's TTL set to the entry's remaining lifetime, so the stored view is where honesty is decided.

- Signatures outside their validity period are not stored. A lapsed sibling received with TTL 0 came back as an hour; one whose inception had not arrived would have been revived once it had.
- An explicit RRSIG question is stored whole or not at all (§3.2.1): a hit may not answer with fewer signatures than the first response did.
- A signed additional RRset keeps its signatures or leaves with them (§3.1.1). It stays only when every signature over it is valid, permits at least the entry's lifetime, exactly, and the records were received with at least that TTL; a tuple signed by more than one signer leaves whole, since its records cannot be told apart by signer. Unsigned glue stays.
- AD is normalised on the storable view before packing: an entry never carries AD over data whose signatures have lapsed, whichever path admitted it.
- A response with nothing to drop is stored from the caller's slices, and the caller's message is never edited.
- A hit on an alias whose target the chase resolves fresh applies the outgoing checks to the merged records, AD withdrawn when a signature has lapsed and TTLs bounded by the merged records and the request's cut, exactly as a miss does. The internal sub-query's own write skips both, as every internal write does, so the hit was serving the target raw.

## 5. The DO=0 shape

RFC 4035 §3.2.1: a DO=0 response carries no authenticating record it did not ask for, and keeps the one type it named.

- `ClearDNSSEC` filters every section, the additional one included, and its exception is the type the question named: a query for RRSIG keeps its signatures and loses the NSEC that came along, a query for NSEC keeps the NSEC and loses the signatures. `ClearDNSSECInPlace` is the same rule for a synthesized answer that owns its sections.
- The packed body's DNSSEC flag is taken the same way, from every section, leaving out the asked-for type, so the stripped body exists exactly when the Msg path would filter something. The RRSIG-only special cases in the stripped-body preparation, the DO=0 body selection and the writer-chain reply facts are gone; the flag is the one source of truth.
- The synthesized denials (aggressive cache, subtree cut) shape DO=0 through the same function. The cut's wire templates hold neither shape for an explicit DNSSEC question, so the wire path declines those before leasing and the Msg path answers.

## What a client sees differently

- A denial at its zone's TTL, never lifted to five seconds.
- A fresh answer at the authority's TTL, and on hits a TTL bounded by the answer's own records and usable signatures, never by a signature the entry ignores.
- No lapsed or pending signature from the cache, in any section.
- A signed additional RRset either complete, with its signatures, or absent.
- At DO=0, exactly the authenticating type it asked for and nothing else, on the miss, on the Msg hit, as bytes, and from the synthesized denials.

## Performance

Clean machine, sequential, 10 samples, main against this branch.

| path | main | branch |
|---|---|---|
| wire hit | 383 ns | 380 ns |
| wire hit, DO=0 stripped | 367 ns | 362 ns |
| Msg hit baseline | 386 ns | 382 ns |
| ToMsg | 194 ns | 188 ns |
| aggressive denial lookup, 4 / 32 records | 399 / 686 ns | 403 / 685 ns |
| admission | 916 ns | 957 ns |
| admission, signed | 879 ns | 908 ns |

Hit paths are unchanged, two redundant question-type checks were removed from them. Admission, the miss path, pays 30 to 40 ns per response for the extra passes. The signature walk costs 17 ns for one signature and 476 ns for four, with no allocation; past eight distinct RRsets it allocates for the map.

## Tests

Every rule above is pinned, and each pin was watched go red before the fix it guards.

- Denial TTL at 0, 1, 4 and 5 seconds for NXDOMAIN and NODATA, at the derivation and through admission.
- Sibling validity, identity and order: future inception, foreign signer, foreign section, zero and hour in both orders, past the inline capacity.
- The canonical-identity matrix: escaped and plain, rooted and unrooted, ASCII case merge; a Kelvin sign does not; owner and signer; both grouping paths; both wire orders; through `HasExpiredSignatures`, admission, AD and the served TTL.
- The stored view: lapsed and pending signatures not revived, explicit RRSIG whole or nothing, additional tuple kept or dropped by signature lifetime, received TTL, signer and DNS-name matching, exact zero refused, one clock.
- DO=0 on every path, including the synthesized denials and the cut's wire precheck through the writer with a lease-counting transport.
- An alias hit with a freshly chased target, signed for two seconds and lapsed, against the miss path's outcome; a sub-second delegation lease served as zero on the first response and on a hit, whole seconds served as whole seconds.
- An independent review pass by a second model found the alias-hit gap and the lease rounding; both are fixed here.
- Allocation pins: the walk's common path, the storable-records pass, the in-place filter.

## Out of scope, tracked separately

- Reusing one signature analysis across classification, lifetime, writer and entry (four passes today, each small).
- Allocation on very large responses (hundreds of signed RRsets), which is the miss pipeline as a whole.
- The same DNS-name comparison in `dnsutil/rrset.go`, the store's collision verification and the denial-proof NextDomain check; the direction there is conservative, they are not part of this rule.
- A resolver allocation-guard test that fails under full-suite load and passes in isolation.

## Documentation

The cache page (`docs/_docs/configuration/cache.md`) gains a "What a hit contains" section covering the four client-visible rules above, and its RFC 4035 paragraph now says which signature sets the bound during a key rollover and that the additional section bounds neither the lifetime nor AD.
