### PR TITLE
resolver: ANY is declined on every path, and the refusal is never a cached failure

### DIFF
--- a/docs/_docs/deployment/diagnostics.md
+++ b/docs/_docs/deployment/diagnostics.md
@@ -152,7 +152,9 @@ resolver is already routing around the bad ones.
 in enforce, an expensive resolution can be terminated. Check
 `dns_recursion_firewall_exhaustions_total` by `reason`.
 
-**7. Is it a query type sdns declines?** `ANY` is answered NOTIMP by design.
+**7. Is it a query type sdns declines?** `ANY` is answered NOTIMP by design,
+in every mode, forwarding included, and the refusal is never cached as a
+failure: the next question for the same name resolves normally.
 
 ## Confirming what is running
 

--- a/internal/dnsutil/any_classify_test.go
+++ b/internal/dnsutil/any_classify_test.go
@@ -1,0 +1,50 @@
+package dnsutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/miekg/dns"
+)
+
+// TestClassifyANYAndNotImplemented pins the two classifier facts behind the
+// ANY policy. An ANY answer holds records of every type but never one of
+// type 255, so it is answered by whatever it carries: a full answer that
+// happened to include a SOA was read as a NODATA denial. And NOTIMP is a
+// statement about the question, not a resolution failure: classified as
+// one, it was recorded in the failure cache and the next identical question
+// was answered SERVFAIL from there.
+func TestClassifyANYAndNotImplemented(t *testing.T) {
+	now := time.Now()
+	soa := &dns.SOA{
+		Hdr: dns.RR_Header{Name: "example.", Rrtype: dns.TypeSOA, Class: dns.ClassINET, Ttl: 300},
+		Ns:  "ns.example.", Mbox: "hostmaster.example.", Minttl: 300,
+	}
+	a := &dns.A{Hdr: dns.RR_Header{Name: "x.example.", Rrtype: dns.TypeA, Class: dns.ClassINET, Ttl: 300}, A: []byte{192, 0, 2, 1}}
+	cname := &dns.CNAME{Hdr: dns.RR_Header{Name: "x.example.", Rrtype: dns.TypeCNAME, Class: dns.ClassINET, Ttl: 300}, Target: "y.example."}
+
+	for _, tc := range []struct {
+		name   string
+		answer []dns.RR
+		ns     []dns.RR
+		rcode  int
+		want   ResponseType
+	}{
+		{"ANY answered with an address and a SOA beside it", []dns.RR{a, soa}, nil, dns.RcodeSuccess, TypeSuccess},
+		{"ANY answered with the SOA in the authority section", []dns.RR{a}, []dns.RR{soa}, dns.RcodeSuccess, TypeSuccess},
+		{"ANY answered by an alias alone", []dns.RR{cname}, nil, dns.RcodeSuccess, TypeSuccess},
+		{"ANY with nothing in the answer and a SOA is a denial", nil, []dns.RR{soa}, dns.RcodeSuccess, TypeNoRecords},
+		{"NOTIMP is not cacheable and not a failure", nil, nil, dns.RcodeNotImplemented, TypeNotCacheable},
+		{"REFUSED stays a failure", nil, nil, dns.RcodeRefused, TypeServerFailure},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			m := new(dns.Msg)
+			m.SetQuestion("x.example.", dns.TypeANY)
+			m.Rcode = tc.rcode
+			m.Answer, m.Ns = tc.answer, tc.ns
+			if got, _ := ClassifyResponse(m, now); got != tc.want {
+				t.Fatalf("classified %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/dnsutil/any_classify_test.go
+++ b/internal/dnsutil/any_classify_test.go
@@ -7,13 +7,13 @@ import (
 	"github.com/miekg/dns"
 )
 
-// TestClassifyANYAndNotImplemented pins the two classifier facts behind the
-// ANY policy. An ANY answer holds records of every type but never one of
-// type 255, so it is answered by whatever it carries: a full answer that
-// happened to include a SOA was read as a NODATA denial. And NOTIMP is a
-// statement about the question, not a resolution failure: classified as
-// one, it was recorded in the failure cache and the next identical question
-// was answered SERVFAIL from there.
+// TestClassifyANYAndNotImplemented pins two classifier facts behind the ANY
+// policy. An ANY answer holds records of every type but never one of type
+// 255, so it is answered by whatever it carries: a full answer that happened
+// to include a SOA was read as a NODATA denial. And NOTIMP from an upstream
+// stays a failure, which is what lets the forwarder and failover move to a
+// server that does support the question; the local policy answer never
+// reaches this classifier.
 func TestClassifyANYAndNotImplemented(t *testing.T) {
 	now := time.Now()
 	soa := &dns.SOA{
@@ -34,7 +34,7 @@ func TestClassifyANYAndNotImplemented(t *testing.T) {
 		{"ANY answered with the SOA in the authority section", []dns.RR{a}, []dns.RR{soa}, dns.RcodeSuccess, TypeSuccess},
 		{"ANY answered by an alias alone", []dns.RR{cname}, nil, dns.RcodeSuccess, TypeSuccess},
 		{"ANY with nothing in the answer and a SOA is a denial", nil, []dns.RR{soa}, dns.RcodeSuccess, TypeNoRecords},
-		{"NOTIMP is not cacheable and not a failure", nil, nil, dns.RcodeNotImplemented, TypeNotCacheable},
+		{"NOTIMP from an upstream stays a failure, so failover moves on", nil, nil, dns.RcodeNotImplemented, TypeServerFailure},
 		{"REFUSED stays a failure", nil, nil, dns.RcodeRefused, TypeServerFailure},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/dnsutil/response.go
+++ b/internal/dnsutil/response.go
@@ -105,6 +105,14 @@ func ClassifyResponse(msg *dns.Msg, now time.Time) (ResponseType, *dns.OPT) {
 		// NXDOMAIN - domain doesn't exist
 		return TypeNXDomain, opt
 
+	case dns.RcodeNotImplemented:
+		// NOTIMP is a statement about the question, not about the upstream:
+		// this server declines the query type (ANY). It is not a resolution
+		// failure in RFC 9520's sense, and classifying it as one recorded it
+		// in the failure cache, so the next identical question was answered
+		// SERVFAIL from there instead of NOTIMP from the policy.
+		return TypeNotCacheable, opt
+
 	default:
 		// Other errors
 		return TypeServerFailure, opt
@@ -336,6 +344,12 @@ func answerHasQType(msg *dns.Msg) bool {
 		return false
 	}
 	qtype := msg.Question[0].Qtype
+	// ANY is satisfied by whatever the answer holds; no record carries type
+	// 255 itself. Looking for the literal type turned a full ANY answer that
+	// happened to carry a SOA into a NODATA denial.
+	if qtype == dns.TypeANY {
+		return len(msg.Answer) > 0
+	}
 	for _, rr := range msg.Answer {
 		if rr.Header().Rrtype == qtype {
 			return true

--- a/internal/dnsutil/response.go
+++ b/internal/dnsutil/response.go
@@ -105,16 +105,12 @@ func ClassifyResponse(msg *dns.Msg, now time.Time) (ResponseType, *dns.OPT) {
 		// NXDOMAIN - domain doesn't exist
 		return TypeNXDomain, opt
 
-	case dns.RcodeNotImplemented:
-		// NOTIMP is a statement about the question, not about the upstream:
-		// this server declines the query type (ANY). It is not a resolution
-		// failure in RFC 9520's sense, and classifying it as one recorded it
-		// in the failure cache, so the next identical question was answered
-		// SERVFAIL from there instead of NOTIMP from the policy.
-		return TypeNotCacheable, opt
-
 	default:
-		// Other errors
+		// Other errors. NOTIMP stays here on purpose: from an upstream it
+		// says that server does not support the question, and the
+		// forwarder and failover move to the next server only on a failure
+		// classification. The local ANY policy answer never reaches this
+		// classifier, the cache passes ANY through unwrapped.
 		return TypeServerFailure, opt
 	}
 }

--- a/middleware/cache/any_notimp_test.go
+++ b/middleware/cache/any_notimp_test.go
@@ -1,0 +1,64 @@
+package cache
+
+import (
+	"context"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/middleware"
+)
+
+// TestNotImplementedIsNeitherCachedNorAFailure pins the cache's view of the
+// ANY policy answer. NOTIMP used to classify as a resolution failure, so the
+// first ANY question was answered NOTIMP by the policy and the second, for
+// the same name, SERVFAIL from the failure cache. Both are NOTIMP now, each
+// from the policy, and nothing about the name is remembered.
+func TestNotImplementedIsNeitherCachedNorAFailure(t *testing.T) {
+	c := New(&config.Config{CacheSize: 1024, Expire: 600})
+	defer c.Stop()
+
+	policy := 0
+	handler := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+		policy++
+		_ = ch.Writer.WriteMsg(SetRcodeForTest(ch.Request.Msg(), dns.RcodeNotImplemented))
+		ch.Cancel()
+	})
+
+	ask := func() *dns.Msg {
+		t.Helper()
+		req := new(dns.Msg)
+		req.SetQuestion("any.example.", dns.TypeANY)
+		req.RecursionDesired = true
+		w := mock.NewWriter("udp", "127.0.0.1:0")
+		chain := middleware.NewChain([]middleware.Handler{c, handler})
+		chain.Reset(w, req)
+		chain.Next(context.Background())
+		if !w.Written() {
+			t.Fatal("no response written")
+		}
+		return w.Msg()
+	}
+
+	for i := 1; i <= 2; i++ {
+		if got := ask().Rcode; got != dns.RcodeNotImplemented {
+			t.Fatalf("question %d answered %s, want NOTIMP", i, dns.RcodeToString[got])
+		}
+	}
+	if policy != 2 {
+		t.Fatalf("the policy answered %d times, want 2: nothing about the name may be remembered", policy)
+	}
+	if c.store.NXDomainCutLen() != 0 || c.store.positive.Len() != 0 {
+		t.Fatal("a NOTIMP answer was stored")
+	}
+}
+
+// SetRcodeForTest builds a reply carrying rcode, the way the resolver's
+// policy answers do.
+func SetRcodeForTest(req *dns.Msg, rcode int) *dns.Msg {
+	m := new(dns.Msg)
+	m.SetRcode(req, rcode)
+	m.RecursionAvailable = true
+	return m
+}

--- a/middleware/cache/any_notimp_test.go
+++ b/middleware/cache/any_notimp_test.go
@@ -2,7 +2,9 @@ package cache
 
 import (
 	"context"
+	"net/netip"
 	"testing"
+	"time"
 
 	"github.com/miekg/dns"
 	"github.com/semihalev/sdns/config"
@@ -10,55 +12,141 @@ import (
 	"github.com/semihalev/sdns/middleware"
 )
 
-// TestNotImplementedIsNeitherCachedNorAFailure pins the cache's view of the
-// ANY policy answer. NOTIMP used to classify as a resolution failure, so the
-// first ANY question was answered NOTIMP by the policy and the second, for
-// the same name, SERVFAIL from the failure cache. Both are NOTIMP now, each
-// from the policy, and nothing about the name is remembered.
-func TestNotImplementedIsNeitherCachedNorAFailure(t *testing.T) {
-	c := New(&config.Config{CacheSize: 1024, Expire: 600})
-	defer c.Stop()
+// TestANYPassesThroughTheCache pins the cache's part in the ANY policy: it
+// has none. Whatever the cache holds for a name, a zone in failure backoff
+// or a subtree cut here, answers the other question types and never ANY,
+// which always reaches the policy behind the cache. And the policy answer
+// goes out with the writer unwrapped: it is not stored, not recorded as a
+// failure, and not taken as the recovery that resets a zone's backoff. A
+// zone in backoff used to answer ANY with SERVFAIL, and, once the answer
+// did get through, its NOTIMP was classified a failure and cached, so the
+// second ANY was SERVFAIL again.
+func TestANYPassesThroughTheCache(t *testing.T) {
+	t.Run("a zone in failure backoff", func(t *testing.T) {
+		c := New(&config.Config{CacheSize: 1024})
+		defer c.Stop()
 
-	policy := 0
-	handler := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
-		policy++
-		_ = ch.Writer.WriteMsg(SetRcodeForTest(ch.Request.Msg(), dns.RcodeNotImplemented))
-		ch.Cancel()
+		policy, reached := 0, 0
+		downstream := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+			reached++
+			q := ch.Request.Msg().Question[0]
+			rcode := dns.RcodeServerFailure
+			if q.Qtype == dns.TypeANY {
+				policy++
+				rcode = dns.RcodeNotImplemented
+			}
+			m := new(dns.Msg)
+			m.SetRcode(ch.Request.Msg(), rcode)
+			_ = ch.Writer.WriteMsg(m)
+			ch.Cancel()
+		})
+		ask := func(qtype uint16) *dns.Msg {
+			t.Helper()
+			req := new(dns.Msg)
+			req.SetQuestion("host.dead.example.", qtype)
+			req.RecursionDesired = true
+			w := mock.NewWriter("udp", "127.0.0.1:0")
+			chain := middleware.NewChain([]middleware.Handler{c, downstream})
+			chain.Reset(w, req)
+			chain.Next(context.Background())
+			if !w.Written() {
+				t.Fatal("no response written")
+			}
+			return w.Msg()
+		}
+		failureOn := func(name string) bool {
+			req := new(dns.Msg)
+			req.SetQuestion(name, dns.TypeA)
+			_, ok := c.store.LookupFailure(req, netip.Prefix{})
+			return ok
+		}
+
+		c.store.RecordZoneFailure(dns.Question{Name: "seed.dead.example.", Qtype: dns.TypeA, Qclass: dns.ClassINET}, "dead.example.")
+		if !failureOn("host.dead.example.") {
+			t.Fatal("fixture: the zone is not in backoff")
+		}
+
+		// An ordinary question is answered from the backoff, downstream untouched.
+		if got := ask(dns.TypeA); got.Rcode != dns.RcodeServerFailure || reached != 0 {
+			t.Fatalf("A under a zone in backoff: %s, downstream reached %d times; want SERVFAIL from the cache", dns.RcodeToString[got.Rcode], reached)
+		}
+		// ANY reaches the policy, twice, and neither answer is remembered.
+		for i := 1; i <= 2; i++ {
+			if got := ask(dns.TypeANY); got.Rcode != dns.RcodeNotImplemented {
+				t.Fatalf("ANY %d: %s, want NOTIMP from the policy", i, dns.RcodeToString[got.Rcode])
+			}
+		}
+		if policy != 2 {
+			t.Fatalf("the policy answered %d times, want 2", policy)
+		}
+		if c.store.positive.Len() != 0 {
+			t.Fatal("a NOTIMP answer was stored")
+		}
+		// The backoff stands: a NOTIMP is not the recovery that resets it.
+		if !failureOn("host.dead.example.") {
+			t.Fatal("the ANY answer reset the zone's failure backoff")
+		}
 	})
 
-	ask := func() *dns.Msg {
-		t.Helper()
-		req := new(dns.Msg)
-		req.SetQuestion("any.example.", dns.TypeANY)
-		req.RecursionDesired = true
-		w := mock.NewWriter("udp", "127.0.0.1:0")
-		chain := middleware.NewChain([]middleware.Handler{c, handler})
-		chain.Reset(w, req)
-		chain.Next(context.Background())
-		if !w.Written() {
-			t.Fatal("no response written")
-		}
-		return w.Msg()
-	}
+	t.Run("a subtree cut", func(t *testing.T) {
+		c := New(&config.Config{CacheSize: 1024, Expire: 600})
+		defer c.Stop()
 
-	for i := 1; i <= 2; i++ {
-		if got := ask().Rcode; got != dns.RcodeNotImplemented {
-			t.Fatalf("question %d answered %s, want NOTIMP", i, dns.RcodeToString[got])
+		sig := func(owner string, covered uint16) dns.RR {
+			return &dns.RRSIG{
+				Hdr:         dns.RR_Header{Name: owner, Rrtype: dns.TypeRRSIG, Class: dns.ClassINET, Ttl: 300},
+				TypeCovered: covered, Algorithm: dns.RSASHA256, Labels: 2, OrigTtl: 300, KeyTag: 4242,
+				SignerName: "zone.test.", Signature: "Tm90QVJlYWxTaWduYXR1cmVCdXRWYWxpZEJhc2U2NA==",
+				Expiration: uint32(time.Now().Add(24 * time.Hour).Unix()), //nolint:gosec // test fixture
+				Inception:  uint32(time.Now().Add(-time.Hour).Unix()),     //nolint:gosec // test fixture
+			}
 		}
-	}
-	if policy != 2 {
-		t.Fatalf("the policy answered %d times, want 2: nothing about the name may be remembered", policy)
-	}
-	if c.store.NXDomainCutLen() != 0 || c.store.positive.Len() != 0 {
-		t.Fatal("a NOTIMP answer was stored")
-	}
-}
+		proof := new(dns.Msg)
+		proof.SetQuestion("gone.zone.test.", dns.TypeA)
+		proof.Rcode = dns.RcodeNameError
+		proof.Ns = []dns.RR{
+			&dns.SOA{
+				Hdr: dns.RR_Header{Name: "zone.test.", Rrtype: dns.TypeSOA, Class: dns.ClassINET, Ttl: 300},
+				Ns:  "ns.zone.test.", Mbox: "hostmaster.zone.test.", Serial: 1, Refresh: 3600, Retry: 600, Expire: 86400, Minttl: 300,
+			},
+			sig("zone.test.", dns.TypeSOA),
+			&dns.NSEC{
+				Hdr:        dns.RR_Header{Name: "glib.zone.test.", Rrtype: dns.TypeNSEC, Class: dns.ClassINET, Ttl: 300},
+				NextDomain: "help.zone.test.", TypeBitMap: []uint16{dns.TypeA, dns.TypeRRSIG, dns.TypeNSEC},
+			},
+			sig("glib.zone.test.", dns.TypeNSEC),
+		}
+		if !c.store.RecordNXDomainCut(proof, "gone.zone.test.", "zone.test.", time.Time{}) {
+			t.Fatal("cut refused")
+		}
 
-// SetRcodeForTest builds a reply carrying rcode, the way the resolver's
-// policy answers do.
-func SetRcodeForTest(req *dns.Msg, rcode int) *dns.Msg {
-	m := new(dns.Msg)
-	m.SetRcode(req, rcode)
-	m.RecursionAvailable = true
-	return m
+		reached := 0
+		policy := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+			reached++
+			m := new(dns.Msg)
+			m.SetRcode(ch.Request.Msg(), dns.RcodeNotImplemented)
+			_ = ch.Writer.WriteMsg(m)
+			ch.Cancel()
+		})
+		ask := func(qtype uint16) *dns.Msg {
+			t.Helper()
+			req := new(dns.Msg)
+			req.SetQuestion("sub.gone.zone.test.", qtype)
+			req.RecursionDesired = true
+			w := mock.NewWriter("udp", "127.0.0.1:0")
+			chain := middleware.NewChain([]middleware.Handler{c, policy})
+			chain.Reset(w, req)
+			chain.Next(context.Background())
+			if !w.Written() {
+				t.Fatal("no response written")
+			}
+			return w.Msg()
+		}
+		if got := ask(dns.TypeA); got.Rcode != dns.RcodeNameError || reached != 0 {
+			t.Fatalf("A under a cut: %s, policy reached %d times; want NXDOMAIN from the cut", dns.RcodeToString[got.Rcode], reached)
+		}
+		if got := ask(dns.TypeANY); got.Rcode != dns.RcodeNotImplemented || reached != 1 {
+			t.Fatalf("ANY under a cut: %s, policy reached %d times; want NOTIMP from the policy", dns.RcodeToString[got.Rcode], reached)
+		}
+	})
 }

--- a/middleware/cache/cache.go
+++ b/middleware/cache/cache.go
@@ -426,6 +426,18 @@ func (c *Cache) ServeDNS(ctx context.Context, ch *middleware.Chain) {
 	// capability set the decline fell back for, and a second ladder walk
 	// would double the decline diagnostics and the per-entry limiter
 	// charge for the same client question.
+	// ANY never touches the cache. The answer to it is the resolver
+	// handler's policy (NOTIMP), and nothing this cache holds for the name,
+	// an exact entry, a subtree cut, an aggressive denial, a zone in failure
+	// backoff, may stand in for it: a zone in backoff was answering ANY
+	// with SERVFAIL. Passed through with the writer unwrapped, so the policy
+	// answer is neither classified, stored, recorded as a failure, nor taken
+	// as the recovery that resets a zone's backoff.
+	if ch.Request != nil && ch.Request.Qtype() == dns.TypeANY {
+		ch.Next(ctx)
+		return
+	}
+
 	var spent *rate.Limiter
 	if ch.Request.Undecoded() && !ch.Replay() && c.serveWire(ctx, ch, &spent) {
 		return

--- a/middleware/cache/negative_cache_test.go
+++ b/middleware/cache/negative_cache_test.go
@@ -47,21 +47,17 @@ func TestResolutionFailureRcodeClassification(t *testing.T) {
 	c := New(&config.Config{CacheSize: 1024})
 	defer c.Stop()
 
-	// NOTIMP is the one rcode that is neither stored nor a failure: it is
-	// this server's answer to a question type it declines (ANY), and a
-	// failure entry for it answered the next question SERVFAIL.
 	tests := []struct {
-		name         string
-		rcode        int
-		wantFailure  bool
-		wantPositive bool
+		name        string
+		rcode       int
+		wantFailure bool
 	}{
-		{"SUCCESS", dns.RcodeSuccess, false, true},
-		{"SERVFAIL", dns.RcodeServerFailure, true, false},
-		{"NXDOMAIN", dns.RcodeNameError, false, true},
-		{"REFUSED", dns.RcodeRefused, true, false},
-		{"FORMERR", dns.RcodeFormatError, true, false},
-		{"NOTIMP", dns.RcodeNotImplemented, false, false},
+		{"SUCCESS", dns.RcodeSuccess, false},
+		{"SERVFAIL", dns.RcodeServerFailure, true},
+		{"NXDOMAIN", dns.RcodeNameError, false},
+		{"REFUSED", dns.RcodeRefused, true},
+		{"FORMERR", dns.RcodeFormatError, true},
+		{"NOTIMP", dns.RcodeNotImplemented, true},
 	}
 
 	for _, tt := range tests {
@@ -102,8 +98,8 @@ func TestResolutionFailureRcodeClassification(t *testing.T) {
 			if !reflect.DeepEqual(tt.wantFailure, inFailure) {
 				t.Errorf("inFailure = %v, want %v", inFailure, tt.wantFailure)
 			}
-			if !reflect.DeepEqual(tt.wantPositive, inPositive) {
-				t.Errorf("inPositive = %v, want %v", inPositive, tt.wantPositive)
+			if !reflect.DeepEqual(!tt.wantFailure, inPositive) {
+				t.Errorf("inPositive = %v, want %v", inPositive, !tt.wantFailure)
 			}
 		})
 	}

--- a/middleware/cache/negative_cache_test.go
+++ b/middleware/cache/negative_cache_test.go
@@ -47,17 +47,21 @@ func TestResolutionFailureRcodeClassification(t *testing.T) {
 	c := New(&config.Config{CacheSize: 1024})
 	defer c.Stop()
 
+	// NOTIMP is the one rcode that is neither stored nor a failure: it is
+	// this server's answer to a question type it declines (ANY), and a
+	// failure entry for it answered the next question SERVFAIL.
 	tests := []struct {
-		name        string
-		rcode       int
-		wantFailure bool
+		name         string
+		rcode        int
+		wantFailure  bool
+		wantPositive bool
 	}{
-		{"SUCCESS", dns.RcodeSuccess, false},
-		{"SERVFAIL", dns.RcodeServerFailure, true},
-		{"NXDOMAIN", dns.RcodeNameError, false},
-		{"REFUSED", dns.RcodeRefused, true},
-		{"FORMERR", dns.RcodeFormatError, true},
-		{"NOTIMP", dns.RcodeNotImplemented, true},
+		{"SUCCESS", dns.RcodeSuccess, false, true},
+		{"SERVFAIL", dns.RcodeServerFailure, true, false},
+		{"NXDOMAIN", dns.RcodeNameError, false, true},
+		{"REFUSED", dns.RcodeRefused, true, false},
+		{"FORMERR", dns.RcodeFormatError, true, false},
+		{"NOTIMP", dns.RcodeNotImplemented, false, false},
 	}
 
 	for _, tt := range tests {
@@ -98,8 +102,8 @@ func TestResolutionFailureRcodeClassification(t *testing.T) {
 			if !reflect.DeepEqual(tt.wantFailure, inFailure) {
 				t.Errorf("inFailure = %v, want %v", inFailure, tt.wantFailure)
 			}
-			if !reflect.DeepEqual(!tt.wantFailure, inPositive) {
-				t.Errorf("inPositive = %v, want %v", inPositive, !tt.wantFailure)
+			if !reflect.DeepEqual(tt.wantPositive, inPositive) {
+				t.Errorf("inPositive = %v, want %v", inPositive, tt.wantPositive)
 			}
 		})
 	}

--- a/middleware/resolver/any_policy_test.go
+++ b/middleware/resolver/any_policy_test.go
@@ -1,0 +1,67 @@
+package resolver
+
+import (
+	"context"
+	"testing"
+
+	"github.com/miekg/dns"
+	"github.com/semihalev/sdns/config"
+	"github.com/semihalev/sdns/internal/mock"
+	"github.com/semihalev/sdns/middleware"
+)
+
+// TestANYIsDeclinedAheadOfEveryForwardingPath pins the ANY policy to the
+// server rather than to the resolver: a whole-server forwarder and a forward
+// zone both used to hand the question on before the resolver's NOTIMP could
+// apply, so the same query was declined in one mode and forwarded in the
+// other. It is declined on every path now, before anything is decoded for
+// the questions that are handed on, with the client's DO echoed.
+func TestANYIsDeclinedAheadOfEveryForwardingPath(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		configure func(*config.Config)
+	}{
+		{"no forwarding", func(*config.Config) {}},
+		{"a whole-server forwarder", func(cfg *config.Config) { cfg.ForwarderServers = []string{"192.0.2.53:53"} }},
+		{"a forward zone covering the name", func(cfg *config.Config) {
+			cfg.ForwardZones = []config.ForwardZoneConfig{{Name: "example.", Servers: []string{"192.0.2.53:53"}}}
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := makeTestConfig()
+			tc.configure(cfg)
+			h := New(cfg)
+			handedOn := false
+			next := middleware.HandlerFunc(func(_ context.Context, ch *middleware.Chain) {
+				handedOn = true
+				ch.Cancel()
+			})
+
+			req := new(dns.Msg)
+			req.SetQuestion("any.example.", dns.TypeANY)
+			req.RecursionDesired = true
+			req.SetEdns0(1232, true)
+			w := mock.NewWriter("udp", "127.0.0.1:0")
+			chain := middleware.NewChain([]middleware.Handler{h, next})
+			chain.Reset(w, req)
+			chain.Next(context.Background())
+
+			if handedOn {
+				t.Fatal("the ANY question was handed on instead of declined")
+			}
+			if !w.Written() {
+				t.Fatal("no response written")
+			}
+			resp := w.Msg()
+			if resp.Rcode != dns.RcodeNotImplemented {
+				t.Fatalf("answered %s, want NOTIMP", dns.RcodeToString[resp.Rcode])
+			}
+			if opt := resp.IsEdns0(); opt == nil || !opt.Do() {
+				t.Fatal("the client's DO was not echoed")
+			}
+			if len(resp.Question) != 1 || resp.Question[0].Qtype != dns.TypeANY {
+				t.Fatalf("question not echoed: %v", resp.Question)
+			}
+		})
+	}
+}

--- a/middleware/resolver/handler.go
+++ b/middleware/resolver/handler.go
@@ -73,6 +73,17 @@ func (h *DNSHandler) Name() string { return name }
 
 // (*DNSHandler).ServeDNS serveDNS implements the Handle interface.
 func (h *DNSHandler) ServeDNS(ctx context.Context, ch *middleware.Chain) {
+	// ANY is declined on every path, the forwarding ones included: the
+	// policy is this server's, not an upstream's, so a forwarder never sees
+	// the question. Read off the wire facts, so a server that hands its
+	// questions on still pays no decode for them.
+	if ch.Request != nil && ch.Request.Qtype() == dns.TypeANY {
+		if _, req := ch.Materialize(ctx); req != nil {
+			_ = ch.Writer.WriteMsg(anyNotImplemented(req))
+		}
+		return
+	}
+
 	// Skip resolver if forwarders are configured
 	if len(h.cfg.ForwarderServers) > 0 {
 		ch.Next(ctx)
@@ -132,7 +143,7 @@ func (h *DNSHandler) handle(ctx context.Context, req *dns.Msg) *dns.Msg {
 	}
 
 	if q.Qtype == dns.TypeANY {
-		return dnsutil.SetRcode(req, dns.RcodeNotImplemented, do)
+		return anyNotImplemented(req)
 	}
 
 	// CHAOS queries: debug nameserver stats (HINFO) or cache purge (NULL)
@@ -326,3 +337,15 @@ func (h *DNSHandler) Stop() {
 }
 
 const name = "resolver"
+
+// anyNotImplemented is the answer to a QTYPE=ANY question: NOTIMP, with the
+// client's DO echoed on the OPT. It is a policy answer about the question,
+// not a resolution failure, and the cache classifies it as neither storable
+// nor a failure, so the next question for the name resolves normally.
+func anyNotImplemented(req *dns.Msg) *dns.Msg {
+	do := false
+	if opt := req.IsEdns0(); opt != nil {
+		do = opt.Do()
+	}
+	return dnsutil.SetRcode(req, dns.RcodeNotImplemented, do)
+}


### PR DESCRIPTION
sdns declines QTYPE=ANY with NOTIMP by design. The policy lived in the resolver's handle, and several paths went around it.

## What was wrong

- **The cache answered ahead of the policy.** In the default chain the cache runs before the resolver, so whatever it held for the name answered ANY: a zone in failure backoff answered SERVFAIL, a subtree cut answered NXDOMAIN, and the resolver never ran.
- **Forwarding bypassed the policy.** A whole-server forwarder and a forward zone handed the question on before the resolver's check, so the same ANY query was declined in one mode and forwarded upstream in the other.
- **The refusal poisoned the failure cache.** Once it did get through, the NOTIMP answer was classified a resolution failure and recorded, so the second ANY for a name was answered SERVFAIL from the failure cache; and, as a non-failure would, it reset the zone's backoff.
- **An ANY answer could read as a denial.** The classifier looked for a record of the literal type 255 in the answer section; a full ANY answer that carried a SOA was classified NODATA and given the SOA's lifetime.

## What changes

- **The cache passes ANY through, unwrapped.** Its `ServeDNS` hands the question on before the wire ladder, the lookups and the writer wrapper, so nothing it holds stands in for the policy, and the policy's answer is neither classified, stored, recorded as a failure, nor taken as the recovery that resets a zone's backoff. This is the whole of the cache-side change; the global classification of NOTIMP is untouched, because from an upstream it means that server does not support the question, and the forwarder and failover move to the next server only on a failure classification.
- **The resolver handler declines ANY first**, ahead of both forwarding branches, reading the question type off the wire facts so a server that hands its questions on still decodes nothing for them. The client's DO is echoed on the OPT.
- **`answerHasQType` treats ANY as satisfied by whatever the answer holds.**
- The diagnostics page says the refusal holds in every mode and is never cached.

## Tests

- ANY through the cache with the zone in failure backoff: an A question is answered from the backoff without reaching downstream, ANY reaches the policy twice and is NOTIMP both times, nothing is stored, and the backoff still stands afterwards. The same under a subtree cut: A is NXDOMAIN from the cut, ANY reaches the policy.
- ANY through the resolver handler with no forwarding, a whole-server forwarder, and a covering forward zone: NOTIMP, the next handler never reached, DO and question echoed.
- The classifier on ANY answered with an address and a SOA, with the SOA in authority, and by an alias alone (success), with an empty answer and a SOA (denial); NOTIMP and REFUSED from an upstream stay failures.
